### PR TITLE
Refactored logs to use a logs/ folder and also roll over after 10MB. …

### DIFF
--- a/API/appsettings.Development.json
+++ b/API/appsettings.Development.json
@@ -17,10 +17,10 @@
       "Microsoft.AspNetCore.Hosting.Internal.WebHost": "Information"
     },
     "File": {
-      "Path": "kavita.log",
+      "Path": "logs/kavita.log",
       "Append": "True",
-      "FileSizeLimitBytes": 0,
-      "MaxRollingFiles": 0
+      "FileSizeLimitBytes": 10485760,
+      "MaxRollingFiles": 5
     }
   },
   "Port": 5000

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -46,6 +46,20 @@ else
 	ln -s /kavita/data/cache /kavita/cache
 fi
 
+if [ -d /kavita/data/logs ]
+then
+	if [ -d /kavita/logs ]
+	then
+		unlink /kavita/logs
+		ln -s /kavita/data/logs /kavita/logs
+	else
+		ln -s /kavita/data/logs /kavita/logs
+	fi
+else
+	mkdir /kavita/data/logs
+	ln -s /kavita/data/logs /kavita/logs
+fi
+
 if [ -d /kavita/data/stats ]
 then
 	if [ -d /kavita/stats ]
@@ -58,25 +72,6 @@ then
 else
 	mkdir /kavita/data/stats
 	ln -s /kavita/data/stats /kavita/stats
-fi
-
-# Checks for the log file
-
-if test -f "/kavita/data/logs/kavita.log"
-then
-	rm /kavita/kavita.log
-	ln -s /kavita/data/logs/kavita.log /kavita/
-else
-	if [ -d /kavita/data/logs ]
-	then
-		echo "" > /kavita/data/logs/kavita.log || true
-		ln -s /kavita/data/logs/kavita.log /kavita/
-	else
-		mkdir /kavita/data/logs
-		echo "" > /kavita/data/logs/kavita.log || true
-		ln -s /kavita/data/logs/kavita.log /kavita/
-	fi
-
 fi
 
 chmod +x ./Kavita


### PR DESCRIPTION
…A maximum of 5 logs will persist (50MB of log data).

# Changed
- Changed: Log files now roll (kavita, kavita1, etc) up to 5 files, each with a max of 10MB each. After all 5 files fill up, they will roll over. (Closes #446 )