### PR TITLE
Don't process pages or cover image optimization

### DIFF
--- a/API/Archive/CoverAndPages.cs
+++ b/API/Archive/CoverAndPages.cs
@@ -1,0 +1,7 @@
+﻿namespace API.Archive
+{
+    public class CoverAndPages
+    {
+        
+    }
+}

--- a/API/Data/Migrations/20210323213507_LastModifiedOnMangaFiles.Designer.cs
+++ b/API/Data/Migrations/20210323213507_LastModifiedOnMangaFiles.Designer.cs
@@ -3,14 +3,16 @@ using System;
 using API.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace API.Data.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20210323213507_LastModifiedOnMangaFiles")]
+    partial class LastModifiedOnMangaFiles
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/API/Data/Migrations/20210323213507_LastModifiedOnMangaFiles.cs
+++ b/API/Data/Migrations/20210323213507_LastModifiedOnMangaFiles.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace API.Data.Migrations
+{
+    public partial class LastModifiedOnMangaFiles : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "LastModified",
+                table: "MangaFile",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "LastModified",
+                table: "MangaFile");
+        }
+    }
+}

--- a/API/Entities/MangaFile.cs
+++ b/API/Entities/MangaFile.cs
@@ -1,5 +1,7 @@
 ﻿
+using System;
 using API.Entities.Enums;
+using API.Entities.Interfaces;
 
 namespace API.Entities
 {
@@ -15,10 +17,13 @@ namespace API.Entities
         /// </summary>
         public int Pages { get; set; }
         public MangaFormat Format { get; set; }
+        /// <summary>
+        /// Last time underlying file was modified
+        /// </summary>
+        public DateTime LastModified { get; set; }
 
         // Relationship Mapping
         public Chapter Chapter { get; set; }
         public int ChapterId { get; set; }
-        
     }
 }

--- a/API/Extensions/FileInfoExtensions.cs
+++ b/API/Extensions/FileInfoExtensions.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.IO;
+
+namespace API.Extensions
+{
+    public static class FileInfoExtensions
+    {
+        public static bool DoesLastWriteMatch(this FileInfo fileInfo, DateTime comparison)
+        {
+            return comparison.Equals(fileInfo.LastWriteTime);
+        }
+    }
+}

--- a/API/Services/ArchiveService.cs
+++ b/API/Services/ArchiveService.cs
@@ -203,7 +203,7 @@ namespace API.Services
             {
                 formatExtension = "." + formatExtension;
             }
-            // TODO: Validate if jpeg is same as jpg
+            
             try
             {
                 using var thumbnail = Image.ThumbnailBuffer(entry, ThumbnailWidth);
@@ -227,7 +227,7 @@ namespace API.Services
             {
                 using var stream = entry.Open();
                 using var thumbnail = Image.ThumbnailStream(stream, ThumbnailWidth);
-                return thumbnail.WriteToBuffer(formatExtension); // TODO: Validate this code works with .png files
+                return thumbnail.WriteToBuffer(formatExtension);
             }
             catch (Exception ex)
             {

--- a/API/Services/MetadataService.cs
+++ b/API/Services/MetadataService.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using API.Entities;
+using API.Extensions;
 using API.Interfaces;
 using API.Interfaces.Services;
 using Microsoft.Extensions.Logging;
@@ -51,7 +53,10 @@ namespace API.Services
              // Skip calculating Cover Image (I/O) if the chapter already has it set
              if (firstChapter == null || ShouldFindCoverImage(firstChapter.CoverImage))
              {
-                if (firstFile != null) volume.CoverImage = _archiveService.GetCoverImage(firstFile.FilePath, true);
+                if (firstFile != null && !new FileInfo(firstFile.FilePath).DoesLastWriteMatch(firstFile.LastModified))
+                {
+                   volume.CoverImage = _archiveService.GetCoverImage(firstFile.FilePath, true);
+                }
              }
              else
              {
@@ -80,9 +85,11 @@ namespace API.Services
           
           var firstVolume = series.Volumes.FirstOrDefault(v => v.Chapters.Any() && v.Number == 1);
           var firstChapter = firstVolume?.Chapters.FirstOrDefault(c => c.Files.Any());
-          if (firstChapter != null)
+          
+          var firstFile = firstChapter?.Files.FirstOrDefault();
+          if (firstFile != null && !new FileInfo(firstFile.FilePath).DoesLastWriteMatch(firstFile.LastModified))
           {
-             series.Summary = _archiveService.GetSummaryInfo(firstChapter.Files.FirstOrDefault()?.FilePath);
+             series.Summary = _archiveService.GetSummaryInfo(firstFile.FilePath);
           }
        }
        


### PR DESCRIPTION
Don't process pages, cover image, or summary if the underlying archive hasn't been written to it since we last processed it. 

Fixes #91 