### PR TITLE
Book Feedback and small bugs

### DIFF
--- a/API/Controllers/AccountController.cs
+++ b/API/Controllers/AccountController.cs
@@ -89,7 +89,7 @@ namespace API.Controllers
 
             var user = _mapper.Map<AppUser>(registerDto);
             user.UserPreferences ??= new AppUserPreferences();
-
+            
             var result = await _userManager.CreateAsync(user, registerDto.Password);
 
             if (!result.Succeeded) return BadRequest(result.Errors);

--- a/API/Controllers/SeriesController.cs
+++ b/API/Controllers/SeriesController.cs
@@ -32,6 +32,8 @@ namespace API.Controllers
                 await _unitOfWork.SeriesRepository.GetSeriesDtoForLibraryIdAsync(libraryId, user.Id, userParams);
             
             // Apply progress/rating information (I can't work out how to do this in initial query)
+            if (series == null) return BadRequest("Could not get series for library");
+
             await _unitOfWork.SeriesRepository.AddSeriesModifiers(user.Id, series);
             
             Response.AddPaginationHeader(series.CurrentPage, series.PageSize, series.TotalCount, series.TotalPages);

--- a/API/DTOs/SeriesDto.cs
+++ b/API/DTOs/SeriesDto.cs
@@ -23,5 +23,6 @@
         public string UserReview { get; set; }
 
         public int LibraryId { get; set; }
+        public string LibraryName { get; set; }
     }
 }

--- a/API/Data/SeriesRepository.cs
+++ b/API/Data/SeriesRepository.cs
@@ -307,7 +307,7 @@ namespace API.Data
         }
 
         /// <summary>
-        /// Returns Series that the user 
+        /// Returns Series that the user has some partial progress on
         /// </summary>
         /// <param name="userId"></param>
         /// <param name="libraryId"></param>
@@ -327,8 +327,8 @@ namespace API.Data
                             && s.PagesRead > 0
                             && s.PagesRead < s.Series.Pages
                             && (libraryId <= 0 || s.Series.LibraryId == libraryId))
-                .OrderByDescending(s => s.LastModified)
                 .Take(limit)
+                .OrderByDescending(s => s.LastModified)
                 .Select(s => s.Series)
                 .ProjectTo<SeriesDto>(_mapper.ConfigurationProvider)
                 .AsNoTracking()

--- a/API/Entities/Enums/ScalingOption.cs
+++ b/API/Entities/Enums/ScalingOption.cs
@@ -4,6 +4,7 @@
     {
         FitToHeight = 0,
         FitToWidth = 1,
-        Original = 2
+        Original = 2,
+        Automatic = 3
     }
 }

--- a/API/Interfaces/IBookService.cs
+++ b/API/Interfaces/IBookService.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
+using API.Parser;
 using VersOne.Epub;
 
 namespace API.Interfaces
@@ -17,5 +18,6 @@ namespace API.Interfaces
         /// <returns></returns>
         Task<string> ScopeStyles(string stylesheetHtml, string apiBase);
         string GetSummaryInfo(string filePath);
+        ParserInfo ParseInfo(string filePath);
     }
 }

--- a/API/Services/BookService.cs
+++ b/API/Services/BookService.cs
@@ -187,22 +187,37 @@ namespace API.Services
             return dict;
         }
 
-        public static ParserInfo ParseInfo(string filePath)
+        /// <summary>
+        /// Parses out Title from book. Chapters and Volumes will always be "0". If there is any exception reading book (malformed books)
+        /// then null is returned.
+        /// </summary>
+        /// <param name="filePath"></param>
+        /// <returns></returns>
+        public ParserInfo ParseInfo(string filePath)
         {
-            var epubBook = EpubReader.OpenBook(filePath);
-
-            return new ParserInfo()
+            try
             {
-                Chapters = "0",
-                Edition = "",
-                Format = MangaFormat.Book,
-                Filename = Path.GetFileName(filePath),
-                Title = epubBook.Title,
-                FullFilePath = filePath,
-                IsSpecial = false,
-                Series = epubBook.Title,
-                Volumes = "0"
-            };
+                var epubBook = EpubReader.OpenBook(filePath);
+
+                return new ParserInfo()
+                {
+                    Chapters = "0",
+                    Edition = "",
+                    Format = MangaFormat.Book,
+                    Filename = Path.GetFileName(filePath),
+                    Title = epubBook.Title,
+                    FullFilePath = filePath,
+                    IsSpecial = false,
+                    Series = epubBook.Title,
+                    Volumes = "0"
+                };
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "There was an exception when opening epub book: {FileName}", filePath);
+            }
+
+            return null;
         }
 
         public byte[] GetCoverImage(string fileFilePath, bool createThumbnail = true)

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -42,6 +42,7 @@ namespace API.Services.Tasks
 
 
        [DisableConcurrentExecution(timeoutInSeconds: 360)]
+       [AutomaticRetry(Attempts = 0)]
        public void ScanLibraries()
        {
           var libraries = Task.Run(() => _unitOfWork.LibraryRepository.GetLibrariesAsync()).Result.ToList();
@@ -68,6 +69,7 @@ namespace API.Services.Tasks
        }
 
        [DisableConcurrentExecution(360)]
+       [AutomaticRetry(Attempts = 0)]
        public void ScanLibrary(int libraryId, bool forceUpdate)
        {
           var sw = Stopwatch.StartNew();
@@ -435,7 +437,7 @@ namespace API.Services.Tasks
           
           if (type == LibraryType.Book && Parser.Parser.IsEpub(path))
           {
-             info = BookService.ParseInfo(path);
+             info = _bookService.ParseInfo(path);
           }
           else
           {
@@ -451,7 +453,7 @@ namespace API.Services.Tasks
           if (type == LibraryType.Book && Parser.Parser.IsEpub(path) && Parser.Parser.ParseVolume(info.Series) != "0")
           {
              info = Parser.Parser.Parse(path, rootPath, type);
-             var info2 = BookService.ParseInfo(path);
+             var info2 = _bookService.ParseInfo(path);
              info.Merge(info2);
           }
           

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -42,7 +42,7 @@ namespace API.Services.Tasks
 
 
        [DisableConcurrentExecution(timeoutInSeconds: 360)]
-       [AutomaticRetry(Attempts = 0)]
+       [AutomaticRetry(Attempts = 0, OnAttemptsExceeded = AttemptsExceededAction.Delete)]
        public void ScanLibraries()
        {
           var libraries = Task.Run(() => _unitOfWork.LibraryRepository.GetLibrariesAsync()).Result.ToList();
@@ -69,7 +69,7 @@ namespace API.Services.Tasks
        }
 
        [DisableConcurrentExecution(360)]
-       [AutomaticRetry(Attempts = 0)]
+       [AutomaticRetry(Attempts = 0, OnAttemptsExceeded = AttemptsExceededAction.Delete)]
        public void ScanLibrary(int libraryId, bool forceUpdate)
        {
           var sw = Stopwatch.StartNew();

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -204,7 +204,27 @@ namespace API.Services.Tasks
           foreach (var (key, infos) in parsedSeries)
           {
              // Key is normalized already
-             var existingSeries = library.Series.FirstOrDefault(s => s.NormalizedName == key || Parser.Parser.Normalize(s.OriginalName) == key);
+             Series existingSeries = null;
+             try
+             {
+                existingSeries = library.Series.SingleOrDefault(s => s.NormalizedName == key || Parser.Parser.Normalize(s.OriginalName) == key);
+             }
+             catch (Exception e)
+             {
+                _logger.LogCritical(e, "There are multiple series that map to normalized key {Key}. You can manually delete the entity via UI and rescan to fix it", key);
+                var duplicateSeries = library.Series.Where(s => s.NormalizedName == key || Parser.Parser.Normalize(s.OriginalName) == key).ToList();
+                //var firstSeries = duplicateSeries.First();
+                //duplicateSeries.
+                foreach (var series in duplicateSeries)
+                {
+                   _logger.LogCritical("{Key} maps with {Series}", key, series.OriginalName);
+                   
+                }
+                // Merge them together? 
+                //_unitOfWork.AppUserProgressRepository.MapSeriesProgressFromTo(firstSeries.Id, );
+                
+                continue;
+             }
              if (existingSeries == null)
              {
                 existingSeries = DbFactory.Series(infos[0].Series);

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -313,7 +313,7 @@ namespace API.Services.Tasks
              foreach (var volume in deletedVolumes)
              {
                 var file = volume.Chapters.FirstOrDefault()?.Files.FirstOrDefault()?.FilePath ?? "no files";
-                if (!new FileInfo(file).Exists)
+                if (new FileInfo(file).Exists)
                 {
                    _logger.LogError("Volume cleanup code was trying to remove a volume with a file still existing on disk. File: {File}", file);
                 }

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -48,7 +48,6 @@ namespace API.Services.Tasks
           var libraries = Task.Run(() => _unitOfWork.LibraryRepository.GetLibrariesAsync()).Result.ToList();
           foreach (var lib in libraries)
           {
-             // BUG?: I think we need to keep _scannedSeries within the ScanLibrary instance since this is multithreaded.
              ScanLibrary(lib.Id, false);
           }
        }
@@ -205,7 +204,7 @@ namespace API.Services.Tasks
           foreach (var (key, infos) in parsedSeries)
           {
              // Key is normalized already
-             var existingSeries = library.Series.SingleOrDefault(s => s.NormalizedName == key || Parser.Parser.Normalize(s.OriginalName) == key);
+             var existingSeries = library.Series.FirstOrDefault(s => s.NormalizedName == key || Parser.Parser.Normalize(s.OriginalName) == key);
              if (existingSeries == null)
              {
                 existingSeries = DbFactory.Series(infos[0].Series);


### PR DESCRIPTION
1. Remove automatic retry for failed scanLibrary jobs
2. When looking for a series to update and scan through, sometimes there can be duplicate series in the DB with same normalized keys (usually due to a bad upgrade). Now we report to the user under a critical error and skip those entries.
3. Implemented Automatic Scaling Option

This is a part of #183
