### PR TITLE
Feature/performance pdf

### DIFF
--- a/API/DTOs/SearchResultDto.cs
+++ b/API/DTOs/SearchResultDto.cs
@@ -1,4 +1,6 @@
-﻿namespace API.DTOs
+﻿using API.Entities.Enums;
+
+namespace API.DTOs
 {
     public class SearchResultDto
     {
@@ -7,6 +9,7 @@
         public string OriginalName { get; init; }
         public string SortName { get; init; }
         public string LocalizedName { get; init; }
+        public MangaFormat Format { get; init; }
 
         // Grouping information
         public string LibraryName { get; set; }

--- a/API/Data/SeriesRepository.cs
+++ b/API/Data/SeriesRepository.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using API.Comparators;

--- a/API/Extensions/SeriesExtensions.cs
+++ b/API/Extensions/SeriesExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using API.Entities;
-using API.Entities.Enums;
 using API.Parser;
 using API.Services.Tasks.Scanner;
 

--- a/API/Extensions/VolumeListExtensions.cs
+++ b/API/Extensions/VolumeListExtensions.cs
@@ -19,12 +19,11 @@ namespace API.Extensions
         /// If there are both specials and non-specials, then the first non-special will be returned.
         /// </summary>
         /// <param name="volumes"></param>
-        /// <param name="libraryType"></param>
+        /// <param name="seriesFormat"></param>
         /// <returns></returns>
-        public static Volume GetCoverImage(this IList<Volume> volumes, LibraryType libraryType)
+        public static Volume GetCoverImage(this IList<Volume> volumes, MangaFormat seriesFormat)
         {
-            // TODO: Refactor this to use MangaFormat Epub instead
-            if (libraryType == LibraryType.Book)
+            if (seriesFormat is MangaFormat.Epub or MangaFormat.Pdf)
             {
                 return volumes.OrderBy(x => x.Number).FirstOrDefault();
             }

--- a/API/Parser/Parser.cs
+++ b/API/Parser/Parser.cs
@@ -11,24 +11,38 @@ namespace API.Parser
     {
         public const string DefaultChapter = "0";
         public const string DefaultVolume = "0";
+        private static readonly TimeSpan RegexTimeout = TimeSpan.FromMilliseconds(250);
 
         public const string ImageFileExtensions = @"^(\.png|\.jpeg|\.jpg)";
         public const string ArchiveFileExtensions = @"\.cbz|\.zip|\.rar|\.cbr|\.tar.gz|\.7zip|\.7z|\.cb7|\.cbt";
         public const string BookFileExtensions = @"\.epub|\.pdf";
-        public const string MangaComicFileExtensions = ArchiveFileExtensions + "|" + ImageFileExtensions + @"|\.pdf";
 
         public const string SupportedExtensions =
             ArchiveFileExtensions + "|" + ImageFileExtensions + "|" + BookFileExtensions;
 
-        public static readonly Regex FontSrcUrlRegex = new Regex(@"(src:url\(.{1})" + "([^\"']*)" + @"(.{1}\))", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-        public static readonly Regex CssImportUrlRegex = new Regex("(@import\\s[\"|'])(?<Filename>[\\w\\d/\\._-]+)([\"|'];?)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        public static readonly Regex FontSrcUrlRegex = new Regex(@"(src:url\(.{1})" + "([^\"']*)" + @"(.{1}\))",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout);
+        public static readonly Regex CssImportUrlRegex = new Regex("(@import\\s[\"|'])(?<Filename>[\\w\\d/\\._-]+)([\"|'];?)",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout);
 
         private static readonly string XmlRegexExtensions = @"\.xml";
-        private static readonly Regex ImageRegex = new Regex(ImageFileExtensions, RegexOptions.IgnoreCase | RegexOptions.Compiled);
-        private static readonly Regex ArchiveFileRegex = new Regex(ArchiveFileExtensions, RegexOptions.IgnoreCase | RegexOptions.Compiled);
-        private static readonly Regex XmlRegex = new Regex(XmlRegexExtensions, RegexOptions.IgnoreCase | RegexOptions.Compiled);
-        private static readonly Regex BookFileRegex = new Regex(BookFileExtensions, RegexOptions.IgnoreCase | RegexOptions.Compiled);
-        private static readonly Regex CoverImageRegex = new Regex(@"(?<![[a-z]\d])(?:!?)(cover|folder)(?![\w\d])", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex ImageRegex = new Regex(ImageFileExtensions,
+            RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout);
+        private static readonly Regex ArchiveFileRegex = new Regex(ArchiveFileExtensions,
+            RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout);
+        private static readonly Regex XmlRegex = new Regex(XmlRegexExtensions,
+            RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout);
+        private static readonly Regex BookFileRegex = new Regex(BookFileExtensions,
+            RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout);
+        private static readonly Regex CoverImageRegex = new Regex(@"(?<![[a-z]\d])(?:!?)(cover|folder)(?![\w\d])",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout);
 
 
         private static readonly Regex[] MangaVolumeRegex = new[]
@@ -36,31 +50,38 @@ namespace API.Parser
             // Dance in the Vampire Bund v16-17
             new Regex(
                 @"(?<Series>.*)(\b|_)v(?<Volume>\d+-?\d+)( |_)",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // NEEDLESS_Vol.4_-Simeon_6_v2[SugoiSugoi].rar
             new Regex(
                 @"(?<Series>.*)(\b|_)(?!\[)(vol\.?)(?<Volume>\d+(-\d+)?)(?!\])",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // Historys Strongest Disciple Kenichi_v11_c90-98.zip or Dance in the Vampire Bund v16-17
             new Regex(
                 @"(?<Series>.*)(\b|_)(?!\[)v(?<Volume>\d+(-\d+)?)(?!\])",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // Kodomo no Jikan vol. 10
             new Regex(
                 @"(?<Series>.*)(\b|_)(vol\.? ?)(?<Volume>\d+(-\d+)?)",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // Killing Bites Vol. 0001 Ch. 0001 - Galactica Scanlations (gb)
             new Regex(
                 @"(vol\.? ?)(?<Volume>\d+)",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // Tonikaku Cawaii [Volume 11].cbz
             new Regex(
                 @"(volume )(?<Volume>\d+)",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // Tower Of God S01 014 (CBT) (digital).cbz
             new Regex(
                 @"(?<Series>.*)(\b|_|)(S(?<Volume>\d+))",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
         };
 
         private static readonly Regex[] MangaSeriesRegex = new[]
@@ -68,130 +89,161 @@ namespace API.Parser
             // Grand Blue Dreaming - SP02
             new Regex(
                 @"(?<Series>.*)(\b|_|-|\s)(?:sp)\d",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // [SugoiSugoi]_NEEDLESS_Vol.2_-_Disk_The_Informant_5_[ENG].rar, Yuusha Ga Shinda! - Vol.tbd Chapter 27.001 V2 Infection ①.cbz
             new Regex(
                 @"^(?<Series>.*)( |_)Vol\.?(\d+|tbd)",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // Ichiban_Ushiro_no_Daimaou_v04_ch34_[VISCANS].zip, VanDread-v01-c01.zip
             new Regex(
             @"(?<Series>.*)(\b|_)v(?<Volume>\d+-?\d*)(\s|_|-)",
-            RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // Gokukoku no Brynhildr - c001-008 (v01) [TrinityBAKumA], Black Bullet - v4 c17 [batoto]
             new Regex(
                 @"(?<Series>.*)( - )(?:v|vo|c)\d",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // Kedouin Makoto - Corpse Party Musume, Chapter 19 [Dametrans].zip
             new Regex(
                 @"(?<Series>.*)(?:, Chapter )(?<Chapter>\d+)",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // Mad Chimera World - Volume 005 - Chapter 026.cbz (couldn't figure out how to get Volume negative lookaround working on below regex)
             new Regex(
                 @"(?<Series>.*)(\s|_|-)(?:Volume(\s|_|-)+\d+)(\s|_|-)+(?:Chapter)(\s|_|-)(?<Chapter>\d+)",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // Please Go Home, Akutsu-San! - Chapter 038.5 - Volume Announcement.cbz
             new Regex(
                 @"(?<Series>.*)(\s|_|-)(?!Vol)(\s|_|-)(?:Chapter)(\s|_|-)(?<Chapter>\d+)",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // [dmntsf.net] One Piece - Digital Colored Comics Vol. 20 Ch. 177 - 30 Million vs 81 Million.cbz
             new Regex(
                 @"(?<Series>.*) (\b|_|-)(vol)\.?",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             //Knights of Sidonia c000 (S2 LE BD Omake - BLAME!) [Habanero Scans]
             new Regex(
                 @"(?<Series>.*)(\bc\d+\b)",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             //Tonikaku Cawaii [Volume 11], Darling in the FranXX - Volume 01.cbz
             new Regex(
                 @"(?<Series>.*)(?: _|-|\[|\()\s?vol(ume)?",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // Momo The Blood Taker - Chapter 027 Violent Emotion.cbz, Grand Blue Dreaming - SP02 Extra (2019) (Digital) (danke-Empire).cbz
             new Regex(
                 @"(?<Series>.*)(\b|_|-|\s)(?:(chapter(\b|_|-|\s))|sp)\d",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // Historys Strongest Disciple Kenichi_v11_c90-98.zip, Killing Bites Vol. 0001 Ch. 0001 - Galactica Scanlations (gb)
             new Regex(
                 @"(?<Series>.*) (\b|_|-)(v|ch\.?|c)\d+",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             //Ichinensei_ni_Nacchattara_v01_ch01_[Taruby]_v1.1.zip must be before [Suihei Kiki]_Kasumi_Otoko_no_Ko_[Taruby]_v1.1.zip
             // due to duplicate version identifiers in file.
             new Regex(
                 @"(?<Series>.*)(v|s)\d+(-\d+)?(_|\s)",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             //[Suihei Kiki]_Kasumi_Otoko_no_Ko_[Taruby]_v1.1.zip
             new Regex(
                 @"(?<Series>.*)(v|s)\d+(-\d+)?",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // Hinowa ga CRUSH! 018 (2019) (Digital) (LuCaZ).cbz
             new Regex(
                 @"(?<Series>.*) (?<Chapter>\d+) (?:\(\d{4}\)) ",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // Goblin Slayer - Brand New Day 006.5 (2019) (Digital) (danke-Empire)
             new Regex(
                 @"(?<Series>.*) (?<Chapter>\d+(?:.\d+|-\d+)?) \(\d{4}\)",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // Noblesse - Episode 429 (74 Pages).7z
             new Regex(
                 @"(?<Series>.*)(\s|_)(?:Episode|Ep\.?)(\s|_)(?<Chapter>\d+(?:.\d+|-\d+)?)",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // Akame ga KILL! ZERO (2016-2019) (Digital) (LuCaZ)
             new Regex(
                 @"(?<Series>.*)\(\d",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // Tonikaku Kawaii (Ch 59-67) (Ongoing)
             new Regex(
                 @"(?<Series>.*)(\s|_)\((c\s|ch\s|chapter\s)",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // Black Bullet (This is very loose, keep towards bottom)
             new Regex(
                 @"(?<Series>.*)(_)(v|vo|c|volume)( |_)\d+",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // [Hidoi]_Amaenaideyo_MS_vol01_chp02.rar
             new Regex(
                 @"(?<Series>.*)( |_)(vol\d+)?( |_)(?:Chp\.? ?\d+)",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // Mahoutsukai to Deshi no Futekisetsu na Kankei Chp. 1
             new Regex(
                 @"(?<Series>.*)( |_)(?:Chp.? ?\d+)",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // Corpse Party -The Anthology- Sachikos game of love Hysteric Birthday 2U Chapter 01
             new Regex(
                 @"^(?!Vol)(?<Series>.*)( |_)Chapter( |_)(\d+)",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
 
             // Fullmetal Alchemist chapters 101-108.cbz
             new Regex(
                 @"^(?!vol)(?<Series>.*)( |_)(chapters( |_)?)\d+-?\d*",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // Umineko no Naku Koro ni - Episode 1 - Legend of the Golden Witch #1
             new Regex(
                 @"^(?!Vol\.?)(?<Series>.*)( |_|-)(?<!-)(episode|chapter|(ch\.?) ?)\d+-?\d*",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
 
             // Baketeriya ch01-05.zip
             new Regex(
                 @"^(?!Vol)(?<Series>.*)ch\d+-?\d?",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // Magi - Ch.252-005.cbz
             new Regex(
                 @"(?<Series>.*)( ?- ?)Ch\.\d+-?\d*",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // [BAA]_Darker_than_Black_Omake-1.zip
             new Regex(
                 @"^(?!Vol)(?<Series>.*)(-)\d+-?\d*", // This catches a lot of stuff ^(?!Vol)(?<Series>.*)( |_)(\d+)
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // Kodoja #001 (March 2016)
             new Regex(
                 @"(?<Series>.*)(\s|_|-)#",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // Baketeriya ch01-05.zip, Akiiro Bousou Biyori - 01.jpg, Beelzebub_172_RHS.zip, Cynthia the Mission 29.rar
             new Regex(
                 @"^(?!Vol\.?)(?<Series>.*)( |_|-)(?<!-)(ch)?\d+-?\d*",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // [BAA]_Darker_than_Black_c1 (This is very greedy, make sure it's close to last)
             new Regex(
                 @"^(?!Vol)(?<Series>.*)( |_|-)(ch?)\d+",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
         };
 
         private static readonly Regex[] ComicSeriesRegex = new[]
@@ -199,51 +251,63 @@ namespace API.Parser
             // Invincible Vol 01 Family matters (2005) (Digital)
             new Regex(
                 @"(?<Series>.*)(\b|_)(vol\.?)( |_)(?<Volume>\d+(-\d+)?)",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // 04 - Asterix the Gladiator (1964) (Digital-Empire) (WebP by Doc MaKS)
             new Regex(
             @"^(?<Volume>\d+) (- |_)?(?<Series>.*(\d{4})?)( |_)(\(|\d+)",
-            RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // 01 Spider-Man & Wolverine 01.cbr
             new Regex(
             @"^(?<Volume>\d+) (?:- )?(?<Series>.*) (\d+)?",
-            RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // Batman & Wildcat (1 of 3)
             new Regex(
             @"(?<Series>.*(\d{4})?)( |_)(?:\((?<Volume>\d+) of \d+)",
-            RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // Teen Titans v1 001 (1966-02) (digital) (OkC.O.M.P.U.T.O.-Novus)
             new Regex(
                 @"^(?<Series>.*)(?: |_)v\d+",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // Amazing Man Comics chapter 25
             new Regex(
                 @"^(?<Series>.*)(?: |_)c(hapter) \d+",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // Amazing Man Comics issue #25
             new Regex(
                 @"^(?<Series>.*)(?: |_)i(ssue) #\d+",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // Batman & Catwoman - Trail of the Gun 01, Batman & Grendel (1996) 01 - Devil's Bones, Teen Titans v1 001 (1966-02) (digital) (OkC.O.M.P.U.T.O.-Novus)
             new Regex(
                 @"^(?<Series>.*)(?: \d+)",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // Batman & Robin the Teen Wonder #0
             new Regex(
                 @"^(?<Series>.*)(?: |_)#\d+",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // Scott Pilgrim 02 - Scott Pilgrim vs. The World (2005)
             new Regex(
                 @"^(?<Series>.*)(?: |_)(?<Volume>\d+)",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // The First Asterix Frieze (WebP by Doc MaKS)
             new Regex(
                 @"^(?<Series>.*)(?: |_)(?!\(\d{4}|\d{4}-\d{2}\))\(",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // MUST BE LAST: Batman & Daredevil - King of New York
             new Regex(
                 @"^(?<Series>.*)",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
         };
 
         private static readonly Regex[] ComicVolumeRegex = new[]
@@ -251,31 +315,38 @@ namespace API.Parser
             // 04 - Asterix the Gladiator (1964) (Digital-Empire) (WebP by Doc MaKS)
             new Regex(
                 @"^(?<Volume>\d+) (- |_)?(?<Series>.*(\d{4})?)( |_)(\(|\d+)",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // 01 Spider-Man & Wolverine 01.cbr
             new Regex(
                 @"^(?<Volume>\d+) (?:- )?(?<Series>.*) (\d+)?",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // Batman & Wildcat (1 of 3)
             new Regex(
                 @"(?<Series>.*(\d{4})?)( |_)(?:\((?<Chapter>\d+) of \d+)",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // Teen Titans v1 001 (1966-02) (digital) (OkC.O.M.P.U.T.O.-Novus)
             new Regex(
                 @"^(?<Series>.*)(?: |_)v(?<Volume>\d+)",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // Scott Pilgrim 02 - Scott Pilgrim vs. The World (2005)
             new Regex(
                 @"^(?<Series>.*)(?<!c(hapter)|i(ssue))(?<!of)(?: |_)(?<!of )(?<Volume>\d+)",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // Batman & Catwoman - Trail of the Gun 01, Batman & Grendel (1996) 01 - Devil's Bones, Teen Titans v1 001 (1966-02) (digital) (OkC.O.M.P.U.T.O.-Novus)
             new Regex(
                 @"^(?<Series>.*)(?<!c(hapter)|i(ssue))(?<!of)(?: (?<Volume>\d+))",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // Batman & Robin the Teen Wonder #0
             new Regex(
                 @"^(?<Series>.*)(?: |_)#(?<Volume>\d+)",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
         };
 
         private static readonly Regex[] ComicChapterRegex = new[]
@@ -283,38 +354,46 @@ namespace API.Parser
           // Batman & Wildcat (1 of 3)
             new Regex(
                 @"(?<Series>.*(\d{4})?)( |_)(?:\((?<Chapter>\d+) of \d+)",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // Teen Titans v1 001 (1966-02) (digital) (OkC.O.M.P.U.T.O.-Novus)
             new Regex(
                 @"^(?<Series>.*)(?: |_)v(?<Volume>\d+)(?: |_)(c? ?)(?<Chapter>(\d+(\.\d)?)-?(\d+(\.\d)?)?)(c? ?)",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // Batman & Catwoman - Trail of the Gun 01, Batman & Grendel (1996) 01 - Devil's Bones, Teen Titans v1 001 (1966-02) (digital) (OkC.O.M.P.U.T.O.-Novus)
             new Regex(
                 @"^(?<Series>.*)(?: (?<Volume>\d+))",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // Batman & Robin the Teen Wonder #0
             new Regex(
                 @"^(?<Series>.*)(?: |_)#(?<Volume>\d+)",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // Invincible 070.5 - Invincible Returns 1 (2010) (digital) (Minutemen-InnerDemons).cbr
             new Regex(
                 @"^(?<Series>.*)(?: |_)(c? ?)(?<Chapter>(\d+(\.\d)?)-?(\d+(\.\d)?)?)(c? ?)-",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // Amazing Man Comics chapter 25
             new Regex(
                 @"^(?!Vol)(?<Series>.*)( |_)c(hapter)( |_)(?<Chapter>\d*)",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // Amazing Man Comics issue #25
             new Regex(
                 @"^(?!Vol)(?<Series>.*)( |_)i(ssue)( |_) #(?<Chapter>\d*)",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
         };
 
         private static readonly Regex[] ReleaseGroupRegex = new[]
         {
             // [TrinityBAKumA Finella&anon], [BAA]_, [SlowManga&OverloadScans], [batoto]
             new Regex(@"(?:\[(?<subgroup>(?!\s).+?(?<!\s))\](?:_|-|\s|\.)?)",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // (Shadowcat-Empire),
             // new Regex(@"(?:\[(?<subgroup>(?!\s).+?(?<!\s))\](?:_|-|\s|\.)?)",
             //     RegexOptions.IgnoreCase | RegexOptions.Compiled),
@@ -325,62 +404,76 @@ namespace API.Parser
             // Historys Strongest Disciple Kenichi_v11_c90-98.zip, ...c90.5-100.5
             new Regex(
                 @"(\b|_)(c|ch)(\.?\s?)(?<Chapter>(\d+(\.\d)?)-?(\d+(\.\d)?)?)",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // [Suihei Kiki]_Kasumi_Otoko_no_Ko_[Taruby]_v1.1.zip
             new Regex(
                 @"v\d+\.(?<Chapter>\d+(?:.\d+|-\d+)?)",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // Umineko no Naku Koro ni - Episode 3 - Banquet of the Golden Witch #02.cbz (Rare case, if causes issue remove)
             new Regex(
                 @"^(?<Series>.*)(?: |_)#(?<Chapter>\d+)",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // Green Worldz - Chapter 027
             new Regex(
                 @"^(?!Vol)(?<Series>.*)\s?(?<!vol\. )\sChapter\s(?<Chapter>\d+(?:\.?[\d-])?)",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // Hinowa ga CRUSH! 018 (2019) (Digital) (LuCaZ).cbz, Hinowa ga CRUSH! 018.5 (2019) (Digital) (LuCaZ).cbz
             new Regex(
                 @"^(?!Vol)(?<Series>.*)\s(?<!vol\. )(?<Chapter>\d+(?:.\d+|-\d+)?)(?:\s\(\d{4}\))?(\b|_|-)",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // Tower Of God S01 014 (CBT) (digital).cbz
             new Regex(
                 @"(?<Series>.*)\sS(?<Volume>\d+)\s(?<Chapter>\d+(?:.\d+|-\d+)?)",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // Beelzebub_01_[Noodles].zip, Beelzebub_153b_RHS.zip
             new Regex(
                 @"^((?!v|vo|vol|Volume).)*(\s|_)(?<Chapter>\.?\d+(?:.\d+|-\d+)?)(?<ChapterPart>b)?(\s|_|\[|\()",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // Yumekui-Merry_DKThias_Chapter21.zip
             new Regex(
                 @"Chapter(?<Chapter>\d+(-\d+)?)", //(?:.\d+|-\d+)?
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // [Hidoi]_Amaenaideyo_MS_vol01_chp02.rar
             new Regex(
                 @"(?<Series>.*)(\s|_)(vol\d+)?(\s|_)Chp\.? ?(?<Chapter>\d+)",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // Vol 1 Chapter 2
             new Regex(
               @"(?<Volume>((vol|volume|v))?(\s|_)?\.?\d+)(\s|_)(Chp|Chapter)\.?(\s|_)?(?<Chapter>\d+)",
-              RegexOptions.IgnoreCase | RegexOptions.Compiled),
+              RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
 
         };
         private static readonly Regex[] MangaEditionRegex = {
             // Tenjo Tenge {Full Contact Edition} v01 (2011) (Digital) (ASTC).cbz
             new Regex(
                 @"(?<Edition>({|\(|\[).* Edition(}|\)|\]))",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // Tenjo Tenge {Full Contact Edition} v01 (2011) (Digital) (ASTC).cbz
             new Regex(
                 @"(\b|_)(?<Edition>Omnibus(( |_)?Edition)?)(\b|_)?",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // To Love Ru v01 Uncensored (Ch.001-007)
             new Regex(
                 @"(\b|_)(?<Edition>Uncensored)(\b|_)",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // AKIRA - c003 (v01) [Full Color] [Darkhorse].cbz
             new Regex(
                 @"(\b|_)(?<Edition>Full(?: |_)Color)(\b|_)?",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
         };
 
         private static readonly Regex[] CleanupRegex =
@@ -388,15 +481,18 @@ namespace API.Parser
             // (), {}, []
             new Regex(
                 @"(?<Cleanup>(\{\}|\[\]|\(\)))",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // (Complete)
             new Regex(
                 @"(?<Cleanup>(\{Complete\}|\[Complete\]|\(Complete\)))",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // Anything in parenthesis
             new Regex(
                 @"\(.*\)",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
         };
 
         private static readonly Regex[] MangaSpecialRegex =
@@ -404,7 +500,8 @@ namespace API.Parser
             // All Keywords, does not account for checking if contains volume/chapter identification. Parser.Parse() will handle.
             new Regex(
                 @"(?<Special>Specials?|OneShot|One\-Shot|Omake|Extra( Chapter)?|Art Collection|Side( |_)Stories|Bonus)",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
         };
 
         // If SP\d+ is in the filename, we force treat it as a special regardless if volume or chapter might have been found.

--- a/API/Services/ArchiveService.cs
+++ b/API/Services/ArchiveService.cs
@@ -387,11 +387,10 @@ namespace API.Services
             if (!archive.HasFiles() && !needsFlattening) return;
 
             archive.ExtractToDirectory(extractPath, true);
-            if (needsFlattening)
-            {
-                _logger.LogDebug("Extracted archive is nested in root folder, flattening...");
-                new DirectoryInfo(extractPath).Flatten();
-            }
+            if (!needsFlattening) return;
+
+            _logger.LogDebug("Extracted archive is nested in root folder, flattening...");
+            new DirectoryInfo(extractPath).Flatten();
         }
 
         /// <summary>

--- a/API/Services/MetadataService.cs
+++ b/API/Services/MetadataService.cs
@@ -95,7 +95,7 @@ namespace API.Services
             if (ShouldFindCoverImage(series.CoverImage, forceUpdate))
             {
                 series.Volumes ??= new List<Volume>();
-                var firstCover = series.Volumes.GetCoverImage(series.Library.Type);
+                var firstCover = series.Volumes.GetCoverImage(series.Format);
                 byte[] coverImage = null;
                 if (firstCover == null && series.Volumes.Any())
                 {

--- a/UI/Web/src/app/_models/search-result.ts
+++ b/UI/Web/src/app/_models/search-result.ts
@@ -1,3 +1,5 @@
+import { MangaFormat } from "./manga-format";
+
 export interface SearchResult {
     seriesId: number;
     libraryId: number;
@@ -6,4 +8,5 @@ export interface SearchResult {
     originalName: string;
     sortName: string;
     coverImage: string; // byte64 encoded
+    format: MangaFormat;
 }

--- a/UI/Web/src/app/_services/server.service.ts
+++ b/UI/Web/src/app/_services/server.service.ts
@@ -16,10 +16,6 @@ export class ServerService {
     return this.httpClient.post(this.baseUrl + 'server/restart', {});
   }
 
-  fetchLogs() {
-    return this.httpClient.get(this.baseUrl + 'server/logs', {responseType: 'blob' as 'text'});
-  }
-
   getServerInfo() {
     return this.httpClient.get<ServerInfo>(this.baseUrl + 'server/server-info');
   }

--- a/UI/Web/src/app/admin/dashboard/dashboard.component.ts
+++ b/UI/Web/src/app/admin/dashboard/dashboard.component.ts
@@ -4,6 +4,7 @@ import { ToastrService } from 'ngx-toastr';
 import { ServerService } from 'src/app/_services/server.service';
 import { saveAs } from 'file-saver';
 import { Title } from '@angular/platform-browser';
+import { DownloadService } from 'src/app/shared/_services/download.service';
 
 
 
@@ -23,7 +24,8 @@ export class DashboardComponent implements OnInit {
   counter = this.tabs.length + 1;
   active = this.tabs[0];
 
-  constructor(public route: ActivatedRoute, private serverService: ServerService, private toastr: ToastrService, private titleService: Title) {
+  constructor(public route: ActivatedRoute, private serverService: ServerService, 
+    private toastr: ToastrService, private titleService: Title, private downloadService: DownloadService) {
     this.route.fragment.subscribe(frag => {
       const tab = this.tabs.filter(item => item.fragment === frag);
       if (tab.length > 0) {
@@ -46,10 +48,7 @@ export class DashboardComponent implements OnInit {
   }
 
   fetchLogs() {
-    this.serverService.fetchLogs().subscribe(res => {
-      const blob = new Blob([res], {type: 'text/plain;charset=utf-8'});
-      saveAs(blob, 'kavita.zip');
-    });
+    this.downloadService.downloadLogs();
   }
 
 }

--- a/UI/Web/src/app/admin/manage-settings/manage-settings.component.scss
+++ b/UI/Web/src/app/admin/manage-settings/manage-settings.component.scss
@@ -1,11 +1,8 @@
-@import '../../../assets/themes/dark.scss';
-
 .accent {
     font-style: italic;
     font-size: 0.7rem;
-    background-color: $dark-form-background;
+    background-color: lightgray;
     padding: 10px;
-    color: lightgray;
+    color: black;
     border-radius: 6px;
-    box-shadow: inset 0px 0px 8px 1px $dark-form-background
 }

--- a/UI/Web/src/app/nav-header/nav-header.component.html
+++ b/UI/Web/src/app/nav-header/nav-header.component.html
@@ -34,6 +34,7 @@
                         <img class="mr-3 search-result" src="{{imageService.getSeriesCoverImage(item.seriesId)}}">
                       </div>
                       <div class="ml-1">
+                        <app-series-format [format]="item.format"></app-series-format>
                         <span *ngIf="item.name.toLowerCase().indexOf(searchTerm) >= 0; else localizedName" [innerHTML]="item.name"></span>
                         <ng-template #localizedName>
                           <span [innerHTML]="item.localizedName"></span>

--- a/UI/Web/src/app/nav-header/nav-header.component.ts
+++ b/UI/Web/src/app/nav-header/nav-header.component.ts
@@ -3,6 +3,7 @@ import { Component, HostListener, Inject, OnDestroy, OnInit, ViewChild } from '@
 import { Router } from '@angular/router';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
+import { UtilityService } from '../shared/_services/utility.service';
 import { SearchResult } from '../_models/search-result';
 import { AccountService } from '../_services/account.service';
 import { ImageService } from '../_services/image.service';

--- a/UI/Web/src/app/series-detail/series-detail.component.html
+++ b/UI/Web/src/app/series-detail/series-detail.component.html
@@ -85,7 +85,7 @@
                         <h5>Type</h5>
                     </div>
                     <div class="col-md-8">
-                        <app-tag-badge><i class="fa {{utilityService.mangaFormatIcon(series.format)}}" aria-hidden="true" title="{{utilityService.mangaFormat(series.format)}}"></i>&nbsp;{{utilityService.mangaFormat(series.format)}} </app-tag-badge>
+                        <app-tag-badge><app-series-format [format]="series.format">{{utilityService.mangaFormat(series.format)}}</app-series-format></app-tag-badge>
                     </div>
                 </div>
             </div>

--- a/UI/Web/src/app/shared/_services/download.service.ts
+++ b/UI/Web/src/app/shared/_services/download.service.ts
@@ -1,4 +1,4 @@
-import { HttpClient, HttpHeaders, HttpResponse } from '@angular/common/http';
+import { HttpClient, HttpHeaders, HttpParams, HttpResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Series } from 'src/app/_models/series';
 import { environment } from 'src/environments/environment';
@@ -46,14 +46,18 @@ export class DownloadService {
     return this.httpClient.get(this.baseUrl + 'download/chapter?chapterId=' + chapterId, {observe: 'response', responseType: 'blob' as 'text'});
   }
 
+  downloadLogs() {
+    this.httpClient.get(this.baseUrl + 'server/logs', {observe: 'response', responseType: 'blob' as 'text'}).subscribe(resp => {
+      this.preformSave(resp.body || '', this.getFilenameFromHeader(resp.headers, 'logs'));
+    });
+  }
+
   downloadSeries(series: Series) {
     this.downloadSeriesSize(series.id).subscribe(async size => {
       if (size >= this.SIZE_WARNING && !await this.confirmService.confirm('The series is ' + this.humanFileSize(size) + '. Are you sure you want to continue?')) {
         return;
       }
       this.downloadSeriesAPI(series.id).subscribe(resp => {
-        //const filename = series.name + '.zip';
-        //this.preformSave(res, filename);
         this.preformSave(resp.body || '', this.getFilenameFromHeader(resp.headers, series.name));
       });
     });

--- a/UI/Web/src/app/shared/series-format/series-format.component.html
+++ b/UI/Web/src/app/shared/series-format/series-format.component.html
@@ -1,0 +1,4 @@
+<ng-container *ngIf="format != MangaFormat.UNKNOWN">
+    <i class="fa {{utilityService.mangaFormatIcon(format)}}" aria-hidden="true" title="{{utilityService.mangaFormat(format)}}"></i>&nbsp;
+    <ng-content></ng-content>
+</ng-container>

--- a/UI/Web/src/app/shared/series-format/series-format.component.ts
+++ b/UI/Web/src/app/shared/series-format/series-format.component.ts
@@ -1,0 +1,23 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { MangaFormat } from 'src/app/_models/manga-format';
+import { UtilityService } from '../_services/utility.service';
+
+@Component({
+  selector: 'app-series-format',
+  templateUrl: './series-format.component.html',
+  styleUrls: ['./series-format.component.scss']
+})
+export class SeriesFormatComponent implements OnInit {
+
+  @Input() format: MangaFormat = MangaFormat.UNKNOWN;
+
+  get MangaFormat(): typeof MangaFormat {
+    return MangaFormat;
+  }
+
+  constructor(public utilityService: UtilityService) { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/UI/Web/src/app/shared/shared.module.ts
+++ b/UI/Web/src/app/shared/shared.module.ts
@@ -16,6 +16,7 @@ import { TagBadgeComponent } from './tag-badge/tag-badge.component';
 import { CardDetailLayoutComponent } from './card-detail-layout/card-detail-layout.component';
 import { ShowIfScrollbarDirective } from './show-if-scrollbar.directive';
 import { A11yClickDirective } from './a11y-click.directive';
+import { SeriesFormatComponent } from './series-format/series-format.component';
 
 
 @NgModule({
@@ -31,7 +32,8 @@ import { A11yClickDirective } from './a11y-click.directive';
     TagBadgeComponent,
     CardDetailLayoutComponent,
     ShowIfScrollbarDirective,
-    A11yClickDirective
+    A11yClickDirective,
+    SeriesFormatComponent
   ],
   imports: [
     CommonModule,
@@ -54,7 +56,8 @@ import { A11yClickDirective } from './a11y-click.directive';
     TagBadgeComponent,
     CardDetailLayoutComponent,
     ShowIfScrollbarDirective,
-    A11yClickDirective
+    A11yClickDirective,
+    SeriesFormatComponent
   ]
 })
 export class SharedModule { }

--- a/UI/Web/src/assets/themes/dark.scss
+++ b/UI/Web/src/assets/themes/dark.scss
@@ -23,6 +23,12 @@ $dark-item-accent-bg: #292d32;
     color: #4ac694;
   }
 
+  .accent {
+    background-color: $dark-form-background !important;
+    color: lightgray !important;
+    box-shadow: inset 0px 0px 8px 1px $dark-form-background !important;
+  }
+
   .breadcrumb {
     background-color: $dark-item-accent-bg;
 


### PR DESCRIPTION
#  Added
- Added: Added series format information to the search typeahead to help identify duplicate series in libraries

# Fixed
- Fixed: Fixed accent color not looking well on light theme
- Fixed: Attempted to fix the memory issues with PDF reading on Docker. Uses a Memory Pool for streams and removes a bitmap operation for fixing books with transparent backgrounds (#424)

# Changed
- Changed: Refactored download logs to use the same download code as rest of Kavita 

# Dev stuff
- Added timeout for Regex's to make sure during matching, malicious filenames doesn't crash user system
- Refactored a missing GetCoverImage to use Series Format rather than old Library Type
