### PR TITLE
Series Catch-all

### DIFF
--- a/API/Parser/Parser.cs
+++ b/API/Parser/Parser.cs
@@ -473,8 +473,11 @@ namespace API.Parser
                 ret.Chapters = DefaultChapter;
                 ret.Volumes = DefaultVolume;
             }
-            
-            
+
+            if (string.IsNullOrEmpty(ret.Series))
+            {
+                ret.Series = CleanTitle(fileName);
+            }
 
             return ret.Series == string.Empty ? null : ret;
         }


### PR DESCRIPTION
# Changed
- Series Parsing now, at the end of the Parse() call if we still haven't figured out the Series, will default to taking the file name and cleaning it. This allows files that have no numbers to be picked up.

Fixes #231 