### PR TITLE
Special parsing issues

### DIFF
--- a/API.Tests/Parser/MangaParserTests.cs
+++ b/API.Tests/Parser/MangaParserTests.cs
@@ -146,6 +146,9 @@ namespace API.Tests.Parser
         [InlineData("Kodoja #001 (March 2016)", "Kodoja")]
         [InlineData("Boku No Kokoro No Yabai Yatsu - Chapter 054 I Prayed At The Shrine (V0).cbz", "Boku No Kokoro No Yabai Yatsu")]
         [InlineData("Kiss x Sis - Ch.36 - A Cold Home Visit.cbz", "Kiss x Sis")]
+        [InlineData("Seraph of the End - Vampire Reign 093 (2020) (Digital) (LuCaZ)", "Seraph of the End - Vampire Reign")]
+        [InlineData("Grand Blue Dreaming - SP02 Extra (2019) (Digital) (danke-Empire).cbz", "Grand Blue Dreaming")]
+        [InlineData("Yuusha Ga Shinda! - Vol.tbd Chapter 27.001 V2 Infection ①.cbz", "Yuusha Ga Shinda!")]
         public void ParseSeriesTest(string filename, string expected)
         {
             Assert.Equal(expected, API.Parser.Parser.ParseSeries(filename));
@@ -349,6 +352,14 @@ namespace API.Tests.Parser
                 Series = "Goblin Slayer - Brand New Day", Volumes = "0", Edition = "",
                 Chapters = "6.5", Filename = "Goblin Slayer - Brand New Day 006.5 (2019) (Digital) (danke-Empire).cbz", Format = MangaFormat.Archive,
                 FullFilePath = filepath
+            });
+            
+            filepath = @"E:\Manga\Summer Time Rendering\Specials\Record 014 (between chapter 083 and ch084) SP11.cbr";
+            expected.Add(filepath, new ParserInfo
+            {
+                Series = "Summer Time Rendering", Volumes = "0", Edition = "",
+                Chapters = "0", Filename = "Record 014 (between chapter 083 and ch084) SP11.cbr", Format = MangaFormat.Archive,
+                FullFilePath = filepath, IsSpecial = true
             });
 
 

--- a/API/API.csproj
+++ b/API/API.csproj
@@ -16,7 +16,7 @@
   <PropertyGroup>
     <Product>Kavita</Product>
     <Company>kareadita.github.io</Company>
-    <Copyright>Copyright 2020-$([System.DateTime]::Now.ToString('yyyy')) kareadita.github.io (GNU General Public v3)</Copyright>
+    <Copyright>Copyright 2020-$([System.DateTime]::Now.ToString('yyyy')) kavitareader.com (GNU General Public v3)</Copyright>
 
     <!-- Should be replaced by CI -->
     <AssemblyVersion>0.4.1</AssemblyVersion>

--- a/API/Services/DirectoryService.cs
+++ b/API/Services/DirectoryService.cs
@@ -50,6 +50,11 @@ namespace API.Services
        /// <returns></returns>
        public static IEnumerable<string> GetFoldersTillRoot(string rootPath, string fullPath)
        {
+          // BUG?: If the rootPath doesn't exist in the fullPath, then infinite loop
+          // if (!fullPath.StartsWith(rootPath))
+          // {
+          //    return Array.Empty<string>();
+          // }
           var separator = Path.AltDirectorySeparatorChar;
           if (fullPath.Contains(Path.DirectorySeparatorChar))
           {

--- a/Kavita.Common/Kavita.Common.csproj
+++ b/Kavita.Common/Kavita.Common.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net5.0</TargetFramework>
         <Company>kareadita.github.io</Company>
         <Product>Kavita</Product>
-        <AssemblyVersion>0.4.2.0</AssemblyVersion>
+        <AssemblyVersion>0.4.2.1</AssemblyVersion>
         <NeutralLanguage>en</NeutralLanguage>
     </PropertyGroup>
 

--- a/Kavita.Common/Kavita.Common.csproj
+++ b/Kavita.Common/Kavita.Common.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net5.0</TargetFramework>
-        <Company>kareadita.github.io</Company>
+        <Company>kavitareader.com</Company>
         <Product>Kavita</Product>
         <AssemblyVersion>0.4.2.1</AssemblyVersion>
         <NeutralLanguage>en</NeutralLanguage>

--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ your reading collection with your friends and family!
 [![Discord](https://img.shields.io/badge/discord-chat-7289DA.svg?maxAge=60)](https://discord.gg/eczRp9eeem)
 [![GitHub - Bugs and Feature Requests Only](https://img.shields.io/badge/github-issues-red.svg?maxAge=60)](https://github.com/Kareadita/Kavita/issues)
 
+## Demo
+If you want to try out Kavita, we have a demo up:
+[https://demo.kavitareader.com/](https://demo.kavitareader.com/)
+```
+Username: demouser
+Password: Demouser64
+```
+
 ## Setup
 ### Non-Docker
 - Unzip the archive for your target OS
@@ -108,7 +116,7 @@ Thank you to [<img src="/Logo/jetbrains.svg" alt="" width="32"> JetBrains](http:
 * [<img src="/Logo/dottrace.svg" alt="" width="32"> dotTrace](http://www.jetbrains.com/dottrace/)
 
 ## Sentry
-Thank you to [<img src="/Logo/sentry.svg" alt="" width="32"> Sentry](https://sentry.io/welcome/) for providing us with free license to their software.
+Thank you to [<img src="/Logo/sentry.svg" alt="" width="64">](https://sentry.io/welcome/) for providing us with free license to their software.
 
 ### License
 


### PR DESCRIPTION
* Fixed: Added parser cases for naming conventions FMD2 uses, including Vol.tbd
* Fixed: Special Markers were taking series name parsed from filename which was unreliable. Instead, it will attempt to parse it from folder name (till library root). Ie) /manga/Hippos Attack/Specials/Artbook SP01.cbz -> Series name: Hippos Attack

Fixes #359 
Fixes #358 