### PR TITLE
Manga Reader Prefetching Fix

### DIFF
--- a/UI/Web/src/app/manga-reader/manga-reader.component.ts
+++ b/UI/Web/src/app/manga-reader/manga-reader.component.ts
@@ -675,7 +675,7 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
   prefetch() {
     let index = 1;
 
-    this.cachedImages.applyFor((item, i) => {
+    this.cachedImages.applyFor((item, internalIndex) => {
       const offsetIndex = this.pageNum + index;
       const urlPageNum = this.readerService.imageUrlToPageNum(item.src);
       if (urlPageNum === offsetIndex) {

--- a/UI/Web/src/app/shared/data-structures/circular-array.ts
+++ b/UI/Web/src/app/shared/data-structures/circular-array.ts
@@ -89,8 +89,7 @@ export class CircularArray<T> {
     applyFor(func: (item: T, index: number) => void, limit: number) {
       for (let offset = 1; offset < limit; offset++) {
         const i = this.currentIndex + offset;
-        const peekIndex = i < this.arr.length ? i : 0;
-  
+        const peekIndex = i < this.arr.length ? i : Math.abs(this.arr.length - i);
         func(this.arr[peekIndex], peekIndex);
       }
   


### PR DESCRIPTION
* Fixed: Manga reader's prefetching buffer had issues with rolling over index, which would require a manual image load every 7 pages.

Fixes #372