### PR TITLE
Cover generation issue on first scan flow

### DIFF
--- a/API.Tests/Extensions/Test Data/modified on run.txt
+++ b/API.Tests/Extensions/Test Data/modified on run.txt
@@ -1,2 +1,3 @@
 This file should be modified by the unit test08/20/2021 10:26:03
 08/20/2021 10:26:29
+08/22/2021 12:39:58

--- a/API.Tests/Services/MetadataServiceTests.cs
+++ b/API.Tests/Services/MetadataServiceTests.cs
@@ -37,13 +37,68 @@ namespace API.Tests.Services
         }
 
         [Fact]
-        public void ShouldUpdateCoverImage_OnSecondRunFileModified()
+        public void ShouldUpdateCoverImage_OnSecondRun_FileModified()
         {
             // Represents first run
             Assert.True(MetadataService.ShouldUpdateCoverImage(null, new MangaFile()
             {
                 FilePath = Path.Join(_testDirectory, "file in folder.zip"),
-                LastModified = DateTime.Now.AddDays(1)
+                LastModified = new FileInfo(Path.Join(_testDirectory, "file in folder.zip")).LastWriteTime.Subtract(TimeSpan.FromDays(1))
+            }, false, false));
+        }
+
+        [Fact]
+        public void ShouldUpdateCoverImage_OnSecondRun_CoverImageLocked()
+        {
+            // Represents first run
+            Assert.False(MetadataService.ShouldUpdateCoverImage(null, new MangaFile()
+            {
+                FilePath = Path.Join(_testDirectory, "file in folder.zip"),
+                LastModified = new FileInfo(Path.Join(_testDirectory, "file in folder.zip")).LastWriteTime
+            }, false, true));
+        }
+
+        [Fact]
+        public void ShouldUpdateCoverImage_OnSecondRun_ForceUpdate()
+        {
+            // Represents first run
+            Assert.True(MetadataService.ShouldUpdateCoverImage(null, new MangaFile()
+            {
+                FilePath = Path.Join(_testDirectory, "file in folder.zip"),
+                LastModified = new FileInfo(Path.Join(_testDirectory, "file in folder.zip")).LastWriteTime
+            }, true, false));
+        }
+
+        [Fact]
+        public void ShouldUpdateCoverImage_OnSecondRun_NoFileChangeButNoCoverImage()
+        {
+            // Represents first run
+            Assert.True(MetadataService.ShouldUpdateCoverImage(null, new MangaFile()
+            {
+                FilePath = Path.Join(_testDirectory, "file in folder.zip"),
+                LastModified = new FileInfo(Path.Join(_testDirectory, "file in folder.zip")).LastWriteTime
+            }, false, false));
+        }
+
+        [Fact]
+        public void ShouldUpdateCoverImage_OnSecondRun_FileChangeButNoCoverImage()
+        {
+            // Represents first run
+            Assert.True(MetadataService.ShouldUpdateCoverImage(null, new MangaFile()
+            {
+                FilePath = Path.Join(_testDirectory, "file in folder.zip"),
+                LastModified = new FileInfo(Path.Join(_testDirectory, "file in folder.zip")).LastWriteTime + TimeSpan.FromDays(1)
+            }, false, false));
+        }
+
+        [Fact]
+        public void ShouldUpdateCoverImage_OnSecondRun_CoverImageSet()
+        {
+            // Represents first run
+            Assert.False(MetadataService.ShouldUpdateCoverImage(new byte[] {1}, new MangaFile()
+            {
+                FilePath = Path.Join(_testDirectory, "file in folder.zip"),
+                LastModified = new FileInfo(Path.Join(_testDirectory, "file in folder.zip")).LastWriteTime
             }, false, false));
         }
     }

--- a/API.Tests/Services/MetadataServiceTests.cs
+++ b/API.Tests/Services/MetadataServiceTests.cs
@@ -35,5 +35,16 @@ namespace API.Tests.Services
                 LastModified = DateTime.Now
             }, false, false));
         }
+
+        [Fact]
+        public void ShouldUpdateCoverImage_OnSecondRunFileModified()
+        {
+            // Represents first run
+            Assert.True(MetadataService.ShouldUpdateCoverImage(null, new MangaFile()
+            {
+                FilePath = Path.Join(_testDirectory, "file in folder.zip"),
+                LastModified = DateTime.Now.AddDays(1)
+            }, false, false));
+        }
     }
 }

--- a/API.Tests/Services/MetadataServiceTests.cs
+++ b/API.Tests/Services/MetadataServiceTests.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using API.Entities;
+using API.Interfaces;
+using API.Interfaces.Services;
+using API.Services;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace API.Tests.Services
+{
+    public class MetadataServiceTests
+    {
+        // private readonly MetadataService _metadataService;
+        // private readonly IUnitOfWork _unitOfWork = Substitute.For<IUnitOfWork>();
+        // private readonly IImageService _imageService = Substitute.For<IImageService>();
+        // private readonly IBookService _bookService = Substitute.For<IBookService>();
+        // private readonly IArchiveService _archiveService = Substitute.For<IArchiveService>();
+        // private readonly ILogger<MetadataService> _logger = Substitute.For<ILogger<MetadataService>>();
+        //
+        // public MetadataServiceTests()
+        // {
+        //     _metadataService = new MetadataService(_unitOfWork, _logger, _archiveService, _bookService, _imageService);
+        // }
+
+        [Fact]
+        public void ShouldUpdateCoverImage_ShouldReturnFalse()
+        {
+            Assert.False(MetadataService.ShouldUpdateCoverImage(null, new MangaFile()
+            {
+                FilePath = String.Empty,
+                LastModified = DateTime.Now
+            }, false, false));
+        }
+    }
+}

--- a/API.Tests/Services/MetadataServiceTests.cs
+++ b/API.Tests/Services/MetadataServiceTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using API.Entities;
 using API.Interfaces;
 using API.Interfaces.Services;
@@ -11,24 +12,26 @@ namespace API.Tests.Services
 {
     public class MetadataServiceTests
     {
-        // private readonly MetadataService _metadataService;
-        // private readonly IUnitOfWork _unitOfWork = Substitute.For<IUnitOfWork>();
-        // private readonly IImageService _imageService = Substitute.For<IImageService>();
-        // private readonly IBookService _bookService = Substitute.For<IBookService>();
-        // private readonly IArchiveService _archiveService = Substitute.For<IArchiveService>();
-        // private readonly ILogger<MetadataService> _logger = Substitute.For<ILogger<MetadataService>>();
-        //
-        // public MetadataServiceTests()
-        // {
-        //     _metadataService = new MetadataService(_unitOfWork, _logger, _archiveService, _bookService, _imageService);
-        // }
+        private readonly string _testDirectory = Path.Join(Directory.GetCurrentDirectory(), "../../../Services/Test Data/ArchiveService/Archives");
+        private readonly MetadataService _metadataService;
+        private readonly IUnitOfWork _unitOfWork = Substitute.For<IUnitOfWork>();
+        private readonly IImageService _imageService = Substitute.For<IImageService>();
+        private readonly IBookService _bookService = Substitute.For<IBookService>();
+        private readonly IArchiveService _archiveService = Substitute.For<IArchiveService>();
+        private readonly ILogger<MetadataService> _logger = Substitute.For<ILogger<MetadataService>>();
+
+        public MetadataServiceTests()
+        {
+            _metadataService = new MetadataService(_unitOfWork, _logger, _archiveService, _bookService, _imageService);
+        }
 
         [Fact]
-        public void ShouldUpdateCoverImage_ShouldReturnFalse()
+        public void ShouldUpdateCoverImage_OnFirstRun()
         {
-            Assert.False(MetadataService.ShouldUpdateCoverImage(null, new MangaFile()
+            // Represents first run
+            Assert.True(MetadataService.ShouldUpdateCoverImage(null, new MangaFile()
             {
-                FilePath = String.Empty,
+                FilePath = Path.Join(_testDirectory, "file in folder.zip"),
                 LastModified = DateTime.Now
             }, false, false));
         }

--- a/API/Controllers/SeriesController.cs
+++ b/API/Controllers/SeriesController.cs
@@ -155,14 +155,14 @@ namespace API.Controllers
             series.Name = updateSeries.Name.Trim();
             series.LocalizedName = updateSeries.LocalizedName.Trim();
             series.SortName = updateSeries.SortName?.Trim();
-            series.Summary = updateSeries.Summary?.Trim(); // BUG: There was an exceptionSystem.NullReferenceException: Object reference not set to an instance of an object.
+            series.Summary = updateSeries.Summary?.Trim();
 
             var needsRefreshMetadata = false;
-            if (!updateSeries.CoverImageLocked)
+            if (series.CoverImageLocked && !updateSeries.CoverImageLocked)
             {
                 // Trigger a refresh when we are moving from a locked image to a non-locked
-                needsRefreshMetadata = series.CoverImageLocked && !updateSeries.CoverImageLocked;
-                series.CoverImageLocked = false;
+                needsRefreshMetadata = true;
+                series.CoverImageLocked = updateSeries.CoverImageLocked;
             }
 
             _unitOfWork.SeriesRepository.Update(series);

--- a/API/Controllers/SeriesController.cs
+++ b/API/Controllers/SeriesController.cs
@@ -160,8 +160,9 @@ namespace API.Controllers
             var needsRefreshMetadata = false;
             if (!updateSeries.CoverImageLocked)
             {
+                // Trigger a refresh when we are moving from a locked image to a non-locked
+                needsRefreshMetadata = series.CoverImageLocked && !updateSeries.CoverImageLocked;
                 series.CoverImageLocked = false;
-                needsRefreshMetadata = true;
             }
 
             _unitOfWork.SeriesRepository.Update(series);

--- a/API/Entities/MangaFile.cs
+++ b/API/Entities/MangaFile.cs
@@ -5,6 +5,9 @@ using API.Entities.Enums;
 
 namespace API.Entities
 {
+    /// <summary>
+    /// Represents a wrapper to the underlying file. This provides information around file, like number of pages, format, etc.
+    /// </summary>
     public class MangaFile
     {
         public int Id { get; set; }

--- a/API/Extensions/FileInfoExtensions.cs
+++ b/API/Extensions/FileInfoExtensions.cs
@@ -13,7 +13,8 @@ namespace API.Extensions
         /// <returns></returns>
         public static bool HasFileBeenModifiedSince(this FileInfo fileInfo, DateTime comparison)
         {
-            return fileInfo?.LastWriteTime > comparison;
+            return DateTime.Compare(fileInfo.LastWriteTime, comparison) > 0;
+            //return fileInfo?.LastWriteTime > comparison;
         }
     }
 }

--- a/API/Services/MetadataService.cs
+++ b/API/Services/MetadataService.cs
@@ -56,7 +56,7 @@ namespace API.Services
             if (isCoverLocked) return false;
             if (forceUpdate) return true;
             return (firstFile != null &&
-                    new FileInfo(firstFile.FilePath).HasFileBeenModifiedSince(firstFile.LastModified) &&
+                    !new FileInfo(firstFile.FilePath).HasFileBeenModifiedSince(firstFile.LastModified) &&
                     (coverImage == null || !coverImage.Any()));
         }
 

--- a/API/Services/MetadataService.cs
+++ b/API/Services/MetadataService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -67,10 +67,10 @@ namespace API.Services
         public void UpdateMetadata(Chapter chapter, bool forceUpdate)
         {
             var firstFile = chapter.Files.OrderBy(x => x.Chapter).FirstOrDefault();
-            if (!chapter.CoverImageLocked
+            if ((!chapter.CoverImageLocked
                 && ShouldFindCoverImage(chapter.CoverImage, forceUpdate)
-                && firstFile != null
-                && (forceUpdate || new FileInfo(firstFile.FilePath).HasFileBeenModifiedSince(firstFile.LastModified)))
+                && firstFile != null)
+                || (!chapter.CoverImageLocked && (forceUpdate || new FileInfo(firstFile.FilePath).HasFileBeenModifiedSince(firstFile.LastModified))))
             {
                 chapter.Files ??= new List<MangaFile>();
                 chapter.CoverImage = GetCoverImage(firstFile);

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -522,13 +522,7 @@ namespace API.Services.Tasks
              if (file != null)
              {
                 chapter.Files.Add(file);
-                existingFile = chapter.Files.Last();
              }
-          }
-
-          if (existingFile != null)
-          {
-             existingFile.LastModified = new FileInfo(existingFile.FilePath).LastWriteTime;
           }
        }
     }


### PR DESCRIPTION
# Fixed
- Fixed: After first scan, cover images were not getting set due to some distorted logic. Logic has been cleaned up and now has testing. (develop)
- Fixed: Fixed a case where after setting a custom cover image, a refresh metadata scan would kick off. Now the scan only kicks off when you perform a reset cover image flow. (develop)
- Fixed: Fixed a case where updating series cover image wouldn't take on the first time (develop)

Fixed #516 