### PR TITLE
Misc Bugfixes and Enhancements

### DIFF
--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -5,7 +5,7 @@ on:
     branches: '**'
   pull_request:
     branches: [ main, develop ]
-    types: [opened, synchronize, reopened]
+    types: [synchronize]
 
 jobs:
   build:

--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -3,6 +3,9 @@ name: .NET Build Test and Sonar Scan
 on:
   push:
     branches: '**'
+  pull_request:
+    branches: [ main, develop ]
+    types: [opened, synchronize, reopened]
 
 jobs:
   build:

--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -3,9 +3,6 @@ name: .NET Build Test and Sonar Scan
 on:
   push:
     branches: '**'
-  pull_request:
-    branches: [ main, develop ]
-    types: [opened, synchronize, reopened]
 
 jobs:
   build:
@@ -98,7 +95,7 @@ jobs:
     needs: [ build, test ]
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
-    steps: 
+    steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
@@ -122,7 +119,7 @@ jobs:
 
   develop:
     name: Build Nightly Docker if Develop push
-    needs: [ build, test, version ] 
+    needs: [ build, test, version ]
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
     steps:
@@ -222,7 +219,7 @@ jobs:
 
   stable:
     name: Build Stable Docker if Main push
-    needs: [ build, test ] 
+    needs: [ build, test ]
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     steps:
@@ -263,9 +260,9 @@ jobs:
 
           echo 'Copying back to Kavita wwwroot'
           rsync -a dist/ ../../API/wwwroot/
-          
+
           cd ../ || exit
- 
+
       - name: Get csproj Version
         uses: naminodarie/get-net-sdk-project-versions-action@v1
         id: get-version
@@ -281,7 +278,7 @@ jobs:
           newVersion=${version%.*}
           echo $newVersion
           echo "::set-output name=VERSION::$newVersion"
-        id: parse-version 
+        id: parse-version
 
       - name: Compile dotnet app
         uses: actions/setup-dotnet@v1
@@ -320,7 +317,7 @@ jobs:
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
-        
+
       - name: Notify Discord
         uses: rjstone/discord-webhook-notify@v1
         with:

--- a/API.Tests/Parser/MangaParserTests.cs
+++ b/API.Tests/Parser/MangaParserTests.cs
@@ -275,6 +275,7 @@ namespace API.Tests.Parser
             Assert.Equal(expected, API.Parser.Parser.ParseMangaSpecial(inputFile));
         }
 
+/*
         private static ParserInfo CreateParserInfo(string series, string chapter, string volume, bool isSpecial = false)
         {
           return new ParserInfo()
@@ -285,6 +286,7 @@ namespace API.Tests.Parser
             Series = series,
           };
         }
+*/
 
         [Theory]
         [InlineData("/manga/Btooom!/Vol.1/Chapter 1/1.cbz", "Btooom!~1~1")]

--- a/API/Archive/ArchiveLibrary.cs
+++ b/API/Archive/ArchiveLibrary.cs
@@ -5,8 +5,17 @@
     /// </summary>
     public enum ArchiveLibrary
     {
+        /// <summary>
+        /// The underlying archive cannot be opened
+        /// </summary>
         NotSupported = 0,
+        /// <summary>
+        /// The underlying archive can be opened by SharpCompress
+        /// </summary>
         SharpCompress = 1,
+        /// <summary>
+        /// The underlying archive can be opened by default .NET
+        /// </summary>
         Default = 2
     }
 }

--- a/API/Archive/CoverAndPages.cs
+++ b/API/Archive/CoverAndPages.cs
@@ -1,7 +1,0 @@
-﻿namespace API.Archive
-{
-    public class CoverAndPages
-    {
-        
-    }
-}

--- a/API/Constants/PolicyConstants.cs
+++ b/API/Constants/PolicyConstants.cs
@@ -1,8 +1,17 @@
 ﻿namespace API.Constants
 {
+    /// <summary>
+    /// Role-based Security
+    /// </summary>
     public static class PolicyConstants
     {
+        /// <summary>
+        /// Admin User. Has all privileges
+        /// </summary>
         public const string AdminRole = "Admin";
+        /// <summary>
+        /// Non-Admin User. Must be granted privileges by an Admin.
+        /// </summary>
         public const string PlebRole = "Pleb";
         /// <summary>
         /// Used to give a user ability to download files from the server

--- a/API/Controllers/LibraryController.cs
+++ b/API/Controllers/LibraryController.cs
@@ -185,6 +185,8 @@ namespace API.Controllers
 
                 if (chapterIds.Any())
                 {
+                    await _unitOfWork.AppUserProgressRepository.CleanupAbandonedChapters();
+                    await _unitOfWork.CommitAsync();
                     _taskScheduler.CleanupChapters(chapterIds);
                 }
                 return Ok(true);

--- a/API/Controllers/ReaderController.cs
+++ b/API/Controllers/ReaderController.cs
@@ -14,6 +14,9 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace API.Controllers
 {
+    /// <summary>
+    /// For all things regarding reading, mainly focusing on non-Book related entities
+    /// </summary>
     public class ReaderController : BaseApiController
     {
         private readonly IDirectoryService _directoryService;
@@ -23,6 +26,7 @@ namespace API.Controllers
         private readonly ChapterSortComparerZeroFirst _chapterSortComparerForInChapterSorting = new ChapterSortComparerZeroFirst();
         private readonly NaturalSortComparer _naturalSortComparer = new NaturalSortComparer();
 
+        /// <inheritdoc />
         public ReaderController(IDirectoryService directoryService, ICacheService cacheService, IUnitOfWork unitOfWork)
         {
             _directoryService = directoryService;
@@ -30,6 +34,12 @@ namespace API.Controllers
             _unitOfWork = unitOfWork;
         }
 
+        /// <summary>
+        /// Returns an image for a given chapter. Side effect: This will cache the chapter images for reading.
+        /// </summary>
+        /// <param name="chapterId"></param>
+        /// <param name="page"></param>
+        /// <returns></returns>
         [HttpGet("image")]
         public async Task<ActionResult> GetImage(int chapterId, int page)
         {
@@ -57,6 +67,12 @@ namespace API.Controllers
             }
         }
 
+        /// <summary>
+        /// Returns various information about a Chapter. Side effect: This will cache the chapter images for reading.
+        /// </summary>
+        /// <param name="seriesId"></param>
+        /// <param name="chapterId"></param>
+        /// <returns></returns>
         [HttpGet("chapter-info")]
         public async Task<ActionResult<ChapterInfoDto>> GetChapterInfo(int seriesId, int chapterId)
         {
@@ -149,6 +165,11 @@ namespace API.Controllers
             return userProgress;
         }
 
+        /// <summary>
+        /// Marks a Chapter as Unread (progress)
+        /// </summary>
+        /// <param name="markReadDto"></param>
+        /// <returns></returns>
         [HttpPost("mark-unread")]
         public async Task<ActionResult> MarkUnread(MarkReadDto markReadDto)
         {
@@ -179,6 +200,11 @@ namespace API.Controllers
             return BadRequest("There was an issue saving progress");
         }
 
+        /// <summary>
+        /// Marks all chapters within a volume as Read
+        /// </summary>
+        /// <param name="markVolumeReadDto"></param>
+        /// <returns></returns>
         [HttpPost("mark-volume-read")]
         public async Task<ActionResult> MarkVolumeAsRead(MarkVolumeReadDto markVolumeReadDto)
         {
@@ -218,6 +244,11 @@ namespace API.Controllers
             return BadRequest("Could not save progress");
         }
 
+        /// <summary>
+        /// Returns Progress (page number) for a chapter for the logged in user
+        /// </summary>
+        /// <param name="chapterId"></param>
+        /// <returns></returns>
         [HttpGet("get-progress")]
         public async Task<ActionResult<ProgressDto>> GetProgress(int chapterId)
         {
@@ -242,6 +273,11 @@ namespace API.Controllers
             return Ok(progressBookmark);
         }
 
+        /// <summary>
+        /// Save page against Chapter for logged in user
+        /// </summary>
+        /// <param name="progressDto"></param>
+        /// <returns></returns>
         [HttpPost("progress")]
         public async Task<ActionResult> BookmarkProgress(ProgressDto progressDto)
         {
@@ -259,13 +295,11 @@ namespace API.Controllers
                 progressDto.PageNum = 0;
             }
 
-
             try
             {
-                // TODO: Look into creating a progress entry when a new item is added to the DB so we can just look it up and modify it
-               user.Progresses ??= new List<AppUserProgress>();
+                user.Progresses ??= new List<AppUserProgress>();
                var userProgress =
-                  user.Progresses.SingleOrDefault(x => x.ChapterId == progressDto.ChapterId && x.AppUserId == user.Id);
+                  user.Progresses.FirstOrDefault(x => x.ChapterId == progressDto.ChapterId && x.AppUserId == user.Id);
 
                if (userProgress == null)
                {
@@ -303,6 +337,11 @@ namespace API.Controllers
             return BadRequest("Could not save progress");
         }
 
+        /// <summary>
+        /// Returns a list of bookmarked pages for a given Chapter
+        /// </summary>
+        /// <param name="chapterId"></param>
+        /// <returns></returns>
         [HttpGet("get-bookmarks")]
         public async Task<ActionResult<IEnumerable<BookmarkDto>>> GetBookmarks(int chapterId)
         {
@@ -311,6 +350,11 @@ namespace API.Controllers
             return Ok(await _unitOfWork.UserRepository.GetBookmarkDtosForChapter(user.Id, chapterId));
         }
 
+        /// <summary>
+        /// Removes all bookmarks for all chapters linked to a Series
+        /// </summary>
+        /// <param name="seriesId"></param>
+        /// <returns></returns>
         [HttpPost("remove-bookmarks")]
         public async Task<ActionResult> RemoveBookmarks(int seriesId)
         {
@@ -335,6 +379,11 @@ namespace API.Controllers
 
         }
 
+        /// <summary>
+        /// Returns all bookmarked pages for a given volume
+        /// </summary>
+        /// <param name="volumeId"></param>
+        /// <returns></returns>
         [HttpGet("get-volume-bookmarks")]
         public async Task<ActionResult<IEnumerable<BookmarkDto>>> GetBookmarksForVolume(int volumeId)
         {
@@ -343,6 +392,11 @@ namespace API.Controllers
             return Ok(await _unitOfWork.UserRepository.GetBookmarkDtosForVolume(user.Id, volumeId));
         }
 
+        /// <summary>
+        /// Returns all bookmarked pages for a given series
+        /// </summary>
+        /// <param name="seriesId"></param>
+        /// <returns></returns>
         [HttpGet("get-series-bookmarks")]
         public async Task<ActionResult<IEnumerable<BookmarkDto>>> GetBookmarksForSeries(int seriesId)
         {
@@ -352,6 +406,11 @@ namespace API.Controllers
             return Ok(await _unitOfWork.UserRepository.GetBookmarkDtosForSeries(user.Id, seriesId));
         }
 
+        /// <summary>
+        /// Bookmarks a page against a Chapter
+        /// </summary>
+        /// <param name="bookmarkDto"></param>
+        /// <returns></returns>
         [HttpPost("bookmark")]
         public async Task<ActionResult> BookmarkPage(BookmarkDto bookmarkDto)
         {
@@ -408,6 +467,11 @@ namespace API.Controllers
             return BadRequest("Could not save bookmark");
         }
 
+        /// <summary>
+        /// Removes a bookmarked page for a Chapter
+        /// </summary>
+        /// <param name="bookmarkDto"></param>
+        /// <returns></returns>
         [HttpPost("unbookmark")]
         public async Task<ActionResult> UnBookmarkPage(BookmarkDto bookmarkDto)
         {

--- a/API/Controllers/SeriesController.cs
+++ b/API/Controllers/SeriesController.cs
@@ -80,6 +80,7 @@ namespace API.Controllers
             if (result)
             {
                 await _unitOfWork.AppUserProgressRepository.CleanupAbandonedChapters();
+                await _unitOfWork.CollectionTagRepository.RemoveTagsWithoutSeries();
                 await _unitOfWork.CommitAsync();
                 _taskScheduler.CleanupChapters(chapterIds);
             }

--- a/API/Controllers/SeriesController.cs
+++ b/API/Controllers/SeriesController.cs
@@ -79,6 +79,8 @@ namespace API.Controllers
 
             if (result)
             {
+                await _unitOfWork.AppUserProgressRepository.CleanupAbandonedChapters();
+                await _unitOfWork.CommitAsync();
                 _taskScheduler.CleanupChapters(chapterIds);
             }
             return Ok(result);

--- a/API/Data/DataContext.cs
+++ b/API/Data/DataContext.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using API.Entities;
 using API.Entities.Interfaces;
 using Microsoft.AspNetCore.Identity;
@@ -67,5 +70,50 @@ namespace API.Data
             if (e.NewState == EntityState.Modified && e.Entry.Entity is IEntityDate entity)
                 entity.LastModified = DateTime.Now;
         }
+
+        private void OnSaveChanges()
+        {
+            var concurrentEntries = base.ChangeTracker.Entries()
+                .Where(x => x.Entity is IHasConcurrencyToken && x.State is EntityState.Added or EntityState.Modified);
+
+            foreach (var entityEntry in concurrentEntries)
+            {
+                var e = (IHasConcurrencyToken)entityEntry.Entity;
+                e.OnSavingChanges();
+            }
+
+        }
+
+        #region SaveChanges overrides
+
+        public override int SaveChanges()
+        {
+            this.OnSaveChanges();
+
+            return base.SaveChanges();
+        }
+
+        public override int SaveChanges(bool acceptAllChangesOnSuccess)
+        {
+            this.OnSaveChanges();
+
+            return base.SaveChanges(acceptAllChangesOnSuccess);
+        }
+
+        public override Task<int> SaveChangesAsync(bool acceptAllChangesOnSuccess, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            this.OnSaveChanges();
+
+            return base.SaveChangesAsync(acceptAllChangesOnSuccess, cancellationToken);
+        }
+
+        public override Task<int> SaveChangesAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            this.OnSaveChanges();
+
+            return base.SaveChangesAsync(cancellationToken);
+        }
+
+        #endregion
     }
 }

--- a/API/Data/DataContext.cs
+++ b/API/Data/DataContext.cs
@@ -73,15 +73,13 @@ namespace API.Data
 
         private void OnSaveChanges()
         {
-            var concurrentEntries = base.ChangeTracker.Entries()
-                .Where(x => x.Entity is IHasConcurrencyToken && x.State is EntityState.Added or EntityState.Modified);
-
-            foreach (var entityEntry in concurrentEntries)
+            foreach (var saveEntity in ChangeTracker.Entries()
+                .Where(e => e.State == EntityState.Modified)
+                .Select(entry => entry.Entity)
+                .OfType<IHasConcurrencyToken>())
             {
-                var e = (IHasConcurrencyToken)entityEntry.Entity;
-                e.OnSavingChanges();
+                saveEntity.OnSavingChanges();
             }
-
         }
 
         #region SaveChanges overrides

--- a/API/Data/Migrations/20210817152226_ProgressConcurencyCheck.Designer.cs
+++ b/API/Data/Migrations/20210817152226_ProgressConcurencyCheck.Designer.cs
@@ -3,14 +3,16 @@ using System;
 using API.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace API.Data.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20210817152226_ProgressConcurencyCheck")]
+    partial class ProgressConcurencyCheck
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/API/Data/Migrations/20210817152226_ProgressConcurencyCheck.cs
+++ b/API/Data/Migrations/20210817152226_ProgressConcurencyCheck.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace API.Data.Migrations
+{
+    public partial class ProgressConcurencyCheck : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<uint>(
+                name: "RowVersion",
+                table: "AppUserProgresses",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0u);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "RowVersion",
+                table: "AppUserProgresses");
+        }
+    }
+}

--- a/API/Data/UnitOfWork.cs
+++ b/API/Data/UnitOfWork.cs
@@ -33,25 +33,46 @@ namespace API.Data
         public IFileRepository FileRepository => new FileRepository(_context);
         public IChapterRepository ChapterRepository => new ChapterRepository(_context);
 
+        /// <summary>
+        /// Commits changes to the DB. Completes the open transaction.
+        /// </summary>
+        /// <returns></returns>
         public bool Commit()
         {
+
             return _context.SaveChanges() > 0;
         }
+        /// <summary>
+        /// Commits changes to the DB. Completes the open transaction.
+        /// </summary>
+        /// <returns></returns>
         public async Task<bool> CommitAsync()
         {
             return await _context.SaveChangesAsync() > 0;
         }
 
+        /// <summary>
+        /// Is the DB Context aware of Changes in loaded entities
+        /// </summary>
+        /// <returns></returns>
         public bool HasChanges()
         {
             return _context.ChangeTracker.HasChanges();
         }
 
+        /// <summary>
+        /// Rollback transaction
+        /// </summary>
+        /// <returns></returns>
         public async Task<bool> RollbackAsync()
         {
             await _context.DisposeAsync();
             return true;
         }
+        /// <summary>
+        /// Rollback transaction
+        /// </summary>
+        /// <returns></returns>
         public bool Rollback()
         {
             _context.Dispose();

--- a/API/Entities/AppUser.cs
+++ b/API/Entities/AppUser.cs
@@ -18,9 +18,11 @@ namespace API.Entities
         public AppUserPreferences UserPreferences { get; set; }
         public ICollection<AppUserBookmark> Bookmarks { get; set; }
 
+        /// <inheritdoc />
         [ConcurrencyCheck]
-        public uint RowVersion { get; set; }
+        public uint RowVersion { get; private set; }
 
+        /// <inheritdoc />
         public void OnSavingChanges()
         {
             RowVersion++;

--- a/API/Entities/AppUserProgress.cs
+++ b/API/Entities/AppUserProgress.cs
@@ -1,30 +1,74 @@
 ﻿
 using System;
+using System.ComponentModel.DataAnnotations;
 using API.Entities.Interfaces;
+using Microsoft.EntityFrameworkCore;
 
 namespace API.Entities
 {
     /// <summary>
     /// Represents the progress a single user has on a given Chapter.
     /// </summary>
-    public class AppUserProgress : IEntityDate
+    //[Index(nameof(SeriesId), nameof(VolumeId), nameof(ChapterId), nameof(AppUserId), IsUnique = true)]
+    public class AppUserProgress : IEntityDate, IHasConcurrencyToken
     {
+        /// <summary>
+        /// Id of Entity
+        /// </summary>
         public int Id { get; set; }
+        /// <summary>
+        /// Pages Read for given Chapter
+        /// </summary>
         public int PagesRead { get; set; }
+        /// <summary>
+        /// Volume belonging to Chapter
+        /// </summary>
         public int VolumeId { get; set; }
+        /// <summary>
+        /// Series belonging to Chapter
+        /// </summary>
         public int SeriesId { get; set; }
+        /// <summary>
+        /// Chapter
+        /// </summary>
         public int ChapterId { get; set; }
         /// <summary>
         /// For Book Reader, represents the nearest passed anchor on the screen that can be used to resume scroll point
         /// on next load
         /// </summary>
         public string BookScrollId { get; set; }
-        
+
         // Relationships
+        /// <summary>
+        /// Navigational Property for EF. Links to a unique AppUser
+        /// </summary>
         public AppUser AppUser { get; set; }
+        /// <summary>
+        /// User this progress belongs to
+        /// </summary>
         public int AppUserId { get; set; }
-        
+
+        /// <summary>
+        /// When this was first created
+        /// </summary>
         public DateTime Created { get; set; }
+        /// <summary>
+        /// Last date this was updated
+        /// </summary>
         public DateTime LastModified { get; set; }
+
+        /// <summary>
+        /// Concurrency check. Ignore.
+        /// </summary>
+        [ConcurrencyCheck]
+        public uint RowVersion { get; set; }
+
+        /// <summary>
+        /// Concurrency check. Ignore.
+        /// </summary>
+        public void OnSavingChanges()
+        {
+            RowVersion++;
+        }
     }
 }

--- a/API/Entities/AppUserProgress.cs
+++ b/API/Entities/AppUserProgress.cs
@@ -57,15 +57,12 @@ namespace API.Entities
         /// </summary>
         public DateTime LastModified { get; set; }
 
-        /// <summary>
-        /// Concurrency check. Ignore.
-        /// </summary>
+        /// <inheritdoc />
         [ConcurrencyCheck]
-        public uint RowVersion { get; set; }
+        public uint RowVersion { get; private set; }
 
-        /// <summary>
-        /// Concurrency check. Ignore.
-        /// </summary>
+
+        /// <inheritdoc />
         public void OnSavingChanges()
         {
             RowVersion++;

--- a/API/Entities/CollectionTag.cs
+++ b/API/Entities/CollectionTag.cs
@@ -43,9 +43,11 @@ namespace API.Entities
         public ICollection<SeriesMetadata> SeriesMetadatas { get; set; }
 
 
+        /// <inheritdoc />
         [ConcurrencyCheck]
-        public uint RowVersion { get; set; }
+        public uint RowVersion { get; private set; }
 
+        /// <inheritdoc />
         public void OnSavingChanges()
         {
             RowVersion++;

--- a/API/Entities/Genre.cs
+++ b/API/Entities/Genre.cs
@@ -9,9 +9,11 @@ namespace API.Entities
         public string Name { get; set; }
         // MetadataUpdate add ProviderId
 
+        /// <inheritdoc />
         [ConcurrencyCheck]
-        public uint RowVersion { get; set; }
+        public uint RowVersion { get; private set; }
 
+        /// <inheritdoc />
         public void OnSavingChanges()
         {
             RowVersion++;

--- a/API/Entities/Person.cs
+++ b/API/Entities/Person.cs
@@ -10,9 +10,11 @@ namespace API.Entities
         public string Name { get; set; }
         public PersonRole Role { get; set; }
 
+        /// <inheritdoc />
         [ConcurrencyCheck]
-        public uint RowVersion { get; set; }
+        public uint RowVersion { get; private set; }
 
+        /// <inheritdoc />
         public void OnSavingChanges()
         {
             RowVersion++;

--- a/API/Entities/SeriesMetadata.cs
+++ b/API/Entities/SeriesMetadata.cs
@@ -16,9 +16,11 @@ namespace API.Entities
         public Series Series { get; set; }
         public int SeriesId { get; set; }
 
+        /// <inheritdoc />
         [ConcurrencyCheck]
-        public uint RowVersion { get; set; }
+        public uint RowVersion { get; private set; }
 
+        /// <inheritdoc />
         public void OnSavingChanges()
         {
             RowVersion++;

--- a/API/Entities/ServerSetting.cs
+++ b/API/Entities/ServerSetting.cs
@@ -10,8 +10,11 @@ namespace API.Entities
         public ServerSettingKey Key { get; set; }
         public string Value { get; set; }
 
+        /// <inheritdoc />
         [ConcurrencyCheck]
-        public uint RowVersion { get; set; }
+        public uint RowVersion { get; private set; }
+
+        /// <inheritdoc />
         public void OnSavingChanges()
         {
             RowVersion++;

--- a/API/Interfaces/ICollectionTagRepository.cs
+++ b/API/Interfaces/ICollectionTagRepository.cs
@@ -15,5 +15,6 @@ namespace API.Interfaces
         Task<CollectionTag> GetTagAsync(int tagId);
         Task<CollectionTag> GetFullTagAsync(int tagId);
         void Update(CollectionTag tag);
+        Task<int> RemoveTagsWithoutSeries();
     }
 }

--- a/API/Services/MetadataService.cs
+++ b/API/Services/MetadataService.cs
@@ -93,7 +93,7 @@ namespace API.Services
             {
                 // NOTE: Why do I do this? By the time this method gets executed, the chapter has already been calculated for
                 // Plus how can we have a volume without at least 1 chapter?
-                var firstFile = firstChapter?.Files.OrderBy(x => x.Chapter).FirstOrDefault();
+                var firstFile = firstChapter.Files.OrderBy(x => x.Chapter).FirstOrDefault();
                 if (firstFile != null && !new FileInfo(firstFile.FilePath).IsLastWriteLessThan(firstFile.LastModified))
                 {
                     firstChapter.CoverImage = GetCoverImage(firstFile);

--- a/API/Services/TaskScheduler.cs
+++ b/API/Services/TaskScheduler.cs
@@ -117,6 +117,7 @@ namespace API.Services
             BackgroundJob.Enqueue(() => _cleanupService.Cleanup());
         }
 
+
         public void CleanupChapters(int[] chapterIds)
         {
             BackgroundJob.Enqueue(() => _cacheService.CleanupChapters(chapterIds));

--- a/API/Services/Tasks/CleanupService.cs
+++ b/API/Services/Tasks/CleanupService.cs
@@ -35,11 +35,5 @@ namespace API.Services.Tasks
             _logger.LogInformation("Cleaning old database backups");
             _backupService.CleanupBackups();
         }
-
-        [AutomaticRetry(Attempts = 3, LogEvents = false, OnAttemptsExceeded = AttemptsExceededAction.Fail)]
-        public void RemoveAbandonedRows()
-        {
-
-        }
     }
 }

--- a/API/Services/Tasks/CleanupService.cs
+++ b/API/Services/Tasks/CleanupService.cs
@@ -21,6 +21,9 @@ namespace API.Services.Tasks
             _backupService = backupService;
         }
 
+        /// <summary>
+        /// Cleans up Temp, cache, and old database backups
+        /// </summary>
         [AutomaticRetry(Attempts = 3, LogEvents = false, OnAttemptsExceeded = AttemptsExceededAction.Fail)]
         public void Cleanup()
         {
@@ -31,6 +34,11 @@ namespace API.Services.Tasks
             _cacheService.Cleanup();
             _logger.LogInformation("Cleaning old database backups");
             _backupService.CleanupBackups();
+        }
+
+        [AutomaticRetry(Attempts = 3, LogEvents = false, OnAttemptsExceeded = AttemptsExceededAction.Fail)]
+        public void RemoveAbandonedRows()
+        {
 
         }
     }

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -134,6 +134,11 @@ namespace API.Services.Tasks
        }
 
 
+       /// <summary>
+       /// Scans a library for file changes. If force update passed, all entities will be rechecked for new cover images and comicInfo.xml changes.
+       /// </summary>
+       /// <param name="libraryId"></param>
+       /// <param name="forceUpdate"></param>
        [DisableConcurrentExecution(360)]
        [AutomaticRetry(Attempts = 0, OnAttemptsExceeded = AttemptsExceededAction.Delete)]
        public void ScanLibrary(int libraryId, bool forceUpdate)

--- a/Kavita.Common/Configuration.cs
+++ b/Kavita.Common/Configuration.cs
@@ -141,8 +141,7 @@ namespace Kavita.Common
 
       public static int GetPort(string filePath)
       {
-         Console.WriteLine(GetAppSettingFilename());
-         const int defaultPort = 5000;
+          const int defaultPort = 5000;
          if (new OsInfo(Array.Empty<IOsVersionAdapter>()).IsDocker)
          {
             return defaultPort;

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ﻿# [<img src="/Logo/kavita.svg" width="32" alt="">]() Kavita
 <div align="center">
 
-![Cover Image](https://github.com/Kareadita/kareadita.github.io/blob/main/img/features/seriesdetail.PNG?raw=true)
+!![high level view](https://user-images.githubusercontent.com/735851/129777364-2c82d01e-5c03-4daf-b203-92b1d48e5b7b.gif)
 
 Kavita is a fast, feature rich, cross platform reading server. Built with a focus for manga, 
 and the goal of being a full solution for all your reading needs. Setup your own server and share 
@@ -122,3 +122,4 @@ Thank you to [<img src="/Logo/sentry.svg" alt="" width="64">](https://sentry.io/
 
 * [GNU GPL v3](http://www.gnu.org/licenses/gpl.html)
 * Copyright 2020-2021
+

--- a/UI/Web/src/app/_models/chapter.ts
+++ b/UI/Web/src/app/_models/chapter.ts
@@ -5,7 +5,10 @@ export interface Chapter {
     range: string;
     number: string;
     files: Array<MangaFile>;
-    //coverImage: string;
+    /**
+     * This is used in the UI, it is not updated or sent to Backend
+     */
+    coverImage: string;
     coverImageLocked: boolean;
     pages: number;
     volumeId: number;

--- a/UI/Web/src/app/_services/action-factory.service.ts
+++ b/UI/Web/src/app/_services/action-factory.service.ts
@@ -104,13 +104,6 @@ export class ActionFactoryService {
           callback: this.dummyCallback,
           requiresAdmin: true
         });
-
-        this.volumeActions.push({
-          action: Action.Edit,
-          title: 'Edit',
-          callback: this.dummyCallback,
-          requiresAdmin: false
-        });
     
         this.chapterActions.push({
           action: Action.Edit,
@@ -201,6 +194,12 @@ export class ActionFactoryService {
       {
         action: Action.MarkAsUnread,
         title: 'Mark as Unread',
+        callback: this.dummyCallback,
+        requiresAdmin: false
+      },
+      {
+        action: Action.Edit,
+        title: 'Info',
         callback: this.dummyCallback,
         requiresAdmin: false
       }

--- a/UI/Web/src/app/admin/manage-users/manage-users.component.html
+++ b/UI/Web/src/app/admin/manage-users/manage-users.component.html
@@ -9,7 +9,7 @@
         <li *ngFor="let member of members" class="list-group-item">
             <div>
                 <h4>
-                    <i class="presence fa fa-circle" title="Active" aria-hidden="true" *ngIf="(presence.onlineUsers$ | async)?.includes(member.username)"></i>{{member.username | titlecase}} <span *ngIf="member.isAdmin" class="badge badge-pill badge-secondary">Admin</span>
+                    <i class="presence fa fa-circle" title="Active" aria-hidden="true" *ngIf="false && (presence.onlineUsers$ | async)?.includes(member.username)"></i>{{member.username | titlecase}} <span *ngIf="member.isAdmin" class="badge badge-pill badge-secondary">Admin</span>
                     <div class="float-right" *ngIf="canEditMember(member)">
                         <button class="btn btn-danger mr-2" (click)="deleteUser(member)" placement="top" ngbTooltip="Delete User" attr.aria-label="Delete User {{member.username | titlecase}}"><i class="fa fa-trash" aria-hidden="true"></i></button>
                         <button class="btn btn-secondary mr-2" (click)="updatePassword(member)" placement="top" ngbTooltip="Change Password" attr.aria-label="Change Password for {{member.username | titlecase}}"><i class="fa fa-key" aria-hidden="true"></i></button>

--- a/UI/Web/src/app/cards/_modals/card-details-modal/card-details-modal.component.html
+++ b/UI/Web/src/app/cards/_modals/card-details-modal/card-details-modal.component.html
@@ -30,11 +30,20 @@
         <h4 *ngIf="!utilityService.isChapter(data)">Chapters</h4>
         <ul class="list-unstyled">
             <li class="media my-4" *ngFor="let chapter of chapters">
-                <img class="mr-3" style="width: 74px" src="{{imageService.randomize(imageService.getChapterCoverImage(chapter.id))}}">
+                <a (click)="readChapter(chapter)" href="javascript:void(0);" title="Read Chapter {{chapter.number}}">
+                    <img class="mr-3" style="width: 74px" [src]="chapter.coverImage">
+                </a>
                 <div class="media-body">
                     <h5 class="mt-0 mb-1">
                         <span *ngIf="chapter.number !== '0'; else specialHeader">
-                            Chapter {{formatChapterNumber(chapter)}}
+                            <span class="">
+                                <app-card-actionables (actionHandler)="performAction($event, chapter)" [actions]="chapterActions" [labelBy]="'Chapter' + formatChapterNumber(chapter)"></app-card-actionables>
+                            </span>&nbsp;Chapter {{formatChapterNumber(chapter)}}
+                            <span class="badge badge-primary badge-pill">
+                                <span *ngIf="chapter.pagesRead > 0 && chapter.pagesRead < chapter.pages">{{chapter.pagesRead}} / {{chapter.pages}}</span>
+                                <span *ngIf="chapter.pagesRead === 0">UNREAD</span>
+                                <span *ngIf="chapter.pagesRead === chapter.pages">READ</span>
+                            </span>
                         </span>
                         <ng-template #specialHeader>File(s)</ng-template>
                     </h5>
@@ -57,7 +66,7 @@
         
     </div>
     <div class="modal-footer">
-        <button type="button" class="btn btn-info" (click)="updateCover()">Update Cover</button>
+        <button type="button" class="btn btn-info" [disabled]="!isAdmin" (click)="updateCover()">Update Cover</button>
         <button type="submit" class="btn btn-primary" (click)="close()">Close</button>
     </div>
 </div>

--- a/UI/Web/src/app/cards/_modals/edit-series-modal/edit-series-modal.component.ts
+++ b/UI/Web/src/app/cards/_modals/edit-series-modal/edit-series-modal.component.ts
@@ -53,10 +53,6 @@ export class EditSeriesModalComponent implements OnInit, OnDestroy {
               private uploadService: UploadService) { }
 
   ngOnInit(): void {
-    // this.imageUrls.push({
-    //   imageUrl: this.imageService.getSeriesCoverImage(this.series.id),
-    //   source: 'Url'
-    // });
     this.imageUrls.push(this.imageService.getSeriesCoverImage(this.series.id));
 
     this.libraryService.getLibraryNames().pipe(takeUntil(this.onDestroy)).subscribe(names => {

--- a/UI/Web/src/app/cards/card-item/card-item.component.html
+++ b/UI/Web/src/app/cards/card-item/card-item.component.html
@@ -1,8 +1,8 @@
 <div class="card">
     <div class="overlay"  (click)="handleClick()">
-      <img *ngIf="total > 0 || supressArchiveWarning" class="card-img-top lazyload" [src]="imageService.placeholderImage" [attr.data-src]="imageUrl" 
+      <img *ngIf="total > 0 || supressArchiveWarning" class="img-top lazyload" [src]="imageService.placeholderImage" [attr.data-src]="imageUrl" 
             (error)="imageService.updateErroredImage($event)" aria-hidden="true" height="230px" width="158px">
-      <img *ngIf="total === 0 && !supressArchiveWarning" class="card-img-top lazyload" [src]="imageService.errorImage" [attr.data-src]="imageUrl" 
+      <img *ngIf="total === 0 && !supressArchiveWarning" class="img-top lazyload" [src]="imageService.errorImage" [attr.data-src]="imageUrl" 
             aria-hidden="true" height="230px" width="158px">
       <div class="progress-banner" *ngIf="read < total && total > 0 && read !== (total -1)">
         <p><ngb-progressbar type="primary" height="5px" [value]="read" [max]="total"></ngb-progressbar></p>

--- a/UI/Web/src/app/cards/card-item/card-item.component.scss
+++ b/UI/Web/src/app/cards/card-item/card-item.component.scss
@@ -38,7 +38,7 @@ $image-width: 160px;
     margin-bottom: 0px;
 }
 
-.card-img-top {
+.img-top {
     height: $image-height;
 }
 

--- a/UI/Web/src/app/series-detail/series-detail.component.ts
+++ b/UI/Web/src/app/series-detail/series-detail.component.ts
@@ -390,6 +390,7 @@ export class SeriesDetailComponent implements OnInit {
     modalRef.componentInstance.data = data;
     modalRef.componentInstance.parentName = this.series?.name;
     modalRef.componentInstance.seriesId = this.series?.id;
+    modalRef.componentInstance.libraryId = this.series?.libraryId;
     modalRef.closed.subscribe((result: {coverImageUpdate: boolean}) => {
       if (result.coverImageUpdate) {
         this.coverImageOffset += 1;


### PR DESCRIPTION
# Fixed
- Fixed: Saving reading progress can duplicate rows which causes the chapter unable to be read unless DB modification was done. This fix will ensure in race conditions that only 1 row is ever created. For existing issues, we will always grab first row.
- Fixed: Concurrency checks in the DB were not fully implemented. No user facing changes.
- Fixed: Card items will remain the same size regardless of read status (previously 5px off)

# Added
- Added: Added new code to remove any user progress items after a series is deleted from DB. 
- Added: Added new code to remove collection tags after all series are deleted that had said tag (#502)
- Added: All users can now view info about a volume/chapter. From the Chapter modal, chapters bundled into a volume can be read by clicking on the image, marked as read/unread, and reading progress can be seen. 


Fixes #504 
Fixes #502 
Fixes #505
Fixes #451  