### PR TITLE
Special Marker Changes

### DIFF
--- a/API.Tests/Parser/MangaParserTests.cs
+++ b/API.Tests/Parser/MangaParserTests.cs
@@ -242,6 +242,8 @@ namespace API.Tests.Parser
         [InlineData("Gifting The Wonderful World With Blessings! - 3 Side Stories [yuNS][Unknown]", true)]
         [InlineData("A Town Where You Live - Bonus Chapter.zip", true)]
         [InlineData("Yuki Merry - 4-Komga Anthology", false)]
+        [InlineData("Beastars - SP01", true)]
+        [InlineData("Beastars SP01", true)]
         public void ParseMangaSpecialTest(string input, bool expected)
         {
             Assert.Equal(expected,  !string.IsNullOrEmpty(API.Parser.Parser.ParseMangaSpecial(input)));

--- a/API.Tests/Parser/MangaParserTests.cs
+++ b/API.Tests/Parser/MangaParserTests.cs
@@ -145,6 +145,7 @@ namespace API.Tests.Parser
         [InlineData("X-Men v1 #201 (September 2007).cbz", "X-Men")]
         [InlineData("Kodoja #001 (March 2016)", "Kodoja")]
         [InlineData("Boku No Kokoro No Yabai Yatsu - Chapter 054 I Prayed At The Shrine (V0).cbz", "Boku No Kokoro No Yabai Yatsu")]
+        [InlineData("Kiss x Sis - Ch.36 - A Cold Home Visit.cbz", "Kiss x Sis")]
         public void ParseSeriesTest(string filename, string expected)
         {
             Assert.Equal(expected, API.Parser.Parser.ParseSeries(filename));
@@ -242,8 +243,8 @@ namespace API.Tests.Parser
         [InlineData("Gifting The Wonderful World With Blessings! - 3 Side Stories [yuNS][Unknown]", true)]
         [InlineData("A Town Where You Live - Bonus Chapter.zip", true)]
         [InlineData("Yuki Merry - 4-Komga Anthology", false)]
-        [InlineData("Beastars - SP01", true)]
-        [InlineData("Beastars SP01", true)]
+        [InlineData("Beastars - SP01", false)]
+        [InlineData("Beastars SP01", false)]
         public void ParseMangaSpecialTest(string input, bool expected)
         {
             Assert.Equal(expected,  !string.IsNullOrEmpty(API.Parser.Parser.ParseMangaSpecial(input)));

--- a/API.Tests/Parser/MangaParserTests.cs
+++ b/API.Tests/Parser/MangaParserTests.cs
@@ -241,7 +241,7 @@ namespace API.Tests.Parser
         [InlineData("Ani-Hina Art Collection.cbz", true)]
         [InlineData("Gifting The Wonderful World With Blessings! - 3 Side Stories [yuNS][Unknown]", true)]
         [InlineData("A Town Where You Live - Bonus Chapter.zip", true)]
-        [InlineData("Yuki Merry - 4-Komga Anthology", true)]
+        [InlineData("Yuki Merry - 4-Komga Anthology", false)]
         public void ParseMangaSpecialTest(string input, bool expected)
         {
             Assert.Equal(expected,  !string.IsNullOrEmpty(API.Parser.Parser.ParseMangaSpecial(input)));

--- a/API.Tests/Parser/ParserTest.cs
+++ b/API.Tests/Parser/ParserTest.cs
@@ -6,6 +6,7 @@ namespace API.Tests.Parser
     public class ParserTests
     {
         
+        [Theory]
         [InlineData("Beastars - SP01", true)]
         [InlineData("Beastars SP01", true)]
         [InlineData("Beastars Special 01", false)]

--- a/API.Tests/Parser/ParserTest.cs
+++ b/API.Tests/Parser/ParserTest.cs
@@ -5,6 +5,15 @@ namespace API.Tests.Parser
 {
     public class ParserTests
     {
+        
+        [InlineData("Beastars - SP01", true)]
+        [InlineData("Beastars SP01", true)]
+        [InlineData("Beastars Special 01", false)]
+        [InlineData("Beastars Extra 01", false)]
+        public void HasSpecialTest(string input, bool expected)
+        {
+            Assert.Equal(expected,  HasSpecialMarker(input));
+        }
 
         [Theory]
         [InlineData("0001", "1")]

--- a/API/Parser/Parser.cs
+++ b/API/Parser/Parser.cs
@@ -374,6 +374,10 @@ namespace API.Parser
             new Regex(
                 @"(?<Special>Specials?|OneShot|One\-Shot|Omake|Extra( Chapter)?|Art Collection|Side( |_)Stories|Bonus)",
                 RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            // If SP\d+ is in the filename, we force treat it as a special regardless if volume or chapter might have been found.
+            new Regex(
+                @"(?<Special>SP\d+)",
+                RegexOptions.IgnoreCase | RegexOptions.Compiled),
         };
 
 

--- a/API/Parser/Parser.cs
+++ b/API/Parser/Parser.cs
@@ -95,7 +95,7 @@ namespace API.Parser
                 RegexOptions.IgnoreCase | RegexOptions.Compiled),
             // Historys Strongest Disciple Kenichi_v11_c90-98.zip, Killing Bites Vol. 0001 Ch. 0001 - Galactica Scanlations (gb)
             new Regex(
-                @"(?<Series>.*) (\b|_|-)v",
+                @"(?<Series>.*) (\b|_|-)(v|ch\.?|c)\d+",
                 RegexOptions.IgnoreCase | RegexOptions.Compiled),
             //Ichinensei_ni_Nacchattara_v01_ch01_[Taruby]_v1.1.zip must be before [Suihei Kiki]_Kasumi_Otoko_no_Ko_[Taruby]_v1.1.zip
             // due to duplicate version identifiers in file.

--- a/API/Parser/Parser.cs
+++ b/API/Parser/Parser.cs
@@ -372,7 +372,7 @@ namespace API.Parser
         {
             // All Keywords, does not account for checking if contains volume/chapter identification. Parser.Parse() will handle.
             new Regex(
-                @"(?<Special>Specials?|OneShot|One\-Shot|Omake|Extra( Chapter)?|Art Collection|Side( |_)Stories|(?<!The\s)Anthology|Bonus)",
+                @"(?<Special>Specials?|OneShot|One\-Shot|Omake|Extra( Chapter)?|Art Collection|Side( |_)Stories|Bonus)",
                 RegexOptions.IgnoreCase | RegexOptions.Compiled),
         };
 

--- a/API/Parser/Parser.cs
+++ b/API/Parser/Parser.cs
@@ -377,10 +377,6 @@ namespace API.Parser
             new Regex(
                 @"(?<Special>Specials?|OneShot|One\-Shot|Omake|Extra( Chapter)?|Art Collection|Side( |_)Stories|Bonus)",
                 RegexOptions.IgnoreCase | RegexOptions.Compiled),
-            // If SP\d+ is in the filename, we force treat it as a special regardless if volume or chapter might have been found.
-            new Regex(
-                @"(?<Special>SP\d+)",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
         };
 
         // If SP\d+ is in the filename, we force treat it as a special regardless if volume or chapter might have been found.

--- a/API/Parser/ParserInfo.cs
+++ b/API/Parser/ParserInfo.cs
@@ -3,7 +3,7 @@
 namespace API.Parser
 {
     /// <summary>
-    /// This represents a single file
+    /// This represents all parsed information from a single file
     /// </summary>
     public class ParserInfo
     {

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -466,7 +466,7 @@ namespace API.Services.Tasks
              return;
           }
           
-          if (type == LibraryType.Book && Parser.Parser.IsEpub(path) && Parser.Parser.ParseVolume(info.Series) != "0")
+          if (type == LibraryType.Book && Parser.Parser.IsEpub(path) && Parser.Parser.ParseVolume(info.Series) != Parser.Parser.DefaultVolume)
           {
              info = Parser.Parser.Parse(path, rootPath, type);
              var info2 = _bookService.ParseInfo(path);


### PR DESCRIPTION
# Changed
- Changed how Special marker is handled. If the marker is found in a file, it will force it to be a special, ignoring any volume/chapter identifiers in the file.