### PR TITLE
Add support for mangapy syntax to parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -499,3 +499,4 @@ _temp/
 _output/
 API/stats/
 UI/Web/dist/
+/API.Tests/Extensions/Test Data/modified on run.txt

--- a/API.Tests/Parser/MangaParserTests.cs
+++ b/API.Tests/Parser/MangaParserTests.cs
@@ -26,6 +26,7 @@ namespace API.Tests.Parser
         [InlineData("Akame ga KILL! ZERO v01 (2016) (Digital) (LuCaZ).cbz", "1")]
         [InlineData("v001", "1")]
         [InlineData("Vol 1", "1")]
+        [InlineData("vol_356-1", "356")] // Mangapy syntax
         [InlineData("No Volume", "0")]
         [InlineData("U12 (Under 12) Vol. 0001 Ch. 0001 - Reiwa Scans (gb)", "1")]
         [InlineData("[Suihei Kiki]_Kasumi_Otoko_no_Ko_[Taruby]_v1.1.zip", "1")]

--- a/API/Parser/Parser.cs
+++ b/API/Parser/Parser.cs
@@ -83,6 +83,11 @@ namespace API.Parser
                 @"(?<Series>.*)(\b|_|)(S(?<Volume>\d+))",
                 RegexOptions.IgnoreCase | RegexOptions.Compiled,
             RegexTimeout),
+            // vol_001-1.cbz for MangaPy default naming convention
+            new Regex(
+                @"(vol_)(?<Volume>\d+)",
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
         };
 
         private static readonly Regex[] MangaSeriesRegex = new[]


### PR DESCRIPTION
# Added
- Added: (Parser) Added support for MangaPy's default naming convention to parser: vol_001-1.cbz