### PR TITLE
Hotfix: ScanLibrary Crash

### DIFF
--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -228,7 +228,6 @@ namespace API.Services.Tasks
              
              existingSeries.NormalizedName = Parser.Parser.Normalize(existingSeries.Name);
              existingSeries.OriginalName ??= infos[0].Series;
-             existingSeries.Metadata ??= DbFactory.SeriesMetadata(new List<CollectionTag>());
           }
 
           // Now, we only have to deal with series that exist on disk. Let's recalculate the volumes for each series


### PR DESCRIPTION
Fixed a critical crash in Scan library where Series Metadata was getting regenerated and unique constraint failed.