### PR TITLE
Backend changes for new manga reader scheme + Compression

### DIFF
--- a/API/DTOs/MarkVolumeReadDto.cs
+++ b/API/DTOs/MarkVolumeReadDto.cs
@@ -1,0 +1,8 @@
+﻿namespace API.DTOs
+{
+    public class MarkVolumeReadDto
+    {
+        public int SeriesId { get; init; }
+        public int VolumeId { get; init; }
+    }
+}

--- a/API/Data/VolumeRepository.cs
+++ b/API/Data/VolumeRepository.cs
@@ -35,9 +35,22 @@ namespace API.Data
         {
             return await _context.Chapter
                 .Include(c => c.Files)
-                .AsNoTracking()
                 .SingleOrDefaultAsync(c => c.Id == chapterId);
         }
+        
+        
+        /// <summary>
+        /// Returns Chapters for a volume id.
+        /// </summary>
+        /// <param name="volumeId"></param>
+        /// <returns></returns>
+        public async Task<IList<Chapter>> GetChaptersAsync(int volumeId)
+        {
+            return await _context.Chapter
+                .Where(c => c.VolumeId == volumeId)
+                .ToListAsync();
+        }
+        
 
         public async Task<ChapterDto> GetChapterDtoAsync(int chapterId)
         {

--- a/API/Extensions/HttpExtensions.cs
+++ b/API/Extensions/HttpExtensions.cs
@@ -18,5 +18,6 @@ namespace API.Extensions
             response.Headers.Add("Pagination", JsonSerializer.Serialize(paginationHeader, options));
             response.Headers.Add("Access-Control-Expose-Headers", "Pagination");
         }
+        
     }
 }

--- a/API/Interfaces/IVolumeRepository.cs
+++ b/API/Interfaces/IVolumeRepository.cs
@@ -11,5 +11,6 @@ namespace API.Interfaces
         Task<Chapter> GetChapterAsync(int chapterId);
         Task<ChapterDto> GetChapterDtoAsync(int chapterId);
         Task<IList<MangaFile>> GetFilesForChapter(int chapterId);
+        Task<IList<Chapter>> GetChaptersAsync(int volumeId);
     }
 }

--- a/API/Interfaces/Services/IDirectoryService.cs
+++ b/API/Interfaces/Services/IDirectoryService.cs
@@ -13,8 +13,6 @@ namespace API.Interfaces.Services
         /// <param name="rootPath">Absolute path of directory to scan.</param>
         /// <returns>List of folder names</returns>
         IEnumerable<string> ListDirectory(string rootPath);
-
-        Task<ImageDto> ReadImageAsync(string imagePath);
         /// <summary>
         /// Gets files in a directory. If searchPatternExpression is passed, will match the regex against for filtering.
         /// </summary>

--- a/API/Services/DirectoryService.cs
+++ b/API/Services/DirectoryService.cs
@@ -145,26 +145,6 @@ namespace API.Services
             
             return dirs;
         }
-       
-       public async Task<ImageDto> ReadImageAsync(string imagePath)
-       {
-          if (!File.Exists(imagePath))
-          {
-             _logger.LogError("Image does not exist on disk");
-             return null;
-          }
-          using var image = Image.NewFromFile(imagePath);
-
-          return new ImageDto
-          {
-             Content = await ReadFileAsync(imagePath),
-             Filename = Path.GetFileNameWithoutExtension(imagePath),
-             FullPath = Path.GetFullPath(imagePath),
-             Width = image.Width,
-             Height = image.Height,
-             Format = image.Format,
-          };
-       }
 
        public async Task<byte[]> ReadFileAsync(string path)
        {

--- a/API/Services/TaskScheduler.cs
+++ b/API/Services/TaskScheduler.cs
@@ -78,6 +78,8 @@ namespace API.Services
         {
             _logger.LogInformation("Enqueuing library scan for: {LibraryId}", libraryId);
             BackgroundJob.Enqueue(() => _scannerService.ScanLibrary(libraryId, forceUpdate));
+            BackgroundJob.Enqueue(() => _cleanupService.Cleanup()); // When we do a scan, force cache to re-unpack in case page numbers change
+            
         }
 
         public void CleanupChapters(int[] chapterIds)

--- a/API/Startup.cs
+++ b/API/Startup.cs
@@ -41,17 +41,19 @@ namespace API
                 c.SwaggerDoc("v1", new OpenApiInfo { Title = "API", Version = "v1" });
             });
             // This doesn't seem to work.
-            // services.AddResponseCompression(options =>
-            // {
-            //     options.Providers.Add<BrotliCompressionProvider>();
-            //     options.MimeTypes = 
-            //         ResponseCompressionDefaults.MimeTypes.Concat(
-            //             new[] { "image/jpeg", "image/jpg" });
-            // });
-            // services.Configure<BrotliCompressionProviderOptions>(options => 
-            // {
-            //     options.Level = CompressionLevel.Fastest;
-            // });
+            services.AddResponseCompression(options =>
+            {
+                options.Providers.Add<BrotliCompressionProvider>();
+                options.Providers.Add<GzipCompressionProvider>();
+                options.MimeTypes = 
+                    ResponseCompressionDefaults.MimeTypes.Concat(
+                        new[] { "image/jpeg", "image/jpg" });
+                options.EnableForHttps = true;
+            });
+            services.Configure<BrotliCompressionProviderOptions>(options => 
+            {
+                options.Level = CompressionLevel.Fastest;
+            });
             
             
         }
@@ -67,6 +69,7 @@ namespace API
                 app.UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "API v1"));
                 app.UseHangfireDashboard();
             }
+            app.UseResponseCompression();
             
             app.UseForwardedHeaders();
 
@@ -85,7 +88,7 @@ namespace API
             app.UseAuthorization();
 
             app.UseDefaultFiles();
-            
+
             app.UseStaticFiles(new StaticFileOptions
             {
                 ContentTypeProvider = new FileExtensionContentTypeProvider()

--- a/API/Startup.cs
+++ b/API/Startup.cs
@@ -1,9 +1,12 @@
+using System.IO.Compression;
+using System.Linq;
 using API.Extensions;
 using API.Middleware;
 using Hangfire;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -37,8 +40,20 @@ namespace API
             {
                 c.SwaggerDoc("v1", new OpenApiInfo { Title = "API", Version = "v1" });
             });
-
-
+            // This doesn't seem to work.
+            // services.AddResponseCompression(options =>
+            // {
+            //     options.Providers.Add<BrotliCompressionProvider>();
+            //     options.MimeTypes = 
+            //         ResponseCompressionDefaults.MimeTypes.Concat(
+            //             new[] { "image/jpeg", "image/jpg" });
+            // });
+            // services.Configure<BrotliCompressionProviderOptions>(options => 
+            // {
+            //     options.Level = CompressionLevel.Fastest;
+            // });
+            
+            
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -62,6 +77,8 @@ namespace API
             {
                 app.UseCors(policy => policy.AllowAnyHeader().AllowAnyMethod().WithOrigins("http://localhost:4200"));
             }
+            
+            //app.UseResponseCaching();
 
             app.UseAuthentication();
 

--- a/API/appsettings.Development.json
+++ b/API/appsettings.Development.json
@@ -8,7 +8,8 @@
       "Default": "Debug",
       "Microsoft": "Information",
       "Microsoft.Hosting.Lifetime": "Error",
-      "Hangfire": "Information"
+      "Hangfire": "Information",
+      "Microsoft.AspNetCore.Hosting.Internal.WebHost": "Information"
     },
     "File": {
       "Path": "kavita.log",


### PR DESCRIPTION
Fixes #73 

This contains some changes to the way data is sent around reading manga. We use binary files instead of base64 encoded strings. 