### PR TITLE
Update Notification Refactor

### DIFF
--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -237,6 +237,7 @@ jobs:
         id: parse-body
         run: |
           body='${{ steps.findPr.outputs.body }}'
+          body=${body//\'/}
           body="${body//'%'/'%25'}"
           body="${body//$'\n'/'%0A'}"
           body="${body//$'\r'/'%0D'}"

--- a/API/Controllers/ServerController.cs
+++ b/API/Controllers/ServerController.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using API.DTOs.Stats;
+using API.DTOs.Update;
 using API.Extensions;
 using API.Interfaces;
 using API.Interfaces.Services;
@@ -25,9 +27,11 @@ namespace API.Controllers
         private readonly IArchiveService _archiveService;
         private readonly ICacheService _cacheService;
         private readonly ITaskScheduler _taskScheduler;
+        private readonly IVersionUpdaterService _versionUpdaterService;
 
         public ServerController(IHostApplicationLifetime applicationLifetime, ILogger<ServerController> logger, IConfiguration config,
-            IBackupService backupService, IArchiveService archiveService, ICacheService cacheService, ITaskScheduler taskScheduler)
+            IBackupService backupService, IArchiveService archiveService, ICacheService cacheService, ITaskScheduler taskScheduler,
+            IVersionUpdaterService versionUpdaterService)
         {
             _applicationLifetime = applicationLifetime;
             _logger = logger;
@@ -36,6 +40,7 @@ namespace API.Controllers
             _archiveService = archiveService;
             _cacheService = cacheService;
             _taskScheduler = taskScheduler;
+            _versionUpdaterService = versionUpdaterService;
         }
 
         /// <summary>
@@ -102,11 +107,16 @@ namespace API.Controllers
             }
         }
 
-        [HttpPost("check-update")]
-        public ActionResult CheckForUpdates()
+        [HttpGet("check-update")]
+        public async Task<ActionResult<UpdateNotificationDto>> CheckForUpdates()
         {
-            _taskScheduler.CheckForUpdate();
-            return Ok();
+            return Ok(await _versionUpdaterService.CheckForUpdate());
+        }
+
+        [HttpGet("changelog")]
+        public async Task<ActionResult<IEnumerable<UpdateNotificationDto>>> GetChangelog()
+        {
+            return Ok(await _versionUpdaterService.GetAllReleases());
         }
     }
 }

--- a/API/DTOs/Update/UpdateNotificationDto.cs
+++ b/API/DTOs/Update/UpdateNotificationDto.cs
@@ -1,0 +1,38 @@
+﻿namespace API.DTOs.Update
+{
+    /// <summary>
+    /// Update Notification denoting a new release available for user to update to
+    /// </summary>
+    public class UpdateNotificationDto
+    {
+        /// <summary>
+        /// Current installed Version
+        /// </summary>
+        public string CurrentVersion { get; init; }
+        /// <summary>
+        /// Semver of the release version
+        /// <example>0.4.3</example>
+        /// </summary>
+        public string UpdateVersion { get; init; }
+        /// <summary>
+        /// Release body in HTML
+        /// </summary>
+        public string UpdateBody { get; init; }
+        /// <summary>
+        /// Title of the release
+        /// </summary>
+        public string UpdateTitle { get; init; }
+        /// <summary>
+        /// Github Url
+        /// </summary>
+        public string UpdateUrl { get; init; }
+        /// <summary>
+        /// If this install is within Docker
+        /// </summary>
+        public bool IsDocker { get; init; }
+        /// <summary>
+        /// Is this a pre-release
+        /// </summary>
+        public bool IsPrerelease { get; init; }
+    }
+}

--- a/API/Interfaces/ITaskScheduler.cs
+++ b/API/Interfaces/ITaskScheduler.cs
@@ -15,6 +15,5 @@
         void RefreshSeriesMetadata(int libraryId, int seriesId);
         void ScanSeries(int libraryId, int seriesId, bool forceUpdate = false);
         void CancelStatsTasks();
-        void CheckForUpdate();
     }
 }

--- a/API/Interfaces/Services/IVersionUpdaterService.cs
+++ b/API/Interfaces/Services/IVersionUpdaterService.cs
@@ -1,11 +1,15 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
+using API.DTOs.Update;
+using API.Services.Tasks;
 
 namespace API.Interfaces.Services
 {
     public interface IVersionUpdaterService
     {
-        public Task CheckForUpdate();
-
+        Task<UpdateNotificationDto> CheckForUpdate();
+        Task PushUpdate(UpdateNotificationDto update);
+        Task<IEnumerable<UpdateNotificationDto>> GetAllReleases();
     }
 }

--- a/API/SignalR/MessageHub.cs
+++ b/API/SignalR/MessageHub.cs
@@ -7,27 +7,30 @@ using Microsoft.AspNetCore.SignalR;
 namespace API.SignalR
 {
 
+    /// <summary>
+    /// Generic hub for sending messages to UI
+    /// </summary>
     [Authorize]
     public class MessageHub : Hub
     {
-        private static readonly HashSet<string> _connections = new HashSet<string>();
+        private static readonly HashSet<string> Connections = new HashSet<string>();
 
         public static bool IsConnected
         {
             get
             {
-                lock (_connections)
+                lock (Connections)
                 {
-                    return _connections.Count != 0;
+                    return Connections.Count != 0;
                 }
             }
         }
 
         public override async Task OnConnectedAsync()
         {
-            lock (_connections)
+            lock (Connections)
             {
-                _connections.Add(Context.ConnectionId);
+                Connections.Add(Context.ConnectionId);
             }
 
             await base.OnConnectedAsync();
@@ -35,9 +38,9 @@ namespace API.SignalR
 
         public override async Task OnDisconnectedAsync(Exception exception)
         {
-            lock (_connections)
+            lock (Connections)
             {
-                _connections.Remove(Context.ConnectionId);
+                Connections.Remove(Context.ConnectionId);
             }
 
             await base.OnDisconnectedAsync(exception);

--- a/API/SignalR/PresenceHub.cs
+++ b/API/SignalR/PresenceHub.cs
@@ -6,6 +6,9 @@ using Microsoft.AspNetCore.SignalR;
 
 namespace API.SignalR
 {
+    /// <summary>
+    /// Keeps track of who is logged into the app
+    /// </summary>
     public class PresenceHub : Hub
     {
         private readonly IPresenceTracker _tracker;

--- a/UI/Web/src/app/_services/message-hub.service.ts
+++ b/UI/Web/src/app/_services/message-hub.service.ts
@@ -2,11 +2,17 @@ import { Injectable } from '@angular/core';
 import { HubConnection, HubConnectionBuilder } from '@microsoft/signalr';
 import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import { User } from '@sentry/angular';
+import { BehaviorSubject, ReplaySubject } from 'rxjs';
 import { environment } from 'src/environments/environment';
 import { UpdateNotificationModalComponent } from '../shared/update-notification/update-notification-modal.component';
 
 export enum EVENTS {
   UpdateAvailable = 'UpdateAvailable'
+}
+
+export interface Message<T> {
+  event: EVENTS;
+  payload: T;
 }
 
 @Injectable({
@@ -16,6 +22,9 @@ export class MessageHubService {
   hubUrl = environment.hubUrl;
   private hubConnection!: HubConnection;
   private updateNotificationModalRef: NgbModalRef | null = null;
+
+  private messagesSource = new ReplaySubject<Message<any>>(1);
+  public messages$ = this.messagesSource.asObservable();
 
   constructor(private modalService: NgbModal) { }
 
@@ -36,6 +45,10 @@ export class MessageHubService {
     });
 
     this.hubConnection.on(EVENTS.UpdateAvailable, resp => {
+      this.messagesSource.next({
+        event: EVENTS.UpdateAvailable,
+        payload: resp.body
+      });
       // Ensure only 1 instance of UpdateNotificationModal can be open at once
       if (this.updateNotificationModalRef != null) { return; }
       this.updateNotificationModalRef = this.modalService.open(UpdateNotificationModalComponent, { scrollable: true, size: 'lg' });

--- a/UI/Web/src/app/_services/server.service.ts
+++ b/UI/Web/src/app/_services/server.service.ts
@@ -34,6 +34,6 @@ export class ServerService {
   }
 
   getChangelog() {
-    return this.httpClient.get<UpdateVersionEvent>(this.baseUrl + 'server/check-update', {});
+    return this.httpClient.get<UpdateVersionEvent[]>(this.baseUrl + 'server/changelog', {});
   }
 }

--- a/UI/Web/src/app/_services/server.service.ts
+++ b/UI/Web/src/app/_services/server.service.ts
@@ -2,6 +2,7 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { environment } from 'src/environments/environment';
 import { ServerInfo } from '../admin/_models/server-info';
+import { UpdateVersionEvent } from '../_models/events/update-version-event';
 
 @Injectable({
   providedIn: 'root'
@@ -29,6 +30,10 @@ export class ServerService {
   }
 
   checkForUpdate() {
-    return this.httpClient.post(this.baseUrl + 'server/check-update', {});
+    return this.httpClient.get<UpdateVersionEvent>(this.baseUrl + 'server/check-update', {});
+  }
+
+  getChangelog() {
+    return this.httpClient.get<UpdateVersionEvent>(this.baseUrl + 'server/check-update', {});
   }
 }

--- a/UI/Web/src/app/admin/admin.module.ts
+++ b/UI/Web/src/app/admin/admin.module.ts
@@ -15,6 +15,7 @@ import { ManageSettingsComponent } from './manage-settings/manage-settings.compo
 import { FilterPipe } from './filter.pipe';
 import { EditRbsModalComponent } from './_modals/edit-rbs-modal/edit-rbs-modal.component';
 import { ManageSystemComponent } from './manage-system/manage-system.component';
+import { ChangelogComponent } from './changelog/changelog.component';
 
 
 
@@ -31,7 +32,8 @@ import { ManageSystemComponent } from './manage-system/manage-system.component';
     ManageSettingsComponent,
     FilterPipe,
     EditRbsModalComponent,
-    ManageSystemComponent
+    ManageSystemComponent,
+    ChangelogComponent
   ],
   imports: [
     CommonModule,

--- a/UI/Web/src/app/admin/changelog/changelog.component.html
+++ b/UI/Web/src/app/admin/changelog/changelog.component.html
@@ -1,0 +1,14 @@
+<ng-container *ngFor="let update of updates; let indx = index;">
+    <div class="card w-100 mb-2" style="width: 18rem;">
+        <div class="card-body">
+          <h5 class="card-title">{{update.updateTitle}}&nbsp;<span class="badge badge-secondary" *ngIf="update.updateVersion === update.currentVersion">Installed</span></h5>
+          <pre class="card-text update-body" [innerHtml]="update.updateBody | safeHtml"></pre>
+          <a *ngIf="!update.isDocker" href="{{update.updateUrl}}" class="btn btn-{{indx === 0 ? 'primary' : 'secondary'}} float-right" target="_blank">Download</a>
+        </div>
+      </div>
+</ng-container>
+
+
+<div class="spinner-border text-secondary" *ngIf="isLoading" role="status">
+    <span class="invisible">Loading...</span>
+</div>

--- a/UI/Web/src/app/admin/changelog/changelog.component.scss
+++ b/UI/Web/src/app/admin/changelog/changelog.component.scss
@@ -1,0 +1,5 @@
+.update-body {
+    width: 100%;
+    word-wrap: break-word;
+    white-space: pre-wrap;
+}

--- a/UI/Web/src/app/admin/changelog/changelog.component.ts
+++ b/UI/Web/src/app/admin/changelog/changelog.component.ts
@@ -1,0 +1,23 @@
+import { Component, OnInit } from '@angular/core';
+import { UpdateVersionEvent } from 'src/app/_models/events/update-version-event';
+import { ServerService } from 'src/app/_services/server.service';
+
+@Component({
+  selector: 'app-changelog',
+  templateUrl: './changelog.component.html',
+  styleUrls: ['./changelog.component.scss']
+})
+export class ChangelogComponent implements OnInit {
+
+  updates: Array<UpdateVersionEvent> = [];
+  isLoading: boolean = true;
+
+  constructor(private serverService: ServerService) { }
+
+  ngOnInit(): void {
+    this.serverService.getChangelog().subscribe(updates => {
+      this.updates = updates;
+      this.isLoading = false;
+    });
+  }
+}

--- a/UI/Web/src/app/admin/dashboard/dashboard.component.html
+++ b/UI/Web/src/app/admin/dashboard/dashboard.component.html
@@ -16,6 +16,9 @@
           </ng-container>
           <ng-container *ngIf="tab.fragment === 'system'">
             <app-manage-system></app-manage-system>
+          </ng-container>
+          <ng-container *ngIf="tab.fragment === 'changelog'">
+            <app-changelog></app-changelog>
         </ng-container>
         </ng-template>
       </li>

--- a/UI/Web/src/app/admin/dashboard/dashboard.component.ts
+++ b/UI/Web/src/app/admin/dashboard/dashboard.component.ts
@@ -17,7 +17,8 @@ export class DashboardComponent implements OnInit {
     {title: 'General', fragment: ''},
     {title: 'Users', fragment: 'users'},
     {title: 'Libraries', fragment: 'libraries'},
-    {title: 'System', fragment: 'system'}
+    {title: 'System', fragment: 'system'},
+    {title: 'Changelog', fragment: 'changelog'},
   ];
   counter = this.tabs.length + 1;
   active = this.tabs[0];

--- a/UI/Web/src/app/admin/manage-system/manage-system.component.html
+++ b/UI/Web/src/app/admin/manage-system/manage-system.component.html
@@ -3,7 +3,7 @@
     <div class="float-right">
         <div class="d-inline-block" ngbDropdown #myDrop="ngbDropdown">
             <button class="btn btn-outline-primary mr-2" id="dropdownManual" ngbDropdownAnchor (focus)="myDrop.open()">
-                <ng-container *ngIf="backupDBInProgress || clearCacheInProgress">
+                <ng-container *ngIf="backupDBInProgress || clearCacheInProgress || isCheckingForUpdate || downloadLogsInProgress">
                     <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
                     <span class="sr-only">Loading...</span>
                 </ng-container>
@@ -19,7 +19,7 @@
               <button ngbDropdownItem (click)="downloadLogs()" [disabled]="downloadLogsInProgress">
                 Download Logs
               </button>
-              <button ngbDropdownItem  (click)="checkForUpdates()" [disabled]="hasCheckedForUpdate">
+              <button ngbDropdownItem (click)="checkForUpdates()">
                 Check for Updates
               </button>
             </div>

--- a/UI/Web/src/app/admin/manage-system/manage-system.component.ts
+++ b/UI/Web/src/app/admin/manage-system/manage-system.component.ts
@@ -1,7 +1,9 @@
 import { Component, OnInit } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
+import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { ToastrService } from 'ngx-toastr';
 import { finalize, take, takeWhile } from 'rxjs/operators';
+import { UpdateNotificationModalComponent } from 'src/app/shared/update-notification/update-notification-modal.component';
 import { DownloadService } from 'src/app/shared/_services/download.service';
 import { ServerService } from 'src/app/_services/server.service';
 import { SettingsService } from '../settings.service';
@@ -21,11 +23,12 @@ export class ManageSystemComponent implements OnInit {
 
   clearCacheInProgress: boolean = false;
   backupDBInProgress: boolean = false;
-  hasCheckedForUpdate: boolean = false;
+  isCheckingForUpdate: boolean = false;
   downloadLogsInProgress: boolean = false;
 
   constructor(private settingsService: SettingsService, private toastr: ToastrService, 
-    private serverService: ServerService, public downloadService: DownloadService) { }
+    private serverService: ServerService, public downloadService: DownloadService, 
+    private modalService: NgbModal) { }
 
   ngOnInit(): void {
 
@@ -82,9 +85,15 @@ export class ManageSystemComponent implements OnInit {
   }
 
   checkForUpdates() {
-    this.hasCheckedForUpdate = true;
-    this.serverService.checkForUpdate().subscribe(() => { 
-      this.toastr.info('This might take a few minutes. If an update is available, the server will notify you.');
+    this.isCheckingForUpdate = true;
+    this.serverService.checkForUpdate().subscribe((update) => { 
+      this.isCheckingForUpdate = false;
+      if (update === null) {
+        this.toastr.info('No updates available');
+        return;
+      }
+      const modalRef = this.modalService.open(UpdateNotificationModalComponent, { scrollable: true, size: 'lg' });
+      modalRef.componentInstance.updateData = update;
     });
   }
 

--- a/UI/Web/src/app/nav-header/nav-header.component.html
+++ b/UI/Web/src/app/nav-header/nav-header.component.html
@@ -61,13 +61,14 @@
         </button>
       </div>
 
-      <!-- TODO: Put SignalR notification button dropdown here. -->
       <div ngbDropdown class="nav-item dropdown" display="dynamic" placement="bottom-right" *ngIf="(accountService.currentUser$ | async) as user" dropdown>
-        <button class="btn btn-outline-secondary primary-text" ngbDropdownToggle>{{user.username | titlecase}}</button>
-        <div ngbDropdownMenu >
-          <button ngbDropdownItem routerLink="/preferences/">User Settings</button>
-          <button ngbDropdownItem routerLink="/admin/dashboard" *ngIf="user.roles.includes('Admin')">Server Settings</button>
-          <button ngbDropdownItem (click)="logout()">Logout</button>
+        <button class="btn btn-outline-secondary primary-text" ngbDropdownToggle>
+          {{user.username | titlecase}}
+        </button>
+        <div ngbDropdownMenu>
+          <a ngbDropdownItem routerLink="/preferences/">User Settings</a>
+          <a ngbDropdownItem routerLink="/admin/dashboard" *ngIf="user.roles.includes('Admin')">Server Settings</a>
+          <a ngbDropdownItem (click)="logout()">Logout</a>
         </div>
       </div>
     </div>

--- a/UI/Web/src/app/nav-header/nav-header.component.ts
+++ b/UI/Web/src/app/nav-header/nav-header.component.ts
@@ -4,7 +4,6 @@ import { Router } from '@angular/router';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { ScrollService } from '../scroll.service';
-import { UtilityService } from '../shared/_services/utility.service';
 import { SearchResult } from '../_models/search-result';
 import { AccountService } from '../_services/account.service';
 import { ImageService } from '../_services/image.service';
@@ -31,7 +30,8 @@ export class NavHeaderComponent implements OnInit, OnDestroy {
   private readonly onDestroy = new Subject<void>();
 
   constructor(public accountService: AccountService, private router: Router, public navService: NavService, 
-    private libraryService: LibraryService, public imageService: ImageService, @Inject(DOCUMENT) private document: Document, private scrollService: ScrollService) { }
+    private libraryService: LibraryService, public imageService: ImageService, @Inject(DOCUMENT) private document: Document, 
+    private scrollService: ScrollService) { }
 
   ngOnInit(): void {
     this.navService.darkMode$.pipe(takeUntil(this.onDestroy)).subscribe(res => {


### PR DESCRIPTION
# Added
- Added: Added a new tab to Admin dashboard to show all releases. The release that is installed will be denoted by a tag badge.

# Changed
- Changed: Checking for an update will immediately open a modal if one exists, else inform you via a toaster that none are available.
- Changed: Profile links (top right) are now anchors, so you can open in a new tab if you so want to

# Fixed
- Fixed: Some users experienced SSL issues connecting with Github. We now ignore Github certs for fetching release notes.

Closes #473
Closes #450 
Closes #497 