### PR TITLE
Special Markers

### DIFF
--- a/API.Tests/Parser/MangaParserTests.cs
+++ b/API.Tests/Parser/MangaParserTests.cs
@@ -242,6 +242,8 @@ namespace API.Tests.Parser
         [InlineData("Gifting The Wonderful World With Blessings! - 3 Side Stories [yuNS][Unknown]", true)]
         [InlineData("A Town Where You Live - Bonus Chapter.zip", true)]
         [InlineData("Yuki Merry - 4-Komga Anthology", false)]
+        [InlineData("Beastars - SP01", true)]
+        [InlineData("Beastars SP01", true)]
         public void ParseMangaSpecialTest(string input, bool expected)
         {
             Assert.Equal(expected,  !string.IsNullOrEmpty(API.Parser.Parser.ParseMangaSpecial(input)));

--- a/API.Tests/Parser/MangaParserTests.cs
+++ b/API.Tests/Parser/MangaParserTests.cs
@@ -241,7 +241,7 @@ namespace API.Tests.Parser
         [InlineData("Ani-Hina Art Collection.cbz", true)]
         [InlineData("Gifting The Wonderful World With Blessings! - 3 Side Stories [yuNS][Unknown]", true)]
         [InlineData("A Town Where You Live - Bonus Chapter.zip", true)]
-        [InlineData("Yuki Merry - 4-Komga Anthology", true)]
+        [InlineData("Yuki Merry - 4-Komga Anthology", false)]
         public void ParseMangaSpecialTest(string input, bool expected)
         {
             Assert.Equal(expected,  !string.IsNullOrEmpty(API.Parser.Parser.ParseMangaSpecial(input)));

--- a/API/Parser/Parser.cs
+++ b/API/Parser/Parser.cs
@@ -374,6 +374,10 @@ namespace API.Parser
             new Regex(
                 @"(?<Special>Specials?|OneShot|One\-Shot|Omake|Extra( Chapter)?|Art Collection|Side( |_)Stories|Bonus)",
                 RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            // If SP\d+ is in the filename, we force treat it as a special regardless if volume or chapter might have been found.
+            new Regex(
+                @"(?<Special>SP\d+)",
+                RegexOptions.IgnoreCase | RegexOptions.Compiled),
         };
 
 

--- a/API/Parser/Parser.cs
+++ b/API/Parser/Parser.cs
@@ -372,7 +372,7 @@ namespace API.Parser
         {
             // All Keywords, does not account for checking if contains volume/chapter identification. Parser.Parse() will handle.
             new Regex(
-                @"(?<Special>Specials?|OneShot|One\-Shot|Omake|Extra( Chapter)?|Art Collection|Side( |_)Stories|(?<!The\s)Anthology|Bonus)",
+                @"(?<Special>Specials?|OneShot|One\-Shot|Omake|Extra( Chapter)?|Art Collection|Side( |_)Stories|Bonus)",
                 RegexOptions.IgnoreCase | RegexOptions.Compiled),
         };
 


### PR DESCRIPTION
# Changed
- Added "SP" as a keyword to force a file to be a special regardless if it's in a specials folder. Kenichi SP01 will force the file to be a special for the Kenichi Manga. 

Fixes #299 