### PR TITLE
Remove SeriesMetadata Migration

### DIFF
--- a/API/Data/Seed.cs
+++ b/API/Data/Seed.cs
@@ -7,7 +7,6 @@ using API.Entities;
 using API.Entities.Enums;
 using API.Services;
 using Microsoft.AspNetCore.Identity;
-using Microsoft.EntityFrameworkCore;
 
 namespace API.Data
 {
@@ -52,22 +51,6 @@ namespace API.Data
                 {
                     await context.ServerSetting.AddAsync(defaultSetting);
                 }
-            }
-
-            await context.SaveChangesAsync();
-        }
-
-        public static async Task SeedSeriesMetadata(DataContext context)
-        {
-            await context.Database.EnsureCreatedAsync();
-            
-            context.Database.EnsureCreated();
-            var series = await context.Series
-                .Include(s => s.Metadata).ToListAsync();
-                
-            foreach (var s in series)
-            {
-                s.Metadata ??= new SeriesMetadata();
             }
 
             await context.SaveChangesAsync();

--- a/API/Program.cs
+++ b/API/Program.cs
@@ -61,8 +61,6 @@ namespace API
                 await context.Database.MigrateAsync();
                 await Seed.SeedRoles(roleManager);
                 await Seed.SeedSettings(context);
-                // TODO: Remove this in v0.4.2
-                await Seed.SeedSeriesMetadata(context);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Removed the SeriesMetadata migration since users have updated to v0.4.1. Any other users will require a scan to get the SeriesMetadata generated.

Fixes #237 