### PR TITLE
chapter and issue parsing for comics

### DIFF
--- a/API.Tests/Parser/ComicParserTests.cs
+++ b/API.Tests/Parser/ComicParserTests.cs
@@ -20,6 +20,8 @@ namespace API.Tests.Parser
         [InlineData("Scott Pilgrim 02 - Scott Pilgrim vs. The World (2005)", "Scott Pilgrim")]
         [InlineData("Wolverine - Origins 003 (2006) (digital) (Minutemen-PhD)", "Wolverine - Origins")]
         [InlineData("Invincible Vol 01 Family matters (2005) (Digital).cbr", "Invincible")]
+        [InlineData("Amazing Man Comics chapter 25", "Amazing Man Comics")]
+        [InlineData("Amazing Man Comics issue #25", "Amazing Man Comics")]
         public void ParseComicSeriesTest(string filename, string expected)
         {
             Assert.Equal(expected, API.Parser.Parser.ParseComicSeries(filename));
@@ -40,6 +42,7 @@ namespace API.Tests.Parser
         [InlineData("Teen Titans v1 001 (1966-02) (digital) (OkC.O.M.P.U.T.O.-Novus)", "1")]
         [InlineData("Scott Pilgrim 02 - Scott Pilgrim vs. The World (2005)", "2")]
         [InlineData("Superman v1 024 (09-10 1943)", "1")]
+        [InlineData("Amazing Man Comics chapter 25", "0")]
         public void ParseComicVolumeTest(string filename, string expected)
         {
             Assert.Equal(expected, API.Parser.Parser.ParseComicVolume(filename));
@@ -61,6 +64,7 @@ namespace API.Tests.Parser
         [InlineData("Teen Titans v1 001 (1966-02) (digital) (OkC.O.M.P.U.T.O.-Novus)", "1")]
         [InlineData("Superman v1 024 (09-10 1943)", "24")]
         [InlineData("Invincible 070.5 - Invincible Returns 1 (2010) (digital) (Minutemen-InnerDemons).cbr", "70.5")]
+        [InlineData("Amazing Man Comics chapter 25", "25")]
         public void ParseComicChapterTest(string filename, string expected)
         {
             Assert.Equal(expected, API.Parser.Parser.ParseComicChapter(filename));

--- a/API/Parser/Parser.cs
+++ b/API/Parser/Parser.cs
@@ -204,7 +204,7 @@ namespace API.Parser
             new Regex(
                 @"^(?<Series>.*)(?: |_)c(hapter) \d+",
                 RegexOptions.IgnoreCase | RegexOptions.Compiled),
-            // Amazing Man Comics issue 25
+            // Amazing Man Comics issue #25
             new Regex(
                 @"^(?<Series>.*)(?: |_)i(ssue) #\d+",
                 RegexOptions.IgnoreCase | RegexOptions.Compiled),

--- a/API/Parser/Parser.cs
+++ b/API/Parser/Parser.cs
@@ -200,6 +200,14 @@ namespace API.Parser
             new Regex(
                 @"^(?<Series>.*)(?: |_)v\d+",
                 RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            // Amazing Man Comics chapter 25
+            new Regex(
+                @"^(?<Series>.*)(?: |_)c(hapter) \d+",
+                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            // Amazing Man Comics issue 25
+            new Regex(
+                @"^(?<Series>.*)(?: |_)i(ssue) #\d+",
+                RegexOptions.IgnoreCase | RegexOptions.Compiled),
             // Batman & Catwoman - Trail of the Gun 01, Batman & Grendel (1996) 01 - Devil's Bones, Teen Titans v1 001 (1966-02) (digital) (OkC.O.M.P.U.T.O.-Novus)
             new Regex(
                 @"^(?<Series>.*)(?: \d+)",
@@ -242,11 +250,11 @@ namespace API.Parser
                 RegexOptions.IgnoreCase | RegexOptions.Compiled),
             // Scott Pilgrim 02 - Scott Pilgrim vs. The World (2005)
             new Regex(
-                @"^(?<Series>.*)(?: |_)(?<!of )(?<Volume>\d+)",
+                @"^(?<Series>.*)(?<!c(hapter)|i(ssue))(?<!of)(?: |_)(?<!of )(?<Volume>\d+)",
                 RegexOptions.IgnoreCase | RegexOptions.Compiled),
             // Batman & Catwoman - Trail of the Gun 01, Batman & Grendel (1996) 01 - Devil's Bones, Teen Titans v1 001 (1966-02) (digital) (OkC.O.M.P.U.T.O.-Novus)
             new Regex(
-                @"^(?<Series>.*)(?<!of)(?: (?<Volume>\d+))",
+                @"^(?<Series>.*)(?<!c(hapter)|i(ssue))(?<!of)(?: (?<Volume>\d+))",
                 RegexOptions.IgnoreCase | RegexOptions.Compiled),
             // Batman & Robin the Teen Wonder #0
             new Regex(
@@ -283,6 +291,14 @@ namespace API.Parser
             // Invincible 070.5 - Invincible Returns 1 (2010) (digital) (Minutemen-InnerDemons).cbr
             new Regex(
                 @"^(?<Series>.*)(?: |_)(c? ?)(?<Chapter>(\d+(\.\d)?)-?(\d+(\.\d)?)?)(c? ?)-",
+                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            // Amazing Man Comics chapter 25
+            new Regex(
+                @"^(?!Vol)(?<Series>.*)( |_)c(hapter)( |_)(?<Chapter>\d*)",
+                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            // Amazing Man Comics issue #25
+            new Regex(
+                @"^(?!Vol)(?<Series>.*)( |_)i(ssue)( |_) #(?<Chapter>\d*)",
                 RegexOptions.IgnoreCase | RegexOptions.Compiled),
         };
 


### PR DESCRIPTION
This adds correct parsing for comic series, volume (0) and chapters in this format:
"Amazing Man Comics c[hapter] 00"
"Amazing Man Comics i[ssue] #00"