### PR TITLE
Epub 3.2 Collection Tag support

### DIFF
--- a/API/Controllers/BookController.cs
+++ b/API/Controllers/BookController.cs
@@ -186,6 +186,9 @@ namespace API.Controllers
                     var content = await contentFileRef.ReadContentAsync();
                     if (contentFileRef.ContentType != EpubContentType.XHTML_1_1) return Ok(content);
                     
+                    // In more cases than not, due to this being XML not HTML, we need to escape the script tags.
+                    content = BookService.EscapeTags(content);
+                    
                     doc.LoadHtml(content);
                     var body = doc.DocumentNode.SelectSingleNode("//body");
 

--- a/API/Parser/Parser.cs
+++ b/API/Parser/Parser.cs
@@ -15,7 +15,7 @@ namespace API.Parser
         public const string ArchiveFileExtensions = @"\.cbz|\.zip|\.rar|\.cbr|\.tar.gz|\.7zip|\.7z|.cb7";
         public const string BookFileExtensions = @"\.epub";
         public const string ImageFileExtensions = @"^(\.png|\.jpeg|\.jpg)";
-        public static readonly Regex FontSrcUrlRegex = new Regex("(src:url\\(\"?'?)([a-z0-9/\\._]+)(\"?'?\\))", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        public static readonly Regex FontSrcUrlRegex = new Regex(@"(src:url\(.{1})" + "([^\"']*)" + @"(.{1}\))", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         public static readonly Regex CssImportUrlRegex = new Regex("(@import\\s[\"|'])(?<Filename>[\\w\\d/\\._-]+)([\"|'];?)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         private static readonly string XmlRegexExtensions = @"\.xml";

--- a/API/Services/BookService.cs
+++ b/API/Services/BookService.cs
@@ -24,9 +24,6 @@ namespace API.Services
         private const int ThumbnailWidth = 320; // 153w x 230h
         private readonly StylesheetParser _cssParser = new ();
 
-        private static readonly Regex ScriptRegex = new Regex(@"<script(.*)(/>)",
-            RegexOptions.Compiled | RegexOptions.Multiline | RegexOptions.IgnoreCase);
-      
         public BookService(ILogger<BookService> logger)
         {
             _logger = logger;


### PR DESCRIPTION
# Added
- In [EPUB 3.2 spec](https://github.com/w3c/epub-specs/issues/1356) there are 3 meta tags that can be used to provide a collection of books. Kavita now parses these tags and will group books in a series rather than individual series.

# Fixed
- EPUB reader now escaped improperly ended script and title tags
- EPUB reader fixed an issue with rewriting urls in src:url css properties

Fixes #300 