### PR TITLE
Prevent cover images showing as a series

### DIFF
--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -136,6 +136,7 @@ jobs:
         id: parse-body
         run: |
           body='${{ steps.findPr.outputs.body }}'
+          body=${body//\'/}
           body="${body//'%'/'%25'}"
           body="${body//$'\n'/'%0A'}"
           body="${body//$'\r'/'%0D'}"

--- a/API.Tests/Parser/MangaParserTests.cs
+++ b/API.Tests/Parser/MangaParserTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using API.Entities.Enums;
 using API.Parser;
 using Xunit;
@@ -403,6 +403,10 @@ namespace API.Tests.Parser
               Chapters = "93", Filename = "Seraph of the End - Vampire Reign 093 (2020) (Digital) (LuCaZ).cbz", Format = MangaFormat.Archive,
               FullFilePath = filepath, IsSpecial = false
             });
+
+            // If an image is cover exclusively, ignore it
+            filepath = @"E:\Manga\Seraph of the End\cover.png";
+            expected.Add(filepath, null);
 
 
             foreach (var file in expected.Keys)

--- a/API/Parser/Parser.cs
+++ b/API/Parser/Parser.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -552,6 +552,8 @@ namespace API.Parser
                 };
             }
 
+            if (IsImage(filePath) && IsCoverImage(fileName)) return null;
+
             if (IsImage(filePath))
             {
               // Reset Chapters, Volumes, and Series as images are not good to parse information out of. Better to use folders.
@@ -1026,6 +1028,7 @@ namespace API.Parser
         {
             return Regex.Replace(name.ToLower(), "[^a-zA-Z0-9]", string.Empty);
         }
+
 
         /// <summary>
         /// Tests whether the file is a cover image such that: contains "cover", is named "folder", and is an image


### PR DESCRIPTION
# Fixed
- Fixed: Cover images (cover.ext) from showing as a separate series
- Fixed: Nightly workflow now properly parses out single quotes '

Fixes #455 