### PR TITLE
Bugfix: Flatten wasn't consistent

### DIFF
--- a/API/Extensions/DirectoryInfoExtensions.cs
+++ b/API/Extensions/DirectoryInfoExtensions.cs
@@ -37,26 +37,29 @@ namespace API.Extensions
         /// <param name="directory"></param>
         public static void Flatten(this DirectoryInfo directory)
         {
-            FlattenDirectory(directory, directory);
+            FlattenDirectory(directory, directory, 0);
         }
 
-        private static void FlattenDirectory(DirectoryInfo root, DirectoryInfo directory)
+        private static void FlattenDirectory(DirectoryInfo root, DirectoryInfo directory, int directoryIndex)
         {
-            if (!root.FullName.Equals(directory.FullName)) // I might be able to replace this with root === directory
+            if (!root.FullName.Equals(directory.FullName))
             {
                 foreach (var file in directory.EnumerateFiles())
                 {
                     if (file.Directory == null) continue;
-                    var newName = $"{file.Directory.Name}_{file.Name}";
+                    var paddedIndex = Parser.Parser.PadZeros(directoryIndex + "");
+                    var newName = $"{paddedIndex}_{file.Name}";
                     var newPath = Path.Join(root.FullName, newName);
                     if (!File.Exists(newPath)) file.MoveTo(newPath);
                     
                 }
             }
-            
+
+            var i = directoryIndex + 1;
             foreach (var subDirectory in directory.EnumerateDirectories())
             {
-                FlattenDirectory(root, subDirectory);
+                FlattenDirectory(root, subDirectory, i);
+                i += 1;
             }
         }
     }

--- a/API/Extensions/DirectoryInfoExtensions.cs
+++ b/API/Extensions/DirectoryInfoExtensions.cs
@@ -1,4 +1,7 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
+using System.Linq;
+using API.Services;
 
 namespace API.Extensions
 {
@@ -37,29 +40,32 @@ namespace API.Extensions
         /// <param name="directory"></param>
         public static void Flatten(this DirectoryInfo directory)
         {
-            FlattenDirectory(directory, directory, 0);
+            var index = 0;
+            FlattenDirectory(directory, directory, ref index);
         }
 
-        private static void FlattenDirectory(DirectoryInfo root, DirectoryInfo directory, int directoryIndex)
+        private static void FlattenDirectory(DirectoryInfo root, DirectoryInfo directory, ref int directoryIndex)
         {
             if (!root.FullName.Equals(directory.FullName))
             {
+                var fileIndex = 1;
                 foreach (var file in directory.EnumerateFiles())
                 {
                     if (file.Directory == null) continue;
                     var paddedIndex = Parser.Parser.PadZeros(directoryIndex + "");
-                    var newName = $"{paddedIndex}_{file.Name}";
+                    // We need to rename the files so that after flattening, they are in the order we found them
+                    var newName = $"{paddedIndex}_{fileIndex}.{file.Extension}";
                     var newPath = Path.Join(root.FullName, newName);
                     if (!File.Exists(newPath)) file.MoveTo(newPath);
-                    
+                    fileIndex++;
                 }
-            }
 
-            var i = directoryIndex + 1;
+                directoryIndex++;
+            }
+            
             foreach (var subDirectory in directory.EnumerateDirectories())
             {
-                FlattenDirectory(root, subDirectory, i);
-                i += 1;
+                FlattenDirectory(root, subDirectory, ref directoryIndex);
             }
         }
     }

--- a/API/Services/ArchiveService.cs
+++ b/API/Services/ArchiveService.cs
@@ -340,7 +340,7 @@ namespace API.Services
             {
                 entry.WriteToDirectory(extractPath, new ExtractionOptions()
                 {
-                    ExtractFullPath = false,
+                    ExtractFullPath = true, // Don't flatten, let the flatterner ensure correct order of nested folders
                     Overwrite = false
                 });
             }

--- a/API/Services/CacheService.cs
+++ b/API/Services/CacheService.cs
@@ -62,10 +62,11 @@ namespace API.Services
 
             }
 
-            if (fileCount > 1)
-            {
-                new DirectoryInfo(extractPath).Flatten();
-            }
+            new DirectoryInfo(extractPath).Flatten();
+            // if (fileCount > 1)
+            // {
+            //     new DirectoryInfo(extractPath).Flatten();
+            // }
 
             return chapter;
         }


### PR DESCRIPTION
# Fixed
Fixed a bug where archives with nested folders and folders of files with special characters would cause the end cached result to be skewed and the reading order would not be consistent. 

C1/01.jpg, C1/02.jpg, C2/[group] 01.jpg

The reading order would be:
[group] 01.jpg (C2), 01.jpg (C1), 02.jpg (C1)

But Should be:
01.jpg (C1), 02.jpg (C1), [group] 01.jpg (C2)