### PR TITLE
Download Refactor

### DIFF
--- a/API/Controllers/DownloadController.cs
+++ b/API/Controllers/DownloadController.cs
@@ -21,6 +21,7 @@ namespace API.Controllers
         private readonly IUnitOfWork _unitOfWork;
         private readonly IArchiveService _archiveService;
         private readonly IDirectoryService _directoryService;
+        private const string DefaultContentType = "application/octet-stream"; // "application/zip"
 
         public DownloadController(IUnitOfWork unitOfWork, IArchiveService archiveService, IDirectoryService directoryService)
         {
@@ -62,7 +63,7 @@ namespace API.Controllers
                 }
                 var (fileBytes, zipPath) = await _archiveService.CreateZipForDownload(files.Select(c => c.FilePath),
                     $"download_{User.GetUsername()}_v{volumeId}");
-                return File(fileBytes, "application/zip", Path.GetFileNameWithoutExtension(zipPath) + ".zip");
+                return File(fileBytes, DefaultContentType, Path.GetFileNameWithoutExtension(zipPath) + ".zip");
             }
             catch (KavitaException ex)
             {
@@ -105,7 +106,7 @@ namespace API.Controllers
                 }
                 var (fileBytes, zipPath) = await _archiveService.CreateZipForDownload(files.Select(c => c.FilePath),
                     $"download_{User.GetUsername()}_c{chapterId}");
-                return File(fileBytes, "application/zip", Path.GetFileNameWithoutExtension(zipPath) + ".zip");
+                return File(fileBytes, DefaultContentType, Path.GetFileNameWithoutExtension(zipPath) + ".zip");
             }
             catch (KavitaException ex)
             {
@@ -125,7 +126,7 @@ namespace API.Controllers
                 }
                 var (fileBytes, zipPath) = await _archiveService.CreateZipForDownload(files.Select(c => c.FilePath),
                     $"download_{User.GetUsername()}_s{seriesId}");
-                return File(fileBytes, "application/zip", Path.GetFileNameWithoutExtension(zipPath) + ".zip");
+                return File(fileBytes, DefaultContentType, Path.GetFileNameWithoutExtension(zipPath) + ".zip");
             }
             catch (KavitaException ex)
             {

--- a/API/Controllers/DownloadController.cs
+++ b/API/Controllers/DownloadController.cs
@@ -62,6 +62,8 @@ namespace API.Controllers
         public async Task<ActionResult> DownloadVolume(int volumeId)
         {
             var files = await _unitOfWork.VolumeRepository.GetFilesForVolume(volumeId);
+            var volume = await _unitOfWork.SeriesRepository.GetVolumeByIdAsync(volumeId);
+            var series = await _unitOfWork.SeriesRepository.GetSeriesByIdAsync(volume.SeriesId);
             try
             {
                 if (files.Count == 1)
@@ -70,7 +72,7 @@ namespace API.Controllers
                 }
                 var (fileBytes, zipPath) = await _archiveService.CreateZipForDownload(files.Select(c => c.FilePath),
                     $"download_{User.GetUsername()}_v{volumeId}");
-                return File(fileBytes, DefaultContentType, Path.GetFileNameWithoutExtension(zipPath) + ".zip");
+                return File(fileBytes, DefaultContentType, $"{series.Name} - Volume {volume.Number}.zip");
             }
             catch (KavitaException ex)
             {
@@ -105,6 +107,9 @@ namespace API.Controllers
         public async Task<ActionResult> DownloadChapter(int chapterId)
         {
             var files = await _unitOfWork.VolumeRepository.GetFilesForChapterAsync(chapterId);
+            var chapter = await _unitOfWork.VolumeRepository.GetChapterAsync(chapterId);
+            var volume = await _unitOfWork.SeriesRepository.GetVolumeByIdAsync(chapter.VolumeId);
+            var series = await _unitOfWork.SeriesRepository.GetSeriesByIdAsync(volume.SeriesId);
             try
             {
                 if (files.Count == 1)
@@ -113,7 +118,7 @@ namespace API.Controllers
                 }
                 var (fileBytes, zipPath) = await _archiveService.CreateZipForDownload(files.Select(c => c.FilePath),
                     $"download_{User.GetUsername()}_c{chapterId}");
-                return File(fileBytes, DefaultContentType, Path.GetFileNameWithoutExtension(zipPath) + ".zip");
+                return File(fileBytes, DefaultContentType, $"{series.Name} - Chapter {chapter.Number}.zip");
             }
             catch (KavitaException ex)
             {
@@ -125,6 +130,7 @@ namespace API.Controllers
         public async Task<ActionResult> DownloadSeries(int seriesId)
         {
             var files = await _unitOfWork.SeriesRepository.GetFilesForSeries(seriesId);
+            var series = await _unitOfWork.SeriesRepository.GetSeriesByIdAsync(seriesId);
             try
             {
                 if (files.Count == 1)
@@ -133,7 +139,7 @@ namespace API.Controllers
                 }
                 var (fileBytes, zipPath) = await _archiveService.CreateZipForDownload(files.Select(c => c.FilePath),
                     $"download_{User.GetUsername()}_s{seriesId}");
-                return File(fileBytes, DefaultContentType, Path.GetFileNameWithoutExtension(zipPath) + ".zip");
+                return File(fileBytes, DefaultContentType, $"{series.Name}.zip");
             }
             catch (KavitaException ex)
             {

--- a/UI/Web/package-lock.json
+++ b/UI/Web/package-lock.json
@@ -31,6 +31,7 @@
         "bowser": "^2.11.0",
         "file-saver": "^2.0.5",
         "lazysizes": "^5.3.2",
+        "ng-circle-progress": "^1.6.0",
         "ng-lazyload-image": "^9.1.0",
         "ng-sidebar": "^9.4.2",
         "ngx-toastr": "^13.2.1",
@@ -12741,6 +12742,19 @@
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
+    },
+    "node_modules/ng-circle-progress": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ng-circle-progress/-/ng-circle-progress-1.6.0.tgz",
+      "integrity": "sha512-HD7Uthog/QjRBFKrrnbOrm313CrkkWiTxENR7PjUy9lSUkuys5HdT0+E8UiHDk8VLSxC/pMmrx3eyYLhNq7EnQ==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@angular/common": ">=9.1.0",
+        "@angular/core": ">=9.1.0",
+        "rxjs": ">=6.4.0"
+      }
     },
     "node_modules/ng-lazyload-image": {
       "version": "9.1.0",
@@ -30963,6 +30977,14 @@
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
+    },
+    "ng-circle-progress": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ng-circle-progress/-/ng-circle-progress-1.6.0.tgz",
+      "integrity": "sha512-HD7Uthog/QjRBFKrrnbOrm313CrkkWiTxENR7PjUy9lSUkuys5HdT0+E8UiHDk8VLSxC/pMmrx3eyYLhNq7EnQ==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
     },
     "ng-lazyload-image": {
       "version": "9.1.0",

--- a/UI/Web/package.json
+++ b/UI/Web/package.json
@@ -38,6 +38,7 @@
     "bowser": "^2.11.0",
     "file-saver": "^2.0.5",
     "lazysizes": "^5.3.2",
+    "ng-circle-progress": "^1.6.0",
     "ng-lazyload-image": "^9.1.0",
     "ng-sidebar": "^9.4.2",
     "ngx-toastr": "^13.2.1",

--- a/UI/Web/src/app/admin/manage-system/manage-system.component.html
+++ b/UI/Web/src/app/admin/manage-system/manage-system.component.html
@@ -16,7 +16,7 @@
               <button ngbDropdownItem (click)="clearCache()" [disabled]="clearCacheInProgress">
                 Clear Cache
               </button>
-              <button ngbDropdownItem (click)="downloadService.downloadLogs()">
+              <button ngbDropdownItem (click)="downloadLogs()" [disabled]="downloadLogsInProgress">
                 Download Logs
               </button>
               <button ngbDropdownItem  (click)="checkForUpdates()" [disabled]="hasCheckedForUpdate">

--- a/UI/Web/src/app/admin/manage-system/manage-system.component.ts
+++ b/UI/Web/src/app/admin/manage-system/manage-system.component.ts
@@ -1,7 +1,8 @@
 import { Component, OnInit } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { ToastrService } from 'ngx-toastr';
-import { take } from 'rxjs/operators';
+import { asyncScheduler } from 'rxjs';
+import { finalize, take, takeWhile, throttleTime } from 'rxjs/operators';
 import { DownloadService } from 'src/app/shared/_services/download.service';
 import { ServerService } from 'src/app/_services/server.service';
 import { SettingsService } from '../settings.service';
@@ -22,6 +23,7 @@ export class ManageSystemComponent implements OnInit {
   clearCacheInProgress: boolean = false;
   backupDBInProgress: boolean = false;
   hasCheckedForUpdate: boolean = false;
+  downloadLogsInProgress: boolean = false;
 
   constructor(private settingsService: SettingsService, private toastr: ToastrService, 
     private serverService: ServerService, public downloadService: DownloadService) { }
@@ -85,6 +87,18 @@ export class ManageSystemComponent implements OnInit {
     this.serverService.checkForUpdate().subscribe(() => { 
       this.toastr.info('This might take a few minutes. If an update is available, the server will notify you.');
     });
+  }
+
+  downloadLogs() {
+    this.downloadLogsInProgress = true;
+    this.downloadService.downloadLogs().pipe(
+      throttleTime(100, asyncScheduler, { leading: true, trailing: true }),
+      takeWhile(val => {
+        return val.state != 'DONE';
+      }),
+      finalize(() => {
+        this.downloadLogsInProgress = false;
+      })).subscribe(() => {/* No Operation */});
   }
 
 }

--- a/UI/Web/src/app/app.module.ts
+++ b/UI/Web/src/app/app.module.ts
@@ -25,6 +25,7 @@ import { ReviewSeriesModalComponent } from './_modals/review-series-modal/review
 import { CarouselModule } from './carousel/carousel.module';
 import { NgxSliderModule } from '@angular-slider/ngx-slider';
 
+
 import * as Sentry from '@sentry/angular';
 import { environment } from 'src/environments/environment';
 import { version } from 'package.json';
@@ -134,6 +135,7 @@ if (environment.production) {
       countDuplicates: true,
       autoDismiss: true
     }),
+    
   ],
   providers: [
     {provide: HTTP_INTERCEPTORS, useClass: ErrorInterceptor, multi: true},

--- a/UI/Web/src/app/series-detail/series-detail.component.html
+++ b/UI/Web/src/app/series-detail/series-detail.component.html
@@ -28,10 +28,14 @@
                     </button>
                 </div>
                 <div class="ml-2" *ngIf="isAdmin || hasDownloadingRole">
-                    <button class="btn btn-secondary" (click)="downloadSeries()" title="Download Series">
-                        <span>
+                    <button class="btn btn-secondary" (click)="downloadSeries()" title="Download Series" [disabled]="downloadInProgress">
+                        <ng-container *ngIf="downloadInProgress; else notDownloading">
+                            <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+                            <span class="sr-only">Downloading...</span>
+                        </ng-container>
+                        <ng-template #notDownloading>
                             <i class="fa fa-arrow-alt-circle-down" aria-hidden="true"></i>
-                        </span>
+                        </ng-template>
                     </button>
                 </div>
                 <div class="ml-2">

--- a/UI/Web/src/app/series-detail/series-detail.component.ts
+++ b/UI/Web/src/app/series-detail/series-detail.component.ts
@@ -145,16 +145,16 @@ export class SeriesDetailComponent implements OnInit {
         });
         break;
       case(Action.ScanLibrary):
-        this.actionService.scanSeries(series, (series) => this.actionInProgress = false);
+        this.actionService.scanSeries(series, () => this.actionInProgress = false);
         break;
       case(Action.RefreshMetadata):
-        this.actionService.refreshMetdata(series, (series) => this.actionInProgress = false);
+        this.actionService.refreshMetdata(series, () => this.actionInProgress = false);
         break;
       case(Action.Delete):
         this.deleteSeries(series);
         break;
       case(Action.Bookmarks):
-        this.actionService.openBookmarkModal(series, (series) => this.actionInProgress = false);
+        this.actionService.openBookmarkModal(series, () => this.actionInProgress = false);
         break;
       default:
         break;
@@ -282,7 +282,7 @@ export class SeriesDetailComponent implements OnInit {
     }
     const seriesId = this.series.id;
 
-    this.actionService.markVolumeAsRead(seriesId, vol, (volume) => {
+    this.actionService.markVolumeAsRead(seriesId, vol, () => {
       this.setContinuePoint();
       this.actionInProgress = false;
     });
@@ -294,7 +294,7 @@ export class SeriesDetailComponent implements OnInit {
     }
     const seriesId = this.series.id;
 
-    this.actionService.markVolumeAsUnread(seriesId, vol, (volume) => {
+    this.actionService.markVolumeAsUnread(seriesId, vol, () => {
       this.setContinuePoint();
       this.actionInProgress = false;
     });
@@ -306,7 +306,7 @@ export class SeriesDetailComponent implements OnInit {
     }
     const seriesId = this.series.id;
     
-    this.actionService.markChapterAsRead(seriesId, chapter, (chapter) => {
+    this.actionService.markChapterAsRead(seriesId, chapter, () => {
       this.setContinuePoint();
       this.actionInProgress = false;
     });
@@ -318,7 +318,7 @@ export class SeriesDetailComponent implements OnInit {
     }
     const seriesId = this.series.id;
 
-    this.actionService.markChapterAsUnread(seriesId, chapter, (chapter) => {
+    this.actionService.markChapterAsUnread(seriesId, chapter, () => {
       this.setContinuePoint();
       this.actionInProgress = false;
     });
@@ -430,6 +430,7 @@ export class SeriesDetailComponent implements OnInit {
   }
 
   downloadSeries() {
+    
     this.downloadService.downloadSeriesSize(this.series.id).pipe(take(1)).subscribe(async (size) => {
       const wantToDownload = await this.downloadService.confirmSize(size, 'series');
       if (!wantToDownload) { return; }
@@ -441,7 +442,7 @@ export class SeriesDetailComponent implements OnInit {
         }),
         finalize(() => {
           this.downloadInProgress = false;
-        })).subscribe(() => {/* No Operation */});
+        }));
     });
   }
 }

--- a/UI/Web/src/app/series-detail/series-detail.component.ts
+++ b/UI/Web/src/app/series-detail/series-detail.component.ts
@@ -169,9 +169,9 @@ export class SeriesDetailComponent implements OnInit {
       case(Action.Info):
         this.openViewInfo(volume);
         break;
-      case(Action.Download):
-        this.downloadService.downloadVolume(volume, this.series.name);
-        break;
+      // case(Action.Download):
+      //   this.downloadService.downloadVolume(volume); // Now that this is generic, we can do within card detail
+      //   break;
       default:
         break;
     }

--- a/UI/Web/src/app/series-detail/series-detail.component.ts
+++ b/UI/Web/src/app/series-detail/series-detail.component.ts
@@ -167,7 +167,7 @@ export class SeriesDetailComponent implements OnInit {
         this.openViewInfo(volume);
         break;
       case(Action.Download):
-      this.downloadService.downloadVolume(volume, this.series.name);
+        this.downloadService.downloadVolume(volume, this.series.name);
         break;
       default:
         break;

--- a/UI/Web/src/app/shared/_models/download.ts
+++ b/UI/Web/src/app/shared/_models/download.ts
@@ -1,0 +1,59 @@
+import {
+    HttpEvent,
+    HttpEventType,
+    HttpProgressEvent,
+    HttpResponse
+  } from "@angular/common/http";
+  import { Observable } from "rxjs";
+  import { distinctUntilChanged, scan, map, tap } from "rxjs/operators";
+  
+  function isHttpResponse<T>(event: HttpEvent<T>): event is HttpResponse<T> {
+    return event.type === HttpEventType.Response;
+  }
+  
+  function isHttpProgressEvent(
+    event: HttpEvent<unknown>
+  ): event is HttpProgressEvent {
+    return (
+      event.type === HttpEventType.DownloadProgress ||
+      event.type === HttpEventType.UploadProgress
+    );
+  }
+  
+export interface Download {
+  content: Blob | null;
+  progress: number;
+  state: "PENDING" | "IN_PROGRESS" | "DONE";
+}
+  
+export function download(
+    saver?: (b: Blob) => void
+  ): (source: Observable<HttpEvent<Blob>>) => Observable<Download> {
+    return (source: Observable<HttpEvent<Blob>>) =>
+      source.pipe(
+        scan((previous: Download, event: HttpEvent<Blob>): Download => {
+            if (isHttpProgressEvent(event)) {
+              return {
+                progress: event.total
+                  ? Math.round((100 * event.loaded) / event.total)
+                  : previous.progress,
+                state: 'IN_PROGRESS',
+                content: null
+              }
+            }
+            if (isHttpResponse(event)) {
+              if (saver && event.body) {
+                saver(event.body)
+              }
+              return {
+                progress: 100,
+                state: 'DONE',
+                content: event.body
+              }
+            }
+            return previous
+          },
+          {state: 'PENDING', progress: 0, content: null}
+        )
+      )
+  }  

--- a/UI/Web/src/app/shared/_models/download.ts
+++ b/UI/Web/src/app/shared/_models/download.ts
@@ -1,6 +1,7 @@
 import {
     HttpEvent,
     HttpEventType,
+    HttpHeaders,
     HttpProgressEvent,
     HttpResponse
   } from "@angular/common/http";
@@ -24,11 +25,10 @@ export interface Download {
   content: Blob | null;
   progress: number;
   state: "PENDING" | "IN_PROGRESS" | "DONE";
+  filename?: string;
 }
   
-export function download(
-    saver?: (b: Blob) => void
-  ): (source: Observable<HttpEvent<Blob>>) => Observable<Download> {
+export function download(saver?: (b: Blob, filename: string) => void): (source: Observable<HttpEvent<Blob>>) => Observable<Download> {
     return (source: Observable<HttpEvent<Blob>>) =>
       source.pipe(
         scan((previous: Download, event: HttpEvent<Blob>): Download => {
@@ -43,17 +43,33 @@ export function download(
             }
             if (isHttpResponse(event)) {
               if (saver && event.body) {
-                saver(event.body)
+                saver(event.body, getFilename(event.headers, ''))
               }
               return {
                 progress: 100,
                 state: 'DONE',
-                content: event.body
+                content: event.body,
+                filename: getFilename(event.headers, '')
               }
             }
-            return previous
+            return previous;
           },
           {state: 'PENDING', progress: 0, content: null}
         )
       )
-  }  
+  }
+
+
+function getFilename(headers: HttpHeaders, defaultName: string) {
+    const tokens = (headers.get('content-disposition') || '').split(';');
+    let filename = tokens[1].replace('filename=', '').replace(/"/ig, '').trim();  
+    if (filename.startsWith('download_') || filename.startsWith('kavita_download_')) {
+      const ext = filename.substring(filename.lastIndexOf('.'), filename.length);
+      if (defaultName !== '') {
+        return defaultName + ext;
+      }
+      return filename.replace('kavita_', '').replace('download_', '');
+      //return defaultName + ext;
+    }
+    return filename;
+  }

--- a/UI/Web/src/app/shared/_providers/saver.provider.ts
+++ b/UI/Web/src/app/shared/_providers/saver.provider.ts
@@ -1,0 +1,10 @@
+import {InjectionToken} from '@angular/core'
+import { saveAs } from 'file-saver';
+
+export type Saver = (blob: Blob, filename?: string) => void
+
+export const SAVER = new InjectionToken<Saver>('saver')
+
+export function getSaver(): Saver {
+  return saveAs;
+}

--- a/UI/Web/src/app/shared/_services/utility.service.ts
+++ b/UI/Web/src/app/shared/_services/utility.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Chapter } from 'src/app/_models/chapter';
 import { MangaFormat } from 'src/app/_models/manga-format';
+import { Series } from 'src/app/_models/series';
 import { Volume } from 'src/app/_models/volume';
 
 export enum KEY_CODES {
@@ -83,6 +84,30 @@ export class UtilityService {
       case MangaFormat.UNKNOWN:
         return 'fa-question';
     }
+  }
+
+  isVolume(d: any) {
+    return d != null && d.hasOwnProperty('chapters');
+  }
+
+  isChapter(d: any) {
+    return d != null && d.hasOwnProperty('volumeId');
+  }
+
+  isSeries(d: any) {
+    return d != null && d.hasOwnProperty('originalName');
+  }
+
+  asVolume(d: any) {
+    return <Volume>d;
+  }
+
+  asChapter(d: any) {
+    return <Chapter>d;
+  }
+
+  asSeries(d: any) {
+    return <Series>d;
   }
 
 }

--- a/UI/Web/src/app/shared/card-item/card-item.component.html
+++ b/UI/Web/src/app/shared/card-item/card-item.component.html
@@ -1,5 +1,6 @@
 <div class="card">
-    <div class="overlay" (click)="handleClick()">
+    <div [ngClass]="{'overlay': true, 'with-background': showOverlay}"  (click)="handleClick()">
+      <!-- <span #downloadProgress class="download-overlay"></span> -->
       <img *ngIf="total > 0 || supressArchiveWarning" class="card-img-top lazyload" [src]="imageSerivce.placeholderImage" [attr.data-src]="imageUrl" 
             (error)="imageSerivce.updateErroredImage($event)" aria-hidden="true" height="230px" width="158px">
       <img *ngIf="total === 0 && !supressArchiveWarning" class="card-img-top lazyload" [src]="imageSerivce.errorImage" [attr.data-src]="imageUrl" 
@@ -7,9 +8,12 @@
       <div class="progress-banner" *ngIf="read < total && total > 0 && read !== (total -1)">
         <p><ngb-progressbar type="primary" height="5px" [value]="read" [max]="total"></ngb-progressbar></p>
 
-        <app-circular-loader></app-circular-loader>
-        
-        <p><ngb-progressbar *ngIf="download$ | async as download" type="primary" height="15px" [value]="download.progress" [max]="total" [striped]="download.state == 'PENDING'"></ngb-progressbar></p>
+        <span class="download" *ngIf="download$ | async as download">
+          <app-circular-loader [currentValue]="download.progress"></app-circular-loader>
+          <span class="sr-only" role="status">
+            {{download.progress}}% downloaded
+          </span>
+        </span>
       </div>
       <div class="error-banner" *ngIf="total === 0 && !supressArchiveWarning">
         Cannot Read Archive

--- a/UI/Web/src/app/shared/card-item/card-item.component.html
+++ b/UI/Web/src/app/shared/card-item/card-item.component.html
@@ -6,10 +6,16 @@
             aria-hidden="true" height="230px" width="158px">
       <div class="progress-banner" *ngIf="read < total && total > 0 && read !== (total -1)">
         <p><ngb-progressbar type="primary" height="5px" [value]="read" [max]="total"></ngb-progressbar></p>
+
+        <app-circular-loader></app-circular-loader>
+        
+        <p><ngb-progressbar *ngIf="download$ | async as download" type="primary" height="15px" [value]="download.progress" [max]="total" [striped]="download.state == 'PENDING'"></ngb-progressbar></p>
       </div>
       <div class="error-banner" *ngIf="total === 0 && !supressArchiveWarning">
         Cannot Read Archive
       </div>
+
+      
       
       <div class="not-read-badge" *ngIf="read === 0 && total > 0"></div>
     </div>

--- a/UI/Web/src/app/shared/card-item/card-item.component.html
+++ b/UI/Web/src/app/shared/card-item/card-item.component.html
@@ -1,6 +1,5 @@
 <div class="card">
-    <div [ngClass]="{'overlay': true, 'with-background': showOverlay}"  (click)="handleClick()">
-      <!-- <span #downloadProgress class="download-overlay"></span> -->
+    <div class="overlay"  (click)="handleClick()">
       <img *ngIf="total > 0 || supressArchiveWarning" class="card-img-top lazyload" [src]="imageSerivce.placeholderImage" [attr.data-src]="imageUrl" 
             (error)="imageSerivce.updateErroredImage($event)" aria-hidden="true" height="230px" width="158px">
       <img *ngIf="total === 0 && !supressArchiveWarning" class="card-img-top lazyload" [src]="imageSerivce.errorImage" [attr.data-src]="imageUrl" 

--- a/UI/Web/src/app/shared/card-item/card-item.component.scss
+++ b/UI/Web/src/app/shared/card-item/card-item.component.scss
@@ -52,6 +52,14 @@ $image-width: 160px;
     }
 }
 
+.download {
+    width: 80px;
+    height: 80px;
+    position: absolute;
+    top: 25%;
+    right: 30%;
+}
+
 .not-read-badge {
     position: absolute;
     top: 0px;
@@ -63,10 +71,20 @@ $image-width: 160px;
     border-color: transparent $primary-color transparent transparent;
 }
 
+.download-overlay {
+    max-height: $image-height;
+    height: 0px;
+    background-color: rgba(74,198,148, 0.6);
+    position: absolute;
+    top: 0px;
+    right: 0px;
+    width: 100%;
+}
+
 .overlay {
     height: $image-height;
+    
     &:hover {
-        //background-color: rgba(0, 0, 0, 0.4);
         visibility: visible;
 
         .overlay-item {

--- a/UI/Web/src/app/shared/card-item/card-item.component.scss
+++ b/UI/Web/src/app/shared/card-item/card-item.component.scss
@@ -71,16 +71,6 @@ $image-width: 160px;
     border-color: transparent $primary-color transparent transparent;
 }
 
-.download-overlay {
-    max-height: $image-height;
-    height: 0px;
-    background-color: rgba(74,198,148, 0.6);
-    position: absolute;
-    top: 0px;
-    right: 0px;
-    width: 100%;
-}
-
 .overlay {
     height: $image-height;
     

--- a/UI/Web/src/app/shared/card-item/card-item.component.ts
+++ b/UI/Web/src/app/shared/card-item/card-item.component.ts
@@ -1,6 +1,6 @@
-import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
-import { Observable, Subject } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
+import { Component, ElementRef, EventEmitter, Input, OnDestroy, OnInit, Output, Renderer2, ViewChild } from '@angular/core';
+import { asyncScheduler, Observable, Subject } from 'rxjs';
+import { debounceTime, finalize, take, takeUntil, takeWhile, tap, throttleTime } from 'rxjs/operators';
 import { Chapter } from 'src/app/_models/chapter';
 import { CollectionTag } from 'src/app/_models/collection-tag';
 import { MangaFormat } from 'src/app/_models/manga-format';
@@ -34,8 +34,9 @@ export class CardItemComponent implements OnInit, OnDestroy {
   supressArchiveWarning: boolean = false; // This will supress the cannot read archive warning when total pages is 0
   format: MangaFormat = MangaFormat.UNKNOWN;
 
-  showDownloadNotification: boolean = false;
-  download$!: Observable<Download>;
+  download$: Observable<Download> | null = null;
+  showOverlay: boolean = false;
+  //@ViewChild('downloadProgress', {static: false}) downloadElemRef!: ElementRef<HTMLSpanElement>;
 
   get MangaFormat(): typeof MangaFormat {
     return MangaFormat;
@@ -43,7 +44,9 @@ export class CardItemComponent implements OnInit, OnDestroy {
 
   private readonly onDestroy = new Subject<void>();
 
-  constructor(public imageSerivce: ImageService, private libraryService: LibraryService, public utilityService: UtilityService, private downloadService: DownloadService) {}
+  constructor(public imageSerivce: ImageService, private libraryService: LibraryService, 
+    public utilityService: UtilityService, private downloadService: DownloadService,
+    private renderer: Renderer2) {}
 
   ngOnInit(): void {
     if (this.entity.hasOwnProperty('promoted') && this.entity.hasOwnProperty('title')) {
@@ -59,6 +62,8 @@ export class CardItemComponent implements OnInit, OnDestroy {
       });
     }
     this.format = (this.entity as Series).format;
+
+
   }
 
   ngOnDestroy() {
@@ -85,10 +90,31 @@ export class CardItemComponent implements OnInit, OnDestroy {
     }
 
     if (action.action == Action.Download) {
-      this.showDownloadNotification = true;
+      //action.disabled = true;
       if (this.entity.hasOwnProperty('chapters')) {
         const volume = (this.entity as Volume);
-        this.download$ = this.downloadService.downloadVolume(volume, '');
+        this.downloadService.downloadVolumeSize(volume.id).pipe(take(1)).subscribe(async (size) => {
+          const wantToDownload = await this.downloadService.confirmSize(size, 'volume');
+          if (!wantToDownload) { return; }
+
+          // Move debounce somewhere so it doesn't affect values in between: debounceTime(300),
+          this.download$ = this.downloadService.downloadVolume(volume).pipe(
+            throttleTime(100, asyncScheduler, { leading: true, trailing: true }),
+            takeWhile(val => {
+              return val.state != 'DONE';
+            }),
+            tap(val => {
+              console.log(val.progress);
+              this.showOverlay = true;
+              //this.renderer.setStyle(this.downloadElemRef.nativeElement, 'height', val.progress + 'px');
+            }),
+            finalize(() => {
+              this.download$ = null;
+              this.showOverlay = false;
+              //this.renderer.setStyle(this.downloadElemRef.nativeElement, 'height', 0 + 'px');
+            })
+            );
+        });
       }
       
     }

--- a/UI/Web/src/app/shared/circular-loader/circular-loader.component.html
+++ b/UI/Web/src/app/shared/circular-loader/circular-loader.component.html
@@ -1,0 +1,12 @@
+<div class="circular">
+    <div class="inner"></div>
+    <div class="number">{{currentValue}}%</div>
+    <div class="circle">
+       <div class="bar left">
+          <div class="progress"></div>
+       </div>
+       <div class="bar right">
+          <div class="progress"></div>
+       </div>
+     </div>
+  </div>

--- a/UI/Web/src/app/shared/circular-loader/circular-loader.component.html
+++ b/UI/Web/src/app/shared/circular-loader/circular-loader.component.html
@@ -1,12 +1,44 @@
-<div class="circular">
+<!-- <div class="circular">
     <div class="inner"></div>
-    <div class="number">{{currentValue}}%</div>
+    <div class="number">
+       <span class="sr-only">{{currentValue}}%</span>
+      <i class="fa fa-angle-double-down" style="font-size: 36px;" aria-hidden="true"></i>
+    </div>
     <div class="circle">
-       <div class="bar left">
+       <div class="bar left" #left>
           <div class="progress"></div>
        </div>
-       <div class="bar right">
+       <div class="bar right" #right>
           <div class="progress"></div>
        </div>
      </div>
-  </div>
+  </div> -->
+<ng-container *ngIf="currentValue > 0">
+   
+<div class="number">
+   <i class="fa fa-angle-double-down" style="font-size: 36px;" aria-hidden="true"></i>
+</div>
+<div style="width: 100px; height: 100px;">
+   <circle-progress
+      [percent]="currentValue"
+      [radius]="100"
+      [outerStrokeWidth]="15"
+      [innerStrokeWidth]="0"
+      [space] = "0"
+      [backgroundPadding]="0"
+      outerStrokeLinecap="butt"
+      [outerStrokeColor]="'#4ac694'"
+      [innerStrokeColor]="'transparent'"
+      titleFontSize= "24"
+      unitsFontSize= "24"
+      [showSubtitle] = "false"
+      [animation]="true"
+      [animationDuration]="300"
+      [startFromZero]="false"
+      [responsive]="true"
+      [backgroundOpacity]="0.5"
+      [backgroundColor]="'#000'"
+      ></circle-progress>
+</div>
+
+</ng-container>

--- a/UI/Web/src/app/shared/circular-loader/circular-loader.component.scss
+++ b/UI/Web/src/app/shared/circular-loader/circular-loader.component.scss
@@ -1,0 +1,86 @@
+$background: rgba(0, 0, 0, .4);
+$primary-color: #4ac694;
+
+// *{
+//     margin: 0;
+//     padding: 0;
+//     font-family: 'Arial', sans-serif;
+//   }
+  html, body{
+    display:grid;
+    height:100%;
+    text-align: center;
+    place-items: center;
+    background: #dde6f0;
+  }
+
+  .circular{
+    height:100px;
+    width: 100px;
+    position: relative;  
+
+    .inner{
+        position: absolute;
+        z-index: 6;
+        top: 50%;
+        left: 50%;
+        height: 80px;
+        width: 80px;
+        margin: -40px 0 0 -40px;
+        background: $background;
+        border-radius: 100%;
+      }
+
+      .number{
+        position: absolute;
+        top:50%;
+        left:50%;
+        transform: translate(-50%, -50%);
+        z-index:10;
+        font-size:18px;
+        font-weight:500;
+        color:$primary-color;
+      }
+
+      .bar{
+        position: absolute;
+        height: 100%;
+        width: 100%;
+        background: #fff;
+        border-radius: 100%;
+        clip: rect(0px, 100px, 100px, 50px);
+      }
+  }
+
+  .circle .bar .progress{
+    position: absolute;
+    height: 100%;
+    width: 100%;
+    border-radius: 100%;
+    clip: rect(0px, 50px, 100px, 0px);
+    background: $primary-color;
+  }
+
+  .circle .left .progress{
+    z-index:1;
+    animation: left 4s linear both;
+  }
+  @keyframes left{
+    100%{
+      transform: rotate(180deg);
+    }
+  }
+  .circle .right {
+    transform: rotate(180deg);
+    z-index:3;
+   
+  }
+  .circle .right .progress{
+    animation: right 4s linear both;
+    animation-delay:4s;
+  }
+  @keyframes right{
+    100%{
+      transform: rotate(180deg);
+    }
+  }

--- a/UI/Web/src/app/shared/circular-loader/circular-loader.component.scss
+++ b/UI/Web/src/app/shared/circular-loader/circular-loader.component.scss
@@ -1,86 +1,23 @@
 $background: rgba(0, 0, 0, .4);
 $primary-color: #4ac694;
 
-// *{
-//     margin: 0;
-//     padding: 0;
-//     font-family: 'Arial', sans-serif;
-//   }
-  html, body{
-    display:grid;
-    height:100%;
-    text-align: center;
-    place-items: center;
-    background: #dde6f0;
-  }
 
-  .circular{
-    height:100px;
-    width: 100px;
-    position: relative;  
+.number {
+  position: absolute;
+  top:50%; 
+  left:50%;
+  z-index:10;
+  font-size:18px;
+  font-weight:500;
+  color:$primary-color;
+  animation: MoveUpDown 1s linear infinite;
+}
 
-    .inner{
-        position: absolute;
-        z-index: 6;
-        top: 50%;
-        left: 50%;
-        height: 80px;
-        width: 80px;
-        margin: -40px 0 0 -40px;
-        background: $background;
-        border-radius: 100%;
-      }
-
-      .number{
-        position: absolute;
-        top:50%;
-        left:50%;
-        transform: translate(-50%, -50%);
-        z-index:10;
-        font-size:18px;
-        font-weight:500;
-        color:$primary-color;
-      }
-
-      .bar{
-        position: absolute;
-        height: 100%;
-        width: 100%;
-        background: #fff;
-        border-radius: 100%;
-        clip: rect(0px, 100px, 100px, 50px);
-      }
-  }
-
-  .circle .bar .progress{
-    position: absolute;
-    height: 100%;
-    width: 100%;
-    border-radius: 100%;
-    clip: rect(0px, 50px, 100px, 0px);
-    background: $primary-color;
-  }
-
-  .circle .left .progress{
-    z-index:1;
-    animation: left 4s linear both;
-  }
-  @keyframes left{
-    100%{
-      transform: rotate(180deg);
+@keyframes MoveUpDown {
+    0%, 100% {
+      transform: translateY(0);
     }
-  }
-  .circle .right {
-    transform: rotate(180deg);
-    z-index:3;
-   
-  }
-  .circle .right .progress{
-    animation: right 4s linear both;
-    animation-delay:4s;
-  }
-  @keyframes right{
-    100%{
-      transform: rotate(180deg);
+    50% {
+      transform: translateY(-10px);
     }
-  }
+}

--- a/UI/Web/src/app/shared/circular-loader/circular-loader.component.ts
+++ b/UI/Web/src/app/shared/circular-loader/circular-loader.component.ts
@@ -1,0 +1,18 @@
+import { Component, Input, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-circular-loader',
+  templateUrl: './circular-loader.component.html',
+  styleUrls: ['./circular-loader.component.scss']
+})
+export class CircularLoaderComponent implements OnInit {
+
+  @Input() currentValue: number = 0;
+  @Input() maxValue: number = 0;
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/UI/Web/src/app/shared/circular-loader/circular-loader.component.ts
+++ b/UI/Web/src/app/shared/circular-loader/circular-loader.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, ElementRef, Input, OnChanges, OnInit, Renderer2, ViewChild } from '@angular/core';
 
 @Component({
   selector: 'app-circular-loader',
@@ -10,7 +10,7 @@ export class CircularLoaderComponent implements OnInit {
   @Input() currentValue: number = 0;
   @Input() maxValue: number = 0;
 
-  constructor() { }
+  constructor(private renderer: Renderer2) { }
 
   ngOnInit(): void {
   }

--- a/UI/Web/src/app/shared/shared.module.ts
+++ b/UI/Web/src/app/shared/shared.module.ts
@@ -18,6 +18,8 @@ import { ShowIfScrollbarDirective } from './show-if-scrollbar.directive';
 import { A11yClickDirective } from './a11y-click.directive';
 import { SeriesFormatComponent } from './series-format/series-format.component';
 import { UpdateNotificationModalComponent } from './update-notification/update-notification-modal.component';
+import { SAVER, getSaver } from './_providers/saver.provider';
+import { CircularLoaderComponent } from './circular-loader/circular-loader.component';
 
 
 @NgModule({
@@ -35,7 +37,8 @@ import { UpdateNotificationModalComponent } from './update-notification/update-n
     ShowIfScrollbarDirective,
     A11yClickDirective,
     SeriesFormatComponent,
-    UpdateNotificationModalComponent
+    UpdateNotificationModalComponent,
+    CircularLoaderComponent
   ],
   imports: [
     CommonModule,
@@ -60,6 +63,7 @@ import { UpdateNotificationModalComponent } from './update-notification/update-n
     ShowIfScrollbarDirective,
     A11yClickDirective,
     SeriesFormatComponent
-  ]
+  ],
+  providers: [{provide: SAVER, useFactory: getSaver}]
 })
 export class SharedModule { }

--- a/UI/Web/src/app/shared/shared.module.ts
+++ b/UI/Web/src/app/shared/shared.module.ts
@@ -63,7 +63,7 @@ import { NgCircleProgressModule } from 'ng-circle-progress';
     CardDetailLayoutComponent,
     ShowIfScrollbarDirective,
     A11yClickDirective,
-    SeriesFormatComponent
+    SeriesFormatComponent,
   ],
   providers: [{provide: SAVER, useFactory: getSaver}]
 })

--- a/UI/Web/src/app/shared/shared.module.ts
+++ b/UI/Web/src/app/shared/shared.module.ts
@@ -20,7 +20,7 @@ import { SeriesFormatComponent } from './series-format/series-format.component';
 import { UpdateNotificationModalComponent } from './update-notification/update-notification-modal.component';
 import { SAVER, getSaver } from './_providers/saver.provider';
 import { CircularLoaderComponent } from './circular-loader/circular-loader.component';
-
+import { NgCircleProgressModule } from 'ng-circle-progress';
 
 @NgModule({
   declarations: [
@@ -49,7 +49,8 @@ import { CircularLoaderComponent } from './circular-loader/circular-loader.compo
     NgbTooltipModule,
     NgbCollapseModule,
     LazyLoadImageModule,
-    NgbPaginationModule // CardDetailLayoutComponent
+    NgbPaginationModule, // CardDetailLayoutComponent
+    NgCircleProgressModule.forRoot()
   ],
   exports: [
     RegisterMemberComponent,


### PR DESCRIPTION
# Added
- New: Cards when processing a download shows a spinner for the progress of the download

# Changed
- Changed: Downloads now always take the backend filename and are streamed in a more optimal manner, reducing the javascript processing that was needed previously.

![download indicator4](https://user-images.githubusercontent.com/735851/129093827-61395e44-13cc-47cc-bf66-e5edde4b7fc5.gif)

Closes #454 