### PR TITLE
removing bump-version

### DIFF
--- a/.github/workflows/nightly-docker.yml
+++ b/.github/workflows/nightly-docker.yml
@@ -31,12 +31,6 @@ jobs:
           
           cd ../ || exit
 
-      - name: Bump versions
-        uses: SiqiLu/dotnet-bump-version@master
-        with:
-          version_files: "Kavita.Common/Kavita.Common.csproj"
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Get csproj Version
         uses: naminodarie/get-net-sdk-project-versions-action@v1
         id: get-version


### PR DESCRIPTION
Github actions are not allowed to push to protected branches. Because of this we must remove this action from the workflow.