### PR TITLE
Fixed a bug where if a chapter had multiple archive files, they would…

### DIFF
--- a/API/Services/CacheService.cs
+++ b/API/Services/CacheService.cs
@@ -41,12 +41,19 @@ namespace API.Services
         public async Task<Chapter> Ensure(int chapterId)
         {
             EnsureCacheDirectory();
-            Chapter chapter = await _unitOfWork.VolumeRepository.GetChapterAsync(chapterId);
+            var chapter = await _unitOfWork.VolumeRepository.GetChapterAsync(chapterId);
+            var fileCount = 0;
+            var extractPath = GetCachePath(chapterId);
             
             foreach (var file in chapter.Files)
             {
-                var extractPath = GetCachePath(chapterId);
-                _archiveService.ExtractArchive(file.FilePath, extractPath);
+                _archiveService.ExtractArchive(file.FilePath, Path.Join(extractPath, file.Id + ""));
+                fileCount++;
+            }
+
+            if (fileCount > 1)
+            {
+                new DirectoryInfo(extractPath).Flatten();
             }
 
             return chapter;

--- a/build.sh
+++ b/build.sh
@@ -62,7 +62,7 @@ Package()
 
     ProgressStart "Creating $runtime Package for $framework"
 
-    
+    # TODO: Use no-restore? Because Build should have already done it for us
     echo "Building"
     cd API
     echo dotnet publish -c release --self-contained --runtime $runtime -o "$lOutputFolder" --framework $framework


### PR DESCRIPTION
…n't all be extracted due to short circuit in ExtractArchive. Now I add the file id then flatten afterwards.

Fixes #112 