### PR TITLE
Bookmarking Pages within the Reader

### DIFF
--- a/API.Tests/API.Tests.csproj
+++ b/API.Tests/API.Tests.csproj
@@ -7,15 +7,15 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.5" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.8" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
         <PackageReference Include="NSubstitute" Version="4.2.2" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.0.3">
+        <PackageReference Include="coverlet.collector" Version="3.1.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/API/API.csproj
+++ b/API/API.csproj
@@ -35,35 +35,35 @@
     <PackageReference Include="ExCSS" Version="4.1.0" />
     <PackageReference Include="Flurl" Version="3.0.2" />
     <PackageReference Include="Flurl.Http" Version="3.2.0" />
-    <PackageReference Include="Hangfire" Version="1.7.20" />
-    <PackageReference Include="Hangfire.AspNetCore" Version="1.7.20" />
+    <PackageReference Include="Hangfire" Version="1.7.24" />
+    <PackageReference Include="Hangfire.AspNetCore" Version="1.7.24" />
     <PackageReference Include="Hangfire.MaximumConcurrentExecutions" Version="1.1.0" />
     <PackageReference Include="Hangfire.MemoryStorage.Core" Version="1.4.0" />
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.32" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.35" />
     <PackageReference Include="MarkdownDeep.NET.Core" Version="1.5.0.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="5.0.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="5.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="5.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="5.0.8" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.4">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.4" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
-    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.8" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
+    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.1.3" />
     <PackageReference Include="NetVips" Version="2.0.1" />
     <PackageReference Include="NetVips.Native" Version="8.11.0" />
-    <PackageReference Include="NReco.Logging.File" Version="1.1.1" />
-    <PackageReference Include="Sentry.AspNetCore" Version="3.8.2" />
+    <PackageReference Include="NReco.Logging.File" Version="1.1.2" />
+    <PackageReference Include="Sentry.AspNetCore" Version="3.8.3" />
     <PackageReference Include="SharpCompress" Version="0.28.3" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.26.0.34506">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.27.0.35380">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.5" />
     <PackageReference Include="System.Drawing.Common" Version="5.0.2" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.10.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.12.0" />
     <PackageReference Include="VersOne.Epub" Version="3.0.3.1" />
   </ItemGroup>
 

--- a/API/API.csproj
+++ b/API/API.csproj
@@ -77,22 +77,38 @@
     <None Remove="Hangfire-log.db" />
     <None Remove="obj\**" />
     <None Remove="wwwroot\**" />
+    <None Remove="cache\**" />
+    <None Remove="backups\**" />
+    <None Remove="logs\**" />
+    <None Remove="temp\**" />
   </ItemGroup>
 
   <ItemGroup>
     <Compile Remove="Interfaces\IMetadataService.cs" />
     <Compile Remove="obj\**" />
     <Compile Remove="wwwroot\**" />
+    <Compile Remove="cache\**" />
+    <Compile Remove="backups\**" />
+    <Compile Remove="logs\**" />
+    <Compile Remove="temp\**" />
   </ItemGroup>
 
   <ItemGroup>
     <EmbeddedResource Remove="obj\**" />
     <EmbeddedResource Remove="wwwroot\**" />
+    <EmbeddedResource Remove="cache\**" />
+    <EmbeddedResource Remove="backups\**" />
+    <EmbeddedResource Remove="logs\**" />
+    <EmbeddedResource Remove="temp\**" />
   </ItemGroup>
 
   <ItemGroup>
     <Content Remove="obj\**" />
     <Content Remove="wwwroot\**" />
+    <Content Remove="cache\**" />
+    <Content Remove="backups\**" />
+    <Content Remove="logs\**" />
+    <Content Remove="temp\**" />
   </ItemGroup>
 
   <ItemGroup>

--- a/API/Controllers/DownloadController.cs
+++ b/API/Controllers/DownloadController.cs
@@ -141,7 +141,10 @@ namespace API.Controllers
             // We know that all bookmarks will be for one single seriesId
             var series = await _unitOfWork.SeriesRepository.GetSeriesByIdAsync(downloadBookmarkDto.Bookmarks.First().SeriesId);
 
-            return BadRequest("Not Implemented");
+            var files = new List<string>();
+            var (fileBytes, zipPath) = await _archiveService.CreateZipForDownload(files,
+                $"download_{series.Id}_bookmarks");
+            return File(fileBytes, "application/zip", $"{series.Name} - Bookmarks.zip");
         }
     }
 }

--- a/API/Controllers/DownloadController.cs
+++ b/API/Controllers/DownloadController.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using API.DTOs;
+using API.DTOs.Downloads;
 using API.Entities;
 using API.Extensions;
 using API.Interfaces;
@@ -133,10 +135,13 @@ namespace API.Controllers
             }
         }
 
-        // [HttpPost]
-        // public async Task<ActionResult> DownloadBookmarkPages()
-        // {
-        //
-        // }
+        [HttpPost("bookmarks")]
+        public async Task<ActionResult> DownloadBookmarkPages(DownloadBookmarkDto downloadBookmarkDto)
+        {
+            // We know that all bookmarks will be for one single seriesId
+            var series = await _unitOfWork.SeriesRepository.GetSeriesByIdAsync(downloadBookmarkDto.Bookmarks.First().SeriesId);
+
+            return BadRequest("Not Implemented");
+        }
     }
 }

--- a/API/Controllers/DownloadController.cs
+++ b/API/Controllers/DownloadController.cs
@@ -132,5 +132,11 @@ namespace API.Controllers
                 return BadRequest(ex.Message);
             }
         }
+
+        // [HttpPost]
+        // public async Task<ActionResult> DownloadBookmarkPages()
+        // {
+        //
+        // }
     }
 }

--- a/API/Controllers/LibraryController.cs
+++ b/API/Controllers/LibraryController.cs
@@ -203,8 +203,7 @@ namespace API.Controllers
         {
             var library = await _unitOfWork.LibraryRepository.GetLibraryForIdAsync(libraryForUserDto.Id);
 
-            var originalFolders = library.Folders.Select(x => x.Path);
-            var differenceBetweenFolders = originalFolders.Except(libraryForUserDto.Folders);
+            var originalFolders = library.Folders.Select(x => x.Path).ToList();
 
             library.Name = libraryForUserDto.Name;
             library.Folders = libraryForUserDto.Folders.Select(s => new FolderPath() {Path = s}).ToList();
@@ -212,9 +211,9 @@ namespace API.Controllers
             _unitOfWork.LibraryRepository.Update(library);
 
             if (!await _unitOfWork.CommitAsync()) return BadRequest("There was a critical issue updating the library.");
-            if (differenceBetweenFolders.Any())
+            if (originalFolders.Count != libraryForUserDto.Folders.Count())
             {
-                _taskScheduler.ScanLibrary(library.Id, true);
+                _taskScheduler.ScanLibrary(library.Id);
             }
 
             return Ok();

--- a/API/Controllers/ReaderController.cs
+++ b/API/Controllers/ReaderController.cs
@@ -298,8 +298,25 @@ namespace API.Controllers
         public async Task<ActionResult<IEnumerable<BookmarkDto>>> GetBookmarks(int chapterId)
         {
             var user = await _unitOfWork.UserRepository.GetUserByUsernameAsync(User.GetUsername());
+            //if (user.Bookmarks == null) return Ok(Array.Empty<BookmarkDto>());
+            return Ok(await _unitOfWork.UserRepository.GetBookmarkDtosForChapter(user.Id, chapterId));
+        }
+
+        [HttpGet("get-volume-bookmarks")]
+        public async Task<ActionResult<IEnumerable<BookmarkDto>>> GetBookmarksForVolume(int volumeId)
+        {
+            var user = await _unitOfWork.UserRepository.GetUserByUsernameAsync(User.GetUsername());
             if (user.Bookmarks == null) return Ok(Array.Empty<BookmarkDto>());
-            return Ok(user.Bookmarks.Where(x => x.AppUserId == user.Id && x.ChapterId == chapterId));
+            return Ok(await _unitOfWork.UserRepository.GetBookmarkDtosForVolume(user.Id, volumeId));
+        }
+
+        [HttpGet("get-series-bookmarks")]
+        public async Task<ActionResult<IEnumerable<BookmarkDto>>> GetBookmarksForSeries(int seriesId)
+        {
+            var user = await _unitOfWork.UserRepository.GetUserByUsernameAsync(User.GetUsername());
+            if (user.Bookmarks == null) return Ok(Array.Empty<BookmarkDto>());
+
+            return Ok(await _unitOfWork.UserRepository.GetBookmarkDtosForSeries(user.Id, seriesId));
         }
 
         [HttpPost("bookmark")]
@@ -324,7 +341,7 @@ namespace API.Controllers
             {
                 user.Bookmarks ??= new List<AppUserBookmark>();
                var userBookmark =
-                  user.Bookmarks.SingleOrDefault(x => x.ChapterId == bookmarkDto.ChapterId && x.AppUserId == user.Id);
+                  user.Bookmarks.SingleOrDefault(x => x.ChapterId == bookmarkDto.ChapterId && x.AppUserId == user.Id && x.Page == bookmarkDto.Page);
 
                if (userBookmark == null)
                {

--- a/API/Controllers/ReaderController.cs
+++ b/API/Controllers/ReaderController.cs
@@ -58,7 +58,7 @@ namespace API.Controllers
 
             var volume = await _unitOfWork.SeriesRepository.GetVolumeDtoAsync(chapter.VolumeId);
             if (volume == null) return BadRequest("Could not find Volume");
-            var mangaFile = (await _unitOfWork.VolumeRepository.GetFilesForChapter(chapterId)).First();
+            var mangaFile = (await _unitOfWork.VolumeRepository.GetFilesForChapterAsync(chapterId)).First();
             var series = await _unitOfWork.SeriesRepository.GetSeriesByIdAsync(seriesId);
 
             return Ok(new ChapterInfoDto()

--- a/API/DTOs/BookmarkDto.cs
+++ b/API/DTOs/BookmarkDto.cs
@@ -2,6 +2,7 @@
 {
     public class BookmarkDto
     {
+        public int Id { get; set; }
         public int Page { get; set; }
         public int VolumeId { get; set; }
         public int SeriesId { get; set; }

--- a/API/DTOs/BookmarkDto.cs
+++ b/API/DTOs/BookmarkDto.cs
@@ -1,0 +1,10 @@
+﻿namespace API.DTOs
+{
+    public class BookmarkDto
+    {
+        public int Page { get; set; }
+        public int VolumeId { get; set; }
+        public int SeriesId { get; set; }
+        public int ChapterId { get; set; }
+    }
+}

--- a/API/DTOs/Downloads/DownloadBookmarkDto.cs
+++ b/API/DTOs/Downloads/DownloadBookmarkDto.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace API.DTOs.Downloads
+{
+    public class DownloadBookmarkDto
+    {
+        public IEnumerable<BookmarkDto> Bookmarks { get; set; }
+    }
+}

--- a/API/DTOs/ProgressDto.cs
+++ b/API/DTOs/ProgressDto.cs
@@ -1,6 +1,6 @@
 ﻿namespace API.DTOs
 {
-    public class BookmarkDto
+    public class ProgressDto
     {
         public int VolumeId { get; set; }
         public int ChapterId { get; set; }

--- a/API/Data/BookmarkRepository.cs
+++ b/API/Data/BookmarkRepository.cs
@@ -1,0 +1,7 @@
+﻿namespace API.Data
+{
+    public class BookmarkRepository
+    {
+        
+    }
+}

--- a/API/Data/DataContext.cs
+++ b/API/Data/DataContext.cs
@@ -8,7 +8,7 @@ using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 namespace API.Data
 {
-    public sealed class DataContext : IdentityDbContext<AppUser, AppRole, int, 
+    public sealed class DataContext : IdentityDbContext<AppUser, AppRole, int,
         IdentityUserClaim<int>, AppUserRole, IdentityUserLogin<int>,
         IdentityRoleClaim<int>, IdentityUserToken<int>>
     {
@@ -17,10 +17,10 @@ namespace API.Data
             ChangeTracker.Tracked += OnEntityTracked;
             ChangeTracker.StateChanged += OnEntityStateChanged;
         }
-        
+
         public DbSet<Library> Library { get; set; }
         public DbSet<Series> Series { get; set; }
-        
+
         public DbSet<Chapter> Chapter { get; set; }
         public DbSet<Volume> Volume { get; set; }
         public DbSet<AppUser> AppUser { get; set; }
@@ -31,18 +31,19 @@ namespace API.Data
         public DbSet<AppUserPreferences> AppUserPreferences { get; set; }
         public DbSet<SeriesMetadata> SeriesMetadata { get; set; }
         public DbSet<CollectionTag> CollectionTag { get; set; }
+        public DbSet<AppUserBookmark> AppUserBookmark { get; set; }
 
         protected override void OnModelCreating(ModelBuilder builder)
         {
             base.OnModelCreating(builder);
-            
+
 
             builder.Entity<AppUser>()
                 .HasMany(ur => ur.UserRoles)
                 .WithOne(u => u.User)
                 .HasForeignKey(ur => ur.UserId)
                 .IsRequired();
-            
+
             builder.Entity<AppRole>()
                 .HasMany(ur => ur.UserRoles)
                 .WithOne(u => u.Role)
@@ -50,7 +51,7 @@ namespace API.Data
                 .IsRequired();
         }
 
-        
+
         void OnEntityTracked(object sender, EntityTrackedEventArgs e)
         {
             if (!e.FromQuery && e.Entry.State == EntityState.Added && e.Entry.Entity is IEntityDate entity)
@@ -58,7 +59,7 @@ namespace API.Data
                 entity.Created = DateTime.Now;
                 entity.LastModified = DateTime.Now;
             }
-                
+
         }
 
         void OnEntityStateChanged(object sender, EntityStateChangedEventArgs e)

--- a/API/Data/Migrations/20210809210326_BookmarkPages.Designer.cs
+++ b/API/Data/Migrations/20210809210326_BookmarkPages.Designer.cs
@@ -3,14 +3,16 @@ using System;
 using API.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace API.Data.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20210809210326_BookmarkPages")]
+    partial class BookmarkPages
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/API/Data/Migrations/20210809210326_BookmarkPages.cs
+++ b/API/Data/Migrations/20210809210326_BookmarkPages.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace API.Data.Migrations
+{
+    public partial class BookmarkPages : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "AppUserBookmark",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    Page = table.Column<int>(type: "INTEGER", nullable: false),
+                    VolumeId = table.Column<int>(type: "INTEGER", nullable: false),
+                    SeriesId = table.Column<int>(type: "INTEGER", nullable: false),
+                    ChapterId = table.Column<int>(type: "INTEGER", nullable: false),
+                    AppUserId = table.Column<int>(type: "INTEGER", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AppUserBookmark", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_AppUserBookmark_AspNetUsers_AppUserId",
+                        column: x => x.AppUserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AppUserBookmark_AppUserId",
+                table: "AppUserBookmark",
+                column: "AppUserId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "AppUserBookmark");
+        }
+    }
+}

--- a/API/Data/UnitOfWork.cs
+++ b/API/Data/UnitOfWork.cs
@@ -20,7 +20,7 @@ namespace API.Data
         }
 
         public ISeriesRepository SeriesRepository => new SeriesRepository(_context, _mapper);
-        public IUserRepository UserRepository => new UserRepository(_context, _userManager);
+        public IUserRepository UserRepository => new UserRepository(_context, _userManager, _mapper);
         public ILibraryRepository LibraryRepository => new LibraryRepository(_context, _mapper);
 
         public IVolumeRepository VolumeRepository => new VolumeRepository(_context, _mapper);

--- a/API/Data/UserRepository.cs
+++ b/API/Data/UserRepository.cs
@@ -80,6 +80,7 @@ namespace API.Data
         {
             return await _context.AppUserBookmark
                 .Where(x => x.AppUserId == userId && x.SeriesId == seriesId)
+                .OrderBy(x => x.Page)
                 .AsNoTracking()
                 .ProjectTo<BookmarkDto>(_mapper.ConfigurationProvider)
                 .ToListAsync();
@@ -89,6 +90,7 @@ namespace API.Data
         {
             return await _context.AppUserBookmark
                 .Where(x => x.AppUserId == userId && x.VolumeId == volumeId)
+                .OrderBy(x => x.Page)
                 .AsNoTracking()
                 .ProjectTo<BookmarkDto>(_mapper.ConfigurationProvider)
                 .ToListAsync();
@@ -98,6 +100,7 @@ namespace API.Data
         {
             return await _context.AppUserBookmark
                 .Where(x => x.AppUserId == userId && x.ChapterId == chapterId)
+                .OrderBy(x => x.Page)
                 .AsNoTracking()
                 .ProjectTo<BookmarkDto>(_mapper.ConfigurationProvider)
                 .ToListAsync();

--- a/API/Data/UserRepository.cs
+++ b/API/Data/UserRepository.cs
@@ -5,6 +5,8 @@ using API.Constants;
 using API.DTOs;
 using API.Entities;
 using API.Interfaces;
+using AutoMapper;
+using AutoMapper.QueryableExtensions;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 
@@ -14,18 +16,20 @@ namespace API.Data
     {
         private readonly DataContext _context;
         private readonly UserManager<AppUser> _userManager;
+        private readonly IMapper _mapper;
 
-        public UserRepository(DataContext context, UserManager<AppUser> userManager)
+        public UserRepository(DataContext context, UserManager<AppUser> userManager, IMapper mapper)
         {
             _context = context;
             _userManager = userManager;
+            _mapper = mapper;
         }
 
         public void Update(AppUser user)
         {
             _context.Entry(user).State = EntityState.Modified;
         }
-        
+
         public void Update(AppUserPreferences preferences)
         {
             _context.Entry(preferences).State = EntityState.Modified;
@@ -45,6 +49,7 @@ namespace API.Data
         {
             return await _context.Users
                 .Include(u => u.Progresses)
+                .Include(u => u.Bookmarks)
                 .SingleOrDefaultAsync(x => x.UserName == username);
         }
 
@@ -69,6 +74,33 @@ namespace API.Data
             return await _context.AppUserPreferences
                 .Include(p => p.AppUser)
                 .SingleOrDefaultAsync(p => p.AppUser.UserName == username);
+        }
+
+        public async Task<IEnumerable<BookmarkDto>> GetBookmarkDtosForSeries(int userId, int seriesId)
+        {
+            return await _context.AppUserBookmark
+                .Where(x => x.AppUserId == userId && x.SeriesId == seriesId)
+                .AsNoTracking()
+                .ProjectTo<BookmarkDto>(_mapper.ConfigurationProvider)
+                .ToListAsync();
+        }
+
+        public async Task<IEnumerable<BookmarkDto>> GetBookmarkDtosForVolume(int userId, int volumeId)
+        {
+            return await _context.AppUserBookmark
+                .Where(x => x.AppUserId == userId && x.VolumeId == volumeId)
+                .AsNoTracking()
+                .ProjectTo<BookmarkDto>(_mapper.ConfigurationProvider)
+                .ToListAsync();
+        }
+
+        public async Task<IEnumerable<BookmarkDto>> GetBookmarkDtosForChapter(int userId, int chapterId)
+        {
+            return await _context.AppUserBookmark
+                .Where(x => x.AppUserId == userId && x.ChapterId == chapterId)
+                .AsNoTracking()
+                .ProjectTo<BookmarkDto>(_mapper.ConfigurationProvider)
+                .ToListAsync();
         }
 
         public async Task<IEnumerable<MemberDto>> GetMembersAsync()

--- a/API/Data/VolumeRepository.cs
+++ b/API/Data/VolumeRepository.cs
@@ -1,7 +1,9 @@
 ﻿using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using API.DTOs;
+using API.DTOs.Reader;
 using API.Entities;
 using API.Interfaces;
 using AutoMapper;

--- a/API/Data/VolumeRepository.cs
+++ b/API/Data/VolumeRepository.cs
@@ -40,7 +40,6 @@ namespace API.Data
                 .SingleOrDefaultAsync(c => c.Id == chapterId);
         }
 
-
         /// <summary>
         /// Returns Chapters for a volume id.
         /// </summary>
@@ -81,10 +80,27 @@ namespace API.Data
             return chapter;
         }
 
-        public async Task<IList<MangaFile>> GetFilesForChapter(int chapterId)
+        /// <summary>
+        /// Returns non-tracked files for a given chapterId
+        /// </summary>
+        /// <param name="chapterId"></param>
+        /// <returns></returns>
+        public async Task<IList<MangaFile>> GetFilesForChapterAsync(int chapterId)
         {
             return await _context.MangaFile
                 .Where(c => chapterId == c.ChapterId)
+                .AsNoTracking()
+                .ToListAsync();
+        }
+        /// <summary>
+        /// Returns non-tracked files for a set of chapterIds
+        /// </summary>
+        /// <param name="chapterIds"></param>
+        /// <returns></returns>
+        public async Task<IList<MangaFile>> GetFilesForChaptersAsync(IReadOnlyList<int> chapterIds)
+        {
+            return await _context.MangaFile
+                .Where(c => chapterIds.Contains(c.ChapterId))
                 .AsNoTracking()
                 .ToListAsync();
         }

--- a/API/Entities/AppUser.cs
+++ b/API/Entities/AppUser.cs
@@ -16,7 +16,8 @@ namespace API.Entities
         public ICollection<AppUserProgress> Progresses { get; set; }
         public ICollection<AppUserRating> Ratings { get; set; }
         public AppUserPreferences UserPreferences { get; set; }
-        
+        public ICollection<AppUserBookmark> Bookmarks { get; set; }
+
         [ConcurrencyCheck]
         public uint RowVersion { get; set; }
 

--- a/API/Entities/AppUserBookmark.cs
+++ b/API/Entities/AppUserBookmark.cs
@@ -1,4 +1,6 @@
-﻿namespace API.Entities
+﻿using System.Text.Json.Serialization;
+
+namespace API.Entities
 {
     /// <summary>
     /// Represents a saved page in a Chapter entity for a given user.
@@ -13,6 +15,7 @@
 
 
         // Relationships
+        [JsonIgnore]
         public AppUser AppUser { get; set; }
         public int AppUserId { get; set; }
     }

--- a/API/Entities/AppUserBookmark.cs
+++ b/API/Entities/AppUserBookmark.cs
@@ -1,0 +1,19 @@
+﻿namespace API.Entities
+{
+    /// <summary>
+    /// Represents a saved page in a Chapter entity for a given user.
+    /// </summary>
+    public class AppUserBookmark
+    {
+        public int Id { get; set; }
+        public int Page { get; set; }
+        public int VolumeId { get; set; }
+        public int SeriesId { get; set; }
+        public int ChapterId { get; set; }
+
+
+        // Relationships
+        public AppUser AppUser { get; set; }
+        public int AppUserId { get; set; }
+    }
+}

--- a/API/Helpers/AutoMapperProfiles.cs
+++ b/API/Helpers/AutoMapperProfiles.cs
@@ -16,11 +16,11 @@ namespace API.Helpers
             CreateMap<Volume, VolumeDto>();
 
             CreateMap<MangaFile, MangaFileDto>();
-            
+
             CreateMap<Chapter, ChapterDto>();
 
             CreateMap<Series, SeriesDto>();
-            
+
             CreateMap<CollectionTag, CollectionTagDto>();
 
             CreateMap<SeriesMetadata, SeriesMetadataDto>();
@@ -29,18 +29,20 @@ namespace API.Helpers
 
             CreateMap<AppUserPreferences, UserPreferencesDto>();
 
+            CreateMap<AppUserBookmark, BookmarkDto>();
+
             CreateMap<Series, SearchResultDto>()
                 .ForMember(dest => dest.SeriesId,
                     opt => opt.MapFrom(src => src.Id))
                 .ForMember(dest => dest.LibraryName,
                     opt => opt.MapFrom(src => src.Library.Name));
-            
-            
+
+
             CreateMap<Library, LibraryDto>()
                 .ForMember(dest => dest.Folders,
-                    opt => 
+                    opt =>
                         opt.MapFrom(src => src.Folders.Select(x => x.Path).ToList()));
-            
+
             CreateMap<AppUser, MemberDto>()
                 .AfterMap((ps, pst, context) => context.Mapper.Map(ps.Libraries, pst.Libraries));
 

--- a/API/Interfaces/IUserRepository.cs
+++ b/API/Interfaces/IUserRepository.cs
@@ -17,7 +17,7 @@ namespace API.Interfaces
         void AddRatingTracking(AppUserRating userRating);
         Task<AppUserPreferences> GetPreferencesAsync(string username);
         Task<IEnumerable<BookmarkDto>> GetBookmarkDtosForSeries(int userId, int seriesId);
-        Task<IEnumerable<BookmarkDto>> GetBookmarkDtosForVolume(int userId, int volume);
+        Task<IEnumerable<BookmarkDto>> GetBookmarkDtosForVolume(int userId, int volumeId);
         Task<IEnumerable<BookmarkDto>> GetBookmarkDtosForChapter(int userId, int chapterId);
     }
 }

--- a/API/Interfaces/IUserRepository.cs
+++ b/API/Interfaces/IUserRepository.cs
@@ -16,5 +16,8 @@ namespace API.Interfaces
         Task<AppUserRating> GetUserRating(int seriesId, int userId);
         void AddRatingTracking(AppUserRating userRating);
         Task<AppUserPreferences> GetPreferencesAsync(string username);
+        Task<IEnumerable<BookmarkDto>> GetBookmarkDtosForSeries(int userId, int seriesId);
+        Task<IEnumerable<BookmarkDto>> GetBookmarkDtosForVolume(int userId, int volume);
+        Task<IEnumerable<BookmarkDto>> GetBookmarkDtosForChapter(int userId, int chapterId);
     }
 }

--- a/API/Interfaces/IVolumeRepository.cs
+++ b/API/Interfaces/IVolumeRepository.cs
@@ -10,7 +10,8 @@ namespace API.Interfaces
         void Update(Volume volume);
         Task<Chapter> GetChapterAsync(int chapterId);
         Task<ChapterDto> GetChapterDtoAsync(int chapterId);
-        Task<IList<MangaFile>> GetFilesForChapter(int chapterId);
+        Task<IList<MangaFile>> GetFilesForChapterAsync(int chapterId);
+        Task<IList<MangaFile>> GetFilesForChaptersAsync(IReadOnlyList<int> chapterIds);
         Task<IList<Chapter>> GetChaptersAsync(int volumeId);
         Task<byte[]> GetChapterCoverImageAsync(int chapterId);
         Task<IList<MangaFile>> GetFilesForVolume(int volumeId);

--- a/API/Interfaces/Services/ICacheService.cs
+++ b/API/Interfaces/Services/ICacheService.cs
@@ -36,5 +36,6 @@ namespace API.Interfaces.Services
 
         void EnsureCacheDirectory();
         string GetCachedEpubFile(int chapterId, Chapter chapter);
+        public void ExtractChapterFiles(string extractPath, IReadOnlyList<MangaFile> files);
     }
 }

--- a/API/Interfaces/Services/IDirectoryService.cs
+++ b/API/Interfaces/Services/IDirectoryService.cs
@@ -20,7 +20,7 @@ namespace API.Interfaces.Services
         /// <returns></returns>
         string[] GetFilesWithExtension(string path, string searchPatternExpression = "");
         Task<byte[]> ReadFileAsync(string path);
-        bool CopyFilesToDirectory(IEnumerable<string> filePaths, string directoryPath);
+        bool CopyFilesToDirectory(IEnumerable<string> filePaths, string directoryPath, string prepend = "");
         bool Exists(string directory);
 
         IEnumerable<string> GetFiles(string path, string searchPatternExpression = "",

--- a/API/Services/ArchiveService.cs
+++ b/API/Services/ArchiveService.cs
@@ -224,17 +224,16 @@ namespace API.Services
 
         public async Task<Tuple<byte[], string>> CreateZipForDownload(IEnumerable<string> files, string tempFolder)
         {
-            var tempDirectory = Path.Join(Directory.GetCurrentDirectory(), "temp");
             var dateString = DateTime.Now.ToShortDateString().Replace("/", "_");
 
-            var tempLocation = Path.Join(tempDirectory, $"{tempFolder}_{dateString}");
+            var tempLocation = Path.Join(DirectoryService.TempDirectory, $"{tempFolder}_{dateString}");
             DirectoryService.ExistOrCreate(tempLocation);
             if (!_directoryService.CopyFilesToDirectory(files, tempLocation))
             {
                 throw new KavitaException("Unable to copy files to temp directory archive download.");
             }
 
-            var zipPath = Path.Join(tempDirectory, $"kavita_{tempFolder}_{dateString}.zip");
+            var zipPath = Path.Join(DirectoryService.TempDirectory, $"kavita_{tempFolder}_{dateString}.zip");
             try
             {
                 ZipFile.CreateFromDirectory(tempLocation, zipPath);

--- a/API/Services/CacheService.cs
+++ b/API/Services/CacheService.cs
@@ -37,7 +37,7 @@ namespace API.Services
 
         public void EnsureCacheDirectory()
         {
-            if (!DirectoryService.ExistOrCreate(CacheDirectory))
+            if (!DirectoryService.ExistOrCreate(DirectoryService.CacheDirectory))
             {
                 _logger.LogError("Cache directory {CacheDirectory} is not accessible or does not exist. Creating...", CacheDirectory);
             }
@@ -60,58 +60,77 @@ namespace API.Services
             return path;
         }
 
+        /// <summary>
+        /// Caches the files for the given chapter to CacheDirectory
+        /// </summary>
+        /// <param name="chapterId"></param>
+        /// <returns>This will always return the Chapter for the chpaterId</returns>
         public async Task<Chapter> Ensure(int chapterId)
         {
             EnsureCacheDirectory();
             var chapter = await _unitOfWork.VolumeRepository.GetChapterAsync(chapterId);
-            var files = chapter.Files.ToList();
-            var fileCount = files.Count;
             var extractPath = GetCachePath(chapterId);
-            var extraPath = "";
-            var removeNonImages = true;
 
-            if (Directory.Exists(extractPath))
+            if (!Directory.Exists(extractPath))
             {
-              return chapter;
+                var files = chapter.Files.ToList();
+                ExtractChapterFiles(extractPath, files);
             }
 
+            return  chapter;
+        }
+
+        /// <summary>
+        /// This is an internal method for cache service for extracting chapter files to disk. The code is structured
+        /// for cache service, but can be re-used (download bookmarks)
+        /// </summary>
+        /// <param name="extractPath"></param>
+        /// <param name="files"></param>
+        /// <returns></returns>
+        public void ExtractChapterFiles(string extractPath, IReadOnlyList<MangaFile> files)
+        {
+            var removeNonImages = true;
+            var fileCount = files.Count;
+            var extraPath = "";
             var extractDi = new DirectoryInfo(extractPath);
 
             if (files.Count > 0 && files[0].Format == MangaFormat.Image)
             {
-              DirectoryService.ExistOrCreate(extractPath);
-              if (files.Count == 1)
-              {
-                  _directoryService.CopyFileToDirectory(files[0].FilePath, extractPath);
-              }
-              else
-              {
-                  _directoryService.CopyDirectoryToDirectory(Path.GetDirectoryName(files[0].FilePath), extractPath, Parser.Parser.ImageFileExtensions);
-              }
+                DirectoryService.ExistOrCreate(extractPath);
+                if (files.Count == 1)
+                {
+                    _directoryService.CopyFileToDirectory(files[0].FilePath, extractPath);
+                }
+                else
+                {
+                    _directoryService.CopyDirectoryToDirectory(Path.GetDirectoryName(files[0].FilePath), extractPath,
+                        Parser.Parser.ImageFileExtensions);
+                }
 
-              extractDi.Flatten();
-              return chapter;
+                extractDi.Flatten();
             }
 
             foreach (var file in files)
             {
-              if (fileCount > 1)
-              {
-                extraPath = file.Id + string.Empty;
-              }
+                if (fileCount > 1)
+                {
+                    extraPath = file.Id + string.Empty;
+                }
 
-              if (file.Format == MangaFormat.Archive)
-              {
-                  _archiveService.ExtractArchive(file.FilePath, Path.Join(extractPath, extraPath));
-              } else if (file.Format == MangaFormat.Pdf)
-              {
-                  _bookService.ExtractPdfImages(file.FilePath, Path.Join(extractPath, extraPath));
-              } else if (file.Format == MangaFormat.Epub)
-              {
-                  removeNonImages = false;
-                  DirectoryService.ExistOrCreate(extractPath);
-                  _directoryService.CopyFileToDirectory(files[0].FilePath, extractPath);
-              }
+                if (file.Format == MangaFormat.Archive)
+                {
+                    _archiveService.ExtractArchive(file.FilePath, Path.Join(extractPath, extraPath));
+                }
+                else if (file.Format == MangaFormat.Pdf)
+                {
+                    _bookService.ExtractPdfImages(file.FilePath, Path.Join(extractPath, extraPath));
+                }
+                else if (file.Format == MangaFormat.Epub)
+                {
+                    removeNonImages = false;
+                    DirectoryService.ExistOrCreate(extractPath);
+                    _directoryService.CopyFileToDirectory(files[0].FilePath, extractPath);
+                }
             }
 
             extractDi.Flatten();
@@ -119,9 +138,6 @@ namespace API.Services
             {
                 extractDi.RemoveNonImages();
             }
-
-
-            return chapter;
         }
 
 
@@ -173,7 +189,7 @@ namespace API.Services
         {
             // Calculate what chapter the page belongs to
             var pagesSoFar = 0;
-            var chapterFiles = chapter.Files ?? await _unitOfWork.VolumeRepository.GetFilesForChapter(chapter.Id);
+            var chapterFiles = chapter.Files ?? await _unitOfWork.VolumeRepository.GetFilesForChapterAsync(chapter.Id);
             foreach (var mangaFile in chapterFiles)
             {
                 if (page <= (mangaFile.Pages + pagesSoFar))

--- a/API/Services/DirectoryService.cs
+++ b/API/Services/DirectoryService.cs
@@ -16,6 +16,9 @@ namespace API.Services
        private static readonly Regex ExcludeDirectories = new Regex(
           @"@eaDir|\.DS_Store",
           RegexOptions.Compiled | RegexOptions.IgnoreCase);
+       public static readonly string TempDirectory = Path.Join(Directory.GetCurrentDirectory(), "temp");
+       public static readonly string LogDirectory = Path.Join(Directory.GetCurrentDirectory(), "logs");
+       public static readonly string CacheDirectory = Path.Join(Directory.GetCurrentDirectory(), "cache");
 
        public DirectoryService(ILogger<DirectoryService> logger)
        {
@@ -247,33 +250,40 @@ namespace API.Services
           }
        }
 
-       public bool CopyFilesToDirectory(IEnumerable<string> filePaths, string directoryPath)
+       /// <summary>
+       /// Copies files to a destination directory. If the destination directory doesn't exist, this will create it.
+       /// </summary>
+       /// <param name="filePaths"></param>
+       /// <param name="directoryPath"></param>
+       /// <param name="prepend">An optional string to prepend to the target file's name</param>
+       /// <returns></returns>
+       public bool CopyFilesToDirectory(IEnumerable<string> filePaths, string directoryPath, string prepend = "")
        {
-          string currentFile = null;
-          try
-          {
-             foreach (var file in filePaths)
-             {
-                currentFile = file;
-                var fileInfo = new FileInfo(file);
-                if (fileInfo.Exists)
-                {
-                   fileInfo.CopyTo(Path.Join(directoryPath, fileInfo.Name));
-                }
-                else
-                {
-                   _logger.LogWarning("Tried to copy {File} but it doesn't exist", file);
-                }
+           ExistOrCreate(directoryPath);
+           string currentFile = null;
+           try
+           {
+               foreach (var file in filePaths)
+               {
+                   currentFile = file;
+                   var fileInfo = new FileInfo(file);
+                   if (fileInfo.Exists)
+                   {
+                       fileInfo.CopyTo(Path.Join(directoryPath, prepend + fileInfo.Name));
+                   }
+                   else
+                   {
+                       _logger.LogWarning("Tried to copy {File} but it doesn't exist", file);
+                   }
+               }
+           }
+           catch (Exception ex)
+           {
+               _logger.LogError(ex, "Unable to copy {File} to {DirectoryPath}", currentFile, directoryPath);
+               return false;
+           }
 
-             }
-          }
-          catch (Exception ex)
-          {
-             _logger.LogError(ex, "Unable to copy {File} to {DirectoryPath}", currentFile, directoryPath);
-             return false;
-          }
-
-          return true;
+           return true;
        }
 
        public IEnumerable<string> ListDirectory(string rootPath)
@@ -404,5 +414,23 @@ namespace API.Services
             return fileCount;
         }
 
+       /// <summary>
+       /// Attempts to delete the files passed to it. Swallows exceptions.
+       /// </summary>
+       /// <param name="files">Full path of files to delete</param>
+       public static void DeleteFiles(IEnumerable<string> files)
+       {
+           foreach (var file in files)
+           {
+               try
+               {
+                   new FileInfo(file).Delete();
+               }
+               catch (Exception)
+               {
+                   /* Swallow exception */
+               }
+           }
+       }
     }
 }

--- a/Kavita.Common/Kavita.Common.csproj
+++ b/Kavita.Common/Kavita.Common.csproj
@@ -11,8 +11,8 @@
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
       <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
-      <PackageReference Include="Sentry" Version="3.8.2" />
-      <PackageReference Include="SonarAnalyzer.CSharp" Version="8.26.0.34506">
+      <PackageReference Include="Sentry" Version="3.8.3" />
+      <PackageReference Include="SonarAnalyzer.CSharp" Version="8.27.0.35380">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>

--- a/UI/Web/src/app/_modals/bookmarks-modal/bookmarks-modal.component.html
+++ b/UI/Web/src/app/_modals/bookmarks-modal/bookmarks-modal.component.html
@@ -9,20 +9,26 @@
     
     <ul class="list-unstyled">
         <li class="media my-4" *ngFor="let bookmark of bookmarks">
-            <img class="mr-3" style="width: 74px" src="{{imageService.getBookmarkedImage(bookmark.chapterId, bookmark.page)}}">
+            <!-- <img class="mr-3" style="width: 74px" src="{{imageService.getBookmarkedImage(bookmark.chapterId, bookmark.page)}}">
             <div class="media-body">
                 <h5 class="mt-0 mb-1">
-                    <!-- <span *ngIf="chapter.number !== '0'; else specialHeader">
-                        Chapter {{formatChapterNumber(chapter)}}
-                    </span>
-                    <ng-template #specialHeader>File(s)</ng-template> -->
                 </h5>
                 Page {{bookmark.page}}
-            </div>
+            </div> -->
+            Page {{bookmark.page}}
+            <!-- <button class="btn btn-icon btn-small" role="checkbox" [attr.aria-checked]="pageBookmarked" title="{{pageBookmarked ? 'Unbookmark Page' : 'Bookmark Page'}}" (click)="bookmarkPage()"><i class="{{pageBookmarked ? 'fa' : 'far'}} fa-bookmark" aria-hidden="true"></i><span class="sr-only">{{pageBookmarked ? 'Unbookmark Page' : 'Bookmark Page'}}</span></button> -->
         </li>
     </ul>
 
 </div>
 <div class="modal-footer">
+    <button type="button" class="btn btn-secondary" (click)="clearBookmarks()" [disabled]="isDownloading || isClearing">
+        <span *ngIf="isClearing" class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+        <span>Clear{{isClearing ? 'ing...' : ''}}</span>
+    </button>
+    <button type="button" class="btn btn-secondary" (click)="downloadBookmarks()" [disabled]="isDownloading || isClearing">
+        <span *ngIf="isDownloading" class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+        <span>Download{{isDownloading ? 'ing...' : ''}}</span>
+    </button>
     <button type="button" class="btn btn-primary" (click)="close()">Close</button>
 </div>

--- a/UI/Web/src/app/_modals/bookmarks-modal/bookmarks-modal.component.html
+++ b/UI/Web/src/app/_modals/bookmarks-modal/bookmarks-modal.component.html
@@ -1,4 +1,3 @@
-
 <div class="modal-header">
     <h4 class="modal-title" id="modal-basic-title">{{title}} Bookmarks</h4>
     <button type="button" class="close" aria-label="Close" (click)="close()">
@@ -8,25 +7,20 @@
 <div class="modal-body">
     
     <ul class="list-unstyled">
-        <li class="list-group-item" *ngFor="let bookmark of bookmarks">
-            <!-- <img class="mr-3" style="width: 74px" src="{{imageService.getBookmarkedImage(bookmark.chapterId, bookmark.page)}}">
-            <div class="media-body">
-                <h5 class="mt-0 mb-1">
-                </h5>
-                Page {{bookmark.page}}
-            </div> -->
-            Page {{bookmark.page}}
-            <!-- <button class="btn btn-icon btn-small" role="checkbox" [attr.aria-checked]="pageBookmarked" title="{{pageBookmarked ? 'Unbookmark Page' : 'Bookmark Page'}}" (click)="bookmarkPage()"><i class="{{pageBookmarked ? 'fa' : 'far'}} fa-bookmark" aria-hidden="true"></i><span class="sr-only">{{pageBookmarked ? 'Unbookmark Page' : 'Bookmark Page'}}</span></button> -->
+        <li class="list-group-item">
+            There are {{bookmarks.length}} pages bookmarked over {{uniqueChapters}} files.
+        </li>
+        <li class="list-group-item" *ngIf="bookmarks.length === 0">
+            No bookmarks yet
         </li>
     </ul>
-
 </div>
 <div class="modal-footer">
-    <button type="button" class="btn btn-secondary" (click)="clearBookmarks()" [disabled]="isDownloading || isClearing">
+    <button type="button" class="btn btn-secondary" (click)="clearBookmarks()" [disabled]="(isDownloading || isClearing) && bookmarks.length > 0">
         <span *ngIf="isClearing" class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
         <span>Clear{{isClearing ? 'ing...' : ''}}</span>
     </button>
-    <button type="button" class="btn btn-secondary" (click)="downloadBookmarks()" [disabled]="isDownloading || isClearing">
+    <button type="button" class="btn btn-secondary" (click)="downloadBookmarks()" [disabled]="(isDownloading || isClearing) && bookmarks.length > 0">
         <span *ngIf="isDownloading" class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
         <span>Download{{isDownloading ? 'ing...' : ''}}</span>
     </button>

--- a/UI/Web/src/app/_modals/bookmarks-modal/bookmarks-modal.component.html
+++ b/UI/Web/src/app/_modals/bookmarks-modal/bookmarks-modal.component.html
@@ -1,0 +1,28 @@
+
+<div class="modal-header">
+    <h4 class="modal-title" id="modal-basic-title">{{title}} Bookmarks</h4>
+    <button type="button" class="close" aria-label="Close" (click)="close()">
+    <span aria-hidden="true">&times;</span>
+    </button>
+</div>
+<div class="modal-body">
+    
+    <ul class="list-unstyled">
+        <li class="media my-4" *ngFor="let bookmark of bookmarks">
+            <img class="mr-3" style="width: 74px" src="{{imageService.getBookmarkedImage(bookmark.chapterId, bookmark.page)}}">
+            <div class="media-body">
+                <h5 class="mt-0 mb-1">
+                    <!-- <span *ngIf="chapter.number !== '0'; else specialHeader">
+                        Chapter {{formatChapterNumber(chapter)}}
+                    </span>
+                    <ng-template #specialHeader>File(s)</ng-template> -->
+                </h5>
+                Page {{bookmark.page}}
+            </div>
+        </li>
+    </ul>
+
+</div>
+<div class="modal-footer">
+    <button type="button" class="btn btn-primary" (click)="close()">Close</button>
+</div>

--- a/UI/Web/src/app/_modals/bookmarks-modal/bookmarks-modal.component.html
+++ b/UI/Web/src/app/_modals/bookmarks-modal/bookmarks-modal.component.html
@@ -8,7 +8,7 @@
 <div class="modal-body">
     
     <ul class="list-unstyled">
-        <li class="media my-4" *ngFor="let bookmark of bookmarks">
+        <li class="list-group-item" *ngFor="let bookmark of bookmarks">
             <!-- <img class="mr-3" style="width: 74px" src="{{imageService.getBookmarkedImage(bookmark.chapterId, bookmark.page)}}">
             <div class="media-body">
                 <h5 class="mt-0 mb-1">

--- a/UI/Web/src/app/_modals/bookmarks-modal/bookmarks-modal.component.ts
+++ b/UI/Web/src/app/_modals/bookmarks-modal/bookmarks-modal.component.ts
@@ -1,0 +1,92 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
+import { take } from 'rxjs/operators';
+import { ChapterInfo } from 'src/app/manga-reader/_models/chapter-info';
+import { Chapter } from 'src/app/_models/chapter';
+import { PageBookmark } from 'src/app/_models/page-bookmark';
+import { Series } from 'src/app/_models/series';
+import { Volume } from 'src/app/_models/volume';
+import { ImageService } from 'src/app/_services/image.service';
+import { ReaderService } from 'src/app/_services/reader.service';
+
+@Component({
+  selector: 'app-bookmarks-modal',
+  templateUrl: './bookmarks-modal.component.html',
+  styleUrls: ['./bookmarks-modal.component.scss']
+})
+export class BookmarksModalComponent implements OnInit {
+
+  @Input() chapterId!: number;
+  @Input() type!: 'series' | 'volume' | 'chapter';
+  @Input() entity!: Series | Volume | Chapter;
+
+  bookmarks: Array<PageBookmark> = [];
+  title: string = '';
+  subtitle: string = '';
+
+  constructor(public imageService: ImageService, private readerService: ReaderService, public modal: NgbActiveModal) { }
+
+  ngOnInit(): void {
+    // TODO: Ensure book is cached (maybe by loading chapterInfo)
+    let chapterId = 0;
+    // if (this.type === 'volume') {
+    //   chapterId = (this.entity as Volume).chapters
+    // };
+    // this.readerService.getChapterInfo(this.chapterId).pipe(take(1)).subscribe(chapterInfo => {
+    //   this.updateTitle(chapterInfo);
+
+      
+    // });
+
+    switch (this.type) {
+      case 'chapter':
+      {
+        this.readerService.getBookmarks(this.entity.id).pipe(take(1)).subscribe(bookmarks => {
+          this.bookmarks = bookmarks;
+        });
+        break;
+      }
+      case 'volume':
+      {
+        this.readerService.getBookmarksForVolume(this.entity.id).pipe(take(1)).subscribe(bookmarks => {
+          this.bookmarks = bookmarks;
+        });
+        break;
+      }
+      case 'series':
+      {
+        this.readerService.getBookmarksForSeries(this.entity.id).pipe(take(1)).subscribe(bookmarks => {
+          this.bookmarks = bookmarks;
+        });
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  updateTitle(chapterInfo: ChapterInfo) {
+    this.title = chapterInfo.seriesName;
+    if (chapterInfo.chapterTitle.length > 0) {
+      this.title += ' - ' + chapterInfo.chapterTitle;
+    }
+
+    this.subtitle = '';
+    if (chapterInfo.isSpecial && chapterInfo.volumeNumber === '0') {
+      this.subtitle = chapterInfo.fileName;
+    } else if (!chapterInfo.isSpecial && chapterInfo.volumeNumber === '0') {
+      this.subtitle = 'Chapter ' + chapterInfo.chapterNumber;
+    } else {
+      this.subtitle = 'Volume ' + chapterInfo.volumeNumber;
+
+      if (chapterInfo.chapterNumber !== '0') {
+        this.subtitle += ' Chapter ' + chapterInfo.chapterNumber;
+      }
+    }
+}
+
+  close() {
+    this.modal.close({success: false, series: undefined});
+  }
+
+}

--- a/UI/Web/src/app/_models/page-bookmark.ts
+++ b/UI/Web/src/app/_models/page-bookmark.ts
@@ -1,4 +1,5 @@
 export interface PageBookmark {
+    id: number;
     page: number;
     seriesId: number;
     volumeId: number;

--- a/UI/Web/src/app/_models/page-bookmark.ts
+++ b/UI/Web/src/app/_models/page-bookmark.ts
@@ -1,0 +1,6 @@
+export interface PageBookmark {
+    page: number;
+    seriesId: number;
+    volumeId: number;
+    chapterId: number;
+}

--- a/UI/Web/src/app/_models/progress-bookmark.ts
+++ b/UI/Web/src/app/_models/progress-bookmark.ts
@@ -1,4 +1,4 @@
-export interface Bookmark {
+export interface ProgressBookmark {
     pageNum: number;
     chapterId: number;
     bookScrollId?: string;

--- a/UI/Web/src/app/_services/action-factory.service.ts
+++ b/UI/Web/src/app/_services/action-factory.service.ts
@@ -14,7 +14,8 @@ export enum Action {
   Edit = 4,
   Info = 5,
   RefreshMetadata = 6,
-  Download = 7
+  Download = 7,
+  Bookmarks = 8
 }
 
 export interface ActionItem<T> {
@@ -156,6 +157,11 @@ export class ActionFactoryService {
         action: Action.MarkAsUnread,
         title: 'Mark as Unread',
         callback: this.dummyCallback
+      }, 
+      {
+        action: Action.Bookmarks,
+        title: 'Bookmarks',
+        callback: this.dummyCallback
       }
     ];
 
@@ -169,6 +175,11 @@ export class ActionFactoryService {
         action: Action.MarkAsUnread,
         title: 'Mark as Unread',
         callback: this.dummyCallback
+      }, 
+      {
+        action: Action.Bookmarks,
+        title: 'Bookmarks',
+        callback: this.dummyCallback
       }
     ];
 
@@ -181,6 +192,11 @@ export class ActionFactoryService {
       {
         action: Action.MarkAsUnread,
         title: 'Mark as Unread',
+        callback: this.dummyCallback
+      }, 
+      {
+        action: Action.Bookmarks,
+        title: 'Bookmarks',
         callback: this.dummyCallback
       }
     ];

--- a/UI/Web/src/app/_services/action-factory.service.ts
+++ b/UI/Web/src/app/_services/action-factory.service.ts
@@ -22,7 +22,7 @@ export interface ActionItem<T> {
   title: string;
   action: Action;
   callback: (action: Action, data: T) => void;
-
+  requiresAdmin: boolean;
 }
 
 @Injectable({
@@ -59,43 +59,50 @@ export class ActionFactoryService {
         this.collectionTagActions.push({
           action: Action.Edit,
           title: 'Edit',
-          callback: this.dummyCallback
+          callback: this.dummyCallback,
+          requiresAdmin: true
         });
 
         this.seriesActions.push({
           action: Action.ScanLibrary,
           title: 'Scan Series',
-          callback: this.dummyCallback
+          callback: this.dummyCallback,
+          requiresAdmin: true
         });
 
         this.seriesActions.push({
           action: Action.RefreshMetadata,
           title: 'Refresh Metadata',
-          callback: this.dummyCallback
+          callback: this.dummyCallback,
+          requiresAdmin: true
         });
 
         this.seriesActions.push({
           action: Action.Delete,
           title: 'Delete',
-          callback: this.dummyCallback
+          callback: this.dummyCallback,
+          requiresAdmin: true
         });
 
         this.seriesActions.push({
           action: Action.Edit,
           title: 'Edit',
-          callback: this.dummyCallback
+          callback: this.dummyCallback,
+          requiresAdmin: true
         });
 
         this.libraryActions.push({
           action: Action.ScanLibrary,
           title: 'Scan Library',
-          callback: this.dummyCallback
+          callback: this.dummyCallback,
+          requiresAdmin: true
         });
 
         this.libraryActions.push({
           action: Action.RefreshMetadata,
           title: 'Refresh Metadata',
-          callback: this.dummyCallback
+          callback: this.dummyCallback,
+          requiresAdmin: true
         });
       }
 
@@ -103,13 +110,15 @@ export class ActionFactoryService {
         this.volumeActions.push({
           action: Action.Download,
           title: 'Download',
-          callback: this.dummyCallback
+          callback: this.dummyCallback,
+          requiresAdmin: false
         });
 
         this.chapterActions.push({
           action: Action.Download,
           title: 'Download',
-          callback: this.dummyCallback
+          callback: this.dummyCallback,
+          requiresAdmin: false
         });
       }
     });
@@ -151,17 +160,20 @@ export class ActionFactoryService {
       {
         action: Action.MarkAsRead,
         title: 'Mark as Read',
-        callback: this.dummyCallback
+        callback: this.dummyCallback,
+          requiresAdmin: false
       },
       {
         action: Action.MarkAsUnread,
         title: 'Mark as Unread',
-        callback: this.dummyCallback
+        callback: this.dummyCallback,
+          requiresAdmin: false
       }, 
       {
         action: Action.Bookmarks,
         title: 'Bookmarks',
-        callback: this.dummyCallback
+        callback: this.dummyCallback,
+          requiresAdmin: false
       }
     ];
 
@@ -169,17 +181,14 @@ export class ActionFactoryService {
       {
         action: Action.MarkAsRead,
         title: 'Mark as Read',
-        callback: this.dummyCallback
+        callback: this.dummyCallback,
+          requiresAdmin: false
       },
       {
         action: Action.MarkAsUnread,
         title: 'Mark as Unread',
-        callback: this.dummyCallback
-      }, 
-      {
-        action: Action.Bookmarks,
-        title: 'Bookmarks',
-        callback: this.dummyCallback
+        callback: this.dummyCallback,
+        requiresAdmin: false
       }
     ];
 
@@ -187,30 +196,29 @@ export class ActionFactoryService {
       {
         action: Action.MarkAsRead,
         title: 'Mark as Read',
-        callback: this.dummyCallback
+        callback: this.dummyCallback,
+        requiresAdmin: false
       },
       {
         action: Action.MarkAsUnread,
         title: 'Mark as Unread',
-        callback: this.dummyCallback
-      }, 
-      {
-        action: Action.Bookmarks,
-        title: 'Bookmarks',
-        callback: this.dummyCallback
+        callback: this.dummyCallback,
+        requiresAdmin: false
       }
     ];
 
     this.volumeActions.push({
       action: Action.Info,
       title: 'Info',
-      callback: this.dummyCallback
+      callback: this.dummyCallback,
+      requiresAdmin: false
     });
 
     this.chapterActions.push({
       action: Action.Info,
       title: 'Info',
-      callback: this.dummyCallback
+      callback: this.dummyCallback,
+      requiresAdmin: false
     });
 
 

--- a/UI/Web/src/app/_services/action.service.ts
+++ b/UI/Web/src/app/_services/action.service.ts
@@ -204,7 +204,10 @@ export class ActionService implements OnDestroy {
       this.bookmarkModalRef = this.modalService.open(BookmarksModalComponent, { scrollable: true, size: 'lg' });
       this.bookmarkModalRef.componentInstance.entity = chapter;
       this.bookmarkModalRef.componentInstance.type = 'chapter';
-      this.bookmarkModalRef.closed.subscribe(() => {
+      this.bookmarkModalRef.closed.pipe(take(1)).subscribe(() => {
+        this.bookmarkModalRef = null;
+      });
+      this.bookmarkModalRef.dismissed.pipe(take(1)).subscribe(() => {
         this.bookmarkModalRef = null;
       });
   }
@@ -214,7 +217,10 @@ export class ActionService implements OnDestroy {
       this.bookmarkModalRef = this.modalService.open(BookmarksModalComponent, { scrollable: true, size: 'lg' });
       this.bookmarkModalRef.componentInstance.entity = series;
       this.bookmarkModalRef.componentInstance.type = 'series';
-      this.bookmarkModalRef.closed.subscribe(() => {
+      this.bookmarkModalRef.closed.pipe(take(1)).subscribe(() => {
+        this.bookmarkModalRef = null;
+      });
+      this.bookmarkModalRef.dismissed.pipe(take(1)).subscribe(() => {
         this.bookmarkModalRef = null;
       });
   }
@@ -224,7 +230,10 @@ export class ActionService implements OnDestroy {
       this.bookmarkModalRef = this.modalService.open(BookmarksModalComponent, { scrollable: true, size: 'lg' });
       this.bookmarkModalRef.componentInstance.entity = volume;
       this.bookmarkModalRef.componentInstance.type = 'volume';
-      this.bookmarkModalRef.closed.subscribe(() => {
+      this.bookmarkModalRef.closed.pipe(take(1)).subscribe(() => {
+        this.bookmarkModalRef = null;
+      });
+      this.bookmarkModalRef.dismissed.pipe(take(1)).subscribe(() => {
         this.bookmarkModalRef = null;
       });
   }

--- a/UI/Web/src/app/_services/action.service.ts
+++ b/UI/Web/src/app/_services/action.service.ts
@@ -1,7 +1,9 @@
 import { Injectable, OnDestroy } from '@angular/core';
+import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import { ToastrService } from 'ngx-toastr';
 import { forkJoin, Subject } from 'rxjs';
 import { take, takeUntil } from 'rxjs/operators';
+import { BookmarksModalComponent } from '../_modals/bookmarks-modal/bookmarks-modal.component';
 import { Chapter } from '../_models/chapter';
 import { Library } from '../_models/library';
 import { Series } from '../_models/series';
@@ -24,9 +26,10 @@ export type ChapterActionCallback = (chapter: Chapter) => void;
 export class ActionService implements OnDestroy {
 
   private readonly onDestroy = new Subject<void>();
+  private bookmarkModalRef: NgbModalRef | null = null;
 
   constructor(private libraryService: LibraryService, private seriesService: SeriesService, 
-    private readerService: ReaderService, private toastr: ToastrService) { }
+    private readerService: ReaderService, private toastr: ToastrService, private modalService: NgbModal) { }
 
   ngOnDestroy() {
     this.onDestroy.next();
@@ -193,6 +196,37 @@ export class ActionService implements OnDestroy {
         callback(chapter);
       }
     });
+  }
+
+
+  openBookmarkModal(chapter: Chapter, callback?: ChapterActionCallback) {
+    if (this.bookmarkModalRef != null) { return; }
+      this.bookmarkModalRef = this.modalService.open(BookmarksModalComponent, { scrollable: true, size: 'lg' });
+      this.bookmarkModalRef.componentInstance.entity = chapter;
+      this.bookmarkModalRef.componentInstance.type = 'chapter';
+      this.bookmarkModalRef.closed.subscribe(() => {
+        this.bookmarkModalRef = null;
+      });
+  }
+
+  openSeriesBookmarkModal(series: Series, callback?: SeriesActionCallback) {
+    if (this.bookmarkModalRef != null) { return; }
+      this.bookmarkModalRef = this.modalService.open(BookmarksModalComponent, { scrollable: true, size: 'lg' });
+      this.bookmarkModalRef.componentInstance.entity = series;
+      this.bookmarkModalRef.componentInstance.type = 'series';
+      this.bookmarkModalRef.closed.subscribe(() => {
+        this.bookmarkModalRef = null;
+      });
+  }
+
+  openVolumeBookmarkModal(volume: Volume, callback?: SeriesActionCallback) {
+    if (this.bookmarkModalRef != null) { return; }
+      this.bookmarkModalRef = this.modalService.open(BookmarksModalComponent, { scrollable: true, size: 'lg' });
+      this.bookmarkModalRef.componentInstance.entity = volume;
+      this.bookmarkModalRef.componentInstance.type = 'volume';
+      this.bookmarkModalRef.closed.subscribe(() => {
+        this.bookmarkModalRef = null;
+      });
   }
 
   

--- a/UI/Web/src/app/_services/action.service.ts
+++ b/UI/Web/src/app/_services/action.service.ts
@@ -199,44 +199,22 @@ export class ActionService implements OnDestroy {
   }
 
 
-  openBookmarkModal(chapter: Chapter, callback?: ChapterActionCallback) {
+  openBookmarkModal(series: Series, callback?: SeriesActionCallback) {
     if (this.bookmarkModalRef != null) { return; }
       this.bookmarkModalRef = this.modalService.open(BookmarksModalComponent, { scrollable: true, size: 'lg' });
-      this.bookmarkModalRef.componentInstance.entity = chapter;
-      this.bookmarkModalRef.componentInstance.type = 'chapter';
+      this.bookmarkModalRef.componentInstance.series = series;
       this.bookmarkModalRef.closed.pipe(take(1)).subscribe(() => {
         this.bookmarkModalRef = null;
+        if (callback) {
+          callback(series);
+        }
       });
       this.bookmarkModalRef.dismissed.pipe(take(1)).subscribe(() => {
         this.bookmarkModalRef = null;
+        if (callback) {
+          callback(series);
+        }
       });
   }
 
-  openSeriesBookmarkModal(series: Series, callback?: SeriesActionCallback) {
-    if (this.bookmarkModalRef != null) { return; }
-      this.bookmarkModalRef = this.modalService.open(BookmarksModalComponent, { scrollable: true, size: 'lg' });
-      this.bookmarkModalRef.componentInstance.entity = series;
-      this.bookmarkModalRef.componentInstance.type = 'series';
-      this.bookmarkModalRef.closed.pipe(take(1)).subscribe(() => {
-        this.bookmarkModalRef = null;
-      });
-      this.bookmarkModalRef.dismissed.pipe(take(1)).subscribe(() => {
-        this.bookmarkModalRef = null;
-      });
-  }
-
-  openVolumeBookmarkModal(volume: Volume, callback?: SeriesActionCallback) {
-    if (this.bookmarkModalRef != null) { return; }
-      this.bookmarkModalRef = this.modalService.open(BookmarksModalComponent, { scrollable: true, size: 'lg' });
-      this.bookmarkModalRef.componentInstance.entity = volume;
-      this.bookmarkModalRef.componentInstance.type = 'volume';
-      this.bookmarkModalRef.closed.pipe(take(1)).subscribe(() => {
-        this.bookmarkModalRef = null;
-      });
-      this.bookmarkModalRef.dismissed.pipe(take(1)).subscribe(() => {
-        this.bookmarkModalRef = null;
-      });
-  }
-
-  
 }

--- a/UI/Web/src/app/_services/action.service.ts
+++ b/UI/Web/src/app/_services/action.service.ts
@@ -153,7 +153,7 @@ export class ActionService implements OnDestroy {
    * @param callback Optional callback to perform actions after API completes
    */
   markVolumeAsUnread(seriesId: number, volume: Volume, callback?: VolumeActionCallback) {
-    forkJoin(volume.chapters?.map(chapter => this.readerService.bookmark(seriesId, volume.id, chapter.id, 0))).pipe(takeUntil(this.onDestroy)).subscribe(results => {
+    forkJoin(volume.chapters?.map(chapter => this.readerService.saveProgress(seriesId, volume.id, chapter.id, 0))).pipe(takeUntil(this.onDestroy)).subscribe(results => {
       volume.pagesRead = 0;
       volume.chapters?.forEach(c => c.pagesRead = 0);
       this.toastr.success('Marked as Unread');
@@ -170,7 +170,7 @@ export class ActionService implements OnDestroy {
    * @param callback Optional callback to perform actions after API completes
    */
   markChapterAsRead(seriesId: number, chapter: Chapter, callback?: ChapterActionCallback) {
-    this.readerService.bookmark(seriesId, chapter.volumeId, chapter.id, chapter.pages).pipe(take(1)).subscribe(results => {
+    this.readerService.saveProgress(seriesId, chapter.volumeId, chapter.id, chapter.pages).pipe(take(1)).subscribe(results => {
       chapter.pagesRead = chapter.pages;
       this.toastr.success('Marked as Read');
       if (callback) {
@@ -186,7 +186,7 @@ export class ActionService implements OnDestroy {
    * @param callback Optional callback to perform actions after API completes
    */
   markChapterAsUnread(seriesId: number, chapter: Chapter, callback?: ChapterActionCallback) {
-    this.readerService.bookmark(seriesId, chapter.volumeId, chapter.id, chapter.pages).pipe(take(1)).subscribe(results => {
+    this.readerService.saveProgress(seriesId, chapter.volumeId, chapter.id, chapter.pages).pipe(take(1)).subscribe(results => {
       chapter.pagesRead = 0;
       this.toastr.success('Marked as unread');
       if (callback) {

--- a/UI/Web/src/app/_services/image.service.ts
+++ b/UI/Web/src/app/_services/image.service.ts
@@ -39,6 +39,10 @@ export class ImageService {
     return this.baseUrl + 'image/chapter-cover?chapterId=' + chapterId;
   }
 
+  getBookmarkedImage(chapterId: number, pageNum: number) {
+    return this.baseUrl + 'image/chapter-cover?chapterId=' + chapterId + '&pageNum=' + pageNum;
+  }
+
   updateErroredImage(event: any) {
     event.target.src = this.placeholderImage;
   }

--- a/UI/Web/src/app/_services/message-hub.service.ts
+++ b/UI/Web/src/app/_services/message-hub.service.ts
@@ -43,6 +43,9 @@ export class MessageHubService {
       this.updateNotificationModalRef.closed.subscribe(() => {
         this.updateNotificationModalRef = null;
       });
+      this.updateNotificationModalRef.dismissed.subscribe(() => {
+        this.updateNotificationModalRef = null;
+      });
     });
   }
 

--- a/UI/Web/src/app/_services/reader.service.ts
+++ b/UI/Web/src/app/_services/reader.service.ts
@@ -3,8 +3,8 @@ import { Injectable } from '@angular/core';
 import { environment } from 'src/environments/environment';
 import { ChapterInfo } from '../manga-reader/_models/chapter-info';
 import { UtilityService } from '../shared/_services/utility.service';
-import { Bookmark } from '../_models/bookmark';
 import { Chapter } from '../_models/chapter';
+import { ProgressBookmark } from '../_models/progress-bookmark';
 import { Volume } from '../_models/volume';
 
 @Injectable({
@@ -20,7 +20,7 @@ export class ReaderService {
   constructor(private httpClient: HttpClient, private utilityService: UtilityService) { }
 
   getBookmark(chapterId: number) {
-    return this.httpClient.get<Bookmark>(this.baseUrl + 'reader/get-bookmark?chapterId=' + chapterId);
+    return this.httpClient.get<ProgressBookmark>(this.baseUrl + 'reader/get-progress?chapterId=' + chapterId);
   }
 
   getPageUrl(chapterId: number, page: number) {
@@ -32,7 +32,7 @@ export class ReaderService {
   }
 
   bookmark(seriesId: number, volumeId: number, chapterId: number, page: number, bookScrollId: string | null = null) {
-    return this.httpClient.post(this.baseUrl + 'reader/bookmark', {seriesId, volumeId, chapterId, pageNum: page, bookScrollId});
+    return this.httpClient.post(this.baseUrl + 'reader/progress', {seriesId, volumeId, chapterId, pageNum: page, bookScrollId});
   }
 
   markVolumeRead(seriesId: number, volumeId: number) {

--- a/UI/Web/src/app/_services/reader.service.ts
+++ b/UI/Web/src/app/_services/reader.service.ts
@@ -40,6 +40,10 @@ export class ReaderService {
     return this.httpClient.get<PageBookmark[]>(this.baseUrl + 'reader/get-series-bookmarks?seriesId=' + seriesId);
   }
 
+  clearBookmarks(seriesId: number) {
+    return this.httpClient.post(this.baseUrl + 'reader/remove-bookmarks', {seriesId});
+  }
+
   getProgress(chapterId: number) {
     return this.httpClient.get<ProgressBookmark>(this.baseUrl + 'reader/get-progress?chapterId=' + chapterId);
   }
@@ -48,8 +52,8 @@ export class ReaderService {
     return this.baseUrl + 'reader/image?chapterId=' + chapterId + '&page=' + page;
   }
 
-  getChapterInfo(chapterId: number) {
-    return this.httpClient.get<ChapterInfo>(this.baseUrl + 'reader/chapter-info?chapterId=' + chapterId);
+  getChapterInfo(seriesId: number, chapterId: number) {
+    return this.httpClient.get<ChapterInfo>(this.baseUrl + 'reader/chapter-info?chapterId=' + chapterId + '&seriesId=' + seriesId);
   }
 
   saveProgress(seriesId: number, volumeId: number, chapterId: number, page: number, bookScrollId: string | null = null) {

--- a/UI/Web/src/app/_services/reader.service.ts
+++ b/UI/Web/src/app/_services/reader.service.ts
@@ -19,7 +19,7 @@ export class ReaderService {
 
   constructor(private httpClient: HttpClient, private utilityService: UtilityService) { }
 
-  getBookmark(chapterId: number) {
+  getProgress(chapterId: number) {
     return this.httpClient.get<ProgressBookmark>(this.baseUrl + 'reader/get-progress?chapterId=' + chapterId);
   }
 
@@ -31,7 +31,7 @@ export class ReaderService {
     return this.httpClient.get<ChapterInfo>(this.baseUrl + 'reader/chapter-info?chapterId=' + chapterId);
   }
 
-  bookmark(seriesId: number, volumeId: number, chapterId: number, page: number, bookScrollId: string | null = null) {
+  saveProgress(seriesId: number, volumeId: number, chapterId: number, page: number, bookScrollId: string | null = null) {
     return this.httpClient.post(this.baseUrl + 'reader/progress', {seriesId, volumeId, chapterId, pageNum: page, bookScrollId});
   }
 

--- a/UI/Web/src/app/_services/reader.service.ts
+++ b/UI/Web/src/app/_services/reader.service.ts
@@ -21,15 +21,23 @@ export class ReaderService {
   constructor(private httpClient: HttpClient, private utilityService: UtilityService) { }
 
   bookmark(seriesId: number, volumeId: number, chapterId: number, page: number) {
-    return this.httpClient.post(this.baseUrl + 'reader/bookmark', {seriesId, volumeId, chapterId, pageNum: page});
+    return this.httpClient.post(this.baseUrl + 'reader/bookmark', {seriesId, volumeId, chapterId, page});
   }
 
   unbookmark(seriesId: number, volumeId: number, chapterId: number, page: number) {
-    return this.httpClient.post(this.baseUrl + 'reader/unbookmark', {seriesId, volumeId, chapterId, pageNum: page});
+    return this.httpClient.post(this.baseUrl + 'reader/unbookmark', {seriesId, volumeId, chapterId, page});
   }
 
   getBookmarks(chapterId: number) {
     return this.httpClient.get<PageBookmark[]>(this.baseUrl + 'reader/get-bookmarks?chapterId=' + chapterId);
+  }
+
+  getBookmarksForVolume(volumeId: number) {
+    return this.httpClient.get<PageBookmark[]>(this.baseUrl + 'reader/get-volume-bookmarks?volumeId=' + volumeId);
+  }
+
+  getBookmarksForSeries(seriesId: number) {
+    return this.httpClient.get<PageBookmark[]>(this.baseUrl + 'reader/get-series-bookmarks?seriesId=' + seriesId);
   }
 
   getProgress(chapterId: number) {

--- a/UI/Web/src/app/_services/reader.service.ts
+++ b/UI/Web/src/app/_services/reader.service.ts
@@ -4,6 +4,7 @@ import { environment } from 'src/environments/environment';
 import { ChapterInfo } from '../manga-reader/_models/chapter-info';
 import { UtilityService } from '../shared/_services/utility.service';
 import { Chapter } from '../_models/chapter';
+import { PageBookmark } from '../_models/page-bookmark';
 import { ProgressBookmark } from '../_models/progress-bookmark';
 import { Volume } from '../_models/volume';
 
@@ -18,6 +19,18 @@ export class ReaderService {
   private originalBodyColor!: string;
 
   constructor(private httpClient: HttpClient, private utilityService: UtilityService) { }
+
+  bookmark(seriesId: number, volumeId: number, chapterId: number, page: number) {
+    return this.httpClient.post(this.baseUrl + 'reader/bookmark', {seriesId, volumeId, chapterId, pageNum: page});
+  }
+
+  unbookmark(seriesId: number, volumeId: number, chapterId: number, page: number) {
+    return this.httpClient.post(this.baseUrl + 'reader/unbookmark', {seriesId, volumeId, chapterId, pageNum: page});
+  }
+
+  getBookmarks(chapterId: number) {
+    return this.httpClient.get<PageBookmark[]>(this.baseUrl + 'reader/get-bookmarks?chapterId=' + chapterId);
+  }
 
   getProgress(chapterId: number) {
     return this.httpClient.get<ProgressBookmark>(this.baseUrl + 'reader/get-progress?chapterId=' + chapterId);

--- a/UI/Web/src/app/app.module.ts
+++ b/UI/Web/src/app/app.module.ts
@@ -39,6 +39,7 @@ import { RecentlyAddedComponent } from './recently-added/recently-added.componen
 import { LibraryCardComponent } from './library-card/library-card.component';
 import { SeriesCardComponent } from './series-card/series-card.component';
 import { InProgressComponent } from './in-progress/in-progress.component';
+import { BookmarksModalComponent } from './_modals/bookmarks-modal/bookmarks-modal.component';
 
 let sentryProviders: any[] = [];
 
@@ -104,7 +105,8 @@ if (environment.production) {
     RecentlyAddedComponent,
     LibraryCardComponent,
     SeriesCardComponent,
-    InProgressComponent
+    InProgressComponent,
+    BookmarksModalComponent
   ],
   imports: [
     HttpClientModule,

--- a/UI/Web/src/app/book-reader/book-reader/book-reader.component.ts
+++ b/UI/Web/src/app/book-reader/book-reader/book-reader.component.ts
@@ -117,11 +117,10 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
    * Last seen progress part path
    */
   lastSeenScrollPartPath: string = '';
-
-  // Temp hack: Override background color for reader and restore it onDestroy
+  /**
+   * Hack: Override background color for reader and restore it onDestroy
+   */
   originalBodyColor: string | undefined;
-
-
 
   darkModeStyles = `
     *:not(input), *:not(select), *:not(code), *:not(:link), *:not(.ngx-toastr) {

--- a/UI/Web/src/app/manga-reader/manga-reader.component.html
+++ b/UI/Web/src/app/manga-reader/manga-reader.component.html
@@ -12,8 +12,8 @@
                     {{subtitle}}
                 </div>
             </div>
-            <div>
-                <button class="btn btn-icon btn-small" (click)="bookmarkPage()"><i class="{{pageBookmarked ? 'fa' : 'far'}} fa-bookmark" aria-hidden="true"></i><span class="sr-only">Bookmark</span></button>
+            <div style="margin-left: auto; padding-right: 3%;">
+                <button class="btn btn-icon btn-small" role="checkbox" [attr.aria-checked]="pageBookmarked" title="{{pageBookmarked ? 'Unbookmark Page' : 'Bookmark Page'}}" (click)="bookmarkPage()"><i class="{{pageBookmarked ? 'fa' : 'far'}} fa-bookmark" aria-hidden="true"></i><span class="sr-only">{{pageBookmarked ? 'Unbookmark Page' : 'Bookmark Page'}}</span></button>
             </div>
         </div>
     </div>

--- a/UI/Web/src/app/manga-reader/manga-reader.component.html
+++ b/UI/Web/src/app/manga-reader/manga-reader.component.html
@@ -12,6 +12,9 @@
                     {{subtitle}}
                 </div>
             </div>
+            <div>
+                <button class="btn btn-icon btn-small"><i class="{{pageBookmarked ? 'fa' : 'far'}} fa-bookmark" aria-hidden="true"></i><span class="sr-only">Bookmark</span></button>
+            </div>
         </div>
     </div>
     <ng-container *ngIf="isLoading">

--- a/UI/Web/src/app/manga-reader/manga-reader.component.html
+++ b/UI/Web/src/app/manga-reader/manga-reader.component.html
@@ -13,7 +13,7 @@
                 </div>
             </div>
             <div>
-                <button class="btn btn-icon btn-small"><i class="{{pageBookmarked ? 'fa' : 'far'}} fa-bookmark" aria-hidden="true"></i><span class="sr-only">Bookmark</span></button>
+                <button class="btn btn-icon btn-small" (click)="bookmarkPage()"><i class="{{pageBookmarked ? 'fa' : 'far'}} fa-bookmark" aria-hidden="true"></i><span class="sr-only">Bookmark</span></button>
             </div>
         </div>
     </div>

--- a/UI/Web/src/app/manga-reader/manga-reader.component.ts
+++ b/UI/Web/src/app/manga-reader/manga-reader.component.ts
@@ -191,6 +191,10 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
 
   
 
+  get pageBookmarked() {
+    //if (this.bookmarks)
+    return false;
+  }
   
 
   get splitIconClass() {

--- a/UI/Web/src/app/manga-reader/manga-reader.component.ts
+++ b/UI/Web/src/app/manga-reader/manga-reader.component.ts
@@ -183,7 +183,9 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
    * If extended settings area is visible. Blocks auto-closing of menu.
    */
   settingsOpen: boolean = false;
-
+  /**
+   * A map of bookmarked pages to anything. Used for O(1) lookup time if a page is bookmarked or not.
+   */
   bookmarks: {[key: string]: number} = {};
 
   private readonly onDestroy = new Subject<void>();
@@ -965,11 +967,11 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
     const pageNum = this.pageNum;
     if (this.pageBookmarked) {
       // Remove bookmark
-      this.readerService.unbookmark(this.seriesId, this.volumeId, this.chapterId, pageNum).subscribe(() => {
+      this.readerService.unbookmark(this.seriesId, this.volumeId, this.chapterId, pageNum).pipe(take(1)).subscribe(() => {
         delete this.bookmarks[pageNum];
       });
     } else {
-      this.readerService.bookmark(this.seriesId, this.volumeId, this.chapterId, pageNum).subscribe(() => {
+      this.readerService.bookmark(this.seriesId, this.volumeId, this.chapterId, pageNum).pipe(take(1)).subscribe(() => {
         this.bookmarks[pageNum] = 1;
       });
     }

--- a/UI/Web/src/app/manga-reader/manga-reader.component.ts
+++ b/UI/Web/src/app/manga-reader/manga-reader.component.ts
@@ -352,13 +352,13 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
     this.pageNum = 1;
 
     forkJoin({
-      bookmark: this.readerService.getBookmark(this.chapterId),
+      progress: this.readerService.getProgress(this.chapterId),
       chapterInfo: this.readerService.getChapterInfo(this.chapterId)
     }).pipe(take(1)).subscribe(results => {
       this.volumeId = results.chapterInfo.volumeId;
       this.maxPages = results.chapterInfo.pages;
 
-      let page = results.bookmark.pageNum;
+      let page = results.progress.pageNum;
       if (page >= this.maxPages) {
         page = this.maxPages - 1;
       }
@@ -751,14 +751,14 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
   loadPage() {
     if (!this.canvas || !this.ctx) { return; }
 
-    // Due to the fact that we start at image 0, but page 1, we need the last page to be bookmarked as page + 1 to be completed
+    // Due to the fact that we start at image 0, but page 1, we need the last page to have progress as page + 1 to be completed
     let pageNum = this.pageNum;
     if (this.pageNum == this.maxPages - 1) {
       pageNum = this.pageNum + 1;
     }
 
 
-    this.readerService.bookmark(this.seriesId, this.volumeId, this.chapterId, pageNum).pipe(take(1)).subscribe(() => {/* No operation */});
+    this.readerService.saveProgress(this.seriesId, this.volumeId, this.chapterId, pageNum).pipe(take(1)).subscribe(() => {/* No operation */});
 
     this.isLoading = true;
     this.canvasImage = this.cachedImages.current();
@@ -909,7 +909,7 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
 
   handleWebtoonPageChange(updatedPageNum: number) {
     this.setPageNum(updatedPageNum);
-    this.readerService.bookmark(this.seriesId, this.volumeId, this.chapterId, this.pageNum).pipe(take(1)).subscribe(() => {/* No operation */});
+    this.readerService.saveProgress(this.seriesId, this.volumeId, this.chapterId, this.pageNum).pipe(take(1)).subscribe(() => {/* No operation */});
   }
 
   saveSettings() {

--- a/UI/Web/src/app/manga-reader/manga-reader.component.ts
+++ b/UI/Web/src/app/manga-reader/manga-reader.component.ts
@@ -356,7 +356,7 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
 
     forkJoin({
       progress: this.readerService.getProgress(this.chapterId),
-      chapterInfo: this.readerService.getChapterInfo(this.chapterId),
+      chapterInfo: this.readerService.getChapterInfo(this.seriesId, this.chapterId),
       bookmarks: this.readerService.getBookmarks(this.chapterId)
     }).pipe(take(1)).subscribe(results => {
       this.volumeId = results.chapterInfo.volumeId;
@@ -828,13 +828,13 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
     if (this.pageNum >= this.maxPages - 10) {
       // Tell server to cache the next chapter
       if (this.nextChapterId > 0 && !this.nextChapterPrefetched) {
-        this.readerService.getChapterInfo(this.nextChapterId).pipe(take(1)).subscribe(res => {
+        this.readerService.getChapterInfo(this.seriesId, this.nextChapterId).pipe(take(1)).subscribe(res => {
           this.nextChapterPrefetched = true;
         });
       }
     } else if (this.pageNum <= 10) {
       if (this.prevChapterId > 0 && !this.prevChapterPrefetched) {
-        this.readerService.getChapterInfo(this.prevChapterId).pipe(take(1)).subscribe(res => {
+        this.readerService.getChapterInfo(this.seriesId, this.prevChapterId).pipe(take(1)).subscribe(res => {
           this.prevChapterPrefetched = true;
         });
       }

--- a/UI/Web/src/app/series-card/series-card.component.ts
+++ b/UI/Web/src/app/series-card/series-card.component.ts
@@ -10,6 +10,7 @@ import { ImageService } from 'src/app/_services/image.service';
 import { ActionFactoryService, Action, ActionItem } from 'src/app/_services/action-factory.service';
 import { SeriesService } from 'src/app/_services/series.service';
 import { ConfirmService } from '../shared/confirm.service';
+import { ActionService } from '../_services/action.service';
 
 @Component({
   selector: 'app-series-card',
@@ -30,7 +31,8 @@ export class SeriesCardComponent implements OnInit, OnChanges {
   constructor(private accountService: AccountService, private router: Router,
               private seriesService: SeriesService, private toastr: ToastrService,
               private modalService: NgbModal, private confirmService: ConfirmService, 
-              public imageService: ImageService, private actionFactoryService: ActionFactoryService) {
+              public imageService: ImageService, private actionFactoryService: ActionFactoryService,
+              private actionService: ActionService) {
     this.accountService.currentUser$.pipe(take(1)).subscribe(user => {
       if (user) {
         this.isAdmin = this.accountService.hasAdminRole(user);
@@ -67,6 +69,9 @@ export class SeriesCardComponent implements OnInit, OnChanges {
         break;
       case(Action.Edit):
         this.openEditModal(series);
+        break;
+      case(Action.Bookmarks):
+        this.actionService.openBookmarkModal(series, (series) => {/* No Operation */ });
         break;
       default:
         break;

--- a/UI/Web/src/app/series-detail/series-detail.component.html
+++ b/UI/Web/src/app/series-detail/series-detail.component.html
@@ -13,12 +13,11 @@
             </div>
             <div class="row no-gutters">
                 <div>
-                    <button class="btn btn-primary" (click)="read()" (mouseover)="showBook = true;" (mouseleave)="showBook = false;" [disabled]="isLoading">
+                    <button class="btn btn-primary" (click)="read()" [disabled]="isLoading">
                         <span>
                             <i class="fa {{showBook ? 'fa-book-open' : 'fa-book'}}"></i>
                         </span>
-                        &nbsp;
-                        <span class="read-btn--text">{{(hasReadingProgress) ? 'Continue' : 'Read'}}</span>
+                        <span class="read-btn--text">&nbsp;{{(hasReadingProgress) ? 'Continue' : 'Read'}}</span>
                     </button>
                 </div>
                 <div class="ml-2" *ngIf="isAdmin">

--- a/UI/Web/src/app/series-detail/series-detail.component.ts
+++ b/UI/Web/src/app/series-detail/series-detail.component.ts
@@ -150,6 +150,9 @@ export class SeriesDetailComponent implements OnInit {
       case(Action.Delete):
         this.deleteSeries(series);
         break;
+      case(Action.Bookmarks):
+        this.actionService.openSeriesBookmarkModal(series, (series) => {});
+        break;
       default:
         break;
     }
@@ -169,6 +172,9 @@ export class SeriesDetailComponent implements OnInit {
       case(Action.Download):
       this.downloadService.downloadVolume(volume, this.series.name);
         break;
+      case(Action.Bookmarks):
+        this.actionService.openVolumeBookmarkModal(volume, (volume) => {});
+        break;
       default:
         break;
     }
@@ -187,6 +193,9 @@ export class SeriesDetailComponent implements OnInit {
         break;
       case(Action.Download):
         this.downloadService.downloadChapter(chapter, this.series.name);
+        break;
+      case(Action.Bookmarks):
+        this.actionService.openBookmarkModal(chapter, (chapter) => {});
         break;
       default:
         break;

--- a/UI/Web/src/app/series-detail/series-detail.component.ts
+++ b/UI/Web/src/app/series-detail/series-detail.component.ts
@@ -151,7 +151,7 @@ export class SeriesDetailComponent implements OnInit {
         this.deleteSeries(series);
         break;
       case(Action.Bookmarks):
-        this.actionService.openSeriesBookmarkModal(series, (series) => {});
+        this.actionService.openBookmarkModal(series, (series) => this.actionInProgress = false);
         break;
       default:
         break;
@@ -172,9 +172,6 @@ export class SeriesDetailComponent implements OnInit {
       case(Action.Download):
       this.downloadService.downloadVolume(volume, this.series.name);
         break;
-      case(Action.Bookmarks):
-        this.actionService.openVolumeBookmarkModal(volume, (volume) => {});
-        break;
       default:
         break;
     }
@@ -193,9 +190,6 @@ export class SeriesDetailComponent implements OnInit {
         break;
       case(Action.Download):
         this.downloadService.downloadChapter(chapter, this.series.name);
-        break;
-      case(Action.Bookmarks):
-        this.actionService.openBookmarkModal(chapter, (chapter) => {});
         break;
       default:
         break;

--- a/UI/Web/src/app/shared/_services/download.service.ts
+++ b/UI/Web/src/app/shared/_services/download.service.ts
@@ -7,6 +7,8 @@ import { saveAs } from 'file-saver';
 import { Chapter } from 'src/app/_models/chapter';
 import { Volume } from 'src/app/_models/volume';
 import { ToastrService } from 'ngx-toastr';
+import { PageBookmark } from 'src/app/_models/page-bookmark';
+import { map, take } from 'rxjs/operators';
 
 @Injectable({
   providedIn: 'root'
@@ -83,6 +85,12 @@ export class DownloadService {
         this.preformSave(resp.body || '', this.getFilenameFromHeader(resp.headers, seriesName + ' - Volume ' + volume.name));
       });
     });
+  }
+
+  downloadBookmarks(bookmarks: PageBookmark[], seriesName: string) {
+    return this.httpClient.post(this.baseUrl + 'download/bookmarks', {bookmarks}, {observe: 'response', responseType: 'blob' as 'text'}).pipe(take(1), map(resp => {
+      this.preformSave(resp.body || '', this.getFilenameFromHeader(resp.headers, seriesName));
+    }));
   }
 
   private preformSave(res: string, filename: string) {

--- a/UI/Web/src/app/shared/card-item/card-actionables/card-actionables.component.html
+++ b/UI/Web/src/app/shared/card-item/card-actionables/card-actionables.component.html
@@ -2,7 +2,9 @@
     <div ngbDropdown container="body" class="d-inline-block">
       <button [disabled]="disabled" class="btn {{btnClass}}" id="actions-{{labelBy}}" ngbDropdownToggle (click)="preventClick($event)"><i class="fa {{iconClass}}" aria-hidden="true"></i></button>
       <div ngbDropdownMenu attr.aria-labelledby="actions-{{labelBy}}">
-        <button ngbDropdownItem *ngFor="let action of actions" (click)="performAction($event, action)">{{action.title}}</button>
+        <button ngbDropdownItem *ngFor="let action of nonAdminActions" (click)="performAction($event, action)">{{action.title}}</button>
+        <div class="dropdown-divider" *ngIf="nonAdminActions.length > 1 && adminActions.length > 1"></div>
+        <button ngbDropdownItem *ngFor="let action of adminActions" (click)="performAction($event, action)">{{action.title}}</button>
       </div>
     </div>
 </ng-container>

--- a/UI/Web/src/app/shared/card-item/card-actionables/card-actionables.component.ts
+++ b/UI/Web/src/app/shared/card-item/card-actionables/card-actionables.component.ts
@@ -15,9 +15,15 @@ export class CardActionablesComponent implements OnInit {
   @Input() disabled: boolean = false;
   @Output() actionHandler = new EventEmitter<ActionItem<any>>();
 
+  adminActions: ActionItem<any>[] = [];
+  nonAdminActions: ActionItem<any>[] = [];
+
+
   constructor() { }
 
   ngOnInit(): void {
+    this.nonAdminActions = this.actions.filter(item => !item.requiresAdmin);
+    this.adminActions = this.actions.filter(item => item.requiresAdmin);
   }
 
   preventClick(event: any) {
@@ -32,5 +38,8 @@ export class CardActionablesComponent implements OnInit {
       this.actionHandler.emit(action);
     }
   }
+
+  // TODO: Insert hr to separate admin actions
+
 
 }

--- a/UI/Web/src/app/shared/confirm.service.ts
+++ b/UI/Web/src/app/shared/confirm.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
+import { take } from 'rxjs/operators';
 import { ConfirmDialogComponent } from './confirm-dialog/confirm-dialog.component';
 import { ConfirmConfig } from './confirm-dialog/_models/confirm-config';
 
@@ -36,8 +37,11 @@ export class ConfirmService {
 
       const modalRef = this.modalService.open(ConfirmDialogComponent);
       modalRef.componentInstance.config = config;
-      modalRef.closed.subscribe(result => {
+      modalRef.closed.pipe(take(1)).subscribe(result => {
         return resolve(result);
+      });
+      modalRef.dismissed.pipe(take(1)).subscribe(() => {
+        return reject(false);
       });
     });
 
@@ -57,8 +61,11 @@ export class ConfirmService {
 
       const modalRef = this.modalService.open(ConfirmDialogComponent);
       modalRef.componentInstance.config = config;
-      modalRef.closed.subscribe(result => {
+      modalRef.closed.pipe(take(1)).subscribe(result => {
         return resolve(result);
+      });
+      modalRef.dismissed.pipe(take(1)).subscribe(() => {
+        return reject(false);
       });
     })
   }

--- a/UI/Web/src/styles.scss
+++ b/UI/Web/src/styles.scss
@@ -46,9 +46,10 @@ body {
   font-family: "EBGaramond", "Helvetica Neue", sans-serif;
 }
 
-// .disabled, :disabled {
-//   cursor: not-allowed !important;
-// }
+
+.btn-icon {
+  cursor: pointer;
+}
 
 // Slider handle override
 ::ng-deep {


### PR DESCRIPTION
# Added
- Added: Added the ability to bookmark certain pages within the manga (image) reader and later download them from the series context menu. 

# Fixed
- Fixed: Fixed an issue where after adding a new folder to an existing library, a scan wouldn't be kicked off
- Fixed: In some cases, after clicking the background of a modal, the modal would close, but state wouldn't be handled as if cancel was pushed

# Changed
- Changed: Admin contextual actions on cards will now be separated by a line to help differentiate. 
- Changed: Performance enhancement on an API used before reading

# Dev
- Bumped dependencies to latest versions

Closes #374
Closes #466 
