### PR TITLE
Scan Series

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,8 +8,13 @@ indent_size = 4
 insert_final_newline = true
 trim_trailing_whitespace = true
 
+[*.cs]
+indent_size = 3
+
 [*.ts]
 quote_type = single
+indent_size = 2
+
 
 [*.md]
 max_line_length = off

--- a/API.Tests/Extensions/SeriesExtensionsTests.cs
+++ b/API.Tests/Extensions/SeriesExtensionsTests.cs
@@ -29,5 +29,21 @@ namespace API.Tests.Extensions
 
             Assert.Equal(expected, series.NameInList(list));
         }
+
+        public void NameInParserInfoTest(string[] seriesInput, string[] list, bool expected)
+        {
+            var series = new Series()
+            {
+                Name = seriesInput[0],
+                LocalizedName = seriesInput[1],
+                OriginalName = seriesInput[2],
+                NormalizedName = seriesInput.Length == 4 ? seriesInput[3] : API.Parser.Parser.Normalize(seriesInput[0]),
+                Metadata = new SeriesMetadata()
+            };
+
+            Assert.Equal(expected, series.NameInList(list));
+        }
+
+
     }
 }

--- a/API.Tests/Extensions/SeriesExtensionsTests.cs
+++ b/API.Tests/Extensions/SeriesExtensionsTests.cs
@@ -34,6 +34,7 @@ namespace API.Tests.Extensions
         [Theory]
         [InlineData(new [] {"Darker than Black", "Darker Than Black", "Darker than Black"}, "Darker than Black", true)]
         [InlineData(new [] {"Rent-a-Girlfriend", "Rent-a-Girlfriend", "Kanojo, Okarishimasu", "rentagirlfriend"}, "Kanojo, Okarishimasu", true)]
+        [InlineData(new [] {"Rent-a-Girlfriend", "Rent-a-Girlfriend", "Kanojo, Okarishimasu", "rentagirlfriend"}, "Rent", false)]
         public void NameInParserInfoTest(string[] seriesInput, string parserSeries, bool expected)
         {
             var series = new Series()

--- a/API.Tests/Extensions/SeriesExtensionsTests.cs
+++ b/API.Tests/Extensions/SeriesExtensionsTests.cs
@@ -1,5 +1,6 @@
 ﻿using API.Entities;
 using API.Extensions;
+using API.Parser;
 using Xunit;
 
 namespace API.Tests.Extensions
@@ -30,7 +31,10 @@ namespace API.Tests.Extensions
             Assert.Equal(expected, series.NameInList(list));
         }
 
-        public void NameInParserInfoTest(string[] seriesInput, string[] list, bool expected)
+        [Theory]
+        [InlineData(new [] {"Darker than Black", "Darker Than Black", "Darker than Black"}, "Darker than Black", true)]
+        [InlineData(new [] {"Rent-a-Girlfriend", "Rent-a-Girlfriend", "Kanojo, Okarishimasu", "rentagirlfriend"}, "Kanojo, Okarishimasu", true)]
+        public void NameInParserInfoTest(string[] seriesInput, string parserSeries, bool expected)
         {
             var series = new Series()
             {
@@ -40,8 +44,10 @@ namespace API.Tests.Extensions
                 NormalizedName = seriesInput.Length == 4 ? seriesInput[3] : API.Parser.Parser.Normalize(seriesInput[0]),
                 Metadata = new SeriesMetadata()
             };
+            var info = new ParserInfo();
+            info.Series = parserSeries;
 
-            Assert.Equal(expected, series.NameInList(list));
+            Assert.Equal(expected, series.NameInParserInfo(info));
         }
 
 

--- a/API.Tests/Parser/MangaParserTests.cs
+++ b/API.Tests/Parser/MangaParserTests.cs
@@ -291,9 +291,7 @@ namespace API.Tests.Parser
         {
           const string rootDirectory = "/manga/";
           var tokens = expectedParseInfo.Split("~");
-          var actual = new ParserInfo();
-          actual.Chapters = "0";
-          actual.Volumes = "0";
+          var actual = new ParserInfo {Chapters = "0", Volumes = "0"};
           API.Parser.Parser.ParseFromFallbackFolders(inputFile, rootDirectory, LibraryType.Manga, ref actual);
           Assert.Equal(tokens[0], actual.Series);
           Assert.Equal(tokens[1], actual.Volumes);

--- a/API.Tests/Parser/MangaParserTests.cs
+++ b/API.Tests/Parser/MangaParserTests.cs
@@ -217,6 +217,8 @@ namespace API.Tests.Parser
         [InlineData("Kodoja #001 (March 2016)", "1")]
         [InlineData("Noblesse - Episode 429 (74 Pages).7z", "429")]
         [InlineData("Boku No Kokoro No Yabai Yatsu - Chapter 054 I Prayed At The Shrine (V0).cbz", "54")]
+        [InlineData("Ijousha No Ai - Vol.01 Chapter 029 8 Years Ago", "29")]
+        [InlineData("Kedouin Makoto - Corpse Party Musume, Chapter 09.cbz", "9")]
         public void ParseChaptersTest(string filename, string expected)
         {
             Assert.Equal(expected, API.Parser.Parser.ParseChapter(filename));

--- a/API.Tests/Parser/MangaParserTests.cs
+++ b/API.Tests/Parser/MangaParserTests.cs
@@ -151,6 +151,7 @@ namespace API.Tests.Parser
         [InlineData("Yuusha Ga Shinda! - Vol.tbd Chapter 27.001 V2 Infection ①.cbz", "Yuusha Ga Shinda!")]
         [InlineData("Seraph of the End - Vampire Reign 093 (2020) (Digital) (LuCaZ).cbz", "Seraph of the End - Vampire Reign")]
         [InlineData("Getsuyoubi no Tawawa - Ch. 001 - Ai-chan, Part 1", "Getsuyoubi no Tawawa")]
+        [InlineData("Please Go Home, Akutsu-San! - Chapter 038.5 - Volume Announcement.cbz", "Please Go Home, Akutsu-San!")]
         public void ParseSeriesTest(string filename, string expected)
         {
             Assert.Equal(expected, API.Parser.Parser.ParseSeries(filename));

--- a/API.Tests/Services/DirectoryServiceTests.cs
+++ b/API.Tests/Services/DirectoryServiceTests.cs
@@ -94,6 +94,8 @@ namespace API.Tests.Services
         [InlineData("C:/Manga", "C:/Manga/Love Hina/Specials/Omake/", "Omake,Specials,Love Hina")]
         [InlineData("C:/Manga", @"C:\Manga\Love Hina\Specials\Omake\", "Omake,Specials,Love Hina")]
         [InlineData(@"/manga/", @"/manga/Love Hina/Specials/Omake/", "Omake,Specials,Love Hina")]
+        [InlineData(@"/manga/", @"/manga/", "")]
+        [InlineData(@"E:\test", @"E:\test\Sweet X Trouble\Sweet X Trouble - Chapter 001.cbz", "Sweet X Trouble")]
         [InlineData(@"C:\/mount/gdrive/Library/Test Library/Comics/", @"C:\/mount/gdrive/Library/Test Library/Comics\godzilla rivals vs hedorah\vol 1\", "vol 1,godzilla rivals vs hedorah")]
         public void GetFoldersTillRoot_Test(string rootPath, string fullpath, string expectedArray)
         {

--- a/API.Tests/Services/DirectoryServiceTests.cs
+++ b/API.Tests/Services/DirectoryServiceTests.cs
@@ -98,6 +98,9 @@ namespace API.Tests.Services
         [InlineData(@"E:\test", @"E:\test\Sweet X Trouble\Sweet X Trouble - Chapter 001.cbz", "Sweet X Trouble")]
         [InlineData(@"C:\/mount/gdrive/Library/Test Library/Comics/", @"C:\/mount/gdrive/Library/Test Library/Comics\godzilla rivals vs hedorah\vol 1\", "vol 1,godzilla rivals vs hedorah")]
         [InlineData(@"/manga/", @"/manga/Btooom!/Vol.1 Chapter 2/1.cbz", "Vol.1 Chapter 2,Btooom!")]
+        [InlineData(@"C:/", @"C://Btooom!/Vol.1 Chapter 2/1.cbz", "Vol.1 Chapter 2,Btooom!")]
+        [InlineData(@"C:\\", @"C://Btooom!/Vol.1 Chapter 2/1.cbz", "Vol.1 Chapter 2,Btooom!")]
+        [InlineData(@"C://mount/gdrive/Library/Test Library/Comics", @"C://mount/gdrive/Library/Test Library/Comics/Dragon Age/Test", "Test,Dragon Age")]
         public void GetFoldersTillRoot_Test(string rootPath, string fullpath, string expectedArray)
         {
             var expected = expectedArray.Split(",");

--- a/API.Tests/Services/DirectoryServiceTests.cs
+++ b/API.Tests/Services/DirectoryServiceTests.cs
@@ -97,6 +97,7 @@ namespace API.Tests.Services
         [InlineData(@"/manga/", @"/manga/", "")]
         [InlineData(@"E:\test", @"E:\test\Sweet X Trouble\Sweet X Trouble - Chapter 001.cbz", "Sweet X Trouble")]
         [InlineData(@"C:\/mount/gdrive/Library/Test Library/Comics/", @"C:\/mount/gdrive/Library/Test Library/Comics\godzilla rivals vs hedorah\vol 1\", "vol 1,godzilla rivals vs hedorah")]
+        [InlineData(@"/manga/", @"/manga/Btooom!/Vol.1 Chapter 2/1.cbz", "Vol.1 Chapter 2,Btooom!")]
         public void GetFoldersTillRoot_Test(string rootPath, string fullpath, string expectedArray)
         {
             var expected = expectedArray.Split(",");

--- a/API/API.csproj
+++ b/API/API.csproj
@@ -50,9 +50,9 @@
     <PackageReference Include="NetVips" Version="2.0.0" />
     <PackageReference Include="NetVips.Native" Version="8.10.6" />
     <PackageReference Include="NReco.Logging.File" Version="1.1.1" />
-    <PackageReference Include="Sentry.AspNetCore" Version="3.3.4" />
-    <PackageReference Include="SharpCompress" Version="0.28.1" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.20.0.28934">
+    <PackageReference Include="Sentry.AspNetCore" Version="3.7.0" />
+    <PackageReference Include="SharpCompress" Version="0.28.3" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.25.0.33663">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/API/Controllers/LibraryController.cs
+++ b/API/Controllers/LibraryController.cs
@@ -25,8 +25,8 @@ namespace API.Controllers
         private readonly ITaskScheduler _taskScheduler;
         private readonly IUnitOfWork _unitOfWork;
 
-        public LibraryController(IDirectoryService directoryService, 
-            ILogger<LibraryController> logger, IMapper mapper, ITaskScheduler taskScheduler, 
+        public LibraryController(IDirectoryService directoryService,
+            ILogger<LibraryController> logger, IMapper mapper, ITaskScheduler taskScheduler,
             IUnitOfWork unitOfWork)
         {
             _directoryService = directoryService;
@@ -35,7 +35,7 @@ namespace API.Controllers
             _taskScheduler = taskScheduler;
             _unitOfWork = unitOfWork;
         }
-        
+
         /// <summary>
         /// Creates a new Library. Upon library creation, adds new library to all Admin accounts.
         /// </summary>
@@ -49,7 +49,7 @@ namespace API.Controllers
             {
                 return BadRequest("Library name already exists. Please choose a unique name to the server.");
             }
-            
+
             var library = new Library
             {
                 Name = createLibraryDto.Name,
@@ -58,14 +58,14 @@ namespace API.Controllers
             };
 
             _unitOfWork.LibraryRepository.Add(library);
-            
+
             var admins = (await _unitOfWork.UserRepository.GetAdminUsersAsync()).ToList();
             foreach (var admin in admins)
             {
                 admin.Libraries ??= new List<Library>();
                 admin.Libraries.Add(library);
             }
-            
+
 
             if (!await _unitOfWork.CommitAsync()) return BadRequest("There was a critical issue. Please try again.");
 
@@ -92,7 +92,7 @@ namespace API.Controllers
 
             return Ok(_directoryService.ListDirectory(path));
         }
-        
+
         [HttpGet]
         public async Task<ActionResult<IEnumerable<LibraryDto>>> GetLibraries()
         {
@@ -105,10 +105,10 @@ namespace API.Controllers
         {
             var user = await _unitOfWork.UserRepository.GetUserByUsernameAsync(updateLibraryForUserDto.Username);
             if (user == null) return BadRequest("Could not validate user");
-            
+
             var libraryString = String.Join(",", updateLibraryForUserDto.SelectedLibraries.Select(x => x.Name));
             _logger.LogInformation("Granting user {UserName} access to: {Libraries}", updateLibraryForUserDto.Username, libraryString);
-            
+
             var allLibraries = await _unitOfWork.LibraryRepository.GetLibrariesAsync();
             foreach (var library in allLibraries)
             {
@@ -117,16 +117,16 @@ namespace API.Controllers
                 var libraryIsSelected = updateLibraryForUserDto.SelectedLibraries.Any(l => l.Id == library.Id);
                 if (libraryContainsUser && !libraryIsSelected)
                 {
-                    // Remove 
+                    // Remove
                     library.AppUsers.Remove(user);
                 }
                 else if (!libraryContainsUser && libraryIsSelected)
                 {
                     library.AppUsers.Add(user);
-                } 
-                
+                }
+
             }
-            
+
             if (!_unitOfWork.HasChanges())
             {
                 _logger.LogInformation("Added: {SelectedLibraries} to {Username}",libraryString, updateLibraryForUserDto.Username);
@@ -138,8 +138,8 @@ namespace API.Controllers
                 _logger.LogInformation("Added: {SelectedLibraries} to {Username}",libraryString, updateLibraryForUserDto.Username);
                 return Ok(_mapper.Map<MemberDto>(user));
             }
-            
-            
+
+
             return BadRequest("There was a critical issue. Please try again.");
         }
 
@@ -150,7 +150,7 @@ namespace API.Controllers
             _taskScheduler.ScanLibrary(libraryId);
             return Ok();
         }
-        
+
         [Authorize(Policy = "RequireAdminRole")]
         [HttpPost("refresh-metadata")]
         public ActionResult RefreshMetadata(int libraryId)
@@ -164,7 +164,7 @@ namespace API.Controllers
         {
             return Ok(await _unitOfWork.LibraryRepository.GetLibraryDtosForUsernameAsync(User.GetUsername()));
         }
-        
+
         [Authorize(Policy = "RequireAdminRole")]
         [HttpDelete("delete")]
         public async Task<ActionResult<bool>> DeleteLibrary(int libraryId)
@@ -176,13 +176,25 @@ namespace API.Controllers
             var chapterIds =
                 await _unitOfWork.SeriesRepository.GetChapterIdsForSeriesAsync(seriesIds);
 
-            var result = await _unitOfWork.LibraryRepository.DeleteLibrary(libraryId);    
-            if (result && chapterIds.Any())
+
+            try
             {
-                _taskScheduler.CleanupChapters(chapterIds);
+                var library = await _unitOfWork.LibraryRepository.GetLibraryForIdAsync(libraryId);
+                _unitOfWork.LibraryRepository.Delete(library);
+                await _unitOfWork.CommitAsync();
+
+                if (chapterIds.Any())
+                {
+                    _taskScheduler.CleanupChapters(chapterIds);
+                }
+                return Ok(true);
             }
-            
-            return Ok(result);
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "There was a critical error trying to delete the library");
+                await _unitOfWork.RollbackAsync();
+                return Ok(false);
+            }
         }
 
         [Authorize(Policy = "RequireAdminRole")]
@@ -204,20 +216,20 @@ namespace API.Controllers
             {
                 _taskScheduler.ScanLibrary(library.Id, true);
             }
-                
+
             return Ok();
 
         }
-        
+
         [HttpGet("search")]
         public async Task<ActionResult<IEnumerable<SearchResultDto>>> Search(string queryString)
         {
             queryString = queryString.Replace(@"%", "");
-            
+
             var user = await _unitOfWork.UserRepository.GetUserByUsernameAsync(User.GetUsername());
             // Get libraries user has access to
             var libraries = (await _unitOfWork.LibraryRepository.GetLibrariesForUserIdAsync(user.Id)).ToList();
-            
+
             if (!libraries.Any()) return BadRequest("User does not have access to any libraries");
 
             var series = await _unitOfWork.SeriesRepository.SearchSeries(libraries.Select(l => l.Id).ToArray(), queryString);

--- a/API/Data/LibraryRepository.cs
+++ b/API/Data/LibraryRepository.cs
@@ -21,7 +21,7 @@ namespace API.Data
             _context = context;
             _mapper = mapper;
         }
-        
+
         public void Add(Library library)
         {
             _context.Library.Add(library);
@@ -30,6 +30,11 @@ namespace API.Data
         public void Update(Library library)
         {
             _context.Entry(library).State = EntityState.Modified;
+        }
+
+        public void Delete(Library library)
+        {
+            _context.Library.Remove(library);
         }
 
         public async Task<IEnumerable<LibraryDto>> GetLibraryDtosForUsernameAsync(string userName)
@@ -43,7 +48,7 @@ namespace API.Data
                 .AsSingleQuery()
                 .ToListAsync();
         }
-        
+
         public async Task<IEnumerable<Library>> GetLibrariesAsync()
         {
             return await _context.Library
@@ -101,7 +106,7 @@ namespace API.Data
         /// <returns></returns>
         public async Task<Library> GetFullLibraryForIdAsync(int libraryId)
         {
-            
+
             return await _context.Library
                 .Where(x => x.Id == libraryId)
                 .Include(f => f.Folders)
@@ -114,7 +119,7 @@ namespace API.Data
                 .AsSplitQuery()
                 .SingleAsync();
         }
-        
+
         public async Task<bool> LibraryExists(string libraryName)
         {
             return await _context.Library
@@ -131,7 +136,7 @@ namespace API.Data
                 .ProjectTo<LibraryDto>(_mapper.ConfigurationProvider)
                 .ToListAsync();
         }
-        
-        
+
+
     }
 }

--- a/API/Data/LibraryRepository.cs
+++ b/API/Data/LibraryRepository.cs
@@ -120,6 +120,28 @@ namespace API.Data
                 .SingleAsync();
         }
 
+        /// <summary>
+        /// This is a heavy call, pulls all entities for a Library, except this version only grabs for one series id
+        /// </summary>
+        /// <param name="libraryId"></param>
+        /// <param name="seriesId"></param>
+        /// <returns></returns>
+        public async Task<Library> GetFullLibraryForIdAsync(int libraryId, int seriesId)
+        {
+
+            return await _context.Library
+                .Where(x => x.Id == libraryId)
+                .Include(f => f.Folders)
+                .Include(l => l.Series.Where(s => s.Id == seriesId))
+                .ThenInclude(s => s.Metadata)
+                .Include(l => l.Series.Where(s => s.Id == seriesId))
+                .ThenInclude(s => s.Volumes)
+                .ThenInclude(v => v.Chapters)
+                .ThenInclude(c => c.Files)
+                .AsSplitQuery()
+                .SingleAsync();
+        }
+
         public async Task<bool> LibraryExists(string libraryName)
         {
             return await _context.Library

--- a/API/Extensions/SeriesExtensions.cs
+++ b/API/Extensions/SeriesExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using API.Entities;
+using API.Parser;
 
 namespace API.Extensions
 {
@@ -16,6 +17,19 @@ namespace API.Extensions
         {
             return list.Any(name => Parser.Parser.Normalize(name) == series.NormalizedName || Parser.Parser.Normalize(name) == Parser.Parser.Normalize(series.Name)
                 || name == series.Name || name == series.LocalizedName || name == series.OriginalName  || Parser.Parser.Normalize(name) == Parser.Parser.Normalize(series.OriginalName));
+        }
+
+        /// <summary>
+        /// Checks against all the name variables of the Series if it matches the <see cref="ParserInfo"/>
+        /// </summary>
+        /// <param name="series"></param>
+        /// <param name="info"></param>
+        /// <returns></returns>
+        public static bool NameInParserInfo(this Series series, ParserInfo info)
+        {
+            if (info == null) return false;
+            return Parser.Parser.Normalize(info.Series) == series.NormalizedName || Parser.Parser.Normalize(info.Series) == Parser.Parser.Normalize(series.Name)
+                || info.Series == series.Name || info.Series == series.LocalizedName || info.Series == series.OriginalName  || Parser.Parser.Normalize(info.Series) == Parser.Parser.Normalize(series.OriginalName);
         }
     }
 }

--- a/API/Interfaces/ILibraryRepository.cs
+++ b/API/Interfaces/ILibraryRepository.cs
@@ -10,6 +10,7 @@ namespace API.Interfaces
     {
         void Add(Library library);
         void Update(Library library);
+        void Delete(Library library);
         Task<IEnumerable<LibraryDto>> GetLibraryDtosAsync();
         Task<bool> LibraryExists(string libraryName);
         Task<Library> GetLibraryForIdAsync(int libraryId);

--- a/API/Interfaces/ILibraryRepository.cs
+++ b/API/Interfaces/ILibraryRepository.cs
@@ -15,6 +15,7 @@ namespace API.Interfaces
         Task<bool> LibraryExists(string libraryName);
         Task<Library> GetLibraryForIdAsync(int libraryId);
         Task<Library> GetFullLibraryForIdAsync(int libraryId);
+        Task<Library> GetFullLibraryForIdAsync(int libraryId, int seriesId);
         Task<IEnumerable<LibraryDto>> GetLibraryDtosForUsernameAsync(string userName);
         Task<IEnumerable<Library>> GetLibrariesAsync();
         Task<bool> DeleteLibrary(int libraryId);

--- a/API/Interfaces/ITaskScheduler.cs
+++ b/API/Interfaces/ITaskScheduler.cs
@@ -11,6 +11,7 @@
         void RefreshMetadata(int libraryId, bool forceUpdate = true);
         void CleanupTemp();
         void RefreshSeriesMetadata(int libraryId, int seriesId);
+        void ScanSeries(int libraryId, int seriesId, bool forceUpdate = false);
         void ScheduleStatsTasks();
         void CancelStatsTasks();
     }

--- a/API/Interfaces/Services/IScannerService.cs
+++ b/API/Interfaces/Services/IScannerService.cs
@@ -1,4 +1,7 @@
 ﻿
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace API.Interfaces.Services
 {
     public interface IScannerService
@@ -11,5 +14,6 @@ namespace API.Interfaces.Services
         /// <param name="forceUpdate">Force overwriting for cover images</param>
         void ScanLibrary(int libraryId, bool forceUpdate);
         void ScanLibraries();
+        Task ScanSeries(int libraryId, int seriesId, bool forceUpdate, CancellationToken token);
     }
 }

--- a/API/Parser/Parser.cs
+++ b/API/Parser/Parser.cs
@@ -324,7 +324,7 @@ namespace API.Parser
                 RegexOptions.IgnoreCase | RegexOptions.Compiled),
             // Green Worldz - Chapter 027
             new Regex(
-                @"^(?!Vol)(?<Series>.*)\s?(?<!vol\. )\sChapter\s(?<Chapter>\d+(?:.\d+|-\d+)?)",
+                @"^(?!Vol)(?<Series>.*)\s?(?<!vol\. )\sChapter\s(?<Chapter>\d+(?:\.?[\d-])?)",
                 RegexOptions.IgnoreCase | RegexOptions.Compiled),
             // Hinowa ga CRUSH! 018 (2019) (Digital) (LuCaZ).cbz, Hinowa ga CRUSH! 018.5 (2019) (Digital) (LuCaZ).cbz
             new Regex(

--- a/API/Parser/Parser.cs
+++ b/API/Parser/Parser.cs
@@ -501,7 +501,7 @@ namespace API.Parser
         /// <param name="ret">Expects a non-null ParserInfo which this method will populate</param>
         public static void ParseFromFallbackFolders(string filePath, string rootPath, LibraryType type, ref ParserInfo ret)
         {
-          var fallbackFolders = DirectoryService.GetFoldersTillRoot(rootPath, Path.GetDirectoryName(filePath)).ToList();
+          var fallbackFolders = DirectoryService.GetFoldersTillRoot(rootPath, filePath).ToList();
             for (var i = 0; i < fallbackFolders.Count; i++)
             {
                 var folder = fallbackFolders[i];

--- a/API/Parser/Parser.cs
+++ b/API/Parser/Parser.cs
@@ -70,20 +70,23 @@ namespace API.Parser
                 RegexOptions.IgnoreCase | RegexOptions.Compiled),
             // Ichiban_Ushiro_no_Daimaou_v04_ch34_[VISCANS].zip, VanDread-v01-c01.zip
             new Regex(
-            @"(?<Series>.*)(\b|_)v(?<Volume>\d+-?\d*)( |_|-)",
+            @"(?<Series>.*)(\b|_)v(?<Volume>\d+-?\d*)(\s|_|-)",
             RegexOptions.IgnoreCase | RegexOptions.Compiled),
             // Gokukoku no Brynhildr - c001-008 (v01) [TrinityBAKumA], Black Bullet - v4 c17 [batoto]
             new Regex(
                 @"(?<Series>.*)( - )(?:v|vo|c)\d",
                 RegexOptions.IgnoreCase | RegexOptions.Compiled),
-            // [dmntsf.net] One Piece - Digital Colored Comics Vol. 20 Ch. 177 - 30 Million vs 81 Million.cbz
-            new Regex(
-                @"(?<Series>.*) (\b|_|-)(vol)\.?",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
-
             // Kedouin Makoto - Corpse Party Musume, Chapter 19 [Dametrans].zip
             new Regex(
                 @"(?<Series>.*)(?:, Chapter )(?<Chapter>\d+)",
+                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            // Please Go Home, Akutsu-San! - Chapter 038.5 - Volume Announcement.cbz
+            new Regex(
+                @"(?<Series>.*)(\s|_|-)(?:Chapter)(\s|_|-)(?<Chapter>\d+)",
+                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            // [dmntsf.net] One Piece - Digital Colored Comics Vol. 20 Ch. 177 - 30 Million vs 81 Million.cbz
+            new Regex(
+                @"(?<Series>.*) (\b|_|-)(vol)\.?",
                 RegexOptions.IgnoreCase | RegexOptions.Compiled),
             //Knights of Sidonia c000 (S2 LE BD Omake - BLAME!) [Habanero Scans]
             new Regex(

--- a/API/Services/DirectoryService.cs
+++ b/API/Services/DirectoryService.cs
@@ -41,7 +41,7 @@ namespace API.Services
        }
 
        /// <summary>
-       /// Returns a list of folders from end of fullPath to rootPath.
+       /// Returns a list of folders from end of fullPath to rootPath. If a file is passed at the end of the fullPath, it will be ignored.
        ///
        /// Example) (C:/Manga/, C:/Manga/Love Hina/Specials/Omake/) returns [Omake, Specials, Love Hina]
        /// </summary>
@@ -50,7 +50,8 @@ namespace API.Services
        /// <returns></returns>
        public static IEnumerable<string> GetFoldersTillRoot(string rootPath, string fullPath)
        {
-         var separator = Path.AltDirectorySeparatorChar;
+
+        var separator = Path.AltDirectorySeparatorChar;
           if (fullPath.Contains(Path.DirectorySeparatorChar))
           {
              fullPath = fullPath.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
@@ -62,13 +63,17 @@ namespace API.Services
           }
 
 
+
           var path = fullPath.EndsWith(separator) ? fullPath.Substring(0, fullPath.Length - 1) : fullPath;
           var root = rootPath.EndsWith(separator) ? rootPath.Substring(0, rootPath.Length - 1) : rootPath;
           var paths = new List<string>();
           while (Path.GetDirectoryName(path) != Path.GetDirectoryName(root))
           {
              var folder = new DirectoryInfo(path).Name;
-             paths.Add(folder);
+             if (Path.GetExtension(folder) == string.Empty)
+             {
+                 paths.Add(folder);
+             }
              path = path.Replace(separator + folder, string.Empty);
           }
 

--- a/API/Services/DirectoryService.cs
+++ b/API/Services/DirectoryService.cs
@@ -40,6 +40,7 @@ namespace API.Services
                 reSearchPattern.IsMatch(Path.GetExtension(file)));
        }
 
+
        /// <summary>
        /// Returns a list of folders from end of fullPath to rootPath. If a file is passed at the end of the fullPath, it will be ignored.
        ///
@@ -50,8 +51,7 @@ namespace API.Services
        /// <returns></returns>
        public static IEnumerable<string> GetFoldersTillRoot(string rootPath, string fullPath)
        {
-
-        var separator = Path.AltDirectorySeparatorChar;
+           var separator = Path.AltDirectorySeparatorChar;
           if (fullPath.Contains(Path.DirectorySeparatorChar))
           {
              fullPath = fullPath.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
@@ -67,13 +67,15 @@ namespace API.Services
           var path = fullPath.EndsWith(separator) ? fullPath.Substring(0, fullPath.Length - 1) : fullPath;
           var root = rootPath.EndsWith(separator) ? rootPath.Substring(0, rootPath.Length - 1) : rootPath;
           var paths = new List<string>();
+          // If a file is at the end of the path, remove it before we start processing folders
+          if (Path.GetExtension(path) != string.Empty)
+          {
+             path = path.Substring(0, path.LastIndexOf(separator));
+          }
           while (Path.GetDirectoryName(path) != Path.GetDirectoryName(root))
           {
              var folder = new DirectoryInfo(path).Name;
-             if (Path.GetExtension(folder) == string.Empty)
-             {
-                 paths.Add(folder);
-             }
+             paths.Add(folder);
              path = path.Replace(separator + folder, string.Empty);
           }
 

--- a/API/Services/DirectoryService.cs
+++ b/API/Services/DirectoryService.cs
@@ -72,11 +72,12 @@ namespace API.Services
           {
              path = path.Substring(0, path.LastIndexOf(separator));
           }
+
           while (Path.GetDirectoryName(path) != Path.GetDirectoryName(root))
           {
              var folder = new DirectoryInfo(path).Name;
              paths.Add(folder);
-             path = path.Replace(separator + folder, string.Empty);
+             path = path.Substring(0, path.LastIndexOf(separator));
           }
 
           return paths;

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -99,22 +99,21 @@ namespace API.Services.Tasks
              foreach (var file in files)
              {
                 // TODO: Validate this on Robbie's filesystem
-                if (file.FilePath.Contains(folder.Path))
-                {
-                   var parts = DirectoryService.GetFoldersTillRoot(folder.Path, file.FilePath).ToList();
-                   if (parts.Count == 0)
-                   {
-                      // Break from all loops, we done, just scan folder.Path (library root)
-                      dirs.Add(folder.Path, string.Empty);
-                      stopLookingForDirectories = true;
-                      break;
-                   }
+                if (!file.FilePath.Contains(folder.Path)) continue;
 
-                   var fullPath = Path.Join(folder.Path, parts.Last());
-                   if (!dirs.ContainsKey(fullPath))
-                   {
-                      dirs.Add(fullPath, string.Empty);
-                   }
+                var parts = DirectoryService.GetFoldersTillRoot(folder.Path, file.FilePath).ToList();
+                if (parts.Count == 0)
+                {
+                   // Break from all loops, we done, just scan folder.Path (library root)
+                   dirs.Add(folder.Path, string.Empty);
+                   stopLookingForDirectories = true;
+                   break;
+                }
+
+                var fullPath = Path.Join(folder.Path, parts.Last());
+                if (!dirs.ContainsKey(fullPath))
+                {
+                   dirs.Add(fullPath, string.Empty);
                 }
              }
           }

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -98,7 +98,6 @@ namespace API.Services.Tasks
              if (stopLookingForDirectories) break;
              foreach (var file in files)
              {
-                // TODO: Validate this on Robbie's filesystem
                 if (!file.FilePath.Contains(folder.Path)) continue;
 
                 var parts = DirectoryService.GetFoldersTillRoot(folder.Path, file.FilePath).ToList();

--- a/Kavita.Common/Kavita.Common.csproj
+++ b/Kavita.Common/Kavita.Common.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
-      <PackageReference Include="Sentry" Version="3.3.4" />
+      <PackageReference Include="Sentry" Version="3.7.0" />
     </ItemGroup>
 
 

--- a/UI/Web/src/app/_services/action-factory.service.ts
+++ b/UI/Web/src/app/_services/action-factory.service.ts
@@ -63,7 +63,7 @@ export class ActionFactoryService {
 
         this.seriesActions.push({
           action: Action.ScanLibrary,
-          title: 'Scan Library',
+          title: 'Scan Series',
           callback: this.dummyCallback
         });
 

--- a/UI/Web/src/app/_services/action.service.ts
+++ b/UI/Web/src/app/_services/action.service.ts
@@ -106,7 +106,7 @@ export class ActionService implements OnDestroy {
    * @param callback Optional callback to perform actions after API completes
    */
   scanSeries(series: Series, callback?: SeriesActionCallback) {
-    this.libraryService.scan(series.libraryId).pipe(take(1)).subscribe((res: any) => {
+    this.seriesService.scan(series.libraryId, series.id).pipe(take(1)).subscribe((res: any) => {
       this.toastr.success('Scan started for ' + series.name);
       if (callback) {
         callback(series);

--- a/UI/Web/src/app/_services/series.service.ts
+++ b/UI/Web/src/app/_services/series.service.ts
@@ -117,6 +117,10 @@ export class SeriesService {
     return this.httpClient.post(this.baseUrl + 'series/refresh-metadata', {libraryId: series.libraryId, seriesId: series.id});
   }
 
+  scan(libraryId: number, seriesId: number) {
+    return this.httpClient.post(this.baseUrl + 'series/scan', {libraryId: libraryId, seriesId: seriesId});
+  }
+
   getMetadata(seriesId: number) {
     return this.httpClient.get<SeriesMetadata>(this.baseUrl + 'series/metadata?seriesId=' + seriesId).pipe(map(items => {
       items?.tags.forEach(tag => tag.coverImage = this.imageService.getCollectionCoverImage(tag.id));

--- a/UI/Web/src/app/shared/series-card/series-card.component.ts
+++ b/UI/Web/src/app/shared/series-card/series-card.component.ts
@@ -97,7 +97,7 @@ export class SeriesCardComponent implements OnInit, OnChanges {
   }
 
   scanLibrary(series: Series) {
-    this.libraryService.scan(series.libraryId).subscribe((res: any) => {
+    this.seriesService.scan(series.libraryId, series.id).subscribe((res: any) => {
       this.toastr.success('Scan started for ' + series.name);
     });
   }


### PR DESCRIPTION
* Changed: From the series actionable menu, instead of scan library, which would kick off a filesystem scan on the library the series belonged to, instead we have "scan series" which will scan the folders represented by that series. If that series has files in the root of the library, the library root is scanned, but only said series files will be processed. This can make a refresh occur in under 500 ms (Fixes #371)
* Fixed: Fixed a bad parsing case for "Series Name - Vol.01 Chapter 029 8 Years Ago" where somehow the chapter would parse as "029 8", thus making the file a special rather than chapter 29.
* [x] Validate on Google Drive setup that Scan Series works

