### PR TITLE
Single Download Failed on Epubs

### DIFF
--- a/API/Controllers/DownloadController.cs
+++ b/API/Controllers/DownloadController.cs
@@ -81,6 +81,10 @@ namespace API.Controllers
                 {
                     ".cbz" => "application/zip",
                     ".cbr" => "application/vnd.rar",
+                    ".cb7" => "application/x-compressed",
+                    ".epub" => "application/epub+zip",
+                    ".7z" => "application/x-7z-compressed",
+                    ".7zip" => "application/x-7z-compressed",
                     _ => contentType
                 };
             }

--- a/API/Services/BookService.cs
+++ b/API/Services/BookService.cs
@@ -89,7 +89,8 @@ namespace API.Services
                 }
                 else
                 {
-                    anchor.Attributes.Add("target", "_blank");    
+                    anchor.Attributes.Add("target", "_blank");
+                    anchor.Attributes.Add("rel", "noreferrer noopener");
                 }
 
                 return;


### PR DESCRIPTION
# Fixed
- Fixed a missed case where downloading a single file that is an epub (or cb7, zip, 7z) file would cause a critical error and the download would fail without any information. 