### PR TITLE
v0.4.4 - Release

### DIFF
--- a/Kavita.Common/Kavita.Common.csproj
+++ b/Kavita.Common/Kavita.Common.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net5.0</TargetFramework>
         <Company>kavitareader.com</Company>
         <Product>Kavita</Product>
-        <AssemblyVersion>0.4.3.46</AssemblyVersion>
+        <AssemblyVersion>0.4.4.0</AssemblyVersion>
         <NeutralLanguage>en</NeutralLanguage>
     </PropertyGroup>
 


### PR DESCRIPTION
# Fixed
- Fixed an issue where marking a series as Unread when the DB gets skewed with duplicate progress rows for that item, would break. Now we cleanup any extra rows we see during the operation. (#435)
- Pagination is now slightly smaller (only 8 pages) as on mobile, it was cutting off screen. (#447)
- Fixed an issue in In Progress where it would not pull the series with correct pagination due to the unique situation with the query. All series that are in progress should now return. (#452)
- After marking something as read/unread or changing name on series, the in progress/recently added cards don't refresh
- Fixed an issue where after adding a new folder to an existing library, a scan wouldn't be kicked off (#469)
- In some cases, after clicking the background of a modal, the modal would close, but state wouldn't be handled as if cancel was pushed (#469)
- Fixed an issue where some series (usually pdf or image) would get deleted and recreated during library scans, thus keeping them always Recently Added (#470)
- Saving reading progress can duplicate rows which causes the chapter unable to be read unless DB modification was done. This fix will ensure in race conditions that only 1 row is ever created. For existing issues, we will always grab first row. (#507)
- Concurrency checks in the DB were not fully implemented. No user facing changes. (#507)
- Card items will remain the same size regardless of read status (previously 5px off) (#507)
- Fixed an issue where kicking off refresh metadata from Series in UI was calling wrong API and a refresh metadata was being done for the whole library rather than just for the individual series. (#512)
- Fixed a case where during refreshing metadata, volumes would re-run cover generation again, after it had already been done. (#512)
- Fixed an issue where a check to see if the underlying file had changed since we last scanned was returning true when it shouldn't have. This should reduce I/O on refreshing metadata. (#512)

# Added
- New button in manage server to manually create a backup of DB (Fixes #322)
- ._ files are now ignored from all I/O operations. This means they will not be considered when scanning a library, for cover generation, or even for comicinfo.xml selection (if you have ._comicinfo.xml and comicinfo.xml, the latter will be picked) (#440)
- Added "In Progress" page to see everything you are currently reading (#442)
- Added the ability to filter series based on format from In Progress, Recently Added, Library Detail, Collection Detail pages. (#442)
- Added total items to the above pages to showcase total series within Kavita (#442)
- Kavita is now an official app on the Unraid software store (#429)
- Ability to check for updates (stable-only) and be notified with a changelog. (#464)
- Added the ability to bookmark certain pages within the manga (image) reader and later download them from the series context menu. (#469)
- Cards when processing a download shows a spinner for the progress of the download (#483)
- Added the ability to customize cover images on Series, Volumes, Chapters, and Collections. The new form allows you to drag and drop, upload a file from PC, or paste a url in. You can reset the cover image and it will refresh from the source files. The images after the user has uploaded is locked in place, refreshing metadata will not change the cover image. You must use the form (or API) to perform the reset action. (#499)
- Added new code to remove any user progress items after a series is deleted from DB. (#507)
- Added new code to remove collection tags after all series are deleted that had said tag (#502)
- All users can now view info about a volume/chapter. From the Chapter modal, chapters bundled into a volume can be read by clicking on the image, marked as read/unread, and reading progress can be seen.
- Added System page in admin dashboard to see current version, OS information, and links to all Kavita resources.
- Added a section in User Settings to show all bookmarks for all series you have saved bookmarks to. You can clear them, view individual chapters, and download whole series bookmarks. (#508)
- Added a new tab to Admin dashboard to show all releases (changelog). The release that is installed will be denoted by a tag badge. (#511)

# Changed
- (Performance) Added the ability for epubs to cache, allowing faster page load for users with network mounted storage. (#433)
- Suppress max page error on bookmark api and just adjust the pages for the user. (#445)
- During library scan and series updates, Series names for Epubs will now trim excess white space (#447)
- Log files now roll (kavita, kavita1, etc) up to 5 files, each with a max of 10MB each. After all 5 files fill up, they will roll over. (#448)
- Moved the server actions into a dropdown as there were too many buttons on screen for mobile devices (#464)
- On load of Login Screen, auto focus the username field
- Admin contextual actions on cards will now be separated by a divider to help differentiate. (#469)
- Performance enhancement on an API used before reading (#469)
- When calculating unique filetypes used within Kavita instance, use lowercase so CBZ and cbz don't count as duplicate entities before sending to KavitaStats. (#470)
- Downloads now always take the backend filename and are streamed in a more optimal manner, reducing the javascript processing that was needed previously. (#483)
- When a file is being cached before reading, if there are any errors, delete the cache directory so next try can occur. (#499)
- Brand new Collection detail page by splitting into dedicated page and giving the user the opportunity to view the summary information around it. (#500)
- When the route changes, any open modals will dismissed (#501)
- User Settings now is within a lazy loaded module. This reduces the load time for the home page slightly. (#508)
- User Settings now uses tabs for the newly added bookmarks (#508)
- Profile links (top right) are now anchors, so you can open in a new tab if you so want to (#511)
- If you have image files that are named cover|folder.ext in your library, they will now be ignored (#513)