### PR TITLE
Bugfixes/misc

### DIFF
--- a/API.Tests/Parser/MangaParserTests.cs
+++ b/API.Tests/Parser/MangaParserTests.cs
@@ -135,6 +135,7 @@ namespace API.Tests.Parser
         [InlineData("[Hidoi]_Amaenaideyo_MS_vol01_chp02.rar", "Amaenaideyo MS")]
         [InlineData("NEEDLESS_Vol.4_-_Simeon_6_v2_[SugoiSugoi].rar", "NEEDLESS")]
         [InlineData("Okusama wa Shougakusei c003 (v01) [bokuwaNEET]", "Okusama wa Shougakusei")]
+        [InlineData("VanDread-v01-c001[MD].zip", "VanDread")]
         public void ParseSeriesTest(string filename, string expected)
         {
             Assert.Equal(expected, API.Parser.Parser.ParseSeries(filename));

--- a/API/Constants/PolicyConstants.cs
+++ b/API/Constants/PolicyConstants.cs
@@ -2,7 +2,7 @@
 {
     public static class PolicyConstants
     {
-        public static readonly string AdminRole = "Admin";
-        public static readonly string PlebRole = "Pleb";
+        public const string AdminRole = "Admin";
+        public const string PlebRole = "Pleb";
     }
 }

--- a/API/Data/SeriesRepository.cs
+++ b/API/Data/SeriesRepository.cs
@@ -350,27 +350,24 @@ namespace API.Data
                     .ToList();
                 series = series.Where(s => s.AppUserId == userId
                                            && s.PagesRead > 0
-                                           && s.PagesRead <
-                                           s.Series.Pages -
-                                           1 // - 1 because when reading, we start at 0 then go to pages - 1. But when summing, pages assumes starting at 1
+                                           && s.PagesRead < s.Series.Pages - 1 // - 1 because when reading, we start at 0 then go to pages - 1. But when summing, pages assumes starting at 1
                                            && userLibraries.Contains(s.Series.LibraryId));
             }
             else
             {
                 series = series.Where(s => s.AppUserId == userId
                             && s.PagesRead > 0
-                            && s.PagesRead <
-                            (s.Series.Pages - 1) // - 1 because when reading, we start at 0 then go to pages - 1. But when summing, pages assumes starting at 1
-                            && (s.Series.LibraryId == libraryId));
+                            && s.PagesRead < s.Series.Pages - 1 // - 1 because when reading, we start at 0 then go to pages - 1. But when summing, pages assumes starting at 1
+                            && s.Series.LibraryId == libraryId);
             }
-            var retSeries = await series.Take(limit)
+            var retSeries = await series
                 .OrderByDescending(s => s.LastModified)
                 .Select(s => s.Series)
                 .ProjectTo<SeriesDto>(_mapper.ConfigurationProvider)
                 .AsNoTracking()
                 .ToListAsync();
                 
-            return retSeries.DistinctBy(s => s.Name);
+            return retSeries.DistinctBy(s => s.Name).Take(limit); // SeriesDTO might need date information
         }
     }
 }

--- a/API/Parser/Parser.cs
+++ b/API/Parser/Parser.cs
@@ -65,9 +65,9 @@ namespace API.Parser
             new Regex(
                 @"^(?<Series>.*)( |_)Vol\.?\d+",
                 RegexOptions.IgnoreCase | RegexOptions.Compiled),
-            // Ichiban_Ushiro_no_Daimaou_v04_ch34_[VISCANS].zip
+            // Ichiban_Ushiro_no_Daimaou_v04_ch34_[VISCANS].zip, VanDread-v01-c01.zip
             new Regex(
-            @"(?<Series>.*)(\b|_)v(?<Volume>\d+-?\d*)( |_)",
+            @"(?<Series>.*)(\b|_)v(?<Volume>\d+-?\d*)( |_|-)",
             RegexOptions.IgnoreCase | RegexOptions.Compiled),
             // Gokukoku no Brynhildr - c001-008 (v01) [TrinityBAKumA], Black Bullet - v4 c17 [batoto]
             new Regex(

--- a/API/Services/ArchiveService.cs
+++ b/API/Services/ArchiveService.cs
@@ -313,10 +313,10 @@ namespace API.Services
                         break;
                     }
                     case ArchiveLibrary.NotSupported:
-                        _logger.LogError("[GetSummaryInfo] This archive cannot be read: {ArchivePath}. Defaulting to 0 pages", archivePath);
+                        _logger.LogError("[GetSummaryInfo] This archive cannot be read: {ArchivePath}", archivePath);
                         return summary;
                     default:
-                        _logger.LogError("[GetSummaryInfo] There was an exception when reading archive stream: {ArchivePath}. Defaulting to 0 pages", archivePath);
+                        _logger.LogError("[GetSummaryInfo] There was an exception when reading archive stream: {ArchivePath}", archivePath);
                         return summary;
                 }
 
@@ -324,8 +324,6 @@ namespace API.Services
                 {
                     return info.Summary;
                 }
-
-                _logger.LogError("[GetSummaryInfo] Could not parse archive file: {Filepath}", archivePath);
             }
             catch (Exception ex)
             {

--- a/API/Services/MetadataService.cs
+++ b/API/Services/MetadataService.cs
@@ -124,7 +124,11 @@ namespace API.Services
           if (firstFile != null &&
               (forceUpdate || firstFile.HasFileBeenModified())) // !new FileInfo(firstFile.FilePath).IsLastWriteLessThan(firstFile.LastModified)
           {
-             series.Summary = isBook ? _bookService.GetSummaryInfo(firstFile.FilePath) : _archiveService.GetSummaryInfo(firstFile.FilePath);
+             var summary = isBook ? _bookService.GetSummaryInfo(firstFile.FilePath) : _archiveService.GetSummaryInfo(firstFile.FilePath);
+             if (string.IsNullOrEmpty(series.Summary))
+             {
+                series.Summary = summary;
+             }
 
              firstFile.LastModified = DateTime.Now;
           }


### PR DESCRIPTION
Fixes #192 
Fixes #191 
Fixes #194 

Adds a few parsing cases for manga files on my server. 
Removed an error log statement which was saying archive was not readable, when really the comicinfo.xml couldn't be found and defaulting to no summary.