### PR TITLE
Book Grouping

### DIFF
--- a/API/Services/BookService.cs
+++ b/API/Services/BookService.cs
@@ -235,7 +235,7 @@ namespace API.Services
             {
                 using var epubBook = EpubReader.OpenBook(filePath);
                 
-                // NOTE: Put a check in here to see if the epub has:
+                // If the epub has the following tags, we can group the books as Volumes
                 // <meta content="5.0" name="calibre:series_index"/>
                 // <meta content="The Dark Tower" name="calibre:series"/>
                 // <meta content="Wolves of the Calla" name="calibre:title_sort"/>

--- a/API/Services/BookService.cs
+++ b/API/Services/BookService.cs
@@ -279,7 +279,7 @@ namespace API.Services
                         };
                     }
                 }
-                catch (Exception ex)
+                catch (Exception)
                 {
                     // Swallow exception
                 }

--- a/API/Services/BookService.cs
+++ b/API/Services/BookService.cs
@@ -234,6 +234,55 @@ namespace API.Services
             try
             {
                 using var epubBook = EpubReader.OpenBook(filePath);
+                
+                // NOTE: Put a check in here to see if the epub has:
+                // <meta content="5.0" name="calibre:series_index"/>
+                // <meta content="The Dark Tower" name="calibre:series"/>
+                // <meta content="Wolves of the Calla" name="calibre:title_sort"/>
+                // If all three are present, we can take that over dc:title and format as:
+                // Series = The Dark Tower, Volume = 5, Filename as "Wolves of the Calla"
+                try
+                {
+                    string seriesIndex = string.Empty;
+                    string series = string.Empty;
+                    string specialName = string.Empty;
+                    
+                    foreach (var metadataItem in epubBook.Schema.Package.Metadata.MetaItems)
+                    {
+                        switch (metadataItem.Name)
+                        {
+                            case "calibre:series_index":
+                                seriesIndex = metadataItem.Content;
+                                break;
+                            case "calibre:series":
+                                series = metadataItem.Content;
+                                break;
+                            case "calibre:title_sort":
+                                specialName = metadataItem.Content;
+                                break;
+                        }
+                    }
+
+                    if (!string.IsNullOrEmpty(series) && !string.IsNullOrEmpty(seriesIndex) && !string.IsNullOrEmpty(specialName))
+                    {
+                        return new ParserInfo()
+                        {
+                            Chapters = "0",
+                            Edition = "",
+                            Format = MangaFormat.Book,
+                            Filename = Path.GetFileName(filePath),
+                            Title = specialName,
+                            FullFilePath = filePath,
+                            IsSpecial = false,
+                            Series = series,
+                            Volumes = seriesIndex.Split(".")[0]
+                        };
+                    }
+                }
+                catch (Exception ex)
+                {
+                    // Swallow exception
+                }
 
                 return new ParserInfo()
                 {


### PR DESCRIPTION
Fixes #290 

# Changed
- If epubs contain certain calibre metadata tags, then they will be grouped as Volumes instead of individual books.