### PR TITLE
Fixed: Series detail spacing issue while keeping a restriction on height for webbtoons

### DIFF
--- a/UI/Web/src/app/series-detail/series-detail.component.html
+++ b/UI/Web/src/app/series-detail/series-detail.component.html
@@ -1,6 +1,6 @@
 <div class="container-fluid" *ngIf="series !== undefined" style="padding-top: 10px">
     <div class="row mb-3">
-        <div class="col-md-2 col-xs-4 col-sm-6 image-center">
+        <div class="col-md-2 col-xs-4 col-sm-6">
             <img class="poster" [lazyLoad]="imageService.getSeriesCoverImage(series.id)" [defaultImage]="imageService.placeholderImage">
         </div>
         <div class="col-md-10 col-xs-8 col-sm-6">

--- a/UI/Web/src/app/series-detail/series-detail.component.scss
+++ b/UI/Web/src/app/series-detail/series-detail.component.scss
@@ -6,12 +6,9 @@
 
 }
 
-.image-center {
-  text-align: center;
-}
-
 .poster {
-    max-height: 230px;
+    width: 100%;
+    max-height: 481px;
 }
 
 .rating-star {


### PR DESCRIPTION
## Fixed:
- Fixed: When the series detail thumbnail was too long it would push down the Volumes/Specials selection.

## Changed:
- Modified: increased the max-height to incorporate a percentage width for responsive scaling.