### PR TITLE
Scan Issues

### DIFF
--- a/API/Data/FileRepository.cs
+++ b/API/Data/FileRepository.cs
@@ -20,7 +20,7 @@ namespace API.Data
         {
             var fileExtensions = await _dbContext.MangaFile
                 .AsNoTracking()
-                .Select(x => x.FilePath)
+                .Select(x => x.FilePath.ToLower())
                 .Distinct()
                 .ToArrayAsync();
 


### PR DESCRIPTION
# Fixed
- Fixed: Fixed an issue where some series (usually pdf or image) would get deleted and recreated during library scans

# Changed
- Changed: When calculating unique filetypes used within Kavita instance, use lowercase so CBZ and cbz don't count as duplicate entities before sending to KavitaStats. 

Fixes #461 