### PR TITLE
v0.4.5 Release

### DIFF
--- a/Kavita.Common/Kavita.Common.csproj
+++ b/Kavita.Common/Kavita.Common.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net5.0</TargetFramework>
         <Company>kavitareader.com</Company>
         <Product>Kavita</Product>
-        <AssemblyVersion>0.4.4.11</AssemblyVersion>
+        <AssemblyVersion>0.4.5.0</AssemblyVersion>
         <NeutralLanguage>en</NeutralLanguage>
     </PropertyGroup>
 


### PR DESCRIPTION
# Added
- Added: OPDS with Open Search and Page Streaming support. This must be enabled at the server level for any feeds to work. Disabling it will instantly stop serving any feeds. Page Streaming means you can stream one page at a time and will capture progress. See our wiki for how this works. (#526)
- Added: API key for users. In order for users to use OPDS, they must use a uniquly generated OPDS Feed url generated for them. This uses an API key, which acts as a password for the user to load up their libraries, etc. (#526)
- Added: Timeout added for Stat collection. After 30 seconds, fail the stat collection and try again the next day. (#526)

- Added: (Parser) Added support for MangaPy's default naming convention to parser: vol_001-1.cbz (#538)

# Fixed
- Fixed: Fixed an issue with ordering of chapters within a volume for selecting first cover image. (#524)
- Fixed: Fixed an issue where when new files were added, the Series cover wouldn't be set due to a logic miss when changing cover generation code from last release. (#527)
- Fixed: On desktop devices, when reading with fit to width or original, next page wouldn't reset scroll position. (#535)

# Changed
- Changed: Stat collection now runs in a separate thread and will not block startup. Checks for if stat collection is enabled will now occur in more places to ensure extra work takes place if it's not enabled. (#534)
- Changed: (Accessibility) Updated Server Settings and User Settings to handle better on screen readers (#352 )
