### PR TITLE
Ignore Mac metadata hidden files ._*

### DIFF
--- a/API/Parser/Parser.cs
+++ b/API/Parser/Parser.cs
@@ -16,6 +16,7 @@ namespace API.Parser
         public const string ImageFileExtensions = @"^(\.png|\.jpeg|\.jpg)";
         public const string ArchiveFileExtensions = @"\.cbz|\.zip|\.rar|\.cbr|\.tar.gz|\.7zip|\.7z|\.cb7|\.cbt";
         public const string BookFileExtensions = @"\.epub|\.pdf";
+        public const string MacOsMetadataFileStartsWith = @"._";
 
         public const string SupportedExtensions =
             ArchiveFileExtensions + "|" + ImageFileExtensions + "|" + BookFileExtensions;

--- a/API/Services/DirectoryService.cs
+++ b/API/Services/DirectoryService.cs
@@ -25,6 +25,7 @@ namespace API.Services
        /// <summary>
        /// Given a set of regex search criteria, get files in the given path.
        /// </summary>
+       /// <remarks>This will always exclude <see cref="Parser.Parser.MacOsMetadataFileStartsWith"/> patterns</remarks>
        /// <param name="path">Directory to search</param>
        /// <param name="searchPatternExpression">Regex version of search pattern (ie \.mp3|\.mp4). Defaults to * meaning all files.</param>
        /// <param name="searchOption">SearchOption to use, defaults to TopDirectoryOnly</param>
@@ -35,9 +36,10 @@ namespace API.Services
        {
           if (!Directory.Exists(path)) return ImmutableList<string>.Empty;
           var reSearchPattern = new Regex(searchPatternExpression, RegexOptions.IgnoreCase);
+
           return Directory.EnumerateFiles(path, "*", searchOption)
              .Where(file =>
-                reSearchPattern.IsMatch(Path.GetExtension(file)));
+                reSearchPattern.IsMatch(Path.GetExtension(file)) && !Path.GetFileName(file).StartsWith(Parser.Parser.MacOsMetadataFileStartsWith));
        }
 
 
@@ -98,7 +100,7 @@ namespace API.Services
              var reSearchPattern = new Regex(searchPatternExpression, RegexOptions.IgnoreCase);
              return Directory.EnumerateFiles(path, "*", searchOption)
                 .Where(file =>
-                   reSearchPattern.IsMatch(file));
+                   reSearchPattern.IsMatch(file) && !file.StartsWith(Parser.Parser.MacOsMetadataFileStartsWith));
           }
 
           return !Directory.Exists(path) ? Array.Empty<string>() : Directory.GetFiles(path);

--- a/Kavita.Common/Kavita.Common.csproj
+++ b/Kavita.Common/Kavita.Common.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net5.0</TargetFramework>
         <Company>kavitareader.com</Company>
         <Product>Kavita</Product>
-        <AssemblyVersion>0.4.3.3</AssemblyVersion>
+        <AssemblyVersion>0.4.3.4</AssemblyVersion>
         <NeutralLanguage>en</NeutralLanguage>
     </PropertyGroup>
 


### PR DESCRIPTION
# Added
- `._` files are now ignored from all I/O operations. This means they will not be considered when scanning a library, for cover generation, or even for comicinfo.xml selection (if you have ._comicinfo.xml and comicinfo.xml, the latter will be picked) (Closes #440 )

