### PR TITLE
Folder Parsing

### DIFF
--- a/API.Tests/Parser/MangaParserTests.cs
+++ b/API.Tests/Parser/MangaParserTests.cs
@@ -9,7 +9,7 @@ namespace API.Tests.Parser
     public class MangaParserTests
     {
         private readonly ITestOutputHelper _testOutputHelper;
-        
+
         public MangaParserTests(ITestOutputHelper testOutputHelper)
         {
             _testOutputHelper = testOutputHelper;
@@ -68,7 +68,7 @@ namespace API.Tests.Parser
         {
             Assert.Equal(expected, API.Parser.Parser.ParseVolume(filename));
         }
-        
+
         [Theory]
         [InlineData("Killing Bites Vol. 0001 Ch. 0001 - Galactica Scanlations (gb)", "Killing Bites")]
         [InlineData("My Girlfriend Is Shobitch v01 - ch. 09 - pg. 008.png", "My Girlfriend Is Shobitch")]
@@ -153,7 +153,7 @@ namespace API.Tests.Parser
         {
             Assert.Equal(expected, API.Parser.Parser.ParseSeries(filename));
         }
-        
+
         [Theory]
         [InlineData("Killing Bites Vol. 0001 Ch. 0001 - Galactica Scanlations (gb)", "1")]
         [InlineData("My Girlfriend Is Shobitch v01 - ch. 09 - pg. 008.png", "9")]
@@ -252,7 +252,7 @@ namespace API.Tests.Parser
         {
             Assert.Equal(expected,  !string.IsNullOrEmpty(API.Parser.Parser.ParseMangaSpecial(input)));
         }
-        
+
         [Theory]
         [InlineData("image.png", MangaFormat.Image)]
         [InlineData("image.cbz", MangaFormat.Archive)]
@@ -269,6 +269,34 @@ namespace API.Tests.Parser
             Assert.Equal(expected, API.Parser.Parser.ParseMangaSpecial(inputFile));
         }
 
+        private static ParserInfo CreateParserInfo(string series, string chapter, string volume, bool isSpecial = false)
+        {
+          return new ParserInfo()
+          {
+            Chapters = chapter,
+            Volumes = volume,
+            IsSpecial = isSpecial,
+            Series = series,
+          };
+        }
+
+        [Theory]
+        [InlineData("/manga/Btooom!/Vol.1/Chapter 1/1.cbz", "Btooom!~1~1")]
+        [InlineData("/manga/Btooom!/Vol.1 Chapter 2/1.cbz", "Btooom!~1~2")]
+        public void ParseFromFallbackFoldersTest(string inputFile, string expectedParseInfo)
+        {
+          const string rootDirectory = "/manga/";
+          var tokens = expectedParseInfo.Split("~");
+          var actual = new ParserInfo();
+          actual.Chapters = "0";
+          actual.Volumes = "0";
+          API.Parser.Parser.ParseFromFallbackFolders(inputFile, rootDirectory, LibraryType.Manga, ref actual);
+          Assert.Equal(tokens[0], actual.Series);
+          Assert.Equal(tokens[1], actual.Volumes);
+          Assert.Equal(tokens[2], actual.Chapters);
+
+        }
+
         [Fact]
         public void ParseInfoTest()
         {
@@ -281,7 +309,7 @@ namespace API.Tests.Parser
                 Chapters = "76", Filename = "Mujaki no Rakuen Vol12 ch76.cbz", Format = MangaFormat.Archive,
                 FullFilePath = filepath
             });
-            
+
             filepath = @"E:/Manga/Shimoneta to Iu Gainen ga Sonzai Shinai Taikutsu na Sekai Man-hen/Vol 1.cbz";
             expected.Add(filepath, new ParserInfo
             {
@@ -289,7 +317,7 @@ namespace API.Tests.Parser
                 Chapters = "0", Filename = "Vol 1.cbz", Format = MangaFormat.Archive,
                 FullFilePath = filepath
             });
-            
+
             filepath = @"E:\Manga\Beelzebub\Beelzebub_01_[Noodles].zip";
             expected.Add(filepath, new ParserInfo
             {
@@ -297,7 +325,7 @@ namespace API.Tests.Parser
                 Chapters = "1", Filename = "Beelzebub_01_[Noodles].zip", Format = MangaFormat.Archive,
                 FullFilePath = filepath
             });
-            
+
             filepath = @"E:\Manga\Ichinensei ni Nacchattara\Ichinensei_ni_Nacchattara_v01_ch01_[Taruby]_v1.1.zip";
             expected.Add(filepath, new ParserInfo
             {
@@ -312,8 +340,8 @@ namespace API.Tests.Parser
                 Series = "Tenjo Tenge", Volumes = "1", Edition = "Full Contact Edition",
                 Chapters = "0", Filename = "Tenjo Tenge {Full Contact Edition} v01 (2011) (Digital) (ASTC).cbz", Format = MangaFormat.Archive,
                 FullFilePath = filepath
-            }); 
-            
+            });
+
             filepath = @"E:\Manga\Akame ga KILL! ZERO (2016-2019) (Digital) (LuCaZ)\Akame ga KILL! ZERO v01 (2016) (Digital) (LuCaZ).cbz";
             expected.Add(filepath, new ParserInfo
             {
@@ -321,7 +349,7 @@ namespace API.Tests.Parser
                 Chapters = "0", Filename = "Akame ga KILL! ZERO v01 (2016) (Digital) (LuCaZ).cbz", Format = MangaFormat.Archive,
                 FullFilePath = filepath
             });
-            
+
             filepath = @"E:\Manga\Dorohedoro\Dorohedoro v01 (2010) (Digital) (LostNerevarine-Empire).cbz";
             expected.Add(filepath, new ParserInfo
             {
@@ -329,7 +357,7 @@ namespace API.Tests.Parser
                 Chapters = "0", Filename = "Dorohedoro v01 (2010) (Digital) (LostNerevarine-Empire).cbz", Format = MangaFormat.Archive,
                 FullFilePath = filepath
             });
-            
+
             filepath = @"E:\Manga\APOSIMZ\APOSIMZ 040 (2020) (Digital) (danke-Empire).cbz";
             expected.Add(filepath, new ParserInfo
             {
@@ -337,7 +365,7 @@ namespace API.Tests.Parser
                 Chapters = "40", Filename = "APOSIMZ 040 (2020) (Digital) (danke-Empire).cbz", Format = MangaFormat.Archive,
                 FullFilePath = filepath
             });
-            
+
             filepath = @"E:\Manga\Corpse Party Musume\Kedouin Makoto - Corpse Party Musume, Chapter 09.cbz";
             expected.Add(filepath, new ParserInfo
             {
@@ -345,7 +373,7 @@ namespace API.Tests.Parser
                 Chapters = "9", Filename = "Kedouin Makoto - Corpse Party Musume, Chapter 09.cbz", Format = MangaFormat.Archive,
                 FullFilePath = filepath
             });
-            
+
             filepath = @"E:\Manga\Goblin Slayer\Goblin Slayer - Brand New Day 006.5 (2019) (Digital) (danke-Empire).cbz";
             expected.Add(filepath, new ParserInfo
             {
@@ -353,7 +381,7 @@ namespace API.Tests.Parser
                 Chapters = "6.5", Filename = "Goblin Slayer - Brand New Day 006.5 (2019) (Digital) (danke-Empire).cbz", Format = MangaFormat.Archive,
                 FullFilePath = filepath
             });
-            
+
             filepath = @"E:\Manga\Summer Time Rendering\Specials\Record 014 (between chapter 083 and ch084) SP11.cbr";
             expected.Add(filepath, new ParserInfo
             {

--- a/API.Tests/Services/DirectoryServiceTests.cs
+++ b/API.Tests/Services/DirectoryServiceTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using API.Services;
@@ -26,7 +27,7 @@ namespace API.Tests.Services
             var files = new List<string>();
             var fileCount = DirectoryService.TraverseTreeParallelForEach(testDirectory, s => files.Add(s),
                 API.Parser.Parser.ArchiveFileExtensions, _logger);
-            
+
             Assert.Equal(28, fileCount);
         }
 
@@ -37,7 +38,7 @@ namespace API.Tests.Services
             var files = _directoryService.GetFiles(testDirectory, @"file\d*.txt");
             Assert.Equal(2, files.Count());
         }
-        
+
         [Fact]
         public void GetFiles_TopLevel_ShouldBeEmpty_Test()
         {
@@ -45,7 +46,7 @@ namespace API.Tests.Services
             var files = _directoryService.GetFiles(testDirectory);
             Assert.Empty(files);
         }
-        
+
         [Fact]
         public void GetFilesWithExtensions_ShouldBeEmpty_Test()
         {
@@ -53,7 +54,7 @@ namespace API.Tests.Services
             var files = _directoryService.GetFiles(testDirectory, "*.txt");
             Assert.Empty(files);
         }
-        
+
         [Fact]
         public void GetFilesWithExtensions_Test()
         {
@@ -61,7 +62,7 @@ namespace API.Tests.Services
             var files = _directoryService.GetFiles(testDirectory, ".cbz|.rar");
             Assert.Equal(3, files.Count());
         }
-        
+
         [Fact]
         public void GetFilesWithExtensions_BadDirectory_ShouldBeEmpty_Test()
         {
@@ -78,7 +79,7 @@ namespace API.Tests.Services
             Assert.Contains(dirs, s => s.Contains("regex"));
 
         }
-        
+
         [Fact]
         public void ListDirectory_NoSubDirectory_Test()
         {
@@ -93,9 +94,14 @@ namespace API.Tests.Services
         [InlineData("C:/Manga", "C:/Manga/Love Hina/Specials/Omake/", "Omake,Specials,Love Hina")]
         [InlineData("C:/Manga", @"C:\Manga\Love Hina\Specials\Omake\", "Omake,Specials,Love Hina")]
         [InlineData(@"/manga/", @"/manga/Love Hina/Specials/Omake/", "Omake,Specials,Love Hina")]
+        [InlineData(@"/manga/", @"/manga2/Love Hina/Specials/Omake/", "")]
         public void GetFoldersTillRoot_Test(string rootPath, string fullpath, string expectedArray)
         {
             var expected = expectedArray.Split(",");
+            if (expectedArray.Equals(string.Empty))
+            {
+              expected = Array.Empty<string>();
+            }
             Assert.Equal(expected, DirectoryService.GetFoldersTillRoot(rootPath, fullpath));
         }
     }

--- a/API/Parser/Parser.cs
+++ b/API/Parser/Parser.cs
@@ -24,7 +24,7 @@ namespace API.Parser
         private static readonly Regex XmlRegex = new Regex(XmlRegexExtensions, RegexOptions.IgnoreCase | RegexOptions.Compiled);
         private static readonly Regex BookFileRegex = new Regex(BookFileExtensions, RegexOptions.IgnoreCase | RegexOptions.Compiled);
         private static readonly Regex CoverImageRegex = new Regex(@"(?<![[a-z]\d])(?:!?)(cover|folder)(?![\w\d])", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-        
+
 
         private static readonly Regex[] MangaVolumeRegex = new[]
         {
@@ -53,7 +53,7 @@ namespace API.Parser
                 @"(volume )(?<Volume>\d+)",
                 RegexOptions.IgnoreCase | RegexOptions.Compiled),
             // Tower Of God S01 014 (CBT) (digital).cbz
-            new Regex(   
+            new Regex(
                 @"(?<Series>.*)(\b|_|)(S(?<Volume>\d+))",
                 RegexOptions.IgnoreCase | RegexOptions.Compiled),
         };
@@ -112,7 +112,7 @@ namespace API.Parser
                 RegexOptions.IgnoreCase | RegexOptions.Compiled),
             // Hinowa ga CRUSH! 018 (2019) (Digital) (LuCaZ).cbz
             new Regex(
-                @"(?<Series>.*) (?<Chapter>\d+) (?:\(\d{4}\)) ", 
+                @"(?<Series>.*) (?<Chapter>\d+) (?:\(\d{4}\)) ",
                 RegexOptions.IgnoreCase | RegexOptions.Compiled),
             // Goblin Slayer - Brand New Day 006.5 (2019) (Digital) (danke-Empire)
             new Regex(
@@ -146,7 +146,7 @@ namespace API.Parser
             new Regex(
                 @"^(?!Vol)(?<Series>.*)( |_)Chapter( |_)(\d+)",
                 RegexOptions.IgnoreCase | RegexOptions.Compiled),
-           
+
             // Fullmetal Alchemist chapters 101-108.cbz
             new Regex(
                 @"^(?!vol)(?<Series>.*)( |_)(chapters( |_)?)\d+-?\d*",
@@ -155,16 +155,16 @@ namespace API.Parser
             new Regex(
                 @"^(?!Vol\.?)(?<Series>.*)( |_|-)(?<!-)(episode ?)\d+-?\d*",
                 RegexOptions.IgnoreCase | RegexOptions.Compiled),
-            
+
             // Baketeriya ch01-05.zip
             new Regex(
                 @"^(?!Vol)(?<Series>.*)ch\d+-?\d?",
                 RegexOptions.IgnoreCase | RegexOptions.Compiled),
             // Magi - Ch.252-005.cbz
             new Regex(
-                @"(?<Series>.*)( ?- ?)Ch\.\d+-?\d*", 
+                @"(?<Series>.*)( ?- ?)Ch\.\d+-?\d*",
                 RegexOptions.IgnoreCase | RegexOptions.Compiled),
-            // [BAA]_Darker_than_Black_Omake-1.zip 
+            // [BAA]_Darker_than_Black_Omake-1.zip
             new Regex(
                 @"^(?!Vol)(?<Series>.*)(-)\d+-?\d*", // This catches a lot of stuff ^(?!Vol)(?<Series>.*)( |_)(\d+)
                 RegexOptions.IgnoreCase | RegexOptions.Compiled),
@@ -181,7 +181,7 @@ namespace API.Parser
                 @"^(?!Vol)(?<Series>.*)( |_|-)(ch?)\d+",
                 RegexOptions.IgnoreCase | RegexOptions.Compiled),
         };
-        
+
         private static readonly Regex[] ComicSeriesRegex = new[]
         {
             // Invincible Vol 01 Family matters (2005) (Digital)
@@ -233,7 +233,7 @@ namespace API.Parser
                 @"^(?<Series>.*)",
                 RegexOptions.IgnoreCase | RegexOptions.Compiled),
         };
-        
+
         private static readonly Regex[] ComicVolumeRegex = new[]
         {
             // 04 - Asterix the Gladiator (1964) (Digital-Empire) (WebP by Doc MaKS)
@@ -265,7 +265,7 @@ namespace API.Parser
                 @"^(?<Series>.*)(?: |_)#(?<Volume>\d+)",
                 RegexOptions.IgnoreCase | RegexOptions.Compiled),
         };
-        
+
         private static readonly Regex[] ComicChapterRegex = new[]
         {
             // // 04 - Asterix the Gladiator (1964) (Digital-Empire) (WebP by Doc MaKS)
@@ -311,7 +311,7 @@ namespace API.Parser
             // [TrinityBAKumA Finella&anon], [BAA]_, [SlowManga&OverloadScans], [batoto]
             new Regex(@"(?:\[(?<subgroup>(?!\s).+?(?<!\s))\](?:_|-|\s|\.)?)",
                 RegexOptions.IgnoreCase | RegexOptions.Compiled),
-            // (Shadowcat-Empire), 
+            // (Shadowcat-Empire),
             // new Regex(@"(?:\[(?<subgroup>(?!\s).+?(?<!\s))\](?:_|-|\s|\.)?)",
             //     RegexOptions.IgnoreCase | RegexOptions.Compiled),
         };
@@ -327,24 +327,24 @@ namespace API.Parser
                 @"v\d+\.(?<Chapter>\d+(?:.\d+|-\d+)?)",
                 RegexOptions.IgnoreCase | RegexOptions.Compiled),
             // Umineko no Naku Koro ni - Episode 3 - Banquet of the Golden Witch #02.cbz (Rare case, if causes issue remove)
-            new Regex(   
+            new Regex(
                 @"^(?<Series>.*)(?: |_)#(?<Chapter>\d+)",
                 RegexOptions.IgnoreCase | RegexOptions.Compiled),
             // Green Worldz - Chapter 027
             new Regex(
                 @"^(?!Vol)(?<Series>.*)\s?(?<!vol\. )\sChapter\s(?<Chapter>\d+(?:.\d+|-\d+)?)",
                 RegexOptions.IgnoreCase | RegexOptions.Compiled),
-            // Hinowa ga CRUSH! 018 (2019) (Digital) (LuCaZ).cbz, Hinowa ga CRUSH! 018.5 (2019) (Digital) (LuCaZ).cbz 
+            // Hinowa ga CRUSH! 018 (2019) (Digital) (LuCaZ).cbz, Hinowa ga CRUSH! 018.5 (2019) (Digital) (LuCaZ).cbz
             new Regex(
-                @"^(?!Vol)(?<Series>.*) (?<!vol\. )(?<Chapter>\d+(?:.\d+|-\d+)?)(?: \(\d{4}\))?(\b|_|-)", 
+                @"^(?!Vol)(?<Series>.*) (?<!vol\. )(?<Chapter>\d+(?:.\d+|-\d+)?)(?: \(\d{4}\))?(\b|_|-)",
                 RegexOptions.IgnoreCase | RegexOptions.Compiled),
             // Tower Of God S01 014 (CBT) (digital).cbz
             new Regex(
-                @"(?<Series>.*) S(?<Volume>\d+) (?<Chapter>\d+(?:.\d+|-\d+)?)", 
+                @"(?<Series>.*) S(?<Volume>\d+) (?<Chapter>\d+(?:.\d+|-\d+)?)",
                 RegexOptions.IgnoreCase | RegexOptions.Compiled),
             // Beelzebub_01_[Noodles].zip, Beelzebub_153b_RHS.zip
             new Regex(
-                @"^((?!v|vo|vol|Volume).)*( |_)(?<Chapter>\.?\d+(?:.\d+|-\d+)?)(?<ChapterPart>b)?( |_|\[|\()", 
+                @"^((?!v|vo|vol|Volume).)*( |_)(?<Chapter>\.?\d+(?:.\d+|-\d+)?)(?<ChapterPart>b)?( |_|\[|\()",
                 RegexOptions.IgnoreCase | RegexOptions.Compiled),
             // Yumekui-Merry_DKThias_Chapter21.zip
             new Regex(
@@ -359,7 +359,7 @@ namespace API.Parser
         private static readonly Regex[] MangaEditionRegex = {
             // Tenjo Tenge {Full Contact Edition} v01 (2011) (Digital) (ASTC).cbz
             new Regex(
-                @"(?<Edition>({|\(|\[).* Edition(}|\)|\]))", 
+                @"(?<Edition>({|\(|\[).* Edition(}|\)|\]))",
                 RegexOptions.IgnoreCase | RegexOptions.Compiled),
             // Tenjo Tenge {Full Contact Edition} v01 (2011) (Digital) (ASTC).cbz
             new Regex(
@@ -448,7 +448,7 @@ namespace API.Parser
             if (ret.Series == string.Empty)
             {
                 // Try to parse information out of each folder all the way to rootPath
-                ParseFromFallbackFolders(filePath, rootPath, ref ret);
+                ParseFromFallbackFolders(filePath, rootPath, type, ref ret);
             }
 
             var edition = ParseEdition(fileName);
@@ -459,7 +459,7 @@ namespace API.Parser
             }
 
             var isSpecial = ParseMangaSpecial(fileName);
-            // We must ensure that we can only parse a special out. As some files will have v20 c171-180+Omake and that 
+            // We must ensure that we can only parse a special out. As some files will have v20 c171-180+Omake and that
             // could cause a problem as Omake is a special term, but there is valid volume/chapter information.
             if (ret.Chapters == DefaultChapter && ret.Volumes == DefaultVolume && !string.IsNullOrEmpty(isSpecial))
             {
@@ -471,10 +471,10 @@ namespace API.Parser
                 ret.IsSpecial = true;
                 ret.Chapters = DefaultChapter;
                 ret.Volumes = DefaultVolume;
-                
-                ParseFromFallbackFolders(filePath, rootPath, ref ret);
+
+                ParseFromFallbackFolders(filePath, rootPath, type, ref ret);
             }
-            // here is the issue. If we are a special with marker, we need to ensure we use the correct series name. 
+            // here is the issue. If we are a special with marker, we need to ensure we use the correct series name.
             // we can do this by falling back
 
             if (string.IsNullOrEmpty(ret.Series))
@@ -485,7 +485,14 @@ namespace API.Parser
             return ret.Series == string.Empty ? null : ret;
         }
 
-        public static void ParseFromFallbackFolders(string filePath, string rootPath, ref ParserInfo ret)
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="filePath"></param>
+        /// <param name="rootPath"></param>
+        /// <param name="type"></param>
+        /// <param name="ret">Expects a non-null ParserInfo which this method will populate</param>
+        public static void ParseFromFallbackFolders(string filePath, string rootPath, LibraryType type, ref ParserInfo ret)
         {
             // TODO: This currently only does series, but we can enhance to do volume/chapter. It will need library type tho
             var fallbackFolders = DirectoryService.GetFoldersTillRoot(rootPath, Path.GetDirectoryName(filePath)).ToList();
@@ -493,7 +500,21 @@ namespace API.Parser
             {
                 var folder = fallbackFolders[i];
                 if (!string.IsNullOrEmpty(ParseMangaSpecial(folder))) continue;
-                if (ParseVolume(folder) != DefaultVolume || ParseChapter(folder) != DefaultChapter) continue;
+                if (ParseVolume(folder) != DefaultVolume || ParseChapter(folder) != DefaultChapter)
+                {
+                  // New code: take volume or chapter from folder
+                  if ((ret.Volumes.Equals(DefaultVolume) || string.IsNullOrEmpty(ret.Volumes)) && !ParseVolume(folder).Equals(DefaultVolume))
+                  {
+                    ret.Volumes = ParseVolume(folder);
+                  }
+                  if ((ret.Chapters.Equals(DefaultChapter) || string.IsNullOrEmpty(ret.Chapters)) && !ParseChapter(folder).Equals(DefaultChapter))
+                  {
+                    ret.Chapters = ParseChapter(folder);
+                  }
+
+                  continue;
+                  // Old code: Ignore volume or chapters from folder continue;
+                }
 
                 var series = ParseSeries(folder);
 
@@ -530,17 +551,17 @@ namespace API.Parser
                     {
                         var edition = match.Groups["Edition"].Value.Replace("{", "").Replace("}", "")
                             .Replace("[", "").Replace("]", "").Replace("(", "").Replace(")", "");
-                        
+
                         return edition;
                     }
                 }
             }
-            
+
             return string.Empty;
         }
-        
+
         /// <summary>
-        /// If the file has SP marker. 
+        /// If the file has SP marker.
         /// </summary>
         /// <param name="filePath"></param>
         /// <returns></returns>
@@ -554,10 +575,10 @@ namespace API.Parser
                     return true;
                 }
             }
-            
+
             return false;
         }
-        
+
         public static string ParseMangaSpecial(string filePath)
         {
             foreach (var regex in MangaSpecialRegex)
@@ -571,10 +592,10 @@ namespace API.Parser
                     }
                 }
             }
-            
+
             return string.Empty;
         }
-        
+
         public static string ParseSeries(string filename)
         {
             foreach (var regex in MangaSeriesRegex)
@@ -588,7 +609,7 @@ namespace API.Parser
                     }
                 }
             }
-            
+
             return string.Empty;
         }
         public static string ParseComicSeries(string filename)
@@ -604,7 +625,7 @@ namespace API.Parser
                     }
                 }
             }
-            
+
             return string.Empty;
         }
 
@@ -616,7 +637,7 @@ namespace API.Parser
                 foreach (Match match in matches)
                 {
                     if (!match.Groups["Volume"].Success || match.Groups["Volume"] == Match.Empty) continue;
-                    
+
                     var value = match.Groups["Volume"].Value;
                     if (!value.Contains("-")) return RemoveLeadingZeroes(match.Groups["Volume"].Value);
                     var tokens = value.Split("-");
@@ -626,7 +647,7 @@ namespace API.Parser
 
                 }
             }
-            
+
             return DefaultVolume;
         }
 
@@ -638,7 +659,7 @@ namespace API.Parser
                 foreach (Match match in matches)
                 {
                     if (!match.Groups["Volume"].Success || match.Groups["Volume"] == Match.Empty) continue;
-                    
+
                     var value = match.Groups["Volume"].Value;
                     if (!value.Contains("-")) return RemoveLeadingZeroes(match.Groups["Volume"].Value);
                     var tokens = value.Split("-");
@@ -648,7 +669,7 @@ namespace API.Parser
 
                 }
             }
-            
+
             return DefaultVolume;
         }
 
@@ -660,7 +681,7 @@ namespace API.Parser
                 foreach (Match match in matches)
                 {
                     if (!match.Groups["Chapter"].Success || match.Groups["Chapter"] == Match.Empty) continue;
-                    
+
                     var value = match.Groups["Chapter"].Value;
                     var hasChapterPart = match.Groups["ChapterPart"].Success;
 
@@ -668,7 +689,7 @@ namespace API.Parser
                     {
                         return RemoveLeadingZeroes(hasChapterPart ? AddChapterPart(value) : value);
                     }
-                    
+
                     var tokens = value.Split("-");
                     var from = RemoveLeadingZeroes(tokens[0]);
                     var to = RemoveLeadingZeroes(hasChapterPart ? AddChapterPart(tokens[1]) : tokens[1]);
@@ -689,7 +710,7 @@ namespace API.Parser
 
             return $"{value}.5";
         }
-        
+
         public static string ParseComicChapter(string filename)
         {
             foreach (var regex in ComicChapterRegex)
@@ -731,7 +752,7 @@ namespace API.Parser
                     }
                 }
             }
-            
+
             foreach (var regex in MangaEditionRegex)
             {
                 var matches = regex.Matches(title);
@@ -746,7 +767,7 @@ namespace API.Parser
 
             return title;
         }
-        
+
         private static string RemoveSpecialTags(string title)
         {
             foreach (var regex in MangaSpecialRegex)
@@ -763,9 +784,9 @@ namespace API.Parser
 
             return title;
         }
-        
-        
-        
+
+
+
         /// <summary>
         /// Translates _ -> spaces, trims front and back of string, removes release groups
         /// </summary>
@@ -833,13 +854,13 @@ namespace API.Parser
                 _ => number
             };
         }
-        
+
         public static string RemoveLeadingZeroes(string title)
         {
             var ret = title.TrimStart(new[] { '0' });
             return ret == string.Empty ? "0" : ret;
         }
-        
+
         public static bool IsArchive(string filePath)
         {
             return ArchiveFileRegex.IsMatch(Path.GetExtension(filePath));
@@ -854,12 +875,12 @@ namespace API.Parser
             if (filePath.StartsWith(".") || (!suppressExtraChecks && filePath.StartsWith("!"))) return false;
             return ImageRegex.IsMatch(Path.GetExtension(filePath));
         }
-        
+
         public static bool IsXml(string filePath)
         {
             return XmlRegex.IsMatch(Path.GetExtension(filePath));
         }
-        
+
         public static float MinimumNumberFromRange(string range)
         {
             try

--- a/API/Services/DirectoryService.cs
+++ b/API/Services/DirectoryService.cs
@@ -14,7 +14,7 @@ namespace API.Services
     {
        private readonly ILogger<DirectoryService> _logger;
        private static readonly Regex ExcludeDirectories = new Regex(
-          @"@eaDir|\.DS_Store", 
+          @"@eaDir|\.DS_Store",
           RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
        public DirectoryService(ILogger<DirectoryService> logger)
@@ -23,13 +23,13 @@ namespace API.Services
        }
 
        /// <summary>
-       /// Given a set of regex search criteria, get files in the given path. 
+       /// Given a set of regex search criteria, get files in the given path.
        /// </summary>
        /// <param name="path">Directory to search</param>
        /// <param name="searchPatternExpression">Regex version of search pattern (ie \.mp3|\.mp4). Defaults to * meaning all files.</param>
        /// <param name="searchOption">SearchOption to use, defaults to TopDirectoryOnly</param>
        /// <returns>List of file paths</returns>
-       private static IEnumerable<string> GetFilesWithCertainExtensions(string path, 
+       private static IEnumerable<string> GetFilesWithCertainExtensions(string path,
           string searchPatternExpression = "",
           SearchOption searchOption = SearchOption.TopDirectoryOnly)
        {
@@ -50,20 +50,21 @@ namespace API.Services
        /// <returns></returns>
        public static IEnumerable<string> GetFoldersTillRoot(string rootPath, string fullPath)
        {
-          // BUG?: If the rootPath doesn't exist in the fullPath, then infinite loop
-          // if (!fullPath.StartsWith(rootPath))
-          // {
-          //    return Array.Empty<string>();
-          // }
-          var separator = Path.AltDirectorySeparatorChar;
+         var separator = Path.AltDirectorySeparatorChar;
           if (fullPath.Contains(Path.DirectorySeparatorChar))
           {
              fullPath = fullPath.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
           }
-          
+
           if (rootPath.Contains(Path.DirectorySeparatorChar))
           {
              rootPath = rootPath.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+          }
+
+          // If the fullPath doesn't have rootPath in it, return empty array
+          if (!fullPath.StartsWith(rootPath))
+          {
+            return Array.Empty<string>();
           }
 
           var path = fullPath.EndsWith(separator) ? fullPath.Substring(0, fullPath.Length - 1) : fullPath;
@@ -85,7 +86,7 @@ namespace API.Services
           return di.Exists;
        }
 
-       public IEnumerable<string> GetFiles(string path, string searchPatternExpression = "", 
+       public IEnumerable<string> GetFiles(string path, string searchPatternExpression = "",
           SearchOption searchOption = SearchOption.TopDirectoryOnly)
        {
           if (searchPatternExpression != string.Empty)
@@ -96,7 +97,7 @@ namespace API.Services
                 .Where(file =>
                    reSearchPattern.IsMatch(file));
           }
-          
+
           return !Directory.Exists(path) ? Array.Empty<string>() : Directory.GetFiles(path);
        }
 
@@ -106,7 +107,7 @@ namespace API.Services
           {
              return GetFilesWithCertainExtensions(path, searchPatternExpression).ToArray();
           }
-          
+
           return !Directory.Exists(path) ? Array.Empty<string>() : Directory.GetFiles(path);
        }
 
@@ -147,11 +148,11 @@ namespace API.Services
        public static void ClearAndDeleteDirectory(string directoryPath)
        {
           if (!Directory.Exists(directoryPath)) return;
-          
+
           DirectoryInfo di = new DirectoryInfo(directoryPath);
 
           ClearDirectory(directoryPath);
-          
+
           di.Delete(true);
        }
 
@@ -167,11 +168,11 @@ namespace API.Services
 
           foreach (var file in di.EnumerateFiles())
           {
-             file.Delete(); 
+             file.Delete();
           }
           foreach (var dir in di.EnumerateDirectories())
           {
-             dir.Delete(true); 
+             dir.Delete(true);
           }
        }
 
@@ -186,13 +187,13 @@ namespace API.Services
                 var fileInfo = new FileInfo(file);
                 if (fileInfo.Exists)
                 {
-                   fileInfo.CopyTo(Path.Join(directoryPath, fileInfo.Name));   
+                   fileInfo.CopyTo(Path.Join(directoryPath, fileInfo.Name));
                 }
                 else
                 {
                    _logger.LogWarning("Tried to copy {File} but it doesn't exist", file);
                 }
-                
+
              }
           }
           catch (Exception ex)
@@ -207,12 +208,12 @@ namespace API.Services
        public IEnumerable<string> ListDirectory(string rootPath)
         {
            if (!Directory.Exists(rootPath)) return ImmutableList<string>.Empty;
-            
+
             var di = new DirectoryInfo(rootPath);
             var dirs = di.GetDirectories()
                 .Where(dir => !(dir.Attributes.HasFlag(FileAttributes.Hidden) || dir.Attributes.HasFlag(FileAttributes.System)))
                 .Select(d => d.Name).ToImmutableList();
-            
+
             return dirs;
         }
 
@@ -331,6 +332,6 @@ namespace API.Services
 
             return fileCount;
         }
-        
+
     }
 }


### PR DESCRIPTION
* New: Ability to parse volume and chapter from directory tree, rather than exclusively from filename. (#313)
* Fixed: Fixed an edge case where GetFoldersTillRoot if given a non-existent root in the file path, would result in an infinite loop.

Closes #313 