### PR TITLE
Correct Incorrect Match

### DIFF
--- a/API/Controllers/AccountController.cs
+++ b/API/Controllers/AccountController.cs
@@ -51,8 +51,9 @@ namespace API.Controllers
             
             result = await _userManager.AddPasswordAsync(user, resetPasswordDto.Password);
             if (!result.Succeeded) return BadRequest("Unable to update password");
-
-            return Ok($"{resetPasswordDto.UserName}'s Password has been reset.");
+            
+            _logger.LogInformation("{User}'s Password has been reset", resetPasswordDto.UserName);
+            return Ok();
         }
 
         [HttpPost("register")]

--- a/API/Controllers/SeriesController.cs
+++ b/API/Controllers/SeriesController.cs
@@ -104,11 +104,16 @@ namespace API.Controllers
             var series = await _unitOfWork.SeriesRepository.GetSeriesByIdAsync(updateSeries.Id);
 
             if (series == null) return BadRequest("Series does not exist");
-
-            // TODO: Support changing series properties once "locking" is implemented.
-            // series.Name = updateSeries.Name;
-            // series.OriginalName = updateSeries.OriginalName;
-            // series.SortName = updateSeries.SortName;
+            
+            // TODO: check if new name isn't an existing series
+            var existingSeries = await _unitOfWork.SeriesRepository.GetSeriesByNameAsync(updateSeries.Name); // NOTE: This isnt checking library
+            if (existingSeries != null && existingSeries.Id != series.Id)
+            {
+                return BadRequest("A series already exists with this name. Name must be unique.");
+            }
+            series.Name = updateSeries.Name;
+            series.LocalizedName = updateSeries.LocalizedName;
+            series.SortName = updateSeries.SortName;
             series.Summary = updateSeries.Summary;
             //series.CoverImage = updateSeries.CoverImage;
             

--- a/API/Controllers/SettingsController.cs
+++ b/API/Controllers/SettingsController.cs
@@ -76,14 +76,12 @@ namespace API.Controllers
 
             if (!_unitOfWork.HasChanges()) return Ok("Nothing was updated");
 
-            if (_unitOfWork.HasChanges() && await _unitOfWork.Complete())
-            {
-                _logger.LogInformation("Server Settings updated");
-                _taskScheduler.ScheduleTasks();
-                return Ok(updateSettingsDto);
-            }
-
-            return BadRequest("There was a critical issue. Please try again.");
+            if (!_unitOfWork.HasChanges() || !await _unitOfWork.Complete())
+                return BadRequest("There was a critical issue. Please try again.");
+            
+            _logger.LogInformation("Server Settings updated");
+            _taskScheduler.ScheduleTasks();
+            return Ok(updateSettingsDto);
         }
 
         [Authorize(Policy = "RequireAdminRole")]

--- a/API/Controllers/SettingsController.cs
+++ b/API/Controllers/SettingsController.cs
@@ -18,11 +18,13 @@ namespace API.Controllers
     {
         private readonly ILogger<SettingsController> _logger;
         private readonly IUnitOfWork _unitOfWork;
+        private readonly ITaskScheduler _taskScheduler;
 
-        public SettingsController(ILogger<SettingsController> logger, IUnitOfWork unitOfWork)
+        public SettingsController(ILogger<SettingsController> logger, IUnitOfWork unitOfWork, ITaskScheduler taskScheduler)
         {
             _logger = logger;
             _unitOfWork = unitOfWork;
+            _taskScheduler = taskScheduler;
         }
 
         [HttpGet("")]
@@ -77,6 +79,7 @@ namespace API.Controllers
             if (_unitOfWork.HasChanges() && await _unitOfWork.Complete())
             {
                 _logger.LogInformation("Server Settings updated");
+                _taskScheduler.ScheduleTasks();
                 return Ok(updateSettingsDto);
             }
 

--- a/API/DTOs/SeriesDto.cs
+++ b/API/DTOs/SeriesDto.cs
@@ -5,6 +5,7 @@
         public int Id { get; init; }
         public string Name { get; init; }
         public string OriginalName { get; init; }
+        public string LocalizedName { get; init; }
         public string SortName { get; init; }
         public string Summary { get; init; }
         public byte[] CoverImage { get; init; }

--- a/API/DTOs/UpdateSeriesDto.cs
+++ b/API/DTOs/UpdateSeriesDto.cs
@@ -4,7 +4,7 @@
     {
         public int Id { get; init; }
         public string Name { get; init; }
-        public string OriginalName { get; init; }
+        public string LocalizedName { get; init; }
         public string SortName { get; init; }
         public string Summary { get; init; }
         public byte[] CoverImage { get; init; }

--- a/API/Data/Migrations/20210225150830_AddLocalizedName.Designer.cs
+++ b/API/Data/Migrations/20210225150830_AddLocalizedName.Designer.cs
@@ -3,14 +3,16 @@ using System;
 using API.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace API.Data.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20210225150830_AddLocalizedName")]
+    partial class AddLocalizedName
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/API/Data/Migrations/20210225150830_AddLocalizedName.cs
+++ b/API/Data/Migrations/20210225150830_AddLocalizedName.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace API.Data.Migrations
+{
+    public partial class AddLocalizedName : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "LocalizedName",
+                table: "Series",
+                type: "TEXT",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "LocalizedName",
+                table: "Series");
+        }
+    }
+}

--- a/API/Entities/Series.cs
+++ b/API/Entities/Series.cs
@@ -20,6 +20,10 @@ namespace API.Entities
         /// </summary>
         public string SortName { get; set; }
         /// <summary>
+        /// Name in Japanese. By default, will be same as Name. 
+        /// </summary>
+        public string LocalizedName { get; set; }
+        /// <summary>
         /// Original Name on disk. Not exposed to UI.
         /// </summary>
         public string OriginalName { get; set; }

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -144,11 +144,14 @@ namespace API.Services.Tasks
 
        private void UpdateLibrary(Library library, Dictionary<string, List<ParserInfo>> parsedSeries)
        {
+          if (parsedSeries == null) throw new ArgumentNullException(nameof(parsedSeries));
+          
           // First, remove any series that are not in parsedSeries list
           var foundSeries = parsedSeries.Select(s => Parser.Parser.Normalize(s.Key)).ToList();
           var missingSeries = library.Series.Where(existingSeries =>
-             !foundSeries.Contains(existingSeries.NormalizedName) || !parsedSeries.ContainsKey(existingSeries.Name) ||
-             !parsedSeries.ContainsKey(existingSeries.OriginalName));
+             !foundSeries.Contains(existingSeries.NormalizedName) || !parsedSeries.ContainsKey(existingSeries.Name)
+              || (existingSeries.LocalizedName != null && !parsedSeries.ContainsKey(existingSeries.LocalizedName))
+              || !parsedSeries.ContainsKey(existingSeries.OriginalName));
           var removeCount = 0;
           foreach (var existingSeries in missingSeries)
           {
@@ -167,6 +170,7 @@ namespace API.Services.Tasks
                 {
                    Name = key,
                    OriginalName = key,
+                   LocalizedName = key,
                    NormalizedName = Parser.Parser.Normalize(key),
                    SortName = key,
                    Summary = "",
@@ -175,6 +179,7 @@ namespace API.Services.Tasks
                 library.Series.Add(existingSeries);
              } 
              existingSeries.NormalizedName = Parser.Parser.Normalize(key);
+             existingSeries.LocalizedName ??= key;
           }
           
           // Now, we only have to deal with series that exist on disk. Let's recalculate the volumes for each series


### PR DESCRIPTION
Implements the ability to allow an admin to correct parsed Series name and set it themselves.
Fixes an issue where after updating scheduled jobs, they were not updated in Hangfire.

The Series Name, Sort Name, and Localized Name are now customizable.

Fixes #64 


