### PR TITLE
Reading Lists & More

### DIFF
--- a/API.Benchmark/ParseScannedFilesBenchmarks.cs
+++ b/API.Benchmark/ParseScannedFilesBenchmarks.cs
@@ -36,5 +36,13 @@ namespace API.Benchmark
                 out var totalFiles, out var scanElapsedTime);
         }
 
+        // [Benchmark]
+        // public void MergeName()
+        // {
+        //     var parsedSeries =_parseScannedFiles.ScanLibrariesForSeries(LibraryType.Manga, new string[] {@"M:\"}, out var totalFiles,
+        //         out var scanElapsedTime);
+        //     //_parseScannedFiles.MergeName()
+        // }
+
     }
 }

--- a/API.Benchmark/ParseScannedFilesBenchmarks.cs
+++ b/API.Benchmark/ParseScannedFilesBenchmarks.cs
@@ -35,14 +35,5 @@ namespace API.Benchmark
             var parsedSeries = _parseScannedFiles.ScanLibrariesForSeries(LibraryType.Manga, new string[] {libraryPath},
                 out var totalFiles, out var scanElapsedTime);
         }
-
-        // [Benchmark]
-        // public void MergeName()
-        // {
-        //     var parsedSeries =_parseScannedFiles.ScanLibrariesForSeries(LibraryType.Manga, new string[] {@"M:\"}, out var totalFiles,
-        //         out var scanElapsedTime);
-        //     //_parseScannedFiles.MergeName()
-        // }
-
     }
 }

--- a/API.Tests/Parser/MangaParserTests.cs
+++ b/API.Tests/Parser/MangaParserTests.cs
@@ -66,6 +66,7 @@ namespace API.Tests.Parser
         [InlineData("Noblesse - Episode 406 (52 Pages).7z", "0")]
         [InlineData("X-Men v1 #201 (September 2007).cbz", "1")]
         [InlineData("Hentai Ouji to Warawanai Neko. - Vol. 06 Ch. 034.5", "6")]
+        [InlineData("The 100 Girlfriends Who Really, Really, Really, Really, Really Love You - Vol. 03 Ch. 023.5 - Volume 3 Extras.cbz", "3")]
         public void ParseVolumeTest(string filename, string expected)
         {
             Assert.Equal(expected, API.Parser.Parser.ParseVolume(filename));
@@ -128,7 +129,6 @@ namespace API.Tests.Parser
         [InlineData("Fullmetal Alchemist chapters 101-108.cbz", "Fullmetal Alchemist")]
         [InlineData("To Love Ru v09 Uncensored (Ch.071-079).cbz", "To Love Ru")]
         [InlineData("[dmntsf.net] One Piece - Digital Colored Comics Vol. 20 Ch. 177 - 30 Million vs 81 Million.cbz", "One Piece - Digital Colored Comics")]
-        //[InlineData("Corpse Party -The Anthology- Sachikos game of love Hysteric Birthday 2U Extra Chapter", "Corpse Party -The Anthology- Sachikos game of love Hysteric Birthday 2U")]
         [InlineData("Corpse Party -The Anthology- Sachikos game of love Hysteric Birthday 2U Chapter 01", "Corpse Party -The Anthology- Sachikos game of love Hysteric Birthday 2U")]
         [InlineData("Vol03_ch15-22.rar", "")]
         [InlineData("Love Hina - Special.cbz", "")] // This has to be a fallback case
@@ -157,6 +157,7 @@ namespace API.Tests.Parser
         [InlineData("Killing Bites - Vol 11 Chapter 050 Save Me, Nunupi!.cbz", "Killing Bites")]
         [InlineData("Mad Chimera World - Volume 005 - Chapter 026.cbz", "Mad Chimera World")]
         [InlineData("Hentai Ouji to Warawanai Neko. - Vol. 06 Ch. 034.5", "Hentai Ouji to Warawanai Neko.")]
+        [InlineData("The 100 Girlfriends Who Really, Really, Really, Really, Really Love You - Vol. 03 Ch. 023.5 - Volume 3 Extras.cbz", "The 100 Girlfriends Who Really, Really, Really, Really, Really Love You")]
         public void ParseSeriesTest(string filename, string expected)
         {
             Assert.Equal(expected, API.Parser.Parser.ParseSeries(filename));

--- a/API/Controllers/LibraryController.cs
+++ b/API/Controllers/LibraryController.cs
@@ -227,9 +227,9 @@ namespace API.Controllers
         {
             queryString = queryString.Trim().Replace(@"%", "");
 
-            var user = await _unitOfWork.UserRepository.GetUserByUsernameAsync(User.GetUsername());
+            var userId = await _unitOfWork.UserRepository.GetUserIdByUsernameAsync(User.GetUsername());
             // Get libraries user has access to
-            var libraries = (await _unitOfWork.LibraryRepository.GetLibrariesForUserIdAsync(user.Id)).ToList();
+            var libraries = (await _unitOfWork.LibraryRepository.GetLibrariesForUserIdAsync(userId)).ToList();
 
             if (!libraries.Any()) return BadRequest("User does not have access to any libraries");
 

--- a/API/Controllers/LibraryController.cs
+++ b/API/Controllers/LibraryController.cs
@@ -225,7 +225,7 @@ namespace API.Controllers
         [HttpGet("search")]
         public async Task<ActionResult<IEnumerable<SearchResultDto>>> Search(string queryString)
         {
-            queryString = queryString.Replace(@"%", "");
+            queryString = queryString.Trim().Replace(@"%", "");
 
             var user = await _unitOfWork.UserRepository.GetUserByUsernameAsync(User.GetUsername());
             // Get libraries user has access to

--- a/API/Controllers/OPDSController.cs
+++ b/API/Controllers/OPDSController.cs
@@ -262,7 +262,6 @@ namespace API.Controllers
 
 
             var feed = CreateFeed("All Reading Lists", $"{apiKey}/reading-list", apiKey);
-            //AddPagination(feed, readingLists, $"{Prefix}{apiKey}/readinglists");
 
             foreach (var readingListDto in readingLists)
             {

--- a/API/Controllers/ReaderController.cs
+++ b/API/Controllers/ReaderController.cs
@@ -49,6 +49,7 @@ namespace API.Controllers
         [HttpGet("image")]
         public async Task<ActionResult> GetImage(int chapterId, int page)
         {
+            // TODO: Default to page 0 if something is sent below that
             if (page < 0) return BadRequest("Page cannot be less than 0");
             var chapter = await _cacheService.Ensure(chapterId);
             if (chapter == null) return BadRequest("There was an issue finding image file for reading");

--- a/API/Controllers/ReaderController.cs
+++ b/API/Controllers/ReaderController.cs
@@ -49,8 +49,7 @@ namespace API.Controllers
         [HttpGet("image")]
         public async Task<ActionResult> GetImage(int chapterId, int page)
         {
-            // TODO: Default to page 0 if something is sent below that
-            if (page < 0) return BadRequest("Page cannot be less than 0");
+            if (page < 0) page = 0;
             var chapter = await _cacheService.Ensure(chapterId);
             if (chapter == null) return BadRequest("There was an issue finding image file for reading");
 

--- a/API/Controllers/ReaderController.cs
+++ b/API/Controllers/ReaderController.cs
@@ -527,8 +527,8 @@ namespace API.Controllers
         [HttpGet("next-chapter")]
         public async Task<ActionResult<int>> GetNextChapter(int seriesId, int volumeId, int currentChapterId)
         {
-            var user = await _unitOfWork.UserRepository.GetUserByUsernameAsync(User.GetUsername());
-            var volumes = await _unitOfWork.SeriesRepository.GetVolumesDtoAsync(seriesId, user.Id);
+            var userId = await _unitOfWork.UserRepository.GetUserIdByUsernameAsync(User.GetUsername());
+            var volumes = await _unitOfWork.SeriesRepository.GetVolumesDtoAsync(seriesId, userId);
             var currentVolume = await _unitOfWork.SeriesRepository.GetVolumeAsync(volumeId);
             var currentChapter = await _unitOfWork.VolumeRepository.GetChapterAsync(currentChapterId);
             if (currentVolume.Number == 0)
@@ -593,8 +593,8 @@ namespace API.Controllers
         [HttpGet("prev-chapter")]
         public async Task<ActionResult<int>> GetPreviousChapter(int seriesId, int volumeId, int currentChapterId)
         {
-            var user = await _unitOfWork.UserRepository.GetUserByUsernameAsync(User.GetUsername());
-            var volumes = await _unitOfWork.SeriesRepository.GetVolumesDtoAsync(seriesId, user.Id);
+            var userId = await _unitOfWork.UserRepository.GetUserIdByUsernameAsync(User.GetUsername());
+            var volumes = await _unitOfWork.SeriesRepository.GetVolumesDtoAsync(seriesId, userId);
             var currentVolume = await _unitOfWork.SeriesRepository.GetVolumeAsync(volumeId);
             var currentChapter = await _unitOfWork.VolumeRepository.GetChapterAsync(currentChapterId);
 

--- a/API/Controllers/ReaderController.cs
+++ b/API/Controllers/ReaderController.cs
@@ -98,7 +98,7 @@ namespace API.Controllers
                 VolumeNumber = volume.Number + string.Empty,
                 VolumeId = volume.Id,
                 FileName = Path.GetFileName(mangaFile.FilePath),
-                SeriesName = series?.Name,
+                SeriesName = series.Name,
                 SeriesFormat = series.Format,
                 SeriesId = series.Id,
                 LibraryId = series.LibraryId,

--- a/API/Controllers/ReadingListController.cs
+++ b/API/Controllers/ReadingListController.cs
@@ -241,7 +241,6 @@ namespace API.Controllers
         private static bool AddChaptersToReadingList(int seriesId, IEnumerable<Chapter> chaptersForSeries,
             ICollection<int> existingChapterIds, ReadingList readingList, int lastOrder)
         {
-            // BUG: There is an order issue with this logic
             var index = lastOrder + 1;
             foreach (var chapter in chaptersForSeries)
             {

--- a/API/Controllers/ReadingListController.cs
+++ b/API/Controllers/ReadingListController.cs
@@ -204,6 +204,32 @@ namespace API.Controllers
             return Ok(await _unitOfWork.ReadingListRepository.GetReadingListDtoByTitleAsync(dto.Title));
         }
 
+        [HttpPost("update")]
+        public async Task<ActionResult> UpdateList(UpdateReadingListDto dto)
+        {
+            var readingList = await _unitOfWork.ReadingListRepository.GetReadingListByIdAsync(dto.ReadingListId);
+            if (readingList == null) return BadRequest("List does not exist");
+
+            if (!string.IsNullOrEmpty(dto.Title))
+            {
+                readingList.Title = dto.Title; // Should I check if this is unique?
+            }
+            if (!string.IsNullOrEmpty(dto.Title))
+            {
+                readingList.Summary = dto.Summary;
+            }
+
+            readingList.Promoted = dto.Promoted;
+
+            _unitOfWork.ReadingListRepository.Update(readingList);
+
+            if (await _unitOfWork.CommitAsync())
+            {
+                return Ok("Updated");
+            }
+            return BadRequest("Could not update reading list");
+        }
+
         [HttpPost("update-by-series")]
         public async Task<ActionResult> UpdateListBySeries(UpdateReadingListBySeriesDto dto)
         {

--- a/API/Controllers/ReadingListController.cs
+++ b/API/Controllers/ReadingListController.cs
@@ -109,12 +109,8 @@ namespace API.Controllers
             if (!_unitOfWork.HasChanges()) return BadRequest("There was a problem creating list");
 
             await _unitOfWork.CommitAsync();
-            return Ok(new ReadingListDto()
-            {
-                Promoted = false,
-                Title = dto.Title,
-                Summary = string.Empty
-            });
+
+            return Ok(await _unitOfWork.ReadingListRepository.GetReadingListDtoByTitleAsync(dto.Title));
         }
 
         [HttpPost("update-by-series")]

--- a/API/Controllers/ReadingListController.cs
+++ b/API/Controllers/ReadingListController.cs
@@ -89,6 +89,26 @@ namespace API.Controllers
             return BadRequest("Couldn't update position");
         }
 
+        [HttpPost("delete-item")]
+        public async Task<ActionResult> DeleteListItem(UpdateReadingListPosition dto)
+        {
+            var items = (await _unitOfWork.ReadingListRepository.GetReadingListItemsByIdAsync(dto.ReadingListId)).ToList();
+            var item = items.Find(r => r.Id == dto.ReadingListItemId);
+            items.Remove(item);
+
+            for (var i = 0; i < items.Count; i++)
+            {
+                items[i].Order = i;
+            }
+
+            if (_unitOfWork.HasChanges() && await _unitOfWork.CommitAsync())
+            {
+                return Ok("Updated");
+            }
+
+            return BadRequest("Couldn't delete item");
+        }
+
         /// <summary>
         /// Removes all entries that are fully read from the reading list
         /// </summary>

--- a/API/Controllers/ReadingListController.cs
+++ b/API/Controllers/ReadingListController.cs
@@ -355,5 +355,26 @@ namespace API.Controllers
 
             return Ok(-1);
         }
+
+        /// <summary>
+        /// Returns the prev chapter within the reading list
+        /// </summary>
+        /// <param name="currentChapterId"></param>
+        /// <param name="readingListId"></param>
+        /// <returns>Chapter Id for next item, -1 if nothing exists</returns>
+        [HttpGet("prev-chapter")]
+        public async Task<ActionResult<int>> GetPrevChapter(int currentChapterId, int readingListId)
+        {
+            var items = (await _unitOfWork.ReadingListRepository.GetReadingListItemsByIdAsync(readingListId)).ToList();
+            var readingListItem = items.SingleOrDefault(rl => rl.ChapterId == currentChapterId);
+            if (readingListItem == null) return BadRequest("Id does not exist");
+            var index = items.IndexOf(readingListItem) - 1;
+            if (0 <= index)
+            {
+                return items[index].ChapterId;
+            }
+
+            return Ok(-1);
+        }
     }
 }

--- a/API/Controllers/ReadingListController.cs
+++ b/API/Controllers/ReadingListController.cs
@@ -1,0 +1,32 @@
+﻿using API.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+
+namespace API.Controllers
+{
+    public class ReadingListController : BaseApiController
+    {
+        private readonly IUnitOfWork _unitOfWork;
+
+        public ReadingListController(IUnitOfWork unitOfWork)
+        {
+            _unitOfWork = unitOfWork;
+        }
+
+        /// <summary>
+        /// Returns reading lists for a given user.
+        /// </summary>
+        /// <param name="includePromoted">Defaults to true</param>
+        /// <returns></returns>
+        [HttpGet]
+        public ActionResult GetListForUser(bool includePromoted = true)
+        {
+            return Ok();
+        }
+
+        [HttpPost("add-to-list")]
+        public ActionResult AddChapterToList()
+        {
+            return Ok();
+        }
+    }
+}

--- a/API/Controllers/ReadingListController.cs
+++ b/API/Controllers/ReadingListController.cs
@@ -44,7 +44,7 @@ namespace API.Controllers
         }
 
         /// <summary>
-        ///
+        /// Fetches all reading list items for a given list including rich metadata around series, volume, chapters, and progress
         /// </summary>
         /// <remarks>This call is expensive</remarks>
         /// <param name="readingListId"></param>

--- a/API/Controllers/ReadingListController.cs
+++ b/API/Controllers/ReadingListController.cs
@@ -1,19 +1,24 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using API.DTOs.ReadingLists;
+using API.Entities;
 using API.Extensions;
 using API.Interfaces;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 
 namespace API.Controllers
 {
     public class ReadingListController : BaseApiController
     {
         private readonly IUnitOfWork _unitOfWork;
+        private readonly ILogger<ReadingListController> _logger;
 
-        public ReadingListController(IUnitOfWork unitOfWork)
+        public ReadingListController(IUnitOfWork unitOfWork, ILogger<ReadingListController> logger)
         {
             _unitOfWork = unitOfWork;
+            _logger = logger;
         }
 
         /// <summary>
@@ -26,13 +31,90 @@ namespace API.Controllers
         {
             var user = await _unitOfWork.UserRepository.GetUserByUsernameAsync(User.GetUsername());
 
-            return Ok(await _unitOfWork.ReadingListRepository.GetReadingListsForUser(user.Id, includePromoted));
+            return Ok(await _unitOfWork.ReadingListRepository.GetReadingListDtosForUserAsync(user.Id, includePromoted));
         }
 
-        [HttpPost("add-to-list")]
-        public ActionResult AddChapterToList()
+        /// <summary>
+        /// Creates a new List with a unique title. Returns the new ReadingList back
+        /// </summary>
+        /// <param name="dto"></param>
+        /// <returns></returns>
+        [HttpPost("create")]
+        public async Task<ActionResult<ReadingListDto>> CreateList(CreateReadingListDto dto)
         {
-            return Ok();
+            var user = await _unitOfWork.UserRepository.GetUserWithReadingListsByUsernameAsync(User.GetUsername());
+
+            // When creating, we need to make sure Title is unique
+            var hasExisting = user.ReadingLists.Any(l => l.Title.Equals(dto.Title));
+            if (hasExisting)
+            {
+                return BadRequest("A list of this name already exists");
+            }
+            user.ReadingLists.Add(new ReadingList()
+            {
+                Promoted = false,
+                Title = dto.Title,
+                Summary = string.Empty
+            });
+
+            if (!_unitOfWork.HasChanges()) return BadRequest("There was a problem creating list");
+
+            await _unitOfWork.CommitAsync();
+            return Ok(new ReadingListDto()
+            {
+                Promoted = false,
+                Title = dto.Title,
+                Summary = string.Empty
+            });
+        }
+
+        [HttpPost("update-by-series")]
+        public async Task<ActionResult> UpdateListBySeries(UpdateReadingListBySeriesDto dto)
+        {
+            var readingList = await _unitOfWork.ReadingListRepository.GetReadingListByIdAsync(dto.ReadingListId);
+            var chaptersForSeries =
+                await _unitOfWork.SeriesRepository.GetChapterIdsForSeriesAsync(new [] {dto.SeriesId}); // This is really slow
+
+            // This should never happen
+            if (readingList == null) return BadRequest("Reading List does not exist");
+            readingList.Items ??= new List<ReadingListItem>();
+            var lastOrder = 0;
+            if (readingList.Items.Any())
+            {
+                lastOrder = readingList.Items.DefaultIfEmpty().Max(rli => rli.Order);
+            }
+            var existingChapterIds = readingList.Items.Select(rli => rli.ChapterId).ToList();
+
+            var index = 1;
+            foreach (var chapterId in chaptersForSeries)
+            {
+                if (existingChapterIds.Contains(chapterId))
+                {
+                    continue;
+                }
+                readingList.Items.Add(new ReadingListItem()
+                {
+                    Order = lastOrder + index,
+                    ChapterId = chapterId,
+                    SeriesId = dto.SeriesId,
+                });
+                index += 1;
+            }
+
+            try
+            {
+                if (_unitOfWork.HasChanges())
+                {
+                    await _unitOfWork.CommitAsync();
+                    return Ok("Updated");
+                }
+            }
+            catch
+            {
+                await _unitOfWork.RollbackAsync();
+            }
+
+            return Ok("Nothing to do");
         }
     }
 }

--- a/API/Controllers/ReadingListController.cs
+++ b/API/Controllers/ReadingListController.cs
@@ -1,4 +1,6 @@
-﻿using API.Interfaces;
+﻿using System.Collections.Generic;
+using API.DTOs.ReadingLists;
+using API.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 
 namespace API.Controllers
@@ -18,9 +20,9 @@ namespace API.Controllers
         /// <param name="includePromoted">Defaults to true</param>
         /// <returns></returns>
         [HttpGet]
-        public ActionResult GetListForUser(bool includePromoted = true)
+        public ActionResult<IEnumerable<ReadingListDto>> GetListForUser(bool includePromoted = true)
         {
-            return Ok();
+            return Ok(new ReadingListDto[] {});
         }
 
         [HttpPost("add-to-list")]

--- a/API/Controllers/ReadingListController.cs
+++ b/API/Controllers/ReadingListController.cs
@@ -59,6 +59,31 @@ namespace API.Controllers
         }
 
         /// <summary>
+        /// Deletes a reading list
+        /// </summary>
+        /// <param name="readingListId"></param>
+        /// <returns></returns>
+        [HttpDelete]
+        public async Task<ActionResult> DeleteList([FromQuery] int readingListId)
+        {
+            var user = await _unitOfWork.UserRepository.GetUserWithReadingListsByUsernameAsync(User.GetUsername());
+            var readingList = user.ReadingLists.SingleOrDefault(r => r.Id == readingListId);
+            if (readingList == null)
+            {
+                return BadRequest("User is not associated with this reading list");
+            }
+
+            user.ReadingLists.Remove(readingList);
+
+            if (_unitOfWork.HasChanges() && await _unitOfWork.CommitAsync())
+            {
+                return Ok("Deleted");
+            }
+
+            return BadRequest("There was an issue deleting reading list");
+        }
+
+        /// <summary>
         /// Creates a new List with a unique title. Returns the new ReadingList back
         /// </summary>
         /// <param name="dto"></param>

--- a/API/Controllers/ReadingListController.cs
+++ b/API/Controllers/ReadingListController.cs
@@ -15,13 +15,11 @@ namespace API.Controllers
     public class ReadingListController : BaseApiController
     {
         private readonly IUnitOfWork _unitOfWork;
-        private readonly ILogger<ReadingListController> _logger;
         private readonly ChapterSortComparerZeroFirst _chapterSortComparerForInChapterSorting = new ChapterSortComparerZeroFirst();
 
-        public ReadingListController(IUnitOfWork unitOfWork, ILogger<ReadingListController> logger)
+        public ReadingListController(IUnitOfWork unitOfWork)
         {
             _unitOfWork = unitOfWork;
-            _logger = logger;
         }
 
         [HttpGet]

--- a/API/Controllers/ReadingListController.cs
+++ b/API/Controllers/ReadingListController.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using API.DTOs.ReadingLists;
+using API.Extensions;
 using API.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 
@@ -20,9 +22,11 @@ namespace API.Controllers
         /// <param name="includePromoted">Defaults to true</param>
         /// <returns></returns>
         [HttpGet]
-        public ActionResult<IEnumerable<ReadingListDto>> GetListForUser(bool includePromoted = true)
+        public async Task<ActionResult<IEnumerable<ReadingListDto>>> GetListForUser(bool includePromoted = true)
         {
-            return Ok(new ReadingListDto[] {});
+            var user = await _unitOfWork.UserRepository.GetUserByUsernameAsync(User.GetUsername());
+
+            return Ok(await _unitOfWork.ReadingListRepository.GetReadingListsForUser(user.Id, includePromoted));
         }
 
         [HttpPost("add-to-list")]

--- a/API/Controllers/ReadingListController.cs
+++ b/API/Controllers/ReadingListController.cs
@@ -5,6 +5,7 @@ using API.Comparators;
 using API.DTOs.ReadingLists;
 using API.Entities;
 using API.Extensions;
+using API.Helpers;
 using API.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -31,16 +32,19 @@ namespace API.Controllers
         }
 
         /// <summary>
-        /// Returns reading lists for a given user.
+        /// Returns reading lists (paginated) for a given user.
         /// </summary>
         /// <param name="includePromoted">Defaults to true</param>
         /// <returns></returns>
-        [HttpGet("lists")]
-        public async Task<ActionResult<IEnumerable<ReadingListDto>>> GetListsForUser(bool includePromoted = true)
+        [HttpPost("lists")]
+        public async Task<ActionResult<IEnumerable<ReadingListDto>>> GetListsForUser([FromQuery] UserParams userParams, [FromQuery] bool includePromoted = true)
         {
             var user = await _unitOfWork.UserRepository.GetUserByUsernameAsync(User.GetUsername());
+            var items = await _unitOfWork.ReadingListRepository.GetReadingListDtosForUserAsync(user.Id, includePromoted,
+                userParams);
+            Response.AddPaginationHeader(items.CurrentPage, items.PageSize, items.TotalCount, items.TotalPages);
 
-            return Ok(await _unitOfWork.ReadingListRepository.GetReadingListDtosForUserAsync(user.Id, includePromoted));
+            return Ok(items);
         }
 
         /// <summary>

--- a/API/Controllers/SeriesController.cs
+++ b/API/Controllers/SeriesController.cs
@@ -32,14 +32,14 @@ namespace API.Controllers
         [HttpPost]
         public async Task<ActionResult<IEnumerable<Series>>> GetSeriesForLibrary(int libraryId, [FromQuery] UserParams userParams, [FromBody] FilterDto filterDto)
         {
-            var user = await _unitOfWork.UserRepository.GetUserByUsernameAsync(User.GetUsername());
+            var userId = await _unitOfWork.UserRepository.GetUserIdByUsernameAsync(User.GetUsername());
             var series =
-                await _unitOfWork.SeriesRepository.GetSeriesDtoForLibraryIdAsync(libraryId, user.Id, userParams, filterDto);
+                await _unitOfWork.SeriesRepository.GetSeriesDtoForLibraryIdAsync(libraryId, userId, userParams, filterDto);
 
             // Apply progress/rating information (I can't work out how to do this in initial query)
             if (series == null) return BadRequest("Could not get series for library");
 
-            await _unitOfWork.SeriesRepository.AddSeriesModifiers(user.Id, series);
+            await _unitOfWork.SeriesRepository.AddSeriesModifiers(userId, series);
 
             Response.AddPaginationHeader(series.CurrentPage, series.PageSize, series.TotalCount, series.TotalPages);
 
@@ -55,10 +55,10 @@ namespace API.Controllers
         [HttpGet("{seriesId}")]
         public async Task<ActionResult<SeriesDto>> GetSeries(int seriesId)
         {
-            var user = await _unitOfWork.UserRepository.GetUserByUsernameAsync(User.GetUsername());
+            var userId = await _unitOfWork.UserRepository.GetUserIdByUsernameAsync(User.GetUsername());
             try
             {
-                return Ok(await _unitOfWork.SeriesRepository.GetSeriesDtoByIdAsync(seriesId, user.Id));
+                return Ok(await _unitOfWork.SeriesRepository.GetSeriesDtoByIdAsync(seriesId, userId));
             }
             catch (Exception e)
             {
@@ -95,15 +95,15 @@ namespace API.Controllers
         [HttpGet("volumes")]
         public async Task<ActionResult<IEnumerable<VolumeDto>>> GetVolumes(int seriesId)
         {
-            var user = await _unitOfWork.UserRepository.GetUserByUsernameAsync(User.GetUsername());
-            return Ok(await _unitOfWork.SeriesRepository.GetVolumesDtoAsync(seriesId, user.Id));
+            var userId = await _unitOfWork.UserRepository.GetUserIdByUsernameAsync(User.GetUsername());
+            return Ok(await _unitOfWork.SeriesRepository.GetVolumesDtoAsync(seriesId, userId));
         }
 
         [HttpGet("volume")]
         public async Task<ActionResult<VolumeDto>> GetVolume(int volumeId)
         {
-            var user = await _unitOfWork.UserRepository.GetUserByUsernameAsync(User.GetUsername());
-            return Ok(await _unitOfWork.SeriesRepository.GetVolumeDtoAsync(volumeId, user.Id));
+            var userId = await _unitOfWork.UserRepository.GetUserIdByUsernameAsync(User.GetUsername());
+            return Ok(await _unitOfWork.SeriesRepository.GetVolumeDtoAsync(volumeId, userId));
         }
 
         [HttpGet("chapter")]
@@ -182,14 +182,14 @@ namespace API.Controllers
         [HttpPost("recently-added")]
         public async Task<ActionResult<IEnumerable<SeriesDto>>> GetRecentlyAdded(FilterDto filterDto, [FromQuery] UserParams userParams, [FromQuery] int libraryId = 0)
         {
-            var user = await _unitOfWork.UserRepository.GetUserByUsernameAsync(User.GetUsername());
+            var userId = await _unitOfWork.UserRepository.GetUserIdByUsernameAsync(User.GetUsername());
             var series =
-                await _unitOfWork.SeriesRepository.GetRecentlyAdded(libraryId, user.Id, userParams, filterDto);
+                await _unitOfWork.SeriesRepository.GetRecentlyAdded(libraryId, userId, userParams, filterDto);
 
             // Apply progress/rating information (I can't work out how to do this in initial query)
             if (series == null) return BadRequest("Could not get series");
 
-            await _unitOfWork.SeriesRepository.AddSeriesModifiers(user.Id, series);
+            await _unitOfWork.SeriesRepository.AddSeriesModifiers(userId, series);
 
             Response.AddPaginationHeader(series.CurrentPage, series.PageSize, series.TotalCount, series.TotalPages);
 
@@ -200,8 +200,8 @@ namespace API.Controllers
         public async Task<ActionResult<IEnumerable<SeriesDto>>> GetInProgress(FilterDto filterDto, [FromQuery] UserParams userParams, [FromQuery] int libraryId = 0)
         {
             // NOTE: This has to be done manually like this due to the DistinctBy requirement
-            var user = await _unitOfWork.UserRepository.GetUserByUsernameAsync(User.GetUsername());
-            var results = await _unitOfWork.SeriesRepository.GetInProgress(user.Id, libraryId, userParams, filterDto);
+            var userId = await _unitOfWork.UserRepository.GetUserIdByUsernameAsync(User.GetUsername());
+            var results = await _unitOfWork.SeriesRepository.GetInProgress(userId, libraryId, userParams, filterDto);
 
             var listResults = results.DistinctBy(s => s.Name).Skip((userParams.PageNumber - 1) * userParams.PageSize)
                 .Take(userParams.PageSize).ToList();
@@ -316,14 +316,14 @@ namespace API.Controllers
         [HttpGet("series-by-collection")]
         public async Task<ActionResult<IEnumerable<SeriesDto>>> GetSeriesByCollectionTag(int collectionId, [FromQuery] UserParams userParams)
         {
-            var user = await _unitOfWork.UserRepository.GetUserByUsernameAsync(User.GetUsername());
+            var userId = await _unitOfWork.UserRepository.GetUserIdByUsernameAsync(User.GetUsername());
             var series =
-                await _unitOfWork.SeriesRepository.GetSeriesDtoForCollectionAsync(collectionId, user.Id, userParams);
+                await _unitOfWork.SeriesRepository.GetSeriesDtoForCollectionAsync(collectionId, userId, userParams);
 
             // Apply progress/rating information (I can't work out how to do this in initial query)
             if (series == null) return BadRequest("Could not get series for collection");
 
-            await _unitOfWork.SeriesRepository.AddSeriesModifiers(user.Id, series);
+            await _unitOfWork.SeriesRepository.AddSeriesModifiers(userId, series);
 
             Response.AddPaginationHeader(series.CurrentPage, series.PageSize, series.TotalCount, series.TotalPages);
 
@@ -339,8 +339,8 @@ namespace API.Controllers
         public async Task<ActionResult<IEnumerable<SeriesDto>>> GetAllSeriesById(SeriesByIdsDto dto)
         {
             if (dto.SeriesIds == null) return BadRequest("Must pass seriesIds");
-            var user = await _unitOfWork.UserRepository.GetUserByUsernameAsync(User.GetUsername());
-            return Ok(await _unitOfWork.SeriesRepository.GetSeriesDtoForIdsAsync(dto.SeriesIds, user.Id));
+            var userId = await _unitOfWork.UserRepository.GetUserIdByUsernameAsync(User.GetUsername());
+            return Ok(await _unitOfWork.SeriesRepository.GetSeriesDtoForIdsAsync(dto.SeriesIds, userId));
         }
 
 

--- a/API/Controllers/SettingsController.cs
+++ b/API/Controllers/SettingsController.cs
@@ -103,7 +103,7 @@ namespace API.Controllers
                     }
                     else
                     {
-                        _taskScheduler.ScheduleStatsTasks();
+                        await _taskScheduler.ScheduleStatsTasks();
                     }
                 }
             }

--- a/API/Controllers/UsersController.cs
+++ b/API/Controllers/UsersController.cs
@@ -18,7 +18,7 @@ namespace API.Controllers
         {
             _unitOfWork = unitOfWork;
         }
-        
+
         [Authorize(Policy = "RequireAdminRole")]
         [HttpDelete("delete-user")]
         public async Task<ActionResult> DeleteUser(string username)
@@ -30,7 +30,7 @@ namespace API.Controllers
 
             return BadRequest("Could not delete the user.");
         }
-        
+
         [Authorize(Policy = "RequireAdminRole")]
         [HttpGet]
         public async Task<ActionResult<IEnumerable<MemberDto>>> GetUsers()
@@ -42,8 +42,8 @@ namespace API.Controllers
         public async Task<ActionResult<bool>> HasReadingProgress(int libraryId)
         {
             var library = await _unitOfWork.LibraryRepository.GetLibraryForIdAsync(libraryId);
-            var user = await _unitOfWork.UserRepository.GetUserByUsernameAsync(User.GetUsername());
-            return Ok(await _unitOfWork.AppUserProgressRepository.UserHasProgress(library.Type, user.Id));
+            var userId = await _unitOfWork.UserRepository.GetUserIdByUsernameAsync(User.GetUsername());
+            return Ok(await _unitOfWork.AppUserProgressRepository.UserHasProgress(library.Type, userId));
         }
 
         [HttpGet("has-library-access")]
@@ -77,7 +77,7 @@ namespace API.Controllers
             {
                 return Ok(preferencesDto);
             }
-            
+
             return BadRequest("There was an issue saving preferences.");
         }
     }

--- a/API/DTOs/Reader/BookInfoDto.cs
+++ b/API/DTOs/Reader/BookInfoDto.cs
@@ -1,0 +1,13 @@
+﻿using API.Entities.Enums;
+
+namespace API.DTOs.Reader
+{
+    public class BookInfoDto
+    {
+        public string BookTitle { get; set; }
+        public int SeriesId { get; set; }
+        public int VolumeId { get; set; }
+        public MangaFormat SeriesFormat { get; set; }
+        public int LibraryId { get; set; }
+    }
+}

--- a/API/DTOs/Reader/ChapterInfoDto.cs
+++ b/API/DTOs/Reader/ChapterInfoDto.cs
@@ -1,16 +1,21 @@
-﻿namespace API.DTOs.Reader
+﻿using API.Entities.Enums;
+
+namespace API.DTOs.Reader
 {
     public class ChapterInfoDto
     {
-        
+
         public string ChapterNumber { get; set; }
         public string VolumeNumber { get; set; }
         public int VolumeId { get; set; }
         public string SeriesName { get; set; }
+        public MangaFormat SeriesFormat { get; set; }
+        public int SeriesId { get; set; }
+        public int LibraryId { get; set; }
         public string ChapterTitle { get; set; } = "";
         public int Pages { get; set; }
         public string FileName { get; set; }
         public bool IsSpecial { get; set; }
-        
+
     }
 }

--- a/API/DTOs/ReadingLists/CreateReadingListDto.cs
+++ b/API/DTOs/ReadingLists/CreateReadingListDto.cs
@@ -1,0 +1,7 @@
+﻿namespace API.DTOs.ReadingLists
+{
+    public class CreateReadingListDto
+    {
+        public string Title { get; init; }
+    }
+}

--- a/API/DTOs/ReadingLists/ReadingListDto.cs
+++ b/API/DTOs/ReadingLists/ReadingListDto.cs
@@ -1,0 +1,13 @@
+﻿namespace API.DTOs.ReadingLists
+{
+    public class ReadingListDto
+    {
+        public string Title { get; set; }
+        public string Summary { get; set; }
+        /// <summary>
+        /// Reading lists that are promoted are only done by admins
+        /// </summary>
+        public bool Promoted { get; set; }
+        //public ICollection<ReadingListItem> Items { get; set; }
+    }
+}

--- a/API/DTOs/ReadingLists/ReadingListDto.cs
+++ b/API/DTOs/ReadingLists/ReadingListDto.cs
@@ -2,12 +2,12 @@
 {
     public class ReadingListDto
     {
+        public int Id { get; init; }
         public string Title { get; set; }
         public string Summary { get; set; }
         /// <summary>
         /// Reading lists that are promoted are only done by admins
         /// </summary>
         public bool Promoted { get; set; }
-        //public ICollection<ReadingListItem> Items { get; set; }
     }
 }

--- a/API/DTOs/ReadingLists/ReadingListItemDto.cs
+++ b/API/DTOs/ReadingLists/ReadingListItemDto.cs
@@ -1,0 +1,18 @@
+﻿using API.Entities.Enums;
+
+namespace API.DTOs.ReadingLists
+{
+    public class ReadingListItemDto
+    {
+        public int Order { get; init; }
+        public int ChapterId { get; init; }
+        public int SeriesId { get; init; }
+        public string SeriesName { get; set; }
+        public MangaFormat SeriesFormat { get; set; }
+        public int PagesRead { get; set; }
+        public int PagesTotal { get; set; }
+        public string ChapterNumber { get; set; }
+        public string VolumeNumber { get; set; }
+        public string Title { get; set; }
+    }
+}

--- a/API/DTOs/ReadingLists/ReadingListItemDto.cs
+++ b/API/DTOs/ReadingLists/ReadingListItemDto.cs
@@ -16,5 +16,9 @@ namespace API.DTOs.ReadingLists
         public string VolumeNumber { get; set; }
         public int LibraryId { get; set; }
         public string Title { get; set; }
+        /// <summary>
+        /// Used internally only
+        /// </summary>
+        public int ReadingListId { get; set; }
     }
 }

--- a/API/DTOs/ReadingLists/ReadingListItemDto.cs
+++ b/API/DTOs/ReadingLists/ReadingListItemDto.cs
@@ -4,6 +4,7 @@ namespace API.DTOs.ReadingLists
 {
     public class ReadingListItemDto
     {
+        public int Id { get; init; }
         public int Order { get; init; }
         public int ChapterId { get; init; }
         public int SeriesId { get; init; }

--- a/API/DTOs/ReadingLists/ReadingListItemDto.cs
+++ b/API/DTOs/ReadingLists/ReadingListItemDto.cs
@@ -14,6 +14,7 @@ namespace API.DTOs.ReadingLists
         public int PagesTotal { get; set; }
         public string ChapterNumber { get; set; }
         public string VolumeNumber { get; set; }
+        public int VolumeId { get; set; }
         public int LibraryId { get; set; }
         public string Title { get; set; }
         /// <summary>

--- a/API/DTOs/ReadingLists/ReadingListItemDto.cs
+++ b/API/DTOs/ReadingLists/ReadingListItemDto.cs
@@ -13,6 +13,7 @@ namespace API.DTOs.ReadingLists
         public int PagesTotal { get; set; }
         public string ChapterNumber { get; set; }
         public string VolumeNumber { get; set; }
+        public int LibraryId { get; set; }
         public string Title { get; set; }
     }
 }

--- a/API/DTOs/ReadingLists/UpdateReadingListByChapterDto.cs
+++ b/API/DTOs/ReadingLists/UpdateReadingListByChapterDto.cs
@@ -1,0 +1,9 @@
+﻿namespace API.DTOs.ReadingLists
+{
+    public class UpdateReadingListByChapterDto
+    {
+        public int ChapterId { get; init; }
+        public int SeriesId { get; init; }
+        public int ReadingListId { get; init; }
+    }
+}

--- a/API/DTOs/ReadingLists/UpdateReadingListBySeriesDto.cs
+++ b/API/DTOs/ReadingLists/UpdateReadingListBySeriesDto.cs
@@ -1,0 +1,8 @@
+﻿namespace API.DTOs.ReadingLists
+{
+    public class UpdateReadingListBySeriesDto
+    {
+        public int SeriesId { get; init; }
+        public int ReadingListId { get; init; }
+    }
+}

--- a/API/DTOs/ReadingLists/UpdateReadingListByVolumeDto.cs
+++ b/API/DTOs/ReadingLists/UpdateReadingListByVolumeDto.cs
@@ -1,0 +1,9 @@
+﻿namespace API.DTOs.ReadingLists
+{
+    public class UpdateReadingListByVolumeDto
+    {
+        public int VolumeId { get; init; }
+        public int SeriesId { get; init; }
+        public int ReadingListId { get; init; }
+    }
+}

--- a/API/DTOs/ReadingLists/UpdateReadingListDto.cs
+++ b/API/DTOs/ReadingLists/UpdateReadingListDto.cs
@@ -1,0 +1,10 @@
+﻿namespace API.DTOs.ReadingLists
+{
+    public class UpdateReadingListDto
+    {
+        public int ReadingListId { get; set; }
+        public string Title { get; set; }
+        public string Summary { get; set; }
+        public bool Promoted { get; set; }
+    }
+}

--- a/API/DTOs/ReadingLists/UpdateReadingListPosition.cs
+++ b/API/DTOs/ReadingLists/UpdateReadingListPosition.cs
@@ -1,0 +1,10 @@
+﻿namespace API.DTOs.ReadingLists
+{
+    public class UpdateReadingListPosition
+    {
+        public int ReadingListId { get; set; }
+        public int ReadingListItemId { get; set; }
+        public int FromPosition { get; set; }
+        public int ToPosition { get; set; }
+    }
+}

--- a/API/DTOs/VolumeDto.cs
+++ b/API/DTOs/VolumeDto.cs
@@ -14,6 +14,7 @@ namespace API.DTOs
         public DateTime LastModified { get; set; }
         public DateTime Created { get; set; }
         public bool IsSpecial { get; set; }
+        public int SeriesId { get; set; }
         public ICollection<ChapterDto> Chapters { get; set; }
     }
 }

--- a/API/Data/DataContext.cs
+++ b/API/Data/DataContext.cs
@@ -36,6 +36,8 @@ namespace API.Data
         public DbSet<CollectionTag> CollectionTag { get; set; }
         public DbSet<AppUserBookmark> AppUserBookmark { get; set; }
         public DbSet<ReadingList> ReadingList { get; set; }
+        public DbSet<ReadingListItem> ReadingListItem { get; set; }
+
 
         protected override void OnModelCreating(ModelBuilder builder)
         {

--- a/API/Data/DataContext.cs
+++ b/API/Data/DataContext.cs
@@ -35,6 +35,7 @@ namespace API.Data
         public DbSet<SeriesMetadata> SeriesMetadata { get; set; }
         public DbSet<CollectionTag> CollectionTag { get; set; }
         public DbSet<AppUserBookmark> AppUserBookmark { get; set; }
+        public DbSet<ReadingList> ReadingList { get; set; }
 
         protected override void OnModelCreating(ModelBuilder builder)
         {

--- a/API/Data/Migrations/20210901020400_ReadingLists.Designer.cs
+++ b/API/Data/Migrations/20210901020400_ReadingLists.Designer.cs
@@ -3,14 +3,16 @@ using System;
 using API.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace API.Data.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20210901020400_ReadingLists")]
+    partial class ReadingLists
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/API/Data/Migrations/20210901020400_ReadingLists.cs
+++ b/API/Data/Migrations/20210901020400_ReadingLists.cs
@@ -1,0 +1,75 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace API.Data.Migrations
+{
+    public partial class ReadingLists : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ReadingList",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    Title = table.Column<string>(type: "TEXT", nullable: true),
+                    Summary = table.Column<string>(type: "TEXT", nullable: true),
+                    Promoted = table.Column<bool>(type: "INTEGER", nullable: false),
+                    AppUserId = table.Column<int>(type: "INTEGER", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ReadingList", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ReadingList_AspNetUsers_AppUserId",
+                        column: x => x.AppUserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ReadingListItem",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    LibraryId = table.Column<int>(type: "INTEGER", nullable: false),
+                    SeriesId = table.Column<int>(type: "INTEGER", nullable: false),
+                    VolumeId = table.Column<int>(type: "INTEGER", nullable: false),
+                    ChapterId = table.Column<int>(type: "INTEGER", nullable: false),
+                    Order = table.Column<int>(type: "INTEGER", nullable: false),
+                    ReadingListId = table.Column<int>(type: "INTEGER", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ReadingListItem", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ReadingListItem_ReadingList_ReadingListId",
+                        column: x => x.ReadingListId,
+                        principalTable: "ReadingList",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ReadingList_AppUserId",
+                table: "ReadingList",
+                column: "AppUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ReadingListItem_ReadingListId",
+                table: "ReadingListItem",
+                column: "ReadingListId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ReadingListItem");
+
+            migrationBuilder.DropTable(
+                name: "ReadingList");
+        }
+    }
+}

--- a/API/Data/Migrations/20210901150310_ReadingLists.Designer.cs
+++ b/API/Data/Migrations/20210901150310_ReadingLists.Designer.cs
@@ -9,7 +9,7 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace API.Data.Migrations
 {
     [DbContext(typeof(DataContext))]
-    [Migration("20210901020400_ReadingLists")]
+    [Migration("20210901150310_ReadingLists")]
     partial class ReadingLists
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
@@ -451,6 +451,12 @@ namespace API.Data.Migrations
                     b.Property<int>("AppUserId")
                         .HasColumnType("INTEGER");
 
+                    b.Property<DateTime>("Created")
+                        .HasColumnType("TEXT");
+
+                    b.Property<DateTime>("LastModified")
+                        .HasColumnType("TEXT");
+
                     b.Property<bool>("Promoted")
                         .HasColumnType("INTEGER");
 
@@ -494,6 +500,9 @@ namespace API.Data.Migrations
                     b.HasKey("Id");
 
                     b.HasIndex("ReadingListId");
+
+                    b.HasIndex("SeriesId", "VolumeId", "ChapterId", "LibraryId")
+                        .IsUnique();
 
                     b.ToTable("ReadingListItem");
                 });

--- a/API/Data/Migrations/20210901150310_ReadingLists.cs
+++ b/API/Data/Migrations/20210901150310_ReadingLists.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace API.Data.Migrations
 {
@@ -15,6 +16,8 @@ namespace API.Data.Migrations
                     Title = table.Column<string>(type: "TEXT", nullable: true),
                     Summary = table.Column<string>(type: "TEXT", nullable: true),
                     Promoted = table.Column<bool>(type: "INTEGER", nullable: false),
+                    Created = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    LastModified = table.Column<DateTime>(type: "TEXT", nullable: false),
                     AppUserId = table.Column<int>(type: "INTEGER", nullable: false)
                 },
                 constraints: table =>
@@ -61,6 +64,12 @@ namespace API.Data.Migrations
                 name: "IX_ReadingListItem_ReadingListId",
                 table: "ReadingListItem",
                 column: "ReadingListId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ReadingListItem_SeriesId_VolumeId_ChapterId_LibraryId",
+                table: "ReadingListItem",
+                columns: new[] { "SeriesId", "VolumeId", "ChapterId", "LibraryId" },
+                unique: true);
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)

--- a/API/Data/Migrations/20210901200442_ReadingListsAdditions.Designer.cs
+++ b/API/Data/Migrations/20210901200442_ReadingListsAdditions.Designer.cs
@@ -3,14 +3,16 @@ using System;
 using API.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace API.Data.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20210901200442_ReadingListsAdditions")]
+    partial class ReadingListsAdditions
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -497,11 +499,7 @@ namespace API.Data.Migrations
 
                     b.HasKey("Id");
 
-                    b.HasIndex("ChapterId");
-
                     b.HasIndex("ReadingListId");
-
-                    b.HasIndex("VolumeId");
 
                     b.HasIndex("SeriesId", "VolumeId", "ChapterId", "LibraryId")
                         .IsUnique();
@@ -862,37 +860,13 @@ namespace API.Data.Migrations
 
             modelBuilder.Entity("API.Entities.ReadingListItem", b =>
                 {
-                    b.HasOne("API.Entities.Chapter", "Chapter")
-                        .WithMany()
-                        .HasForeignKey("ChapterId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
                     b.HasOne("API.Entities.ReadingList", "ReadingList")
                         .WithMany("Items")
                         .HasForeignKey("ReadingListId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
-                    b.HasOne("API.Entities.Series", "Series")
-                        .WithMany()
-                        .HasForeignKey("SeriesId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.HasOne("API.Entities.Volume", "Volume")
-                        .WithMany()
-                        .HasForeignKey("VolumeId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("Chapter");
-
                     b.Navigation("ReadingList");
-
-                    b.Navigation("Series");
-
-                    b.Navigation("Volume");
                 });
 
             modelBuilder.Entity("API.Entities.Series", b =>

--- a/API/Data/Migrations/20210901200442_ReadingListsAdditions.cs
+++ b/API/Data/Migrations/20210901200442_ReadingListsAdditions.cs
@@ -1,0 +1,55 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace API.Data.Migrations
+{
+    public partial class ReadingListsAdditions : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_ReadingListItem_ReadingList_ReadingListId",
+                table: "ReadingListItem");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "ReadingListId",
+                table: "ReadingListItem",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "INTEGER",
+                oldNullable: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ReadingListItem_ReadingList_ReadingListId",
+                table: "ReadingListItem",
+                column: "ReadingListId",
+                principalTable: "ReadingList",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_ReadingListItem_ReadingList_ReadingListId",
+                table: "ReadingListItem");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "ReadingListId",
+                table: "ReadingListItem",
+                type: "INTEGER",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "INTEGER");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ReadingListItem_ReadingList_ReadingListId",
+                table: "ReadingListItem",
+                column: "ReadingListId",
+                principalTable: "ReadingList",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+    }
+}

--- a/API/Data/Migrations/20210902110705_ReadingListsExtraRealationships.Designer.cs
+++ b/API/Data/Migrations/20210902110705_ReadingListsExtraRealationships.Designer.cs
@@ -3,14 +3,16 @@ using System;
 using API.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace API.Data.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20210902110705_ReadingListsExtraRealationships")]
+    partial class ReadingListsExtraRealationships
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/API/Data/Migrations/20210902110705_ReadingListsExtraRealationships.cs
+++ b/API/Data/Migrations/20210902110705_ReadingListsExtraRealationships.cs
@@ -1,0 +1,67 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace API.Data.Migrations
+{
+    public partial class ReadingListsExtraRealationships : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_ReadingListItem_ChapterId",
+                table: "ReadingListItem",
+                column: "ChapterId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ReadingListItem_VolumeId",
+                table: "ReadingListItem",
+                column: "VolumeId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ReadingListItem_Chapter_ChapterId",
+                table: "ReadingListItem",
+                column: "ChapterId",
+                principalTable: "Chapter",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ReadingListItem_Series_SeriesId",
+                table: "ReadingListItem",
+                column: "SeriesId",
+                principalTable: "Series",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ReadingListItem_Volume_VolumeId",
+                table: "ReadingListItem",
+                column: "VolumeId",
+                principalTable: "Volume",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_ReadingListItem_Chapter_ChapterId",
+                table: "ReadingListItem");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_ReadingListItem_Series_SeriesId",
+                table: "ReadingListItem");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_ReadingListItem_Volume_VolumeId",
+                table: "ReadingListItem");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ReadingListItem_ChapterId",
+                table: "ReadingListItem");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ReadingListItem_VolumeId",
+                table: "ReadingListItem");
+        }
+    }
+}

--- a/API/Data/Migrations/20210906140845_ReadingListsChanges.Designer.cs
+++ b/API/Data/Migrations/20210906140845_ReadingListsChanges.Designer.cs
@@ -3,14 +3,16 @@ using System;
 using API.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace API.Data.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20210906140845_ReadingListsChanges")]
+    partial class ReadingListsChanges
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/API/Data/Migrations/20210906140845_ReadingListsChanges.cs
+++ b/API/Data/Migrations/20210906140845_ReadingListsChanges.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace API.Data.Migrations
+{
+    public partial class ReadingListsChanges : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_ReadingListItem_SeriesId_VolumeId_ChapterId_LibraryId",
+                table: "ReadingListItem");
+
+            migrationBuilder.DropColumn(
+                name: "LibraryId",
+                table: "ReadingListItem");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ReadingListItem_SeriesId",
+                table: "ReadingListItem",
+                column: "SeriesId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_ReadingListItem_SeriesId",
+                table: "ReadingListItem");
+
+            migrationBuilder.AddColumn<int>(
+                name: "LibraryId",
+                table: "ReadingListItem",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ReadingListItem_SeriesId_VolumeId_ChapterId_LibraryId",
+                table: "ReadingListItem",
+                columns: new[] { "SeriesId", "VolumeId", "ChapterId", "LibraryId" },
+                unique: true);
+        }
+    }
+}

--- a/API/Data/Migrations/DataContextModelSnapshot.cs
+++ b/API/Data/Migrations/DataContextModelSnapshot.cs
@@ -449,6 +449,12 @@ namespace API.Data.Migrations
                     b.Property<int>("AppUserId")
                         .HasColumnType("INTEGER");
 
+                    b.Property<DateTime>("Created")
+                        .HasColumnType("TEXT");
+
+                    b.Property<DateTime>("LastModified")
+                        .HasColumnType("TEXT");
+
                     b.Property<bool>("Promoted")
                         .HasColumnType("INTEGER");
 
@@ -492,6 +498,9 @@ namespace API.Data.Migrations
                     b.HasKey("Id");
 
                     b.HasIndex("ReadingListId");
+
+                    b.HasIndex("SeriesId", "VolumeId", "ChapterId", "LibraryId")
+                        .IsUnique();
 
                     b.ToTable("ReadingListItem");
                 });

--- a/API/Data/Repositories/AppUserProgressRepository.cs
+++ b/API/Data/Repositories/AppUserProgressRepository.cs
@@ -2,9 +2,10 @@
 using System.Threading.Tasks;
 using API.Entities.Enums;
 using API.Interfaces;
+using API.Interfaces.Repositories;
 using Microsoft.EntityFrameworkCore;
 
-namespace API.Data
+namespace API.Data.Repositories
 {
     public class AppUserProgressRepository : IAppUserProgressRepository
     {
@@ -25,7 +26,7 @@ namespace API.Data
             var rowsToRemove = await _context.AppUserProgresses
                 .Where(progress => !chapterIds.Contains(progress.ChapterId))
                 .ToListAsync();
-            
+
             _context.RemoveRange(rowsToRemove);
             return await _context.SaveChangesAsync() > 0 ? rowsToRemove.Count : 0;
         }
@@ -45,7 +46,7 @@ namespace API.Data
                 .ToListAsync();
 
             if (seriesIds.Count == 0) return false;
-            
+
             return await _context.Series
                 .Include(s => s.Library)
                 .Where(s => seriesIds.Contains(s.Id) && s.Library.Type == libraryType)

--- a/API/Data/Repositories/BookmarkRepository.cs
+++ b/API/Data/Repositories/BookmarkRepository.cs
@@ -1,7 +1,0 @@
-﻿namespace API.Data.Repositories
-{
-    public class BookmarkRepository
-    {
-
-    }
-}

--- a/API/Data/Repositories/BookmarkRepository.cs
+++ b/API/Data/Repositories/BookmarkRepository.cs
@@ -1,7 +1,7 @@
-﻿namespace API.Data
+﻿namespace API.Data.Repositories
 {
     public class BookmarkRepository
     {
-        
+
     }
 }

--- a/API/Data/Repositories/ChapterRepository.cs
+++ b/API/Data/Repositories/ChapterRepository.cs
@@ -25,6 +25,7 @@ namespace API.Data.Repositories
         {
             return await _context.Chapter
                 .Where(c => chapterIds.Contains(c.Id))
+                .Include(c => c.Volume)
                 .ToListAsync();
         }
 

--- a/API/Data/Repositories/ChapterRepository.cs
+++ b/API/Data/Repositories/ChapterRepository.cs
@@ -1,4 +1,7 @@
-﻿using API.Entities;
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using API.Entities;
 using API.Interfaces.Repositories;
 using Microsoft.EntityFrameworkCore;
 
@@ -16,6 +19,11 @@ namespace API.Data.Repositories
         public void Update(Chapter chapter)
         {
             _context.Entry(chapter).State = EntityState.Modified;
+        }
+
+        public async Task<IEnumerable<Chapter>> GetChaptersByIdsAsync(IList<int> chapterIds)
+        {
+            return await _context.Chapter.Where(c => chapterIds.Contains(c.Id)).ToListAsync();
         }
 
         // TODO: Move over Chapter based queries here

--- a/API/Data/Repositories/ChapterRepository.cs
+++ b/API/Data/Repositories/ChapterRepository.cs
@@ -2,7 +2,7 @@
 using API.Interfaces.Repositories;
 using Microsoft.EntityFrameworkCore;
 
-namespace API.Data
+namespace API.Data.Repositories
 {
     public class ChapterRepository : IChapterRepository
     {

--- a/API/Data/Repositories/ChapterRepository.cs
+++ b/API/Data/Repositories/ChapterRepository.cs
@@ -23,7 +23,9 @@ namespace API.Data.Repositories
 
         public async Task<IEnumerable<Chapter>> GetChaptersByIdsAsync(IList<int> chapterIds)
         {
-            return await _context.Chapter.Where(c => chapterIds.Contains(c.Id)).ToListAsync();
+            return await _context.Chapter
+                .Where(c => chapterIds.Contains(c.Id))
+                .ToListAsync();
         }
 
         // TODO: Move over Chapter based queries here

--- a/API/Data/Repositories/CollectionTagRepository.cs
+++ b/API/Data/Repositories/CollectionTagRepository.cs
@@ -4,11 +4,12 @@ using System.Threading.Tasks;
 using API.DTOs;
 using API.Entities;
 using API.Interfaces;
+using API.Interfaces.Repositories;
 using AutoMapper;
 using AutoMapper.QueryableExtensions;
 using Microsoft.EntityFrameworkCore;
 
-namespace API.Data
+namespace API.Data.Repositories
 {
     public class CollectionTagRepository : ICollectionTagRepository
     {

--- a/API/Data/Repositories/FileRepository.cs
+++ b/API/Data/Repositories/FileRepository.cs
@@ -3,9 +3,10 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using API.Interfaces;
+using API.Interfaces.Repositories;
 using Microsoft.EntityFrameworkCore;
 
-namespace API.Data
+namespace API.Data.Repositories
 {
     public class FileRepository : IFileRepository
     {

--- a/API/Data/Repositories/LibraryRepository.cs
+++ b/API/Data/Repositories/LibraryRepository.cs
@@ -5,11 +5,12 @@ using API.DTOs;
 using API.Entities;
 using API.Entities.Enums;
 using API.Interfaces;
+using API.Interfaces.Repositories;
 using AutoMapper;
 using AutoMapper.QueryableExtensions;
 using Microsoft.EntityFrameworkCore;
 
-namespace API.Data
+namespace API.Data.Repositories
 {
     public class LibraryRepository : ILibraryRepository
     {

--- a/API/Data/Repositories/ReadingListRepository.cs
+++ b/API/Data/Repositories/ReadingListRepository.cs
@@ -135,6 +135,12 @@ namespace API.Data.Repositories
             return items;
         }
 
-
+        public async Task<ReadingListDto> GetReadingListDtoByTitleAsync(string title)
+        {
+            return await _context.ReadingList
+                .Where(r => r.Title.Equals(title))
+                .ProjectTo<ReadingListDto>(_mapper.ConfigurationProvider)
+                .SingleOrDefaultAsync();
+        }
     }
 }

--- a/API/Data/Repositories/ReadingListRepository.cs
+++ b/API/Data/Repositories/ReadingListRepository.cs
@@ -59,6 +59,13 @@ namespace API.Data.Repositories
 
         public async Task<IEnumerable<ReadingListItemDto>> GetReadingListItemDtosByIdAsync(int readingListId, int userId)
         {
+            var userLibraries = _context.Library
+                .Include(l => l.AppUsers)
+                .Where(library => library.AppUsers.Any(user => user.Id == userId))
+                .AsNoTracking()
+                .Select(library => library.Id)
+                .ToList();
+
             var items = await _context.ReadingListItem
                 .Where(s => s.ReadingListId == readingListId)
                 .Join(_context.Chapter, s => s.ChapterId, chapter => chapter.Id, (data, chapter) => new
@@ -102,6 +109,7 @@ namespace API.Data.Repositories
                     VolumeId = data.VolumeId,
                     ReadingListId = data.readingListItem.ReadingListId
                 })
+                .Where(o => userLibraries.Contains(o.LibraryId))
                 .OrderBy(rli => rli.Order)
                 .AsNoTracking()
                 .ToListAsync();

--- a/API/Data/Repositories/ReadingListRepository.cs
+++ b/API/Data/Repositories/ReadingListRepository.cs
@@ -22,6 +22,11 @@ namespace API.Data.Repositories
             _mapper = mapper;
         }
 
+        public void Remove(ReadingListItem item)
+        {
+            _context.ReadingListItem.Remove(item);
+        }
+
 
         public async Task<PagedList<ReadingListDto>> GetReadingListDtosForUserAsync(int userId, bool includePromoted, UserParams userParams)
         {
@@ -153,5 +158,7 @@ namespace API.Data.Repositories
                 .OrderBy(r => r.Order)
                 .ToListAsync();
         }
+
+
     }
 }

--- a/API/Data/Repositories/ReadingListRepository.cs
+++ b/API/Data/Repositories/ReadingListRepository.cs
@@ -1,6 +1,12 @@
-﻿using API.Interfaces;
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using API.DTOs.ReadingLists;
+using API.Interfaces;
 using API.Interfaces.Repositories;
 using AutoMapper;
+using AutoMapper.QueryableExtensions;
+using Microsoft.EntityFrameworkCore;
 
 namespace API.Data.Repositories
 {
@@ -16,7 +22,14 @@ namespace API.Data.Repositories
         }
 
 
-
-
+        public async Task<IEnumerable<ReadingListDto>> GetReadingListsForUser(int userId, bool includePromoted)
+        {
+            return await _context.ReadingList
+                .Where(l => l.AppUserId == userId || (includePromoted &&  l.Promoted ))
+                .OrderBy(l => l.LastModified)
+                .ProjectTo<ReadingListDto>(_mapper.ConfigurationProvider)
+                .AsNoTracking()
+                .ToListAsync();
+        }
     }
 }

--- a/API/Data/Repositories/ReadingListRepository.cs
+++ b/API/Data/Repositories/ReadingListRepository.cs
@@ -76,9 +76,9 @@ namespace API.Data.Repositories
                 })
                 .Join(_context.Volume, s => s.readingListItem.VolumeId, volume => volume.Id, (data, volume) => new
                 {
-                    readingListItem = data.readingListItem,
-                    TotalPages = data.TotalPages,
-                    ChapterNumber = data.ChapterNumber,
+                    data.readingListItem,
+                    data.TotalPages,
+                    data.ChapterNumber,
                     VolumeId = volume.Id,
                     VolumeNumber = volume.Name,
                 })

--- a/API/Data/Repositories/ReadingListRepository.cs
+++ b/API/Data/Repositories/ReadingListRepository.cs
@@ -54,6 +54,7 @@ namespace API.Data.Repositories
                 {
                     SeriesName = s.Name,
                     SeriesFormat = s.Format,
+                    LibraryId = s.LibraryId,
                     readingListItem
                 })
                 .Join(_context.Chapter, s => s.readingListItem.ChapterId, chapter => chapter.Id, (data, chapter) => new
@@ -61,6 +62,7 @@ namespace API.Data.Repositories
                     SeriesName = data.SeriesName,
                     SeriesFormat = data.SeriesFormat,
                     readingListItem = data.readingListItem,
+                    LibraryId = data.LibraryId,
                     TotalPages = chapter.Pages,
                     ChapterNumber = chapter.Range,
                 })
@@ -72,6 +74,7 @@ namespace API.Data.Repositories
                     TotalPages = data.TotalPages,
                     ChapterNumber = data.ChapterNumber,
                     VolumeNumber = volume.Name,
+                    LibraryId = data.LibraryId,
                 })
                 .Select(data => new ReadingListItemDto()
                 {
@@ -82,7 +85,8 @@ namespace API.Data.Repositories
                     SeriesFormat = data.SeriesFormat,
                     PagesTotal = data.TotalPages,
                     ChapterNumber = data.ChapterNumber,
-                    VolumeNumber = data.VolumeNumber
+                    VolumeNumber = data.VolumeNumber,
+                    LibraryId = data.LibraryId
                 })
                 .OrderBy(rli => rli.Order)
                 .AsNoTracking();

--- a/API/Data/Repositories/ReadingListRepository.cs
+++ b/API/Data/Repositories/ReadingListRepository.cs
@@ -1,0 +1,20 @@
+﻿using API.Interfaces;
+using API.Interfaces.Repositories;
+using AutoMapper;
+
+namespace API.Data.Repositories
+{
+    public class ReadingListRepository : IReadingListRepository
+    {
+        private readonly DataContext _context;
+        private readonly IMapper _mapper;
+
+        public ReadingListRepository(DataContext context, IMapper mapper)
+        {
+            _context = context;
+            _mapper = mapper;
+        }
+
+
+    }
+}

--- a/API/Data/Repositories/ReadingListRepository.cs
+++ b/API/Data/Repositories/ReadingListRepository.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using API.DTOs.ReadingLists;
+using API.Entities;
 using API.Interfaces;
 using API.Interfaces.Repositories;
 using AutoMapper;
@@ -22,7 +23,7 @@ namespace API.Data.Repositories
         }
 
 
-        public async Task<IEnumerable<ReadingListDto>> GetReadingListsForUser(int userId, bool includePromoted)
+        public async Task<IEnumerable<ReadingListDto>> GetReadingListDtosForUserAsync(int userId, bool includePromoted)
         {
             return await _context.ReadingList
                 .Where(l => l.AppUserId == userId || (includePromoted &&  l.Promoted ))
@@ -30,6 +31,14 @@ namespace API.Data.Repositories
                 .ProjectTo<ReadingListDto>(_mapper.ConfigurationProvider)
                 .AsNoTracking()
                 .ToListAsync();
+        }
+
+        public async Task<ReadingList> GetReadingListByIdAsync(int readingListId)
+        {
+            return await _context.ReadingList
+                .Where(r => r.Id == readingListId)
+                .Include(r => r.Items)
+                .SingleOrDefaultAsync();
         }
     }
 }

--- a/API/Data/Repositories/ReadingListRepository.cs
+++ b/API/Data/Repositories/ReadingListRepository.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using API.DTOs.ReadingLists;
 using API.Entities;
+using API.Helpers;
 using API.Interfaces.Repositories;
 using AutoMapper;
 using AutoMapper.QueryableExtensions;
@@ -22,14 +23,15 @@ namespace API.Data.Repositories
         }
 
 
-        public async Task<IEnumerable<ReadingListDto>> GetReadingListDtosForUserAsync(int userId, bool includePromoted)
+        public async Task<PagedList<ReadingListDto>> GetReadingListDtosForUserAsync(int userId, bool includePromoted, UserParams userParams)
         {
-            return await _context.ReadingList
+            var query = _context.ReadingList
                 .Where(l => l.AppUserId == userId || (includePromoted &&  l.Promoted ))
                 .OrderBy(l => l.LastModified)
                 .ProjectTo<ReadingListDto>(_mapper.ConfigurationProvider)
-                .AsNoTracking()
-                .ToListAsync();
+                .AsNoTracking();
+
+            return await PagedList<ReadingListDto>.CreateAsync(query, userParams.PageNumber, userParams.PageSize);
         }
 
         public async Task<ReadingList> GetReadingListByIdAsync(int readingListId)

--- a/API/Data/Repositories/ReadingListRepository.cs
+++ b/API/Data/Repositories/ReadingListRepository.cs
@@ -72,6 +72,7 @@ namespace API.Data.Repositories
                     readingListItem = data.readingListItem,
                     TotalPages = data.TotalPages,
                     ChapterNumber = data.ChapterNumber,
+                    VolumeId = volume.Id,
                     VolumeNumber = volume.Name,
                 })
                 .Join(_context.Series, s => s.readingListItem.SeriesId, series => series.Id,
@@ -83,7 +84,8 @@ namespace API.Data.Repositories
                         data.readingListItem,
                         data.TotalPages,
                         data.ChapterNumber,
-                        data.VolumeNumber
+                        data.VolumeNumber,
+                        data.VolumeId
                     })
                 .Select(data => new ReadingListItemDto()
                 {
@@ -97,6 +99,7 @@ namespace API.Data.Repositories
                     ChapterNumber = data.ChapterNumber,
                     VolumeNumber = data.VolumeNumber,
                     LibraryId = data.LibraryId,
+                    VolumeId = data.VolumeId,
                     ReadingListId = data.readingListItem.ReadingListId
                 })
                 .OrderBy(rli => rli.Order)

--- a/API/Data/Repositories/ReadingListRepository.cs
+++ b/API/Data/Repositories/ReadingListRepository.cs
@@ -81,6 +81,7 @@ namespace API.Data.Repositories
                 })
                 .Select(data => new ReadingListItemDto()
                 {
+                    Id = data.readingListItem.Id,
                     ChapterId = data.readingListItem.ChapterId,
                     Order = data.readingListItem.Order,
                     SeriesId = data.readingListItem.SeriesId,
@@ -143,6 +144,14 @@ namespace API.Data.Repositories
                 .Where(r => r.Title.Equals(title))
                 .ProjectTo<ReadingListDto>(_mapper.ConfigurationProvider)
                 .SingleOrDefaultAsync();
+        }
+
+        public async Task<IEnumerable<ReadingListItem>> GetReadingListItemsByIdAsync(int readingListId)
+        {
+            return await _context.ReadingListItem
+                .Where(r => r.ReadingListId == readingListId)
+                .OrderBy(r => r.Order)
+                .ToListAsync();
         }
     }
 }

--- a/API/Data/Repositories/ReadingListRepository.cs
+++ b/API/Data/Repositories/ReadingListRepository.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using API.DTOs.ReadingLists;
 using API.Entities;
-using API.Interfaces;
 using API.Interfaces.Repositories;
 using AutoMapper;
 using AutoMapper.QueryableExtensions;
@@ -40,5 +39,126 @@ namespace API.Data.Repositories
                 .Include(r => r.Items)
                 .SingleOrDefaultAsync();
         }
+
+        public async Task<IEnumerable<ReadingListItemDto>> GetReadingListItemDtosByIdAsync(int readingListId, int userId)
+        {
+
+            var seriesIds = await _context.ReadingListItem
+                .Where(rli => rli.ReadingListId == readingListId)
+                .Select(rli => rli.SeriesId)
+                .ToListAsync();
+
+            var items = _context.Series
+                .Where(s => seriesIds.Contains(s.Id))
+                .Join(_context.ReadingListItem, s => s.Id, readingListItem => readingListItem.SeriesId, (s, readingListItem) => new
+                {
+                    SeriesName = s.Name,
+                    SeriesFormat = s.Format,
+                    readingListItem
+                })
+                .Join(_context.Chapter, s => s.readingListItem.ChapterId, chapter => chapter.Id, (data, chapter) => new
+                {
+                    SeriesName = data.SeriesName,
+                    SeriesFormat = data.SeriesFormat,
+                    readingListItem = data.readingListItem,
+                    TotalPages = chapter.Pages,
+                    ChapterNumber = chapter.Range,
+                })
+                .Join(_context.Volume, s => s.readingListItem.VolumeId, volume =>  volume.Id, (data, volume) => new
+                {
+                    SeriesName = data.SeriesName,
+                    SeriesFormat = data.SeriesFormat,
+                    readingListItem = data.readingListItem,
+                    TotalPages = data.TotalPages,
+                    ChapterNumber = data.ChapterNumber,
+                    VolumeNumber = volume.Name,
+                })
+                .Select(data => new ReadingListItemDto()
+                {
+                    ChapterId = data.readingListItem.ChapterId,
+                    Order = data.readingListItem.Order,
+                    SeriesId = data.readingListItem.SeriesId,
+                    SeriesName = data.SeriesName,
+                    SeriesFormat = data.SeriesFormat,
+                    PagesTotal = data.TotalPages,
+                    ChapterNumber = data.ChapterNumber,
+                    VolumeNumber = data.VolumeNumber
+                })
+                .OrderBy(rli => rli.Order)
+                .AsNoTracking();
+
+            // var items2 = _context.ReadingListItem
+            //     .Where(s => seriesIds.Contains(s.Id))
+            //     .Include(r => r.Series)
+            //     .Include(r => r.Volume)
+            //     .Include(r => r.Chapter)
+            //     .Select
+            //     .Join(_context.ReadingListItem, s => s.Id, readingListItem => readingListItem.SeriesId, (s, readingListItem) => new
+            //     {
+            //         SeriesName = s.Name,
+            //         SeriesFormat = s.Format,
+            //         readingListItem
+            //     })
+            //     .Join(_context.Chapter, s => s.readingListItem.ChapterId, chapter => chapter.Id, (data, chapter) => new
+            //     {
+            //         SeriesName = data.SeriesName,
+            //         SeriesFormat = data.SeriesFormat,
+            //         readingListItem = data.readingListItem,
+            //         TotalPages = chapter.Pages,
+            //         ChapterNumber = chapter.Range,
+            //     })
+            //     .Join(_context.Volume, s => s.readingListItem.VolumeId, volume =>  volume.Id, (data, volume) => new
+            //     {
+            //         SeriesName = data.SeriesName,
+            //         SeriesFormat = data.SeriesFormat,
+            //         readingListItem = data.readingListItem,
+            //         TotalPages = data.TotalPages,
+            //         ChapterNumber = data.ChapterNumber,
+            //         VolumeNumber = volume.Name,
+            //     })
+            //     .Select(data => new ReadingListItemDto()
+            //     {
+            //         ChapterId = data.readingListItem.ChapterId,
+            //         Order = data.readingListItem.Order,
+            //         SeriesId = data.readingListItem.SeriesId,
+            //         SeriesName = data.SeriesName,
+            //         SeriesFormat = data.SeriesFormat,
+            //         PagesTotal = data.TotalPages,
+            //         ChapterNumber = data.ChapterNumber,
+            //         VolumeNumber = data.VolumeNumber
+            //     })
+            //     .OrderBy(rli => rli.Order)
+            //     .AsNoTracking();
+
+
+            return await items.ToListAsync();
+        }
+
+        public async Task<ReadingListDto> GetReadingListDtoByIdAsync(int readingListId, int userId)
+        {
+            return await _context.ReadingList
+                .Where(r => r.Id == readingListId && (r.AppUserId == userId || r.Promoted))
+                .ProjectTo<ReadingListDto>(_mapper.ConfigurationProvider)
+                .SingleOrDefaultAsync();
+        }
+
+        public async Task<IEnumerable<ReadingListItemDto>> AddReadingProgressModifiers(int userId, IList<ReadingListItemDto> items)
+        {
+            var chapterIds = items.Select(i => i.ChapterId).Distinct().ToList();
+            var userProgress = await _context.AppUserProgresses
+                .Where(p => p.AppUserId == userId && chapterIds.Contains(p.ChapterId))
+                .AsNoTracking()
+                .ToListAsync();
+
+            foreach (var item in items)
+            {
+                var progress = userProgress.Where(p => p.ChapterId == item.ChapterId);
+                item.PagesRead = progress.Sum(p => p.PagesRead);
+            }
+
+            return items;
+        }
+
+
     }
 }

--- a/API/Data/Repositories/ReadingListRepository.cs
+++ b/API/Data/Repositories/ReadingListRepository.cs
@@ -16,5 +16,7 @@ namespace API.Data.Repositories
         }
 
 
+
+
     }
 }

--- a/API/Data/Repositories/SeriesRepository.cs
+++ b/API/Data/Repositories/SeriesRepository.cs
@@ -222,21 +222,17 @@ namespace API.Data.Repositories
 
         public async Task<int[]> GetChapterIdsForSeriesAsync(int[] seriesIds)
         {
-            var series = await _context.Series
-                .Where(s => seriesIds.Contains(s.Id))
-                .Include(s => s.Volumes)
-                .ThenInclude(v => v.Chapters)
+            var volumes = await _context.Volume
+                .Where(v => seriesIds.Contains(v.SeriesId))
+                .Include(v => v.Chapters)
                 .ToListAsync();
 
             IList<int> chapterIds = new List<int>();
-            foreach (var s in series)
+            foreach (var v in volumes)
             {
-                foreach (var v in s.Volumes)
+                foreach (var c in v.Chapters)
                 {
-                    foreach (var c in v.Chapters)
-                    {
-                        chapterIds.Add(c.Id);
-                    }
+                    chapterIds.Add(c.Id);
                 }
             }
 

--- a/API/Data/Repositories/SeriesRepository.cs
+++ b/API/Data/Repositories/SeriesRepository.cs
@@ -8,11 +8,12 @@ using API.Entities;
 using API.Extensions;
 using API.Helpers;
 using API.Interfaces;
+using API.Interfaces.Repositories;
 using AutoMapper;
 using AutoMapper.QueryableExtensions;
 using Microsoft.EntityFrameworkCore;
 
-namespace API.Data
+namespace API.Data.Repositories
 {
     public class SeriesRepository : ISeriesRepository
     {

--- a/API/Data/Repositories/SettingsRepository.cs
+++ b/API/Data/Repositories/SettingsRepository.cs
@@ -5,10 +5,11 @@ using API.DTOs;
 using API.Entities;
 using API.Entities.Enums;
 using API.Interfaces;
+using API.Interfaces.Repositories;
 using AutoMapper;
 using Microsoft.EntityFrameworkCore;
 
-namespace API.Data
+namespace API.Data.Repositories
 {
     public class SettingsRepository : ISettingsRepository
     {

--- a/API/Data/Repositories/UserRepository.cs
+++ b/API/Data/Repositories/UserRepository.cs
@@ -55,6 +55,18 @@ namespace API.Data.Repositories
         }
 
         /// <summary>
+        /// Gets an AppUser by username. Returns back Progress information.
+        /// </summary>
+        /// <param name="username"></param>
+        /// <returns></returns>
+        public async Task<AppUser> GetUserWithReadingListsByUsernameAsync(string username)
+        {
+            return await _context.Users
+                .Include(u => u.ReadingLists)
+                .SingleOrDefaultAsync(x => x.UserName == username);
+        }
+
+        /// <summary>
         /// Gets an AppUser by id. Returns back Progress information.
         /// </summary>
         /// <param name="username"></param>

--- a/API/Data/Repositories/UserRepository.cs
+++ b/API/Data/Repositories/UserRepository.cs
@@ -55,7 +55,18 @@ namespace API.Data.Repositories
         }
 
         /// <summary>
-        /// Gets an AppUser by username. Returns back Progress information.
+        /// This fetches JUST the User object, no extra relationships are pulled
+        /// </summary>
+        /// <param name="username"></param>
+        /// <returns></returns>
+        public async Task<AppUser> GetUserByUsernameFastAsync(string username)
+        {
+            return await _context.Users
+                .SingleOrDefaultAsync(x => x.UserName == username);
+        }
+
+        /// <summary>
+        /// Gets an AppUser by username. Returns back Reading List and their Items.
         /// </summary>
         /// <param name="username"></param>
         /// <returns></returns>
@@ -63,6 +74,7 @@ namespace API.Data.Repositories
         {
             return await _context.Users
                 .Include(u => u.ReadingLists)
+                .ThenInclude(l => l.Items)
                 .SingleOrDefaultAsync(x => x.UserName == username);
         }
 

--- a/API/Data/Repositories/UserRepository.cs
+++ b/API/Data/Repositories/UserRepository.cs
@@ -83,7 +83,7 @@ namespace API.Data.Repositories
         /// <summary>
         /// Gets an AppUser by id. Returns back Progress information.
         /// </summary>
-        /// <param name="username"></param>
+        /// <param name="id"></param>
         /// <returns></returns>
         public async Task<AppUser> GetUserByIdAsync(int id)
         {

--- a/API/Data/Repositories/UserRepository.cs
+++ b/API/Data/Repositories/UserRepository.cs
@@ -55,14 +55,16 @@ namespace API.Data.Repositories
         }
 
         /// <summary>
-        /// This fetches JUST the User object, no extra relationships are pulled
+        /// This fetches the Id for a user. Use whenever you just need an ID.
         /// </summary>
         /// <param name="username"></param>
         /// <returns></returns>
-        public async Task<AppUser> GetUserByUsernameFastAsync(string username)
+        public async Task<int> GetUserIdByUsernameAsync(string username)
         {
             return await _context.Users
-                .SingleOrDefaultAsync(x => x.UserName == username);
+                .Where(x => x.UserName == username)
+                .Select(u => u.Id)
+                .SingleOrDefaultAsync();
         }
 
         /// <summary>

--- a/API/Data/Repositories/UserRepository.cs
+++ b/API/Data/Repositories/UserRepository.cs
@@ -5,12 +5,13 @@ using API.Constants;
 using API.DTOs;
 using API.Entities;
 using API.Interfaces;
+using API.Interfaces.Repositories;
 using AutoMapper;
 using AutoMapper.QueryableExtensions;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 
-namespace API.Data
+namespace API.Data.Repositories
 {
     public class UserRepository : IUserRepository
     {

--- a/API/Data/Repositories/VolumeRepository.cs
+++ b/API/Data/Repositories/VolumeRepository.cs
@@ -4,11 +4,12 @@ using System.Threading.Tasks;
 using API.DTOs;
 using API.Entities;
 using API.Interfaces;
+using API.Interfaces.Repositories;
 using AutoMapper;
 using AutoMapper.QueryableExtensions;
 using Microsoft.EntityFrameworkCore;
 
-namespace API.Data
+namespace API.Data.Repositories
 {
     public class VolumeRepository : IVolumeRepository
     {

--- a/API/Data/UnitOfWork.cs
+++ b/API/Data/UnitOfWork.cs
@@ -41,7 +41,6 @@ namespace API.Data
         /// <returns></returns>
         public bool Commit()
         {
-
             return _context.SaveChanges() > 0;
         }
         /// <summary>

--- a/API/Data/UnitOfWork.cs
+++ b/API/Data/UnitOfWork.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using API.Data.Repositories;
 using API.Entities;
 using API.Interfaces;
 using API.Interfaces.Repositories;
@@ -32,6 +33,7 @@ namespace API.Data
         public ICollectionTagRepository CollectionTagRepository => new CollectionTagRepository(_context, _mapper);
         public IFileRepository FileRepository => new FileRepository(_context);
         public IChapterRepository ChapterRepository => new ChapterRepository(_context);
+        public IReadingListRepository ReadingListRepository => new ReadingListRepository(_context, _mapper);
 
         /// <summary>
         /// Commits changes to the DB. Completes the open transaction.

--- a/API/Entities/AppUser.cs
+++ b/API/Entities/AppUser.cs
@@ -18,6 +18,10 @@ namespace API.Entities
         public AppUserPreferences UserPreferences { get; set; }
         public ICollection<AppUserBookmark> Bookmarks { get; set; }
         /// <summary>
+        /// Reading lists associated with this user
+        /// </summary>
+        public ICollection<ReadingList> ReadingLists { get; set; }
+        /// <summary>
         /// An API Key to interact with external services, like OPDS
         /// </summary>
         public string ApiKey { get; set; }

--- a/API/Entities/ReadingList.cs
+++ b/API/Entities/ReadingList.cs
@@ -1,11 +1,13 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using API.Entities.Interfaces;
 
 namespace API.Entities
 {
     /// <summary>
     /// This is a collection of <see cref="ReadingListItem"/> which represent individual chapters and an order.
     /// </summary>
-    public class ReadingList
+    public class ReadingList : IEntityDate
     {
         public int Id { get; init; }
         public string Title { get; set; }
@@ -16,9 +18,12 @@ namespace API.Entities
         public bool Promoted { get; set; }
 
         public ICollection<ReadingListItem> Items { get; set; }
+        public DateTime Created { get; set; }
+        public DateTime LastModified { get; set; }
 
         // Relationships
         public int AppUserId { get; set; }
         public AppUser AppUser { get; set; }
+
     }
 }

--- a/API/Entities/ReadingList.cs
+++ b/API/Entities/ReadingList.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+
+namespace API.Entities
+{
+    /// <summary>
+    /// This is a collection of <see cref="ReadingListItem"/> which represent individual chapters and an order.
+    /// </summary>
+    public class ReadingList
+    {
+        public int Id { get; init; }
+        public string Title { get; set; }
+        public string Summary { get; set; }
+        /// <summary>
+        /// Reading lists that are promoted are only done by admins
+        /// </summary>
+        public bool Promoted { get; set; }
+
+        public ICollection<ReadingListItem> Items { get; set; }
+
+        // Relationships
+        public int AppUserId { get; set; }
+        public AppUser AppUser { get; set; }
+    }
+}

--- a/API/Entities/ReadingListItem.cs
+++ b/API/Entities/ReadingListItem.cs
@@ -1,5 +1,8 @@
-﻿namespace API.Entities
+﻿using Microsoft.EntityFrameworkCore;
+
+namespace API.Entities
 {
+    [Index(nameof(SeriesId), nameof(VolumeId), nameof(ChapterId), nameof(LibraryId), IsUnique = true)]
     public class ReadingListItem
     {
         public int Id { get; init; }

--- a/API/Entities/ReadingListItem.cs
+++ b/API/Entities/ReadingListItem.cs
@@ -1,0 +1,16 @@
+﻿namespace API.Entities
+{
+    public class ReadingListItem
+    {
+        public int Id { get; init; }
+        public int LibraryId { get; set; }
+        public int SeriesId { get; set; }
+        public int VolumeId { get; set; }
+        public int ChapterId { get; set; }
+        /// <summary>
+        /// Order of the chapter within a Reading List
+        /// </summary>
+        public int Order { get; set; }
+
+    }
+}

--- a/API/Entities/ReadingListItem.cs
+++ b/API/Entities/ReadingListItem.cs
@@ -2,11 +2,10 @@
 
 namespace API.Entities
 {
-    [Index(nameof(SeriesId), nameof(VolumeId), nameof(ChapterId), nameof(LibraryId), IsUnique = true)]
+    //[Index(nameof(SeriesId), nameof(VolumeId), nameof(ChapterId), IsUnique = true)]
     public class ReadingListItem
     {
         public int Id { get; init; }
-        public int LibraryId { get; set; }
         public int SeriesId { get; set; }
         public int VolumeId { get; set; }
         public int ChapterId { get; set; }

--- a/API/Entities/ReadingListItem.cs
+++ b/API/Entities/ReadingListItem.cs
@@ -15,5 +15,14 @@ namespace API.Entities
         /// </summary>
         public int Order { get; set; }
 
+        // Relationship
+        public ReadingList ReadingList { get; set; }
+        public int ReadingListId { get; set; }
+
+        // Idea, keep these for easy join statements
+        public Series Series { get; set; }
+        public Volume Volume { get; set; }
+        public Chapter Chapter { get; set; }
+
     }
 }

--- a/API/Extensions/FileInfoExtensions.cs
+++ b/API/Extensions/FileInfoExtensions.cs
@@ -14,7 +14,6 @@ namespace API.Extensions
         public static bool HasFileBeenModifiedSince(this FileInfo fileInfo, DateTime comparison)
         {
             return DateTime.Compare(fileInfo.LastWriteTime, comparison) > 0;
-            //return fileInfo?.LastWriteTime > comparison;
         }
     }
 }

--- a/API/Helpers/AutoMapperProfiles.cs
+++ b/API/Helpers/AutoMapperProfiles.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using API.DTOs;
+using API.DTOs.ReadingLists;
 using API.Entities;
 using API.Helpers.Converters;
 using AutoMapper;
@@ -30,6 +31,8 @@ namespace API.Helpers
             CreateMap<AppUserPreferences, UserPreferencesDto>();
 
             CreateMap<AppUserBookmark, BookmarkDto>();
+
+            CreateMap<ReadingList, ReadingListDto>();
 
             CreateMap<Series, SearchResultDto>()
                 .ForMember(dest => dest.SeriesId,

--- a/API/Helpers/AutoMapperProfiles.cs
+++ b/API/Helpers/AutoMapperProfiles.cs
@@ -33,6 +33,7 @@ namespace API.Helpers
             CreateMap<AppUserBookmark, BookmarkDto>();
 
             CreateMap<ReadingList, ReadingListDto>();
+            CreateMap<ReadingListItem, ReadingListItemDto>();
 
             CreateMap<Series, SearchResultDto>()
                 .ForMember(dest => dest.SeriesId,

--- a/API/Interfaces/IUnitOfWork.cs
+++ b/API/Interfaces/IUnitOfWork.cs
@@ -14,6 +14,7 @@ namespace API.Interfaces
         ICollectionTagRepository CollectionTagRepository { get; }
         IFileRepository FileRepository { get; }
         IChapterRepository ChapterRepository { get; }
+        IReadingListRepository ReadingListRepository { get; }
         bool Commit();
         Task<bool> CommitAsync();
         bool HasChanges();

--- a/API/Interfaces/Repositories/IAppUserProgressRepository.cs
+++ b/API/Interfaces/Repositories/IAppUserProgressRepository.cs
@@ -1,7 +1,7 @@
 ﻿using System.Threading.Tasks;
 using API.Entities.Enums;
 
-namespace API.Interfaces
+namespace API.Interfaces.Repositories
 {
     public interface IAppUserProgressRepository
     {

--- a/API/Interfaces/Repositories/IChapterRepository.cs
+++ b/API/Interfaces/Repositories/IChapterRepository.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
+using API.DTOs;
 using API.Entities;
 
 namespace API.Interfaces.Repositories

--- a/API/Interfaces/Repositories/IChapterRepository.cs
+++ b/API/Interfaces/Repositories/IChapterRepository.cs
@@ -1,9 +1,12 @@
-﻿using API.Entities;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using API.Entities;
 
 namespace API.Interfaces.Repositories
 {
     public interface IChapterRepository
     {
         void Update(Chapter chapter);
+        Task<IEnumerable<Chapter>> GetChaptersByIdsAsync(IList<int> chapterIds);
     }
 }

--- a/API/Interfaces/Repositories/ICollectionTagRepository.cs
+++ b/API/Interfaces/Repositories/ICollectionTagRepository.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 using API.DTOs;
 using API.Entities;
 
-namespace API.Interfaces
+namespace API.Interfaces.Repositories
 {
     public interface ICollectionTagRepository
     {

--- a/API/Interfaces/Repositories/IFileRepository.cs
+++ b/API/Interfaces/Repositories/IFileRepository.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 
-namespace API.Interfaces
+namespace API.Interfaces.Repositories
 {
     public interface IFileRepository
     {

--- a/API/Interfaces/Repositories/ILibraryRepository.cs
+++ b/API/Interfaces/Repositories/ILibraryRepository.cs
@@ -4,7 +4,7 @@ using API.DTOs;
 using API.Entities;
 using API.Entities.Enums;
 
-namespace API.Interfaces
+namespace API.Interfaces.Repositories
 {
     public interface ILibraryRepository
     {

--- a/API/Interfaces/Repositories/IReadingListRepository.cs
+++ b/API/Interfaces/Repositories/IReadingListRepository.cs
@@ -1,0 +1,7 @@
+﻿namespace API.Interfaces.Repositories
+{
+    public interface IReadingListRepository
+    {
+
+    }
+}

--- a/API/Interfaces/Repositories/IReadingListRepository.cs
+++ b/API/Interfaces/Repositories/IReadingListRepository.cs
@@ -1,11 +1,13 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using API.DTOs.ReadingLists;
+using API.Entities;
 
 namespace API.Interfaces.Repositories
 {
     public interface IReadingListRepository
     {
-        Task<IEnumerable<ReadingListDto>> GetReadingListsForUser(int userId, bool includePromoted);
+        Task<IEnumerable<ReadingListDto>> GetReadingListDtosForUserAsync(int userId, bool includePromoted);
+        Task<ReadingList> GetReadingListByIdAsync(int readingListId);
     }
 }

--- a/API/Interfaces/Repositories/IReadingListRepository.cs
+++ b/API/Interfaces/Repositories/IReadingListRepository.cs
@@ -15,5 +15,6 @@ namespace API.Interfaces.Repositories
         Task<IEnumerable<ReadingListItemDto>> AddReadingProgressModifiers(int userId, IList<ReadingListItemDto> items);
         Task<ReadingListDto> GetReadingListDtoByTitleAsync(string title);
         Task<IEnumerable<ReadingListItem>> GetReadingListItemsByIdAsync(int readingListId);
+        void Remove(ReadingListItem item);
     }
 }

--- a/API/Interfaces/Repositories/IReadingListRepository.cs
+++ b/API/Interfaces/Repositories/IReadingListRepository.cs
@@ -16,5 +16,7 @@ namespace API.Interfaces.Repositories
         Task<ReadingListDto> GetReadingListDtoByTitleAsync(string title);
         Task<IEnumerable<ReadingListItem>> GetReadingListItemsByIdAsync(int readingListId);
         void Remove(ReadingListItem item);
+        void BulkRemove(IEnumerable<ReadingListItem> items);
+        void Update(ReadingList list);
     }
 }

--- a/API/Interfaces/Repositories/IReadingListRepository.cs
+++ b/API/Interfaces/Repositories/IReadingListRepository.cs
@@ -14,5 +14,6 @@ namespace API.Interfaces.Repositories
         Task<ReadingListDto> GetReadingListDtoByIdAsync(int readingListId, int userId);
         Task<IEnumerable<ReadingListItemDto>> AddReadingProgressModifiers(int userId, IList<ReadingListItemDto> items);
         Task<ReadingListDto> GetReadingListDtoByTitleAsync(string title);
+        Task<IEnumerable<ReadingListItem>> GetReadingListItemsByIdAsync(int readingListId);
     }
 }

--- a/API/Interfaces/Repositories/IReadingListRepository.cs
+++ b/API/Interfaces/Repositories/IReadingListRepository.cs
@@ -9,5 +9,8 @@ namespace API.Interfaces.Repositories
     {
         Task<IEnumerable<ReadingListDto>> GetReadingListDtosForUserAsync(int userId, bool includePromoted);
         Task<ReadingList> GetReadingListByIdAsync(int readingListId);
+        Task<IEnumerable<ReadingListItemDto>> GetReadingListItemDtosByIdAsync(int readingListId, int userId);
+        Task<ReadingListDto> GetReadingListDtoByIdAsync(int readingListId, int userId);
+        Task<IEnumerable<ReadingListItemDto>> AddReadingProgressModifiers(int userId, IList<ReadingListItemDto> items);
     }
 }

--- a/API/Interfaces/Repositories/IReadingListRepository.cs
+++ b/API/Interfaces/Repositories/IReadingListRepository.cs
@@ -2,12 +2,13 @@
 using System.Threading.Tasks;
 using API.DTOs.ReadingLists;
 using API.Entities;
+using API.Helpers;
 
 namespace API.Interfaces.Repositories
 {
     public interface IReadingListRepository
     {
-        Task<IEnumerable<ReadingListDto>> GetReadingListDtosForUserAsync(int userId, bool includePromoted);
+        Task<PagedList<ReadingListDto>> GetReadingListDtosForUserAsync(int userId, bool includePromoted, UserParams userParams);
         Task<ReadingList> GetReadingListByIdAsync(int readingListId);
         Task<IEnumerable<ReadingListItemDto>> GetReadingListItemDtosByIdAsync(int readingListId, int userId);
         Task<ReadingListDto> GetReadingListDtoByIdAsync(int readingListId, int userId);

--- a/API/Interfaces/Repositories/IReadingListRepository.cs
+++ b/API/Interfaces/Repositories/IReadingListRepository.cs
@@ -1,7 +1,11 @@
-﻿namespace API.Interfaces.Repositories
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using API.DTOs.ReadingLists;
+
+namespace API.Interfaces.Repositories
 {
     public interface IReadingListRepository
     {
-
+        Task<IEnumerable<ReadingListDto>> GetReadingListsForUser(int userId, bool includePromoted);
     }
 }

--- a/API/Interfaces/Repositories/IReadingListRepository.cs
+++ b/API/Interfaces/Repositories/IReadingListRepository.cs
@@ -12,5 +12,6 @@ namespace API.Interfaces.Repositories
         Task<IEnumerable<ReadingListItemDto>> GetReadingListItemDtosByIdAsync(int readingListId, int userId);
         Task<ReadingListDto> GetReadingListDtoByIdAsync(int readingListId, int userId);
         Task<IEnumerable<ReadingListItemDto>> AddReadingProgressModifiers(int userId, IList<ReadingListItemDto> items);
+        Task<ReadingListDto> GetReadingListDtoByTitleAsync(string title);
     }
 }

--- a/API/Interfaces/Repositories/ISeriesRepository.cs
+++ b/API/Interfaces/Repositories/ISeriesRepository.cs
@@ -5,7 +5,7 @@ using API.DTOs.Filtering;
 using API.Entities;
 using API.Helpers;
 
-namespace API.Interfaces
+namespace API.Interfaces.Repositories
 {
     public interface ISeriesRepository
     {

--- a/API/Interfaces/Repositories/ISettingsRepository.cs
+++ b/API/Interfaces/Repositories/ISettingsRepository.cs
@@ -4,7 +4,7 @@ using API.DTOs;
 using API.Entities;
 using API.Entities.Enums;
 
-namespace API.Interfaces
+namespace API.Interfaces.Repositories
 {
     public interface ISettingsRepository
     {
@@ -12,6 +12,6 @@ namespace API.Interfaces
         Task<ServerSettingDto> GetSettingsDtoAsync();
         Task<ServerSetting> GetSettingAsync(ServerSettingKey key);
         Task<IEnumerable<ServerSetting>> GetSettingsAsync();
-        
+
     }
 }

--- a/API/Interfaces/Repositories/IUserRepository.cs
+++ b/API/Interfaces/Repositories/IUserRepository.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 using API.DTOs;
 using API.Entities;
 
-namespace API.Interfaces
+namespace API.Interfaces.Repositories
 {
     public interface IUserRepository
     {

--- a/API/Interfaces/Repositories/IUserRepository.cs
+++ b/API/Interfaces/Repositories/IUserRepository.cs
@@ -11,6 +11,7 @@ namespace API.Interfaces.Repositories
         void Update(AppUserPreferences preferences);
         public void Delete(AppUser user);
         Task<AppUser> GetUserByUsernameAsync(string username);
+        Task<AppUser> GetUserWithReadingListsByUsernameAsync(string username);
         Task<AppUser> GetUserByIdAsync(int id);
         Task<IEnumerable<MemberDto>>  GetMembersAsync();
         Task<IEnumerable<AppUser>> GetAdminUsersAsync();

--- a/API/Interfaces/Repositories/IUserRepository.cs
+++ b/API/Interfaces/Repositories/IUserRepository.cs
@@ -11,7 +11,7 @@ namespace API.Interfaces.Repositories
         void Update(AppUserPreferences preferences);
         public void Delete(AppUser user);
         Task<AppUser> GetUserByUsernameAsync(string username);
-        Task<AppUser> GetUserByUsernameFastAsync(string username);
+        Task<int> GetUserIdByUsernameAsync(string username);
         Task<AppUser> GetUserWithReadingListsByUsernameAsync(string username);
         Task<AppUser> GetUserByIdAsync(int id);
         Task<IEnumerable<MemberDto>>  GetMembersAsync();

--- a/API/Interfaces/Repositories/IUserRepository.cs
+++ b/API/Interfaces/Repositories/IUserRepository.cs
@@ -11,6 +11,7 @@ namespace API.Interfaces.Repositories
         void Update(AppUserPreferences preferences);
         public void Delete(AppUser user);
         Task<AppUser> GetUserByUsernameAsync(string username);
+        Task<AppUser> GetUserByUsernameFastAsync(string username);
         Task<AppUser> GetUserWithReadingListsByUsernameAsync(string username);
         Task<AppUser> GetUserByIdAsync(int id);
         Task<IEnumerable<MemberDto>>  GetMembersAsync();

--- a/API/Interfaces/Repositories/IVolumeRepository.cs
+++ b/API/Interfaces/Repositories/IVolumeRepository.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 using API.DTOs;
 using API.Entities;
 
-namespace API.Interfaces
+namespace API.Interfaces.Repositories
 {
     public interface IVolumeRepository
     {

--- a/API/Parser/Parser.cs
+++ b/API/Parser/Parser.cs
@@ -129,9 +129,14 @@ namespace API.Parser
             RegexTimeout),
             // [dmntsf.net] One Piece - Digital Colored Comics Vol. 20 Ch. 177 - 30 Million vs 81 Million.cbz
             new Regex(
-                @"(?<Series>.*) (\b|_|-)(vol)\.?",
+                @"(?<Series>.*) (\b|_|-)(vol)\.?(\s|-|_)?\d+",
                 RegexOptions.IgnoreCase | RegexOptions.Compiled,
             RegexTimeout),
+            // [xPearse] Kyochuu Rettou Volume 1 [English] [Manga] [Volume Scans]
+            new Regex(
+                @"(?<Series>.*) (\b|_|-)(vol)(ume)",
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+                RegexTimeout),
             //Knights of Sidonia c000 (S2 LE BD Omake - BLAME!) [Habanero Scans]
             new Regex(
                 @"(?<Series>.*)(\bc\d+\b)",

--- a/API/Services/TaskScheduler.cs
+++ b/API/Services/TaskScheduler.cs
@@ -161,6 +161,7 @@ namespace API.Services
         /// <summary>
         /// Not an external call. Only public so that we can call this for a Task
         /// </summary>
+        // ReSharper disable once MemberCanBePrivate.Global
         public async Task CheckForUpdate()
         {
             var update = await _versionUpdaterService.CheckForUpdate();

--- a/UI/Web/package-lock.json
+++ b/UI/Web/package-lock.json
@@ -245,6 +245,28 @@
         "tslib": "^2.0.0"
       }
     },
+    "@angular/cdk": {
+      "version": "12.2.3",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-12.2.3.tgz",
+      "integrity": "sha512-ahY3k5X3eoQlsCX/fYiwbe1z7nfmwY15EiLpcJ8YrnUoB+ZshPm8qFIZi6gwY4tsMmUN8OfsIGcUO701bdxFpg==",
+      "requires": {
+        "parse5": "^5.0.0",
+        "tslib": "^2.2.0"
+      },
+      "dependencies": {
+        "parse5": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+          "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
+          "optional": true
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
     "@angular/cli": {
       "version": "11.2.11",
       "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-11.2.11.tgz",

--- a/UI/Web/package.json
+++ b/UI/Web/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@angular-slider/ngx-slider": "^2.0.3",
     "@angular/animations": "~11.0.0",
+    "@angular/cdk": "^12.2.3",
     "@angular/common": "~11.0.0",
     "@angular/compiler": "~11.0.0",
     "@angular/core": "~11.0.0",

--- a/UI/Web/src/app/_models/reading-list.ts
+++ b/UI/Web/src/app/_models/reading-list.ts
@@ -1,0 +1,17 @@
+import { Chapter } from "./chapter";
+
+export interface ReadingListItem {
+    libraryId: number;
+    seriesId: number;
+    volumeId: number;
+    chapterId: number;
+    //chapter: Chapter; // maybe?
+    order: number;
+}
+
+export interface ReadingList {
+    id: number;
+    title: string;
+    summary: string;
+    items: Array<ReadingListItem>;
+}

--- a/UI/Web/src/app/_models/reading-list.ts
+++ b/UI/Web/src/app/_models/reading-list.ts
@@ -2,7 +2,7 @@ import { MangaFormat } from "./manga-format";
 
 export interface ReadingListItem {
     pagesRead: number;
-    totalPages: number;
+    pagesTotal: number;
     seriesName: string;
     seriesFormat: MangaFormat;
     seriesId: number;

--- a/UI/Web/src/app/_models/reading-list.ts
+++ b/UI/Web/src/app/_models/reading-list.ts
@@ -11,6 +11,7 @@ export interface ReadingListItem {
     chapterNumber: string;
     volumeNumber: string;
     libraryId: number;
+    id: number;
 }
 
 export interface ReadingList {

--- a/UI/Web/src/app/_models/reading-list.ts
+++ b/UI/Web/src/app/_models/reading-list.ts
@@ -2,10 +2,10 @@ import { Chapter } from "./chapter";
 
 export interface ReadingListItem {
     libraryId: number;
-    seriesId: number;
     volumeId: number;
+    
+    seriesId: number;
     chapterId: number;
-    //chapter: Chapter; // maybe?
     order: number;
 }
 

--- a/UI/Web/src/app/_models/reading-list.ts
+++ b/UI/Web/src/app/_models/reading-list.ts
@@ -17,5 +17,6 @@ export interface ReadingList {
     id: number;
     title: string;
     summary: string;
+    promoted: boolean;
     items: Array<ReadingListItem>;
 }

--- a/UI/Web/src/app/_models/reading-list.ts
+++ b/UI/Web/src/app/_models/reading-list.ts
@@ -10,6 +10,7 @@ export interface ReadingListItem {
     order: number;
     chapterNumber: string;
     volumeNumber: string;
+    libraryId: number;
 }
 
 export interface ReadingList {

--- a/UI/Web/src/app/_models/reading-list.ts
+++ b/UI/Web/src/app/_models/reading-list.ts
@@ -1,12 +1,15 @@
-import { Chapter } from "./chapter";
+import { MangaFormat } from "./manga-format";
 
 export interface ReadingListItem {
-    libraryId: number;
-    volumeId: number;
-    
+    pagesRead: number;
+    totalPages: number;
+    seriesName: string;
+    seriesFormat: MangaFormat;
     seriesId: number;
     chapterId: number;
     order: number;
+    chapterNumber: string;
+    volumeNumber: string;
 }
 
 export interface ReadingList {

--- a/UI/Web/src/app/_services/action-factory.service.ts
+++ b/UI/Web/src/app/_services/action-factory.service.ts
@@ -16,7 +16,8 @@ export enum Action {
   Info = 5,
   RefreshMetadata = 6,
   Download = 7,
-  Bookmarks = 8
+  Bookmarks = 8,
+  AddToReadingList = 9
 }
 
 export interface ActionItem<T> {
@@ -187,7 +188,13 @@ export class ActionFactoryService {
         title: 'Bookmarks',
         callback: this.dummyCallback,
           requiresAdmin: false
-      }
+      },
+      {
+        action: Action.AddToReadingList,
+        title: 'Add to Reading List',
+        callback: this.dummyCallback,
+        requiresAdmin: false
+      },
     ];
 
     this.volumeActions = [
@@ -200,6 +207,12 @@ export class ActionFactoryService {
       {
         action: Action.MarkAsUnread,
         title: 'Mark as Unread',
+        callback: this.dummyCallback,
+        requiresAdmin: false
+      },
+      {
+        action: Action.AddToReadingList,
+        title: 'Add to Reading List',
         callback: this.dummyCallback,
         requiresAdmin: false
       },
@@ -223,7 +236,13 @@ export class ActionFactoryService {
         title: 'Mark as Unread',
         callback: this.dummyCallback,
         requiresAdmin: false
-      }
+      },
+      {
+        action: Action.AddToReadingList,
+        title: 'Add to Reading List',
+        callback: this.dummyCallback,
+        requiresAdmin: false
+      },
     ];
   }
 }

--- a/UI/Web/src/app/_services/action-factory.service.ts
+++ b/UI/Web/src/app/_services/action-factory.service.ts
@@ -269,20 +269,14 @@ export class ActionFactoryService {
 
     this.readingListActions = [
       {
-        action: Action.Delete,
-        title: 'Delete',
-        callback: this.dummyCallback,
-        requiresAdmin: false
-      },
-      {
         action: Action.Edit,
         title: 'Edit',
         callback: this.dummyCallback,
         requiresAdmin: false
       },
       {
-        action: Action.IncognitoRead,
-        title: 'Read in Incognito',
+        action: Action.Delete,
+        title: 'Delete',
         callback: this.dummyCallback,
         requiresAdmin: false
       },

--- a/UI/Web/src/app/_services/action-factory.service.ts
+++ b/UI/Web/src/app/_services/action-factory.service.ts
@@ -3,6 +3,7 @@ import { Chapter } from '../_models/chapter';
 import { CollectionTag } from '../_models/collection-tag';
 import { Library } from '../_models/library';
 import { MangaFormat } from '../_models/manga-format';
+import { ReadingList } from '../_models/reading-list';
 import { Series } from '../_models/series';
 import { Volume } from '../_models/volume';
 import { AccountService } from './account.service';
@@ -41,6 +42,8 @@ export class ActionFactoryService {
   chapterActions: Array<ActionItem<Chapter>> = [];
 
   collectionTagActions: Array<ActionItem<CollectionTag>> = [];
+
+  readingListActions: Array<ActionItem<ReadingList>> = [];
 
   isAdmin = false;
   hasDownloadRole = false;
@@ -113,6 +116,13 @@ export class ActionFactoryService {
           callback: this.dummyCallback,
           requiresAdmin: false
         });
+
+        // this.readingListActions.push({
+        //   action: Action.Promote, // Should I just use CollectionTag modal-like instead?
+        //   title: 'Delete',
+        //   callback: this.dummyCallback,
+        //   requiresAdmin: true
+        // });
       }
 
       if (this.hasDownloadRole || this.isAdmin) {
@@ -156,6 +166,11 @@ export class ActionFactoryService {
   getCollectionTagActions(callback: (action: Action, collectionTag: CollectionTag) => void) {
     this.collectionTagActions.forEach(action => action.callback = callback);
     return this.collectionTagActions;
+  }
+
+  getReadingListActions(callback: (action: Action, readingList: ReadingList) => void) {
+    this.readingListActions.forEach(action => action.callback = callback);
+    return this.readingListActions;
   }
 
   filterBookmarksForFormat(action: ActionItem<Series>, series: Series) {
@@ -243,6 +258,15 @@ export class ActionFactoryService {
         callback: this.dummyCallback,
         requiresAdmin: false
       },
+    ];
+
+    this.readingListActions = [
+      {
+        action: Action.Delete,
+        title: 'Delete',
+        callback: this.dummyCallback,
+        requiresAdmin: false
+      }
     ];
   }
 }

--- a/UI/Web/src/app/_services/action-factory.service.ts
+++ b/UI/Web/src/app/_services/action-factory.service.ts
@@ -266,6 +266,12 @@ export class ActionFactoryService {
         title: 'Delete',
         callback: this.dummyCallback,
         requiresAdmin: false
+      },
+      {
+        action: Action.Edit,
+        title: 'Edit',
+        callback: this.dummyCallback,
+        requiresAdmin: false
       }
     ];
   }

--- a/UI/Web/src/app/_services/action.service.ts
+++ b/UI/Web/src/app/_services/action.service.ts
@@ -226,8 +226,6 @@ export class ActionService implements OnDestroy {
       this.readingListModalRef.componentInstance.title = series.name;
       this.readingListModalRef.componentInstance.type = ADD_FLOW.Series;
 
-      console.log('series: ', series);
-
 
       this.readingListModalRef.closed.pipe(take(1)).subscribe(() => {
         this.readingListModalRef = null;
@@ -243,12 +241,48 @@ export class ActionService implements OnDestroy {
       });
   }
 
-  addVolumeToReadingList(volume: Volume, callback?: VolumeActionCallback) {
-    //TODO
+  addVolumeToReadingList(volume: Volume, seriesId: number, callback?: VolumeActionCallback) {
+    if (this.readingListModalRef != null) { return; }
+      this.readingListModalRef = this.modalService.open(AddToListModalComponent, { scrollable: true, size: 'md' });
+      this.readingListModalRef.componentInstance.seriesId = seriesId; 
+      this.readingListModalRef.componentInstance.volumeId = volume.id;
+      this.readingListModalRef.componentInstance.type = ADD_FLOW.Volume;
+
+
+      this.readingListModalRef.closed.pipe(take(1)).subscribe(() => {
+        this.readingListModalRef = null;
+        if (callback) {
+          callback(volume);
+        }
+      });
+      this.readingListModalRef.dismissed.pipe(take(1)).subscribe(() => {
+        this.readingListModalRef = null;
+        if (callback) {
+          callback(volume);
+        }
+      });
   }
 
-  addChapterToReadingList(chapter: Chapter, callback?: ChapterActionCallback) {
-    //TODO
+  addChapterToReadingList(chapter: Chapter, seriesId: number, callback?: ChapterActionCallback) {
+    if (this.readingListModalRef != null) { return; }
+      this.readingListModalRef = this.modalService.open(AddToListModalComponent, { scrollable: true, size: 'md' });
+      this.readingListModalRef.componentInstance.seriesId = seriesId; 
+      this.readingListModalRef.componentInstance.chapterId = chapter.id;
+      this.readingListModalRef.componentInstance.type = ADD_FLOW.Chapter;
+
+
+      this.readingListModalRef.closed.pipe(take(1)).subscribe(() => {
+        this.readingListModalRef = null;
+        if (callback) {
+          callback(chapter);
+        }
+      });
+      this.readingListModalRef.dismissed.pipe(take(1)).subscribe(() => {
+        this.readingListModalRef = null;
+        if (callback) {
+          callback(chapter);
+        }
+      });
   }
 
 }

--- a/UI/Web/src/app/_services/action.service.ts
+++ b/UI/Web/src/app/_services/action.service.ts
@@ -4,7 +4,7 @@ import { ToastrService } from 'ngx-toastr';
 import { forkJoin, Subject } from 'rxjs';
 import { take, takeUntil } from 'rxjs/operators';
 import { BookmarksModalComponent } from '../cards/_modals/bookmarks-modal/bookmarks-modal.component';
-import { AddToListModalComponent } from '../reading-list/_modals/add-to-list-modal/add-to-list-modal.component';
+import { AddToListModalComponent, ADD_FLOW } from '../reading-list/_modals/add-to-list-modal/add-to-list-modal.component';
 import { Chapter } from '../_models/chapter';
 import { Library } from '../_models/library';
 import { Series } from '../_models/series';
@@ -222,7 +222,13 @@ export class ActionService implements OnDestroy {
   addSeriesToReadingList(series: Series, callback?: SeriesActionCallback) {
     if (this.readingListModalRef != null) { return; }
       this.readingListModalRef = this.modalService.open(AddToListModalComponent, { scrollable: true, size: 'md' });
-      this.readingListModalRef.componentInstance.series = series; // TODO: Decide on what to pass in
+      this.readingListModalRef.componentInstance.seriesId = series.id; 
+      this.readingListModalRef.componentInstance.title = series.name;
+      this.readingListModalRef.componentInstance.type = ADD_FLOW.Series;
+
+      console.log('series: ', series);
+
+
       this.readingListModalRef.closed.pipe(take(1)).subscribe(() => {
         this.readingListModalRef = null;
         if (callback) {

--- a/UI/Web/src/app/_services/action.service.ts
+++ b/UI/Web/src/app/_services/action.service.ts
@@ -221,8 +221,8 @@ export class ActionService implements OnDestroy {
 
   addSeriesToReadingList(series: Series, callback?: SeriesActionCallback) {
     if (this.readingListModalRef != null) { return; }
-      this.readingListModalRef = this.modalService.open(AddToListModalComponent, { scrollable: true, size: 'sm' });
-      this.readingListModalRef.componentInstance.series = series;
+      this.readingListModalRef = this.modalService.open(AddToListModalComponent, { scrollable: true, size: 'md' });
+      this.readingListModalRef.componentInstance.series = series; // TODO: Decide on what to pass in
       this.readingListModalRef.closed.pipe(take(1)).subscribe(() => {
         this.readingListModalRef = null;
         if (callback) {

--- a/UI/Web/src/app/_services/action.service.ts
+++ b/UI/Web/src/app/_services/action.service.ts
@@ -5,8 +5,10 @@ import { forkJoin, Subject } from 'rxjs';
 import { take, takeUntil } from 'rxjs/operators';
 import { BookmarksModalComponent } from '../cards/_modals/bookmarks-modal/bookmarks-modal.component';
 import { AddToListModalComponent, ADD_FLOW } from '../reading-list/_modals/add-to-list-modal/add-to-list-modal.component';
+import { EditReadingListModalComponent } from '../reading-list/_modals/edit-reading-list-modal/edit-reading-list-modal.component';
 import { Chapter } from '../_models/chapter';
 import { Library } from '../_models/library';
+import { ReadingList } from '../_models/reading-list';
 import { Series } from '../_models/series';
 import { Volume } from '../_models/volume';
 import { LibraryService } from './library.service';
@@ -17,6 +19,7 @@ export type LibraryActionCallback = (library: Partial<Library>) => void;
 export type SeriesActionCallback = (series: Series) => void;
 export type VolumeActionCallback = (volume: Volume) => void;
 export type ChapterActionCallback = (chapter: Chapter) => void;
+export type ReadingListActionCallback = (readingList: ReadingList) => void;
 
 /**
  * Responsible for executing actions
@@ -283,6 +286,21 @@ export class ActionService implements OnDestroy {
           callback(chapter);
         }
       });
+  }
+
+  editReadingList(readingList: ReadingList, callback?: ReadingListActionCallback) {
+    const readingListModalRef = this.modalService.open(EditReadingListModalComponent, { scrollable: true, size: 'md' });
+    readingListModalRef.componentInstance.readingList = readingList; 
+    readingListModalRef.closed.pipe(take(1)).subscribe((list) => {
+      if (callback && list !== undefined) {
+        callback(readingList);
+      }
+    });
+    readingListModalRef.dismissed.pipe(take(1)).subscribe((list) => {
+      if (callback && list !== undefined) {
+        callback(readingList);
+      }
+    });
   }
 
 }

--- a/UI/Web/src/app/_services/action.service.ts
+++ b/UI/Web/src/app/_services/action.service.ts
@@ -4,6 +4,7 @@ import { ToastrService } from 'ngx-toastr';
 import { forkJoin, Subject } from 'rxjs';
 import { take, takeUntil } from 'rxjs/operators';
 import { BookmarksModalComponent } from '../cards/_modals/bookmarks-modal/bookmarks-modal.component';
+import { AddToListModalComponent } from '../reading-list/_modals/add-to-list-modal/add-to-list-modal.component';
 import { Chapter } from '../_models/chapter';
 import { Library } from '../_models/library';
 import { Series } from '../_models/series';
@@ -27,6 +28,7 @@ export class ActionService implements OnDestroy {
 
   private readonly onDestroy = new Subject<void>();
   private bookmarkModalRef: NgbModalRef | null = null;
+  private readingListModalRef: NgbModalRef | null = null;
 
   constructor(private libraryService: LibraryService, private seriesService: SeriesService, 
     private readerService: ReaderService, private toastr: ToastrService, private modalService: NgbModal) { }
@@ -215,6 +217,32 @@ export class ActionService implements OnDestroy {
           callback(series);
         }
       });
+  }
+
+  addSeriesToReadingList(series: Series, callback?: SeriesActionCallback) {
+    if (this.readingListModalRef != null) { return; }
+      this.readingListModalRef = this.modalService.open(AddToListModalComponent, { scrollable: true, size: 'sm' });
+      this.readingListModalRef.componentInstance.series = series;
+      this.readingListModalRef.closed.pipe(take(1)).subscribe(() => {
+        this.readingListModalRef = null;
+        if (callback) {
+          callback(series);
+        }
+      });
+      this.readingListModalRef.dismissed.pipe(take(1)).subscribe(() => {
+        this.readingListModalRef = null;
+        if (callback) {
+          callback(series);
+        }
+      });
+  }
+
+  addVolumeToReadingList(volume: Volume, callback?: VolumeActionCallback) {
+    //TODO
+  }
+
+  addChapterToReadingList(chapter: Chapter, callback?: ChapterActionCallback) {
+    //TODO
   }
 
 }

--- a/UI/Web/src/app/_services/reader.service.ts
+++ b/UI/Web/src/app/_services/reader.service.ts
@@ -1,6 +1,5 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
 import { environment } from 'src/environments/environment';
 import { ChapterInfo } from '../manga-reader/_models/chapter-info';
 import { UtilityService } from '../shared/_services/utility.service';
@@ -147,16 +146,33 @@ export class ReaderService {
   getNextChapterUrl(url: string, nextChapterId: number, incognitoMode: boolean = false, readingListMode: boolean = false, readingListId: number = -1) {
     const lastSlashIndex = url.lastIndexOf('/');
     let newRoute = url.substring(0, lastSlashIndex + 1) + nextChapterId + '';
-      if (incognitoMode) {
-        newRoute += '?incognitoMode=true';
+    newRoute += this.getQueryParams(incognitoMode, readingListMode, readingListId);
+    return newRoute;
+  }
+
+  getQueryParamsObject(incognitoMode: boolean = false, readingListMode: boolean = false, readingListId: number = -1) {
+    let params: {[key: string]: any} = {};
+    if (incognitoMode) {
+      params['incognitoMode'] = true;
+    }
+    if (readingListMode) {
+      params['readingListId'] = readingListId;
+    }
+    return params;
+  }
+
+  getQueryParams(incognitoMode: boolean = false, readingListMode: boolean = false, readingListId: number = -1) {
+    let params = '';
+    if (incognitoMode) {
+      params += '?incognitoMode=true';
+    }
+    if (readingListMode) {
+      if (params.indexOf('?') > 0) {
+        params += '&readingListId=' + readingListId;
+      } else {
+        params += '?readingListId=' + readingListId;
       }
-      if (readingListMode) {
-        if (newRoute.indexOf('?') > 0) {
-          newRoute += '&readingListId=' + readingListId;
-        } else {
-          newRoute += '?readingListId=' + readingListId;
-        }
-      }
-      return newRoute;
+    }
+    return params;
   }
 }

--- a/UI/Web/src/app/_services/reader.service.ts
+++ b/UI/Web/src/app/_services/reader.service.ts
@@ -80,7 +80,10 @@ export class ReaderService {
     return this.httpClient.get<number>(this.baseUrl + 'reader/next-chapter?seriesId=' + seriesId + '&volumeId=' + volumeId + '&currentChapterId=' + currentChapterId);
   }
 
-  getPrevChapter(seriesId: number, volumeId: number, currentChapterId: number) {
+  getPrevChapter(seriesId: number, volumeId: number, currentChapterId: number, readingListId: number = -1) {
+    if (readingListId > 0) {
+      return this.httpClient.get<number>(this.baseUrl + 'readinglist/prev-chapter?seriesId=' + seriesId + '&currentChapterId=' + currentChapterId + '&readingListId=' + readingListId);
+    }
     return this.httpClient.get<number>(this.baseUrl + 'reader/prev-chapter?seriesId=' + seriesId + '&volumeId=' + volumeId + '&currentChapterId=' + currentChapterId);
   }
 

--- a/UI/Web/src/app/_services/reader.service.ts
+++ b/UI/Web/src/app/_services/reader.service.ts
@@ -89,7 +89,7 @@ export class ReaderService {
 
   getCurrentChapter(volumes: Array<Volume>): Chapter {
     let currentlyReadingChapter: Chapter | undefined = undefined;
-    const chapters = volumes.filter(v => v.number !== 0).map(v => v.chapters || []).flat().sort(this.utilityService.sortChapters); // changed from === 0 to != 0
+    const chapters = volumes.filter(v => v.number !== 0).map(v => v.chapters || []).flat().sort(this.utilityService.sortChapters); 
 
     for (const c of chapters) {
       if (c.pagesRead < c.pages) {

--- a/UI/Web/src/app/_services/reader.service.ts
+++ b/UI/Web/src/app/_services/reader.service.ts
@@ -143,4 +143,20 @@ export class ReaderService {
     if (imageSrc === undefined || imageSrc === '') { return -1; }
     return parseInt(imageSrc.split('&page=')[1], 10);
   }
+
+  getNextChapterUrl(url: string, nextChapterId: number, incognitoMode: boolean = false, readingListMode: boolean = false, readingListId: number = -1) {
+    const lastSlashIndex = url.lastIndexOf('/');
+    let newRoute = url.substring(0, lastSlashIndex + 1) + nextChapterId + '';
+      if (incognitoMode) {
+        newRoute += '?incognitoMode=true';
+      }
+      if (readingListMode) {
+        if (newRoute.indexOf('?') > 0) {
+          newRoute += '&readingListId=' + readingListId;
+        } else {
+          newRoute += '?readingListId=' + readingListId;
+        }
+      }
+      return newRoute;
+  }
 }

--- a/UI/Web/src/app/_services/reader.service.ts
+++ b/UI/Web/src/app/_services/reader.service.ts
@@ -73,7 +73,10 @@ export class ReaderService {
     return this.httpClient.post(this.baseUrl + 'reader/mark-volume-unread', {seriesId, volumeId});
   }
 
-  getNextChapter(seriesId: number, volumeId: number, currentChapterId: number) {
+  getNextChapter(seriesId: number, volumeId: number, currentChapterId: number, readingListId: number = -1) {
+    if (readingListId > 0) {
+      return this.httpClient.get<number>(this.baseUrl + 'readinglist/next-chapter?seriesId=' + seriesId + '&currentChapterId=' + currentChapterId + '&readingListId=' + readingListId);
+    }
     return this.httpClient.get<number>(this.baseUrl + 'reader/next-chapter?seriesId=' + seriesId + '&volumeId=' + volumeId + '&currentChapterId=' + currentChapterId);
   }
 

--- a/UI/Web/src/app/_services/reading-list.service.ts
+++ b/UI/Web/src/app/_services/reading-list.service.ts
@@ -1,0 +1,9 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ReadingListService {
+
+  constructor() { }
+}

--- a/UI/Web/src/app/_services/reading-list.service.ts
+++ b/UI/Web/src/app/_services/reading-list.service.ts
@@ -41,6 +41,14 @@ export class ReadingListService {
     return this.httpClient.post(this.baseUrl + 'readinglist/update-by-series', {readingListId, seriesId}, { responseType: 'text' as 'json' });
   }
 
+  updateByVolume(readingListId: number, seriesId: number, volumeId: number) {
+    return this.httpClient.post(this.baseUrl + 'readinglist/update-by-volume', {readingListId, seriesId, volumeId}, { responseType: 'text' as 'json' });
+  }
+
+  updateByChapter(readingListId: number, seriesId: number, chapterId: number) {
+    return this.httpClient.post(this.baseUrl + 'readinglist/update-by-chapter', {readingListId, seriesId, chapterId}, { responseType: 'text' as 'json' });
+  }
+
   delete(readingListId: number) {
     return this.httpClient.delete(this.baseUrl + 'readinglist?readingListId=' + readingListId, { responseType: 'text' as 'json' });
   }

--- a/UI/Web/src/app/_services/reading-list.service.ts
+++ b/UI/Web/src/app/_services/reading-list.service.ts
@@ -57,6 +57,10 @@ export class ReadingListService {
     return this.httpClient.post(this.baseUrl + 'readinglist/update-position', {readingListId, readingListItemId, fromPosition, toPosition}, { responseType: 'text' as 'json' });
   }
 
+  deleteItem(readingListId: number, readingListItemId: number) {
+    return this.httpClient.post(this.baseUrl + 'readinglist/delete-item', {readingListId, readingListItemId}, { responseType: 'text' as 'json' });
+  }
+
   removeRead(readingListId: number) {
     return this.httpClient.post(this.baseUrl + 'readinglist/remove-read?readingListId=' + readingListId, { responseType: 'text' as 'json' });
   }

--- a/UI/Web/src/app/_services/reading-list.service.ts
+++ b/UI/Web/src/app/_services/reading-list.service.ts
@@ -31,4 +31,8 @@ export class ReadingListService {
   updateBySeries(readingListId: number, seriesId: number) {
     return this.httpClient.post(this.baseUrl + 'readinglist/update-by-series', {readingListId, seriesId}, { responseType: 'text' as 'json' });
   }
+
+  delete(readingListId: number) {
+    return this.httpClient.delete(this.baseUrl + 'readinglist?readingListId=' + readingListId, { responseType: 'text' as 'json' });
+  }
 }

--- a/UI/Web/src/app/_services/reading-list.service.ts
+++ b/UI/Web/src/app/_services/reading-list.service.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { environment } from 'src/environments/environment';
-import { ReadingList } from '../_models/reading-list';
+import { ReadingList, ReadingListItem } from '../_models/reading-list';
 
 @Injectable({
   providedIn: 'root'
@@ -12,8 +12,16 @@ export class ReadingListService {
 
   constructor(private httpClient: HttpClient) { }
 
+  getReadingList(readingListId: number) {
+    return this.httpClient.get<ReadingList>(this.baseUrl + 'readinglist?readingListId=' + readingListId);
+  }
+
   getReadingLists(includePromoted: boolean = true) {
-    return this.httpClient.get<ReadingList[]>(this.baseUrl + 'readinglist?includePromoted=' + includePromoted);
+    return this.httpClient.get<ReadingList[]>(this.baseUrl + 'readinglist/lists?includePromoted=' + includePromoted);
+  }
+
+  getListItems(readingListId: number) {
+    return this.httpClient.get<ReadingListItem[]>(this.baseUrl + 'readinglist/items?readingListId=' + readingListId);
   }
 
   createList(title: string) {

--- a/UI/Web/src/app/_services/reading-list.service.ts
+++ b/UI/Web/src/app/_services/reading-list.service.ts
@@ -37,6 +37,10 @@ export class ReadingListService {
     return this.httpClient.post<ReadingList>(this.baseUrl + 'readinglist/create', {title});
   }
 
+  update(model: {readingListId: number, title?: string, summary?: string, promoted: boolean}) {
+    return this.httpClient.post(this.baseUrl + 'readinglist/update', model, { responseType: 'text' as 'json' });
+  }
+
   updateBySeries(readingListId: number, seriesId: number) {
     return this.httpClient.post(this.baseUrl + 'readinglist/update-by-series', {readingListId, seriesId}, { responseType: 'text' as 'json' });
   }

--- a/UI/Web/src/app/_services/reading-list.service.ts
+++ b/UI/Web/src/app/_services/reading-list.service.ts
@@ -15,4 +15,12 @@ export class ReadingListService {
   getReadingLists(includePromoted: boolean = true) {
     return this.httpClient.get<ReadingList[]>(this.baseUrl + 'readinglist?includePromoted=' + includePromoted);
   }
+
+  createList(title: string) {
+    return this.httpClient.post<ReadingList>(this.baseUrl + 'readinglist/create', {title});
+  }
+
+  updateBySeries(readingListId: number, seriesId: number) {
+    return this.httpClient.post(this.baseUrl + 'readinglist/update-by-series', {readingListId, seriesId}, { responseType: 'text' as 'json' });
+  }
 }

--- a/UI/Web/src/app/_services/reading-list.service.ts
+++ b/UI/Web/src/app/_services/reading-list.service.ts
@@ -1,6 +1,8 @@
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+import { map } from 'rxjs/operators';
 import { environment } from 'src/environments/environment';
+import { PaginatedResult } from '../_models/pagination';
 import { ReadingList, ReadingListItem } from '../_models/reading-list';
 
 @Injectable({
@@ -16,8 +18,15 @@ export class ReadingListService {
     return this.httpClient.get<ReadingList>(this.baseUrl + 'readinglist?readingListId=' + readingListId);
   }
 
-  getReadingLists(includePromoted: boolean = true) {
-    return this.httpClient.get<ReadingList[]>(this.baseUrl + 'readinglist/lists?includePromoted=' + includePromoted);
+  getReadingLists(includePromoted: boolean = true, pageNum?: number, itemsPerPage?: number) {
+    let params = new HttpParams();
+    params = this._addPaginationIfExists(params, pageNum, itemsPerPage);
+
+    return this.httpClient.post<PaginatedResult<ReadingList[]>>(this.baseUrl + 'readinglist/lists?includePromoted=' + includePromoted, {}, {observe: 'response', params}).pipe(
+      map((response: any) => {
+        return this._cachePaginatedResults(response, new PaginatedResult<ReadingList[]>());
+      })
+    );
   }
 
   getListItems(readingListId: number) {
@@ -34,5 +43,30 @@ export class ReadingListService {
 
   delete(readingListId: number) {
     return this.httpClient.delete(this.baseUrl + 'readinglist?readingListId=' + readingListId, { responseType: 'text' as 'json' });
+  }
+
+  _addPaginationIfExists(params: HttpParams, pageNum?: number, itemsPerPage?: number) {
+    // TODO: Move to utility service
+    if (pageNum !== null && pageNum !== undefined && itemsPerPage !== null && itemsPerPage !== undefined) {
+      params = params.append('pageNumber', pageNum + '');
+      params = params.append('pageSize', itemsPerPage + '');
+    }
+    return params;
+  }
+
+  _cachePaginatedResults(response: any, paginatedVariable: PaginatedResult<any[]>) {
+    // TODO: Move to utility service
+    if (response.body === null) {
+      paginatedVariable.result = [];
+    } else {
+      paginatedVariable.result = response.body;
+    }
+
+    const pageHeader = response.headers.get('Pagination');
+    if (pageHeader !== null) {
+      paginatedVariable.pagination = JSON.parse(pageHeader);
+    }
+
+    return paginatedVariable;
   }
 }

--- a/UI/Web/src/app/_services/reading-list.service.ts
+++ b/UI/Web/src/app/_services/reading-list.service.ts
@@ -49,6 +49,10 @@ export class ReadingListService {
     return this.httpClient.post(this.baseUrl + 'readinglist/update-position', {readingListId, readingListItemId, fromPosition, toPosition}, { responseType: 'text' as 'json' });
   }
 
+  removeRead(readingListId: number) {
+    return this.httpClient.post(this.baseUrl + 'readinglist/remove-read?readingListId=' + readingListId, { responseType: 'text' as 'json' });
+  }
+
   _addPaginationIfExists(params: HttpParams, pageNum?: number, itemsPerPage?: number) {
     // TODO: Move to utility service
     if (pageNum !== null && pageNum !== undefined && itemsPerPage !== null && itemsPerPage !== undefined) {

--- a/UI/Web/src/app/_services/reading-list.service.ts
+++ b/UI/Web/src/app/_services/reading-list.service.ts
@@ -1,9 +1,18 @@
+import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+import { environment } from 'src/environments/environment';
+import { ReadingList } from '../_models/reading-list';
 
 @Injectable({
   providedIn: 'root'
 })
 export class ReadingListService {
 
-  constructor() { }
+  baseUrl = environment.apiUrl;
+
+  constructor(private httpClient: HttpClient) { }
+
+  getReadingLists(includePromoted: boolean = true) {
+    return this.httpClient.get<ReadingList[]>(this.baseUrl + 'readinglist?includePromoted=' + includePromoted);
+  }
 }

--- a/UI/Web/src/app/_services/reading-list.service.ts
+++ b/UI/Web/src/app/_services/reading-list.service.ts
@@ -45,6 +45,10 @@ export class ReadingListService {
     return this.httpClient.delete(this.baseUrl + 'readinglist?readingListId=' + readingListId, { responseType: 'text' as 'json' });
   }
 
+  updatePosition(readingListId: number, readingListItemId: number, fromPosition: number, toPosition: number) {
+    return this.httpClient.post(this.baseUrl + 'readinglist/update-position', {readingListId, readingListItemId, fromPosition, toPosition}, { responseType: 'text' as 'json' });
+  }
+
   _addPaginationIfExists(params: HttpParams, pageNum?: number, itemsPerPage?: number) {
     // TODO: Move to utility service
     if (pageNum !== null && pageNum !== undefined && itemsPerPage !== null && itemsPerPage !== undefined) {

--- a/UI/Web/src/app/_services/reading-list.service.ts
+++ b/UI/Web/src/app/_services/reading-list.service.ts
@@ -4,6 +4,7 @@ import { map } from 'rxjs/operators';
 import { environment } from 'src/environments/environment';
 import { PaginatedResult } from '../_models/pagination';
 import { ReadingList, ReadingListItem } from '../_models/reading-list';
+import { ActionItem } from './action-factory.service';
 
 @Injectable({
   providedIn: 'root'
@@ -67,6 +68,11 @@ export class ReadingListService {
 
   removeRead(readingListId: number) {
     return this.httpClient.post(this.baseUrl + 'readinglist/remove-read?readingListId=' + readingListId, { responseType: 'text' as 'json' });
+  }
+
+  actionListFilter(action: ActionItem<ReadingList>, readingList: ReadingList, isAdmin: boolean) {
+    if (readingList?.promoted && !isAdmin) return false;
+    return true;
   }
 
   _addPaginationIfExists(params: HttpParams, pageNum?: number, itemsPerPage?: number) {

--- a/UI/Web/src/app/admin/_modals/directory-picker/directory-picker.component.html
+++ b/UI/Web/src/app/admin/_modals/directory-picker/directory-picker.component.html
@@ -27,7 +27,7 @@
           </li>
         </ol>
         <ng-template #noBreadcrumb>
-            <div class="breadcrumb">Select a folder to view breadcrumb</div>
+            <div class="breadcrumb">Select a folder to view breadcrumb. Don't see your directory, try checking / first.</div>
         </ng-template>
     </nav>
     <ul class="list-group">
@@ -50,5 +50,6 @@
     </ul>
 </div>
 <div class="modal-footer">
+    <a class="btn btn-info" href="https://wiki.kavitareader.com/en/guides/adding-a-library" target="_blank">Help</a>
     <button type="button" class="btn btn-secondary" (click)="close()">Cancel</button>
 </div>

--- a/UI/Web/src/app/admin/_modals/library-editor-modal/library-editor-modal.component.ts
+++ b/UI/Web/src/app/admin/_modals/library-editor-modal/library-editor-modal.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { NgbActiveModal, NgbModal } from '@ng-bootstrap/ng-bootstrap';
+import { ToastrService } from 'ngx-toastr';
 import { Library } from 'src/app/_models/library';
 import { LibraryService } from 'src/app/_services/library.service';
 import { SettingsService } from '../../settings.service';
@@ -26,7 +27,8 @@ export class LibraryEditorModalComponent implements OnInit {
   libraryTypes: string[] = []
 
 
-  constructor(private modalService: NgbModal, private libraryService: LibraryService, public modal: NgbActiveModal, private settingService: SettingsService) { }
+  constructor(private modalService: NgbModal, private libraryService: LibraryService, public modal: NgbActiveModal, private settingService: SettingsService,
+    private toastr: ToastrService) { }
 
   ngOnInit(): void {
 
@@ -64,6 +66,7 @@ export class LibraryEditorModalComponent implements OnInit {
       model.folders = model.folders.map((item: string) => item.startsWith('\\') ? item.substr(1, item.length) : item);
       model.type = parseInt(model.type, 10);
       this.libraryService.create(model).subscribe(() => {
+        this.toastr.success('Library created, a scan has been started');
         this.close(true);
       }, err => {
         this.errorMessage = err;

--- a/UI/Web/src/app/admin/dashboard/dashboard.component.html
+++ b/UI/Web/src/app/admin/dashboard/dashboard.component.html
@@ -1,7 +1,7 @@
 <div class="container">
   <h2>Admin Dashboard</h2>
 
-  <ul ngbNav #nav="ngbNav" [(activeId)]="active" class="nav-tabs">
+  <ul ngbNav #nav="ngbNav" [(activeId)]="active" class="nav-tabs nav-pills">
       <li *ngFor="let tab of tabs" [ngbNavItem]="tab">
         <a ngbNavLink routerLink="." [fragment]="tab.fragment">{{ tab.title | titlecase }}</a>
         <ng-template ngbNavContent>

--- a/UI/Web/src/app/app-routing.module.ts
+++ b/UI/Web/src/app/app-routing.module.ts
@@ -28,6 +28,10 @@ const routes: Routes = [
     loadChildren: () => import('./user-settings/user-settings.module').then(m => m.UserSettingsModule)
   },
   {
+    path: 'lists',
+    loadChildren: () => import('./reading-list/reading-list.module').then(m => m.ReadingListModule)
+  },
+  {
     path: '',
     runGuardsAndResolvers: 'always',
     canActivate: [AuthGuard, LibraryAccessGuard],

--- a/UI/Web/src/app/app-routing.module.ts
+++ b/UI/Web/src/app/app-routing.module.ts
@@ -10,6 +10,8 @@ import { UserLoginComponent } from './user-login/user-login.component';
 import { AuthGuard } from './_guards/auth.guard';
 import { LibraryAccessGuard } from './_guards/library-access.guard';
 import { InProgressComponent } from './in-progress/in-progress.component';
+import { DashboardComponent as AdminDashboardComponent } from './admin/dashboard/dashboard.component';
+import { DashboardComponent } from './dashboard/dashboard.component';
 
 // TODO: Once we modularize the components, use this and measure performance impact: https://angular.io/guide/lazy-loading-ngmodules#preloading-modules
 
@@ -53,7 +55,7 @@ const routes: Routes = [
     runGuardsAndResolvers: 'always',
     canActivate: [AuthGuard],
     children: [
-      {path: 'library', component: LibraryComponent},
+      {path: 'library', component: DashboardComponent},
       {path: 'recently-added', component: RecentlyAddedComponent},
       {path: 'in-progress', component: InProgressComponent},
     ]

--- a/UI/Web/src/app/app.module.ts
+++ b/UI/Web/src/app/app.module.ts
@@ -36,6 +36,8 @@ import { CardsModule } from './cards/cards.module';
 import { CollectionsModule } from './collections/collections.module';
 import { InProgressComponent } from './in-progress/in-progress.component';
 import { SAVER, getSaver } from './shared/_providers/saver.provider';
+import { ReadingListModule } from './reading-list/reading-list.module';
+import { DashboardComponent } from './dashboard/dashboard.component';
 
 let sentryProviders: any[] = [];
 
@@ -96,6 +98,7 @@ if (environment.production) {
     PersonBadgeComponent,
     RecentlyAddedComponent,
     InProgressComponent,
+    DashboardComponent,
   ],
   imports: [
     HttpClientModule,
@@ -116,6 +119,7 @@ if (environment.production) {
     TypeaheadModule,
     CardsModule,
     CollectionsModule,
+    ReadingListModule,
 
     ToastrModule.forRoot({
       positionClass: 'toast-bottom-right',

--- a/UI/Web/src/app/app.module.ts
+++ b/UI/Web/src/app/app.module.ts
@@ -7,7 +7,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { HomeComponent } from './home/home.component';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
-import { NgbAccordionModule, NgbDropdownModule, NgbNavModule, NgbPaginationModule, NgbRatingModule, NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
+import { NgbDropdownModule, NgbNavModule, NgbPaginationModule, NgbRatingModule } from '@ng-bootstrap/ng-bootstrap';
 import { NavHeaderComponent } from './nav-header/nav-header.component';
 import { JwtInterceptor } from './_interceptors/jwt.interceptor';
 import { UserLoginComponent } from './user-login/user-login.component';
@@ -21,7 +21,6 @@ import { NotConnectedComponent } from './not-connected/not-connected.component';
 import { AutocompleteLibModule } from 'angular-ng-autocomplete';
 import { ReviewSeriesModalComponent } from './_modals/review-series-modal/review-series-modal.component';
 import { CarouselModule } from './carousel/carousel.module';
-import { NgxSliderModule } from '@angular-slider/ngx-slider';
 
 
 import * as Sentry from '@sentry/angular';
@@ -33,10 +32,9 @@ import { Dedupe as DedupeIntegration } from '@sentry/integrations';
 import { PersonBadgeComponent } from './person-badge/person-badge.component';
 import { TypeaheadModule } from './typeahead/typeahead.module';
 import { RecentlyAddedComponent } from './recently-added/recently-added.component';
-import { InProgressComponent } from './in-progress/in-progress.component';
 import { CardsModule } from './cards/cards.module';
 import { CollectionsModule } from './collections/collections.module';
-import { CommonModule } from '@angular/common';
+import { InProgressComponent } from './in-progress/in-progress.component';
 import { SAVER, getSaver } from './shared/_providers/saver.provider';
 
 let sentryProviders: any[] = [];
@@ -109,13 +107,9 @@ if (environment.production) {
 
     NgbDropdownModule, // Nav
     AutocompleteLibModule, // Nav
-    //NgbTooltipModule, // Shared & SettingsModule
     NgbRatingModule, // Series Detail
     NgbNavModule,
-    //NgbAccordionModule, // User Preferences
-    //NgxSliderModule, // User Preference
     NgbPaginationModule,
-
 
     SharedModule,
     CarouselModule,

--- a/UI/Web/src/app/book-reader/_models/book-info.ts
+++ b/UI/Web/src/app/book-reader/_models/book-info.ts
@@ -1,0 +1,9 @@
+import { MangaFormat } from "src/app/_models/manga-format";
+
+export interface BookInfo {
+    bookTitle: string;
+    seriesFormat: MangaFormat;
+    seriesId: number;
+    libraryId: number;
+    volumeId: number;
+}

--- a/UI/Web/src/app/book-reader/book-reader/book-reader.component.html
+++ b/UI/Web/src/app/book-reader/book-reader/book-reader.component.html
@@ -130,7 +130,7 @@
             </button>
             <button *ngIf="!this.adhocPageHistory.isEmpty()" class="btn btn-outline-secondary btn-icon col-2 col-xs-1" (click)="goBack()" title="Go Back"><i class="fa fa-reply" aria-hidden="true"></i><span class="phone-hidden">&nbsp;Go Back</span></button>
             <button class="btn btn-secondary col-2 col-xs-1" (click)="toggleDrawer()"><i class="fa fa-bars" aria-hidden="true"></i><span class="phone-hidden">&nbsp;Settings</span></button>
-            <div class="book-title col-2 phone-hidden">{{bookTitle}} </div>
+            <div class="book-title col-2 phone-hidden">{{bookTitle}}  <span *ngIf="incognitoMode">(<i class="fa fa-glasses"  aria-hidden="true"></i><span class="sr-only">Incognito Mode</span>)</span></div>
             <button class="btn btn-secondary col-2 col-xs-1" (click)="closeReader()"><i class="fa fa-times-circle" aria-hidden="true"></i><span class="phone-hidden">&nbsp;Close</span></button>
             <button class="btn btn-outline-secondary btn-icon col-2  col-xs-1" 
                 [disabled]="IsNextDisabled" 

--- a/UI/Web/src/app/book-reader/book-reader/book-reader.component.html
+++ b/UI/Web/src/app/book-reader/book-reader/book-reader.component.html
@@ -67,7 +67,7 @@
                     <div class="col-10" style="margin-top: 9px">
                         <ngb-progressbar style="cursor: pointer" title="Go to page" (click)="goToPage()" type="primary" height="5px" [value]="pageNum" [max]="maxPages - 1"></ngb-progressbar>
                     </div>
-                    <div class="col-1">{{maxPages - 1}}</div>
+                    <div class="col-1 btn-icon" (click)="goToPage(maxPages - 1)" title="Go to last page">{{maxPages - 1}}</div>
                 </div>
                 <div class="table-of-contents">
                     <h3>Table of Contents</h3>
@@ -77,18 +77,18 @@
                     <div *ngIf="chapters.length === 1; else nestedChildren">
                         <ul>
                             <li *ngFor="let chapter of chapters[0].children">
-                                <a href="javascript:void(0);" (click)="loadChapter(chapter.page, chapter.part)">{{chapter.title}}</a>
+                                <a href="javascript:void(0);" (click)="loadChapterPage(chapter.page, chapter.part)">{{chapter.title}}</a>
                             </li>
                         </ul>
                     </div>
                     <ng-template #nestedChildren>
                         <ul *ngFor="let chapterGroup of chapters" style="padding-inline-start: 0px">
-                            <li class="{{chapterGroup.page == pageNum ? 'active': ''}}" (click)="loadChapter(chapterGroup.page, '')">
+                            <li class="{{chapterGroup.page == pageNum ? 'active': ''}}" (click)="loadChapterPage(chapterGroup.page, '')">
                                 {{chapterGroup.title}}
                             </li>
                             <ul *ngFor="let chapter of chapterGroup.children">
                                 <li class="{{cleanIdSelector(chapter.part) === currentPageAnchor ? 'active' : ''}}">
-                                    <a href="javascript:void(0);" (click)="loadChapter(chapter.page, chapter.part)">{{chapter.title}}</a>
+                                    <a href="javascript:void(0);" (click)="loadChapterPage(chapter.page, chapter.part)">{{chapter.title}}</a>
                                 </li>
                             </ul>
                         </ul>
@@ -122,12 +122,12 @@
 
     <ng-template #actionBar>
         <div class="reading-bar row no-gutters justify-content-between">
-            <button class="btn btn-outline-secondary btn-icon col-2  col-xs-1" (click)="prevPage()" [disabled]="readingDirection === 0 ? pageNum === 0 : pageNum + 1 >= maxPages - 1" title="{{readingDirection === 0 ? 'Previous' : 'Next'}} Page"><i class="fa fa-arrow-left" aria-hidden="true"></i><span class="phone-hidden">&nbsp;{{readingDirection === 0 ? 'Previous' : 'Next'}}</span></button>
+            <button class="btn btn-outline-secondary btn-icon col-2  col-xs-1" (click)="prevPage()" [disabled]="nextPageDisabled && readingDirection === 0 ? pageNum === 0 : pageNum + 1 >= maxPages - 1" title="{{readingDirection === 0 ? 'Previous' : 'Next'}} Page"><i class="fa fa-arrow-left" aria-hidden="true"></i><span class="phone-hidden">&nbsp;{{readingDirection === 0 ? 'Previous' : 'Next'}}</span></button>
             <button *ngIf="!this.adhocPageHistory.isEmpty()" class="btn btn-outline-secondary btn-icon col-2 col-xs-1" (click)="goBack()" title="Go Back"><i class="fa fa-reply" aria-hidden="true"></i><span class="phone-hidden">&nbsp;Go Back</span></button>
             <button class="btn btn-secondary col-2 col-xs-1" (click)="toggleDrawer()"><i class="fa fa-bars" aria-hidden="true"></i><span class="phone-hidden">&nbsp;Settings</span></button>
             <div class="book-title col-2 phone-hidden">{{bookTitle}} </div>
             <button class="btn btn-secondary col-2 col-xs-1" (click)="closeReader()"><i class="fa fa-times-circle" aria-hidden="true"></i><span class="phone-hidden">&nbsp;Close</span></button>
-            <button class="btn btn-outline-secondary btn-icon col-2  col-xs-1" [disabled]="readingDirection === 0 ? pageNum + 1 >= maxPages - 1 : pageNum === 0" (click)="nextPage()" title="{{readingDirection === 0 ? 'Next' : 'Previous'}} Page"><span class="phone-hidden">{{readingDirection === 0 ? 'Next' : 'Previous'}}&nbsp;</span><i class="fa fa-arrow-right" aria-hidden="true"></i></button>
+            <button class="btn btn-outline-secondary btn-icon col-2  col-xs-1" [disabled]="nextPageDisabled && readingDirection === 0 ? pageNum + 1 >= maxPages - 1 : pageNum === 0" (click)="nextPage()" title="{{readingDirection === 0 ? 'Next' : 'Previous'}} Page"><span class="phone-hidden">{{readingDirection === 0 ? 'Next' : 'Previous'}}&nbsp;</span><i class="fa fa-arrow-right" aria-hidden="true"></i></button>
         </div>
     </ng-template>
 

--- a/UI/Web/src/app/book-reader/book-reader/book-reader.component.html
+++ b/UI/Web/src/app/book-reader/book-reader/book-reader.component.html
@@ -122,12 +122,22 @@
 
     <ng-template #actionBar>
         <div class="reading-bar row no-gutters justify-content-between">
-            <button class="btn btn-outline-secondary btn-icon col-2  col-xs-1" (click)="prevPage()" [disabled]="nextPageDisabled && readingDirection === 0 ? pageNum === 0 : pageNum + 1 >= maxPages - 1" title="{{readingDirection === 0 ? 'Previous' : 'Next'}} Page"><i class="fa fa-arrow-left" aria-hidden="true"></i><span class="phone-hidden">&nbsp;{{readingDirection === 0 ? 'Previous' : 'Next'}}</span></button>
+            <button class="btn btn-outline-secondary btn-icon col-2  col-xs-1" (click)="prevPage()" 
+                [disabled]="IsPrevDisabled" 
+                title="{{readingDirection === ReadingDirection.LeftToRight ? 'Previous' : 'Next'}} Page">
+                <i class="fa {{(readingDirection === ReadingDirection.LeftToRight ? pageNum === 0 : pageNum + 1 >= maxPages - 1) ? 'fa-angle-double-left' : 'fa-angle-left'}}" aria-hidden="true"></i>
+                <span class="phone-hidden">&nbsp;{{readingDirection === ReadingDirection.LeftToRight ? 'Previous' : 'Next'}}</span>
+            </button>
             <button *ngIf="!this.adhocPageHistory.isEmpty()" class="btn btn-outline-secondary btn-icon col-2 col-xs-1" (click)="goBack()" title="Go Back"><i class="fa fa-reply" aria-hidden="true"></i><span class="phone-hidden">&nbsp;Go Back</span></button>
             <button class="btn btn-secondary col-2 col-xs-1" (click)="toggleDrawer()"><i class="fa fa-bars" aria-hidden="true"></i><span class="phone-hidden">&nbsp;Settings</span></button>
             <div class="book-title col-2 phone-hidden">{{bookTitle}} </div>
             <button class="btn btn-secondary col-2 col-xs-1" (click)="closeReader()"><i class="fa fa-times-circle" aria-hidden="true"></i><span class="phone-hidden">&nbsp;Close</span></button>
-            <button class="btn btn-outline-secondary btn-icon col-2  col-xs-1" [disabled]="nextPageDisabled && readingDirection === 0 ? pageNum + 1 >= maxPages - 1 : pageNum === 0" (click)="nextPage()" title="{{readingDirection === 0 ? 'Next' : 'Previous'}} Page"><span class="phone-hidden">{{readingDirection === 0 ? 'Next' : 'Previous'}}&nbsp;</span><i class="fa fa-arrow-right" aria-hidden="true"></i></button>
+            <button class="btn btn-outline-secondary btn-icon col-2  col-xs-1" 
+                [disabled]="IsNextDisabled" 
+                (click)="nextPage()" title="{{readingDirection === ReadingDirection.LeftToRight ? 'Next' : 'Previous'}} Page">
+                <span class="phone-hidden">{{readingDirection === ReadingDirection.LeftToRight ? 'Next' : 'Previous'}}&nbsp;</span>
+                <i class="fa {{(readingDirection === ReadingDirection.LeftToRight ? pageNum + 1 >= maxPages - 1 : pageNum === 0) ? 'fa-angle-double-right' : 'fa-angle-right'}}" aria-hidden="true"></i>
+            </button>
         </div>
     </ng-template>
 

--- a/UI/Web/src/app/book-reader/book-reader/book-reader.component.ts
+++ b/UI/Web/src/app/book-reader/book-reader/book-reader.component.ts
@@ -188,6 +188,24 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
     }
   `;
 
+  get ReadingDirection(): typeof ReadingDirection {
+    return ReadingDirection;
+  }
+
+  get IsPrevDisabled() {
+    if (this.readingDirection === ReadingDirection.LeftToRight) {
+      return this.prevPageDisabled && this.pageNum === 0;
+    } 
+    return this.nextPageDisabled && this.pageNum + 1 >= this.maxPages - 1;
+  }
+
+  get IsNextDisabled() {
+    if (this.readingDirection === ReadingDirection.LeftToRight) {
+      this.nextPageDisabled && this.pageNum + 1 >= this.maxPages - 1;
+    }
+    return this.prevPageDisabled && this.pageNum === 0;
+  }
+
   constructor(private route: ActivatedRoute, private router: Router, private accountService: AccountService,
     private seriesService: SeriesService, private readerService: ReaderService, private location: Location,
     private renderer: Renderer2, private navService: NavService, private toastr: ToastrService, 
@@ -686,13 +704,14 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       this.setPageNum(this.pageNum + 1);
     }
 
-    if (this.pageNum === 0) {
+    if (oldPageNum === 0) {
       // Move to next volume/chapter automatically
       this.loadPrevChapter();
       return;
     }
 
     if (oldPageNum === this.pageNum) { return; }
+
     this.loadPage();
   }
 
@@ -713,7 +732,7 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       // Move to next volume/chapter automatically
       this.loadNextChapter();
     }
-    
+
     if (oldPageNum === this.pageNum) { return; }
 
     this.loadPage();

--- a/UI/Web/src/app/book-reader/book-reader/book-reader.component.ts
+++ b/UI/Web/src/app/book-reader/book-reader/book-reader.component.ts
@@ -495,18 +495,7 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       this.chapterId = chapterId;
       this.continuousChaptersStack.push(chapterId); 
       // Load chapter Id onto route but don't reload
-      const lastSlashIndex = this.router.url.lastIndexOf('/');
-      let newRoute = this.router.url.substring(0, lastSlashIndex + 1) + this.chapterId + '';
-      if (this.incognitoMode) {
-        newRoute += '?incognitoMode=true';
-      }
-      if (this.readingListMode) {
-        if (newRoute.indexOf('?') > 0) {
-          newRoute += '&readingListId=' + this.readingListId;
-        } else {
-          newRoute += '?readingListId=' + this.readingListId;
-        }
-      }
+      const newRoute = this.readerService.getNextChapterUrl(this.router.url, this.chapterId, this.incognitoMode, this.readingListMode, this.readingListId);
       window.history.replaceState({}, '', newRoute);
       this.init();
     } else {

--- a/UI/Web/src/app/book-reader/book.service.ts
+++ b/UI/Web/src/app/book-reader/book.service.ts
@@ -2,6 +2,7 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { environment } from 'src/environments/environment';
 import { BookChapterItem } from './_models/book-chapter-item';
+import { BookInfo } from './_models/book-info';
 
 export interface BookPage {
   bookTitle: string;
@@ -32,7 +33,7 @@ export class BookService {
   }
 
   getBookInfo(chapterId: number) {
-    return this.http.get<string>(this.baseUrl + 'book/' + chapterId + '/book-info', {responseType: 'text' as 'json'});
+    return this.http.get<BookInfo>(this.baseUrl + 'book/' + chapterId + '/book-info');
   }
 
   getBookPageUrl(chapterId: number, page: number) {

--- a/UI/Web/src/app/cards/_modals/card-details-modal/card-details-modal.component.html
+++ b/UI/Web/src/app/cards/_modals/card-details-modal/card-details-modal.component.html
@@ -37,8 +37,8 @@
                     <h5 class="mt-0 mb-1">
                         <span *ngIf="chapter.number !== '0'; else specialHeader">
                             <span class="">
-                                <app-card-actionables (actionHandler)="performAction($event, chapter)" [actions]="chapterActions" [labelBy]="'Chapter' + formatChapterNumber(chapter)"></app-card-actionables>
-                            </span>&nbsp;Chapter {{formatChapterNumber(chapter)}}
+                                <app-card-actionables (actionHandler)="performAction($event, chapter)" [actions]="chapterActions" [labelBy]="'Chapter' + formatChapterNumber(chapter)"></app-card-actionables>&nbsp;
+                            </span>Chapter {{formatChapterNumber(chapter)}}
                             <span class="badge badge-primary badge-pill">
                                 <span *ngIf="chapter.pagesRead > 0 && chapter.pagesRead < chapter.pages">{{chapter.pagesRead}} / {{chapter.pages}}</span>
                                 <span *ngIf="chapter.pagesRead === 0">UNREAD</span>

--- a/UI/Web/src/app/cards/_modals/edit-collection-tags/edit-collection-tags.component.html
+++ b/UI/Web/src/app/cards/_modals/edit-collection-tags/edit-collection-tags.component.html
@@ -11,7 +11,7 @@
         Promotion means that the tag can be seen server-wide, not just for admin users. All series that have this tag will still have user-access restrictions placed on them.
     </p>
 
-        <ul ngbNav #nav="ngbNav" [(activeId)]="active" class="nav-tabs">
+        <ul ngbNav #nav="ngbNav" [(activeId)]="active" class="nav-tabs nav-pills">
             <li [ngbNavItem]="tabs[0]">
             <a ngbNavLink>{{tabs[0]}}</a>
             <ng-template ngbNavContent>

--- a/UI/Web/src/app/cards/_modals/edit-series-modal/edit-series-modal.component.ts
+++ b/UI/Web/src/app/cards/_modals/edit-series-modal/edit-series-modal.component.ts
@@ -83,6 +83,7 @@ export class EditSeriesModalComponent implements OnInit, OnDestroy {
       if (metadata) {
         this.metadata = metadata;
         this.settings.savedData = metadata.tags;
+        this.tags = metadata.tags;
       }
     });
 
@@ -146,6 +147,7 @@ export class EditSeriesModalComponent implements OnInit, OnDestroy {
       this.seriesService.updateSeries(model),
       this.seriesService.updateMetadata(this.metadata, this.tags)
     ];
+
 
     if (selectedIndex > 0) {
       apis.push(this.uploadService.updateSeriesCoverImage(model.id, this.selectedCover));

--- a/UI/Web/src/app/cards/card-detail-layout/card-detail-layout.component.html
+++ b/UI/Web/src/app/cards/card-detail-layout/card-detail-layout.component.html
@@ -3,8 +3,8 @@
         <div class="col mr-auto">
             <h2 style="display: inline-block">
                 <span *ngIf="actions.length > 0" class="">
-                    <app-card-actionables (actionHandler)="performAction($event)" [actions]="actions" [labelBy]="header"></app-card-actionables>
-                </span>&nbsp;{{header}}&nbsp;
+                    <app-card-actionables (actionHandler)="performAction($event)" [actions]="actions" [labelBy]="header"></app-card-actionables>&nbsp;
+                </span>{{header}}&nbsp;
                 <!-- NOTE: On mobile the pill can eat up a lot of space, we can hide it and move to the filter section if user is interested -->
                 <span class="badge badge-primary badge-pill" attr.aria-label="{{pagination.totalItems}} total items" *ngIf="pagination != undefined">{{pagination.totalItems}}</span>
             </h2>

--- a/UI/Web/src/app/cards/card-item/card-item.component.ts
+++ b/UI/Web/src/app/cards/card-item/card-item.component.ts
@@ -146,6 +146,7 @@ export class CardItemComponent implements OnInit, OnDestroy {
 
   isPromoted() {
     const tag = this.entity as CollectionTag;
+    // TODO: Validate if this works with reading lists
     return tag.hasOwnProperty('promoted') && tag.promoted;
   }
 }

--- a/UI/Web/src/app/cards/series-card/series-card.component.ts
+++ b/UI/Web/src/app/cards/series-card/series-card.component.ts
@@ -78,6 +78,9 @@ export class SeriesCardComponent implements OnInit, OnChanges {
       case(Action.Bookmarks):
         this.actionService.openBookmarkModal(series, (series) => {/* No Operation */ });
         break;
+      case(Action.AddToReadingList):
+        this.actionService.addSeriesToReadingList(series, (series) => {/* No Operation */ });
+        break;
       default:
         break;
     }

--- a/UI/Web/src/app/collections/all-collections/all-collections.component.html
+++ b/UI/Web/src/app/collections/all-collections/all-collections.component.html
@@ -1,23 +1,8 @@
-<ng-container *ngIf="collectionTagId === 0; else collectionTagDetail;">
-    <app-card-detail-layout header="Collections" 
+<app-card-detail-layout header="Collections" 
     [isLoading]="isLoading"
     [items]="collections"
-    (pageChange)="onPageChange($event)"
     >
         <ng-template #cardItem let-item let-position="idx">
             <app-card-item [title]="item.title" [entity]="item" [actions]="collectionTagActions" [imageUrl]="item.coverImage" (clicked)="loadCollection(item)"></app-card-item>
         </ng-template>
-    </app-card-detail-layout>
-</ng-container>
-<ng-template #collectionTagDetail>
-    <app-card-detail-layout header="{{collectionTagName}} Collection" 
-    [isLoading]="isLoading"
-    [items]="series"
-    [pagination]="seriesPagination"
-    (pageChange)="onPageChange($event)"
-    >
-        <ng-template #cardItem let-item let-position="idx">
-            <app-series-card [data]="item" [libraryId]="item.libraryId" (reload)="loadPage()"></app-series-card>
-        </ng-template>
-    </app-card-detail-layout>
-</ng-template>
+</app-card-detail-layout>

--- a/UI/Web/src/app/collections/all-collections/all-collections.component.ts
+++ b/UI/Web/src/app/collections/all-collections/all-collections.component.ts
@@ -1,16 +1,12 @@
 import { Component, OnInit } from '@angular/core';
 import { Title } from '@angular/platform-browser';
-import { ActivatedRoute, Router } from '@angular/router';
+import { Router } from '@angular/router';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
-import { ToastrService } from 'ngx-toastr';
 import { EditCollectionTagsComponent } from 'src/app/cards/_modals/edit-collection-tags/edit-collection-tags.component';
 import { CollectionTag } from 'src/app/_models/collection-tag';
-import { Pagination } from 'src/app/_models/pagination';
-import { Series } from 'src/app/_models/series';
 import { ActionItem, ActionFactoryService, Action } from 'src/app/_services/action-factory.service';
 import { CollectionTagService } from 'src/app/_services/collection-tag.service';
 import { ImageService } from 'src/app/_services/image.service';
-import { SeriesService } from 'src/app/_services/series.service';
 
 
 /**
@@ -25,32 +21,13 @@ export class AllCollectionsComponent implements OnInit {
 
   isLoading: boolean = true;
   collections: CollectionTag[] = [];
-  collectionTagId: number = 0; // 0 is not a valid id, if 0, we will load all tags
-  collectionTagName: string = '';
-  series: Array<Series> = [];
-  seriesPagination!: Pagination;
   collectionTagActions: ActionItem<CollectionTag>[] = [];
 
-  constructor(private collectionService: CollectionTagService, private router: Router, private route: ActivatedRoute, 
-    private seriesService: SeriesService, private toastr: ToastrService, private actionFactoryService: ActionFactoryService, 
-    private modalService: NgbModal, private titleService: Title, private imageService: ImageService) {
+  constructor(private collectionService: CollectionTagService, private router: Router,
+    private actionFactoryService: ActionFactoryService, private modalService: NgbModal, 
+    private titleService: Title, private imageService: ImageService) {
     this.router.routeReuseStrategy.shouldReuseRoute = () => false;
-
-    const routeId = this.route.snapshot.paramMap.get('id');
-    if (routeId != null) {
-      this.collectionTagId = parseInt(routeId, 10);
-      this.collectionService.allTags().subscribe(tags => {
-        this.collections = tags;
-        const matchingTags = this.collections.filter(t => t.id === this.collectionTagId);
-        if (matchingTags.length === 0) {
-          this.toastr.error('You don\'t have access to any libraries this tag belongs to or this tag is invalid');
-          this.router.navigate(['collections']);
-          return;
-        }
-        this.collectionTagName = tags.filter(item => item.id === this.collectionTagId)[0].title;
-        this.titleService.setTitle('Kavita - ' + this.collectionTagName + ' Collection');
-      });
-    }
+    this.titleService.setTitle('Kavita - Collections');
   }
 
   ngOnInit() {
@@ -60,38 +37,15 @@ export class AllCollectionsComponent implements OnInit {
 
 
   loadCollection(item: CollectionTag) {
-    this.collectionTagId = item.id;
-    this.collectionTagName = item.title;
-    this.router.navigate(['collections', this.collectionTagId]);
+    this.router.navigate(['collections', item.id]);
     this.loadPage();
   }
 
-  onPageChange(pagination: Pagination) {
-    this.router.navigate(['collections', this.collectionTagId], {replaceUrl: true, queryParamsHandling: 'merge', queryParams: {page: this.seriesPagination.currentPage} });
-  }
-
   loadPage() {
-    const page = this.route.snapshot.queryParamMap.get('page');
-    if (page != null) {
-      if (this.seriesPagination === undefined || this.seriesPagination === null) {
-        this.seriesPagination = {currentPage: 0, itemsPerPage: 30, totalItems: 0, totalPages: 1};
-      }
-      this.seriesPagination.currentPage = parseInt(page, 10);
-    }
-    // Reload page after a series is updated or first load
-    if (this.collectionTagId === 0) {
-      this.collectionService.allTags().subscribe(tags => {
-        this.collections = tags;
-        this.isLoading = false;
-      });
-    } else {
-      this.seriesService.getSeriesForTag(this.collectionTagId, this.seriesPagination?.currentPage, this.seriesPagination?.itemsPerPage).subscribe(tags => {
-        this.series = tags.result;
-        this.seriesPagination = tags.pagination;
-        this.isLoading = false;
-        window.scrollTo(0, 0);
-      });
-    }
+    this.collectionService.allTags().subscribe(tags => {
+      this.collections = tags;
+      this.isLoading = false;
+    });
   }
 
   handleCollectionActionCallback(action: Action, collectionTag: CollectionTag) {

--- a/UI/Web/src/app/collections/all-collections/all-collections.component.ts
+++ b/UI/Web/src/app/collections/all-collections/all-collections.component.ts
@@ -9,9 +9,6 @@ import { CollectionTagService } from 'src/app/_services/collection-tag.service';
 import { ImageService } from 'src/app/_services/image.service';
 
 
-/**
- * This component is used as a standard layout for any card detail. ie) series, in-progress, collections, etc.
- */
 @Component({
   selector: 'app-all-collections',
   templateUrl: './all-collections.component.html',

--- a/UI/Web/src/app/collections/collections.module.ts
+++ b/UI/Web/src/app/collections/collections.module.ts
@@ -18,6 +18,9 @@ import { AllCollectionsComponent } from './all-collections/all-collections.compo
     SharedModule,
     CardsModule,
     CollectionsRoutingModule,
+  ],
+  exports: [
+    AllCollectionsComponent
   ]
 })
 export class CollectionsModule { }

--- a/UI/Web/src/app/dashboard/dashboard.component.html
+++ b/UI/Web/src/app/dashboard/dashboard.component.html
@@ -1,0 +1,21 @@
+<div class="container-fluid" >
+    <nav role="navigation">
+        <ul ngbNav #nav="ngbNav" [(activeId)]="active" class="nav nav-pills justify-content-center" role="tab">
+            <li *ngFor="let tab of tabs" [ngbNavItem]="tab" class="nav-item">
+            <a ngbNavLink routerLink="." [fragment]="tab.fragment">{{ tab.title | titlecase }}</a>
+            <ng-template ngbNavContent>
+                <ng-container *ngIf="tab.fragment === ''">
+                    <app-library></app-library>
+                </ng-container>
+                <ng-container *ngIf="tab.fragment === 'lists'">
+                    <app-reading-lists></app-reading-lists>
+                </ng-container>
+                <ng-container *ngIf="tab.fragment === 'collections'">
+                    <app-all-collections></app-all-collections>
+                </ng-container>
+            </ng-template>
+            </li>
+        </ul>
+    </nav>
+    <div [ngbNavOutlet]="nav" class="mt-3"></div>
+</div>

--- a/UI/Web/src/app/dashboard/dashboard.component.html
+++ b/UI/Web/src/app/dashboard/dashboard.component.html
@@ -1,6 +1,6 @@
-<div class="container-fluid" >
+<div class="container-fluid">
     <nav role="navigation">
-        <ul ngbNav #nav="ngbNav" [(activeId)]="active" class="nav nav-pills justify-content-center" role="tab">
+        <ul ngbNav #nav="ngbNav" [(activeId)]="active" class="nav nav-pills justify-content-center mt-3" role="tab">
             <li *ngFor="let tab of tabs" [ngbNavItem]="tab" class="nav-item">
             <a ngbNavLink routerLink="." [fragment]="tab.fragment">{{ tab.title | titlecase }}</a>
             <ng-template ngbNavContent>

--- a/UI/Web/src/app/dashboard/dashboard.component.ts
+++ b/UI/Web/src/app/dashboard/dashboard.component.ts
@@ -1,0 +1,37 @@
+import { Component, OnInit } from '@angular/core';
+import { Title } from '@angular/platform-browser';
+import { ActivatedRoute } from '@angular/router';
+import { ToastrService } from 'ngx-toastr';
+import { ServerService } from '../_services/server.service';
+
+@Component({
+  selector: 'app-dashboard',
+  templateUrl: './dashboard.component.html',
+  styleUrls: ['./dashboard.component.scss']
+})
+export class DashboardComponent implements OnInit {
+
+  tabs: Array<{title: string, fragment: string}> = [
+    {title: 'Libraries', fragment: ''},
+    {title: 'Lists', fragment: 'lists'},
+    {title: 'Collections', fragment: 'collections'},
+  ];
+  active = this.tabs[0];
+
+  constructor(public route: ActivatedRoute, private serverService: ServerService, 
+    private toastr: ToastrService, private titleService: Title) {
+    this.route.fragment.subscribe(frag => {
+      const tab = this.tabs.filter(item => item.fragment === frag);
+      if (tab.length > 0) {
+        this.active = tab[0];
+      } else {
+        this.active = this.tabs[0]; // Default to first tab
+      }
+    });
+    this.titleService.setTitle('Kavita - Dashboard');
+  }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/UI/Web/src/app/library/library.component.html
+++ b/UI/Web/src/app/library/library.component.html
@@ -1,33 +1,30 @@
-
-<div class="container-fluid">
-    <div *ngIf="libraries.length === 0 && !isLoading && isAdmin" class="d-flex justify-content-center">
-        <p>There are no libraries setup yet. Configure some in <a href="/admin/dashboard#libraries">Server settings</a>.</p>
-    </div>
-    <div *ngIf="libraries.length === 0 && !isLoading && !isAdmin" class="d-flex justify-content-center">
-        <p>You haven't been granted access to any libraries.</p>
-    </div>
-    <app-carousel-reel [items]="libraries" title="Libraries">
-        <ng-template #carouselItem let-item let-position="idx">
-            <app-library-card [data]="item"></app-library-card>
-        </ng-template>
-    </app-carousel-reel>
-
-    <app-carousel-reel [items]="inProgress" title="In Progress" (sectionClick)="handleSectionClick($event)">
-        <ng-template #carouselItem let-item let-position="idx">
-            <app-series-card [data]="item" [libraryId]="item.libraryId" (reload)="reloadInProgress($event)" (dataChanged)="reloadInProgress($event)"></app-series-card>
-        </ng-template>
-    </app-carousel-reel>
-
-    <app-carousel-reel [items]="recentlyAdded" title="Recently Added" (sectionClick)="handleSectionClick($event)">
-        <ng-template #carouselItem let-item let-position="idx">
-            <app-series-card [data]="item" [libraryId]="item.libraryId" (reload)="reloadTags()" (dataChanged)="loadRecentlyAdded()"></app-series-card>
-        </ng-template>
-    </app-carousel-reel>
-
-    <app-carousel-reel [items]="collectionTags" title="Collections" (sectionClick)="handleSectionClick($event)">
-        <ng-template #carouselItem let-item let-position="idx">
-            <app-card-item [title]="item.title" [entity]="item" [actions]="collectionTagActions" [imageUrl]="item.coverImage" (clicked)="loadCollection(item)"></app-card-item>
-        </ng-template>
-    </app-carousel-reel>
-    
+<div *ngIf="libraries.length === 0 && !isLoading && isAdmin" class="d-flex justify-content-center">
+    <p>There are no libraries setup yet. Configure some in <a href="/admin/dashboard#libraries">Server settings</a>.</p>
 </div>
+<div *ngIf="libraries.length === 0 && !isLoading && !isAdmin" class="d-flex justify-content-center">
+    <p>You haven't been granted access to any libraries.</p>
+</div>
+
+<app-carousel-reel [items]="inProgress" title="In Progress" (sectionClick)="handleSectionClick($event)">
+    <ng-template #carouselItem let-item let-position="idx">
+        <app-series-card [data]="item" [libraryId]="item.libraryId" (reload)="reloadInProgress($event)" (dataChanged)="reloadInProgress($event)"></app-series-card>
+    </ng-template>
+</app-carousel-reel>
+
+<app-carousel-reel [items]="recentlyAdded" title="Recently Added" (sectionClick)="handleSectionClick($event)">
+    <ng-template #carouselItem let-item let-position="idx">
+        <app-series-card [data]="item" [libraryId]="item.libraryId" (reload)="reloadTags()" (dataChanged)="loadRecentlyAdded()"></app-series-card>
+    </ng-template>
+</app-carousel-reel>
+
+<app-carousel-reel [items]="libraries" title="Libraries">
+    <ng-template #carouselItem let-item let-position="idx">
+        <app-library-card [data]="item"></app-library-card>
+    </ng-template>
+</app-carousel-reel>
+
+<!-- <app-carousel-reel [items]="collectionTags" title="Collections" (sectionClick)="handleSectionClick($event)">
+    <ng-template #carouselItem let-item let-position="idx">
+        <app-card-item [title]="item.title" [entity]="item" [actions]="collectionTagActions" [imageUrl]="item.coverImage" (clicked)="loadCollection(item)"></app-card-item>
+    </ng-template>
+</app-carousel-reel> -->

--- a/UI/Web/src/app/library/library.component.html
+++ b/UI/Web/src/app/library/library.component.html
@@ -22,9 +22,3 @@
         <app-library-card [data]="item"></app-library-card>
     </ng-template>
 </app-carousel-reel>
-
-<!-- <app-carousel-reel [items]="collectionTags" title="Collections" (sectionClick)="handleSectionClick($event)">
-    <ng-template #carouselItem let-item let-position="idx">
-        <app-card-item [title]="item.title" [entity]="item" [actions]="collectionTagActions" [imageUrl]="item.coverImage" (clicked)="loadCollection(item)"></app-card-item>
-    </ng-template>
-</app-carousel-reel> -->

--- a/UI/Web/src/app/library/library.component.ts
+++ b/UI/Web/src/app/library/library.component.ts
@@ -5,7 +5,6 @@ import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { Subject } from 'rxjs';
 import { take, takeUntil } from 'rxjs/operators';
 import { EditCollectionTagsComponent } from '../cards/_modals/edit-collection-tags/edit-collection-tags.component';
-import { ScrollService } from '../scroll.service';
 import { CollectionTag } from '../_models/collection-tag';
 import { InProgressChapter } from '../_models/in-progress-chapter';
 import { Library } from '../_models/library';
@@ -33,8 +32,8 @@ export class LibraryComponent implements OnInit, OnDestroy {
   recentlyAdded: Series[] = [];
   inProgress: Series[] = [];
   continueReading: InProgressChapter[] = [];
-  collectionTags: CollectionTag[] = [];
-  collectionTagActions: ActionItem<CollectionTag>[] = [];
+  // collectionTags: CollectionTag[] = [];
+  // collectionTagActions: ActionItem<CollectionTag>[] = [];
 
   private readonly onDestroy = new Subject<void>();
 
@@ -43,8 +42,7 @@ export class LibraryComponent implements OnInit, OnDestroy {
   constructor(public accountService: AccountService, private libraryService: LibraryService, 
     private seriesService: SeriesService, private actionFactoryService: ActionFactoryService, 
     private collectionService: CollectionTagService, private router: Router, 
-    private modalService: NgbModal, private titleService: Title, public imageService: ImageService, 
-    private scrollService: ScrollService) { }
+    private modalService: NgbModal, private titleService: Title, public imageService: ImageService) { }
 
   ngOnInit(): void {
     this.titleService.setTitle('Kavita - Dashboard');
@@ -58,7 +56,7 @@ export class LibraryComponent implements OnInit, OnDestroy {
       });
     });
 
-    this.collectionTagActions = this.actionFactoryService.getCollectionTagActions(this.handleCollectionActionCallback.bind(this));
+    //this.collectionTagActions = this.actionFactoryService.getCollectionTagActions(this.handleCollectionActionCallback.bind(this));
 
     this.reloadSeries();
   }
@@ -103,9 +101,9 @@ export class LibraryComponent implements OnInit, OnDestroy {
   }
 
   reloadTags() {
-    this.collectionService.allTags().pipe(takeUntil(this.onDestroy)).subscribe(tags => {
-      this.collectionTags = tags;
-    });
+    // this.collectionService.allTags().pipe(takeUntil(this.onDestroy)).subscribe(tags => {
+    //   this.collectionTags = tags;
+    // });
   }
 
   handleSectionClick(sectionTitle: string) {
@@ -119,24 +117,24 @@ export class LibraryComponent implements OnInit, OnDestroy {
   }
 
   loadCollection(item: CollectionTag) {
-    this.router.navigate(['collections', item.id]);
+    //this.router.navigate(['collections', item.id]);
   }
 
-  handleCollectionActionCallback(action: Action, collectionTag: CollectionTag) {
-    switch (action) {
-      case(Action.Edit):
-        const modalRef = this.modalService.open(EditCollectionTagsComponent, { size: 'lg', scrollable: true });
-        modalRef.componentInstance.tag = collectionTag;
-        modalRef.closed.subscribe((results: {success: boolean, coverImageUpdated: boolean}) => {
-          this.reloadTags();
-          if (results.coverImageUpdated) {
-            collectionTag.coverImage = this.imageService.randomize(collectionTag.coverImage);
-          }
-        });
-        break;
-      default:
-        break;
-    }
-  }
+  // handleCollectionActionCallback(action: Action, collectionTag: CollectionTag) {
+  //   switch (action) {
+  //     case(Action.Edit):
+  //       const modalRef = this.modalService.open(EditCollectionTagsComponent, { size: 'lg', scrollable: true });
+  //       modalRef.componentInstance.tag = collectionTag;
+  //       modalRef.closed.subscribe((results: {success: boolean, coverImageUpdated: boolean}) => {
+  //         this.reloadTags();
+  //         if (results.coverImageUpdated) {
+  //           collectionTag.coverImage = this.imageService.randomize(collectionTag.coverImage);
+  //         }
+  //       });
+  //       break;
+  //     default:
+  //       break;
+  //   }
+  // }
 
 }

--- a/UI/Web/src/app/manga-reader/_models/chapter-info.ts
+++ b/UI/Web/src/app/manga-reader/_models/chapter-info.ts
@@ -1,8 +1,13 @@
+import { MangaFormat } from "src/app/_models/manga-format";
+
 export interface ChapterInfo {
     chapterNumber: string;
     volumeNumber: string;
     chapterTitle: string;
     seriesName: string;
+    seriesFormat: MangaFormat;
+    seriesId: number;
+    libraryId: number;
     fileName: string;
     isSpecial: boolean;
     volumeId: number;

--- a/UI/Web/src/app/manga-reader/manga-reader.component.ts
+++ b/UI/Web/src/app/manga-reader/manga-reader.component.ts
@@ -65,12 +65,20 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
   seriesId!: number;
   volumeId!: number;
   chapterId!: number;
+  /**
+   * Reading List id. Defaults to -1.
+   */
+  readingListId: number = CHAPTER_ID_DOESNT_EXIST;
 
   /**
    * If this is true, no progress will be saved.
    */
   incognitoMode: boolean = false;
 
+  /**
+   * If this is true, chapters will be fetched in the order of a reading list, rather than natural series order. 
+   */
+  readingListMode: boolean = false;
   /**
    * The current page. UI will show this number + 1.
    */
@@ -265,6 +273,14 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
     this.seriesId = parseInt(seriesId, 10);
     this.chapterId = parseInt(chapterId, 10);
     this.incognitoMode = this.route.snapshot.queryParamMap.get('incognitoMode') === 'true';
+    
+    const readingListId = this.route.snapshot.queryParamMap.get('readingListId');
+    console.log('reading list id: ', readingListId);
+    if (readingListId != null) {
+      this.readingListMode = true;
+      this.readingListId = parseInt(readingListId, 10);
+    }
+    
 
     this.continuousChaptersStack.push(this.chapterId);
 
@@ -387,7 +403,7 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
         this.bookmarks[bookmark.page] = 1;
       });
 
-      this.readerService.getNextChapter(this.seriesId, this.volumeId, this.chapterId).pipe(take(1)).subscribe(chapterId => {
+      this.readerService.getNextChapter(this.seriesId, this.volumeId, this.chapterId, this.readingListId).pipe(take(1)).subscribe(chapterId => {
         this.nextChapterId = chapterId;
         if (chapterId === CHAPTER_ID_DOESNT_EXIST || chapterId === this.chapterId) {
           this.nextChapterDisabled = true;
@@ -674,7 +690,7 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
     if (this.nextPageDisabled) { return; }
     this.isLoading = true;
     if (this.nextChapterId === CHAPTER_ID_NOT_FETCHED || this.nextChapterId === this.chapterId) {
-      this.readerService.getNextChapter(this.seriesId, this.volumeId, this.chapterId).pipe(take(1)).subscribe(chapterId => {
+      this.readerService.getNextChapter(this.seriesId, this.volumeId, this.chapterId, this.readingListId).pipe(take(1)).subscribe(chapterId => {
         this.nextChapterId = chapterId;
         this.loadChapter(chapterId, 'next');
       });

--- a/UI/Web/src/app/manga-reader/manga-reader.component.ts
+++ b/UI/Web/src/app/manga-reader/manga-reader.component.ts
@@ -409,7 +409,7 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
           this.nextChapterDisabled = true;
         }
       });
-      this.readerService.getPrevChapter(this.seriesId, this.volumeId, this.chapterId).pipe(take(1)).subscribe(chapterId => {
+      this.readerService.getPrevChapter(this.seriesId, this.volumeId, this.chapterId, this.readingListId).pipe(take(1)).subscribe(chapterId => {
         this.prevChapterId = chapterId;
         if (chapterId === CHAPTER_ID_DOESNT_EXIST || chapterId === this.chapterId) {
           this.prevChapterDisabled = true;
@@ -713,7 +713,7 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
     }
 
     if (this.prevChapterId === CHAPTER_ID_NOT_FETCHED || this.prevChapterId === this.chapterId) {
-      this.readerService.getPrevChapter(this.seriesId, this.volumeId, this.chapterId).pipe(take(1)).subscribe(chapterId => {
+      this.readerService.getPrevChapter(this.seriesId, this.volumeId, this.chapterId, this.readingListId).pipe(take(1)).subscribe(chapterId => {
         this.prevChapterId = chapterId;
         this.loadChapter(chapterId, 'prev');
       });

--- a/UI/Web/src/app/manga-reader/manga-reader.component.ts
+++ b/UI/Web/src/app/manga-reader/manga-reader.component.ts
@@ -22,6 +22,7 @@ import { ChapterInfo } from './_models/chapter-info';
 import { COLOR_FILTER, FITTING_OPTION, PAGING_DIRECTION, SPLIT_PAGE_PART } from './_models/reader-enums';
 import { Preferences, scalingOptions } from '../_models/preferences/preferences';
 import { READER_MODE } from '../_models/preferences/reader-mode';
+import { MangaFormat } from '../_models/manga-format';
 
 const PREFETCH_PAGES = 5;
 
@@ -380,6 +381,14 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       chapterInfo: this.readerService.getChapterInfo(this.seriesId, this.chapterId),
       bookmarks: this.readerService.getBookmarks(this.chapterId)
     }).pipe(take(1)).subscribe(results => {
+
+      if (this.readingListMode && results.chapterInfo.seriesFormat === MangaFormat.EPUB) {
+        // Redirect to the book reader. 
+        const params = this.readerService.getQueryParamsObject(this.incognitoMode, this.readingListMode, this.readingListId);
+        this.router.navigate(['library', results.chapterInfo.libraryId, 'series', results.chapterInfo.seriesId, 'book', this.chapterId], {queryParams: params});
+        return;
+      }
+
       this.volumeId = results.chapterInfo.volumeId;
       this.maxPages = results.chapterInfo.pages;
 

--- a/UI/Web/src/app/manga-reader/manga-reader.component.ts
+++ b/UI/Web/src/app/manga-reader/manga-reader.component.ts
@@ -275,7 +275,6 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
     this.incognitoMode = this.route.snapshot.queryParamMap.get('incognitoMode') === 'true';
     
     const readingListId = this.route.snapshot.queryParamMap.get('readingListId');
-    console.log('reading list id: ', readingListId);
     if (readingListId != null) {
       this.readingListMode = true;
       this.readingListId = parseInt(readingListId, 10);
@@ -731,6 +730,13 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       let newRoute = this.router.url.substring(0, lastSlashIndex + 1) + this.chapterId + '';
       if (this.incognitoMode) {
         newRoute += '?incognitoMode=true';
+      }
+      if (this.readingListMode) {
+        if (newRoute.indexOf('?') > 0) {
+          newRoute += '&readingListId=' + this.readingListId;
+        } else {
+          newRoute += '?readingListId=' + this.readingListId;
+        }
       }
       window.history.replaceState({}, '', newRoute);
       this.init();

--- a/UI/Web/src/app/manga-reader/manga-reader.component.ts
+++ b/UI/Web/src/app/manga-reader/manga-reader.component.ts
@@ -726,18 +726,7 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       this.chapterId = chapterId;
       this.continuousChaptersStack.push(chapterId); 
       // Load chapter Id onto route but don't reload
-      const lastSlashIndex = this.router.url.lastIndexOf('/');
-      let newRoute = this.router.url.substring(0, lastSlashIndex + 1) + this.chapterId + '';
-      if (this.incognitoMode) {
-        newRoute += '?incognitoMode=true';
-      }
-      if (this.readingListMode) {
-        if (newRoute.indexOf('?') > 0) {
-          newRoute += '&readingListId=' + this.readingListId;
-        } else {
-          newRoute += '?readingListId=' + this.readingListId;
-        }
-      }
+      const newRoute = this.readerService.getNextChapterUrl(this.router.url, this.chapterId, this.incognitoMode, this.readingListMode, this.readingListId);
       window.history.replaceState({}, '', newRoute);
       this.init();
     } else {
@@ -756,7 +745,6 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
   renderPage() {
     if (this.ctx && this.canvas) {
       this.canvasImage.onload = null;
-      //this.ctx.imageSmoothingEnabled = true;
       this.canvas.nativeElement.width = this.canvasImage.width;
       this.canvas.nativeElement.height = this.canvasImage.height;
       const needsSplitting = this.canvasImage.width > this.canvasImage.height;

--- a/UI/Web/src/app/manga-reader/manga-reader.router.module.ts
+++ b/UI/Web/src/app/manga-reader/manga-reader.router.module.ts
@@ -6,7 +6,12 @@ const routes: Routes = [
   {
       path: ':chapterId',
       component: MangaReaderComponent
-  }
+  },
+  {
+    // This will allow the MangaReader to have a list to use for next/prev chapters rather than natural sort order
+    path: ':chapterId/list/:listId',
+    component: MangaReaderComponent
+}
 ];
 
 

--- a/UI/Web/src/app/nav-header/nav-header.component.ts
+++ b/UI/Web/src/app/nav-header/nav-header.component.ts
@@ -72,7 +72,7 @@ export class NavHeaderComponent implements OnInit, OnDestroy {
 
   onChangeSearch(val: string) {
       this.isLoading = true;
-      this.searchTerm = val;
+      this.searchTerm = val.trim();
       this.libraryService.search(val).pipe(takeUntil(this.onDestroy)).subscribe(results => {
         this.searchResults = results;
         this.isLoading = false;

--- a/UI/Web/src/app/reading-list/_modals/add-to-list-modal/add-to-list-modal.component.html
+++ b/UI/Web/src/app/reading-list/_modals/add-to-list-modal/add-to-list-modal.component.html
@@ -6,14 +6,31 @@
     </button>
 </div>
 <div class="modal-body">
+
     <ul class="list-group">
-        <li class="list-group-item" *ngFor="let readingList of lists; let i = index">
+        <li class="list-group-item" *ngFor="let readingList of lists; let i = index" (click)="addToList(readingList)">
             
+        </li>
+        <li class="list-group-item" *ngIf="lists.length === 0 && !loading">No lists created yet</li>
+        <li class="list-group-item" *ngIf="loading">
+            <div class="spinner-border text-secondary" role="status">
+                <span>Loading...</span>
+            </div>
         </li>
     </ul>
 </div>
-<div class="modal-footer">
-    <label class="sr-only" for="add-rlist">Reading List</label>
-    <input width="100%" type="text" id="add-rlist">
-    <button type="button" class="btn btn-primary" (click)="close()">Add</button>
+<div class="modal-footer" style="justify-content: normal">
+    <form style="width: 100%">
+        <div class="form-row">
+          <div class="col-md-10">
+            <label class="sr-only" for="add-rlist">Reading List</label>
+            <input width="100%" type="text" class="form-control mb-2" id="add-rlist">
+          </div>
+          <div class="col-md-2">
+            <button type="submit" class="btn btn-primary" (click)="close()">Create</button>
+          </div>
+        </div>
+    </form>
 </div>
+
+

--- a/UI/Web/src/app/reading-list/_modals/add-to-list-modal/add-to-list-modal.component.html
+++ b/UI/Web/src/app/reading-list/_modals/add-to-list-modal/add-to-list-modal.component.html
@@ -1,0 +1,19 @@
+
+<div class="modal-header">
+    <h4 class="modal-title" id="modal-basic-title">Add to Reading List</h4>
+    <button type="button" class="close" aria-label="Close" (click)="close()">
+    <span aria-hidden="true">&times;</span>
+    </button>
+</div>
+<div class="modal-body">
+    <ul class="list-group">
+        <li class="list-group-item" *ngFor="let readingList of lists; let i = index">
+            
+        </li>
+    </ul>
+</div>
+<div class="modal-footer">
+    <label class="sr-only" for="add-rlist">Reading List</label>
+    <input width="100%" type="text" id="add-rlist">
+    <button type="button" class="btn btn-primary" (click)="close()">Add</button>
+</div>

--- a/UI/Web/src/app/reading-list/_modals/add-to-list-modal/add-to-list-modal.component.html
+++ b/UI/Web/src/app/reading-list/_modals/add-to-list-modal/add-to-list-modal.component.html
@@ -6,7 +6,7 @@
     </button>
 </div>
 <div class="modal-body">
-
+    <!-- TODO: Put filter here -->
     <ul class="list-group">
         <li class="list-group-item clickable" tabindex="0" role="button" *ngFor="let readingList of lists; let i = index" (click)="addToList(readingList)">
             <!-- Think about using radio buttons maybe for screen reader-->

--- a/UI/Web/src/app/reading-list/_modals/add-to-list-modal/add-to-list-modal.component.html
+++ b/UI/Web/src/app/reading-list/_modals/add-to-list-modal/add-to-list-modal.component.html
@@ -8,7 +8,7 @@
 <div class="modal-body">
 
     <ul class="list-group">
-        <li class="list-group-item" *ngFor="let readingList of lists; let i = index" (click)="addToList(readingList)">
+        <li class="list-group-item clickable" tabindex="0" role="button" *ngFor="let readingList of lists; let i = index" (click)="addToList(readingList)">
             <!-- Think about using radio buttons maybe for screen reader-->
             {{readingList.title}} <i class="fa fa-angle-double-up" *ngIf="readingList.promoted" title="Promoted"></i>
         </li>

--- a/UI/Web/src/app/reading-list/_modals/add-to-list-modal/add-to-list-modal.component.html
+++ b/UI/Web/src/app/reading-list/_modals/add-to-list-modal/add-to-list-modal.component.html
@@ -10,7 +10,7 @@
     <ul class="list-group">
         <li class="list-group-item" *ngFor="let readingList of lists; let i = index" (click)="addToList(readingList)">
             <!-- Think about using radio buttons maybe for screen reader-->
-            {{readingList.title}}
+            {{readingList.title}} <i class="fa fa-angle-double-up" *ngIf="readingList.promoted" title="Promoted"></i>
         </li>
         <li class="list-group-item" *ngIf="lists.length === 0 && !loading">No lists created yet</li>
         <li class="list-group-item" *ngIf="loading">

--- a/UI/Web/src/app/reading-list/_modals/add-to-list-modal/add-to-list-modal.component.html
+++ b/UI/Web/src/app/reading-list/_modals/add-to-list-modal/add-to-list-modal.component.html
@@ -9,25 +9,26 @@
 
     <ul class="list-group">
         <li class="list-group-item" *ngFor="let readingList of lists; let i = index" (click)="addToList(readingList)">
-            
+            <!-- Think about using radio buttons maybe for screen reader-->
+            {{readingList.title}}
         </li>
         <li class="list-group-item" *ngIf="lists.length === 0 && !loading">No lists created yet</li>
         <li class="list-group-item" *ngIf="loading">
             <div class="spinner-border text-secondary" role="status">
-                <span>Loading...</span>
+                <span class="sr-only">Loading...</span>
             </div>
         </li>
     </ul>
 </div>
 <div class="modal-footer" style="justify-content: normal">
-    <form style="width: 100%">
+    <form style="width: 100%" [formGroup]="listForm">
         <div class="form-row">
           <div class="col-md-10">
             <label class="sr-only" for="add-rlist">Reading List</label>
-            <input width="100%" type="text" class="form-control mb-2" id="add-rlist">
+            <input width="100%" #title ngbAutofocus type="text" class="form-control mb-2" id="add-rlist" formControlName="title">
           </div>
           <div class="col-md-2">
-            <button type="submit" class="btn btn-primary" (click)="close()">Create</button>
+            <button type="submit" class="btn btn-primary" (click)="create()">Create</button>
           </div>
         </div>
     </form>

--- a/UI/Web/src/app/reading-list/_modals/add-to-list-modal/add-to-list-modal.component.scss
+++ b/UI/Web/src/app/reading-list/_modals/add-to-list-modal/add-to-list-modal.component.scss
@@ -1,0 +1,7 @@
+.clickable {
+    cursor: pointer;
+}
+
+.clickable:hover, .clickable:focus {
+    background-color: lightgreen;
+}

--- a/UI/Web/src/app/reading-list/_modals/add-to-list-modal/add-to-list-modal.component.ts
+++ b/UI/Web/src/app/reading-list/_modals/add-to-list-modal/add-to-list-modal.component.ts
@@ -44,7 +44,7 @@ export class AddToListModalComponent implements OnInit, AfterViewInit {
     
     this.loading = true;
     this.readingListService.getReadingLists(false).subscribe(lists => {
-      this.lists = lists;
+      this.lists = lists.result;
       this.loading = false;
     });
 

--- a/UI/Web/src/app/reading-list/_modals/add-to-list-modal/add-to-list-modal.component.ts
+++ b/UI/Web/src/app/reading-list/_modals/add-to-list-modal/add-to-list-modal.component.ts
@@ -1,36 +1,74 @@
-import { Component, OnInit } from '@angular/core';
+import { AfterViewInit, Component, ElementRef, Input, OnInit, ViewChild } from '@angular/core';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
+import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { ReadingList } from 'src/app/_models/reading-list';
 import { ReadingListService } from 'src/app/_services/reading-list.service';
+
+export enum ADD_FLOW {
+  Series = 0,
+  Volume = 1,
+  Chapter = 2
+}
 
 @Component({
   selector: 'app-add-to-list-modal',
   templateUrl: './add-to-list-modal.component.html',
   styleUrls: ['./add-to-list-modal.component.scss']
 })
-export class AddToListModalComponent implements OnInit {
+export class AddToListModalComponent implements OnInit, AfterViewInit {
+
+  @Input() title!: string;
+  @Input() seriesId?: number;
+  @Input() volumeId?: number;
+  @Input() chapterId?: number;
+  /**
+   * Determines which Input is required and which API is used to associate to the Reading List
+   */
+  @Input() type!: ADD_FLOW;
 
   /**
    * All existing reading lists sorted by recent use date
    */
   lists: Array<any> = [];
   loading: boolean = false;
+  listForm: FormGroup = new FormGroup({});
 
-  constructor(private readingListService: ReadingListService) { }
+  @ViewChild('title') inputElem!: ElementRef<HTMLInputElement>;
+
+
+  constructor(private modal: NgbActiveModal, private readingListService: ReadingListService) { }
 
   ngOnInit(): void {
+
+    this.listForm.addControl('title', new FormControl(this.title, []));
+    
     this.loading = true;
     this.readingListService.getReadingLists(false).subscribe(lists => {
       this.lists = lists;
       this.loading = false;
     });
+
+    
+  }
+
+  ngAfterViewInit() {
+    // Shift focus to input
+    if (this.inputElem) {
+      this.inputElem.nativeElement.select();
+    }
   }
 
   close() {
+    this.modal.close();
+  }
 
+  create() {
+
+    this.modal.close();
   }
 
   addToList(readingList: ReadingList) {
-
+    this.modal.close();
   }
 
 }

--- a/UI/Web/src/app/reading-list/_modals/add-to-list-modal/add-to-list-modal.component.ts
+++ b/UI/Web/src/app/reading-list/_modals/add-to-list-modal/add-to-list-modal.component.ts
@@ -1,0 +1,24 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-add-to-list-modal',
+  templateUrl: './add-to-list-modal.component.html',
+  styleUrls: ['./add-to-list-modal.component.scss']
+})
+export class AddToListModalComponent implements OnInit {
+
+  /**
+   * All existing reading lists sorted by recent use date
+   */
+  lists: Array<any> = [];
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+  close() {
+
+  }
+
+}

--- a/UI/Web/src/app/reading-list/_modals/add-to-list-modal/add-to-list-modal.component.ts
+++ b/UI/Web/src/app/reading-list/_modals/add-to-list-modal/add-to-list-modal.component.ts
@@ -69,8 +69,18 @@ export class AddToListModalComponent implements OnInit, AfterViewInit {
   }
 
   addToList(readingList: ReadingList) {
-    if (this.type === ADD_FLOW.Series && this.seriesId != undefined) {
+    if (this.seriesId === undefined) return;
+
+    if (this.type === ADD_FLOW.Series) {
       this.readingListService.updateBySeries(readingList.id, this.seriesId).subscribe(() => {
+        this.modal.close();
+      });
+    } else if (this.type === ADD_FLOW.Volume && this.volumeId !== undefined) {
+      this.readingListService.updateByVolume(readingList.id, this.seriesId, this.volumeId).subscribe(() => {
+        this.modal.close();
+      });
+    } else if (this.type === ADD_FLOW.Chapter && this.chapterId !== undefined) {
+      this.readingListService.updateByChapter(readingList.id, this.seriesId, this.chapterId).subscribe(() => {
         this.modal.close();
       });
     }

--- a/UI/Web/src/app/reading-list/_modals/add-to-list-modal/add-to-list-modal.component.ts
+++ b/UI/Web/src/app/reading-list/_modals/add-to-list-modal/add-to-list-modal.component.ts
@@ -1,4 +1,6 @@
 import { Component, OnInit } from '@angular/core';
+import { ReadingList } from 'src/app/_models/reading-list';
+import { ReadingListService } from 'src/app/_services/reading-list.service';
 
 @Component({
   selector: 'app-add-to-list-modal',
@@ -11,13 +13,23 @@ export class AddToListModalComponent implements OnInit {
    * All existing reading lists sorted by recent use date
    */
   lists: Array<any> = [];
+  loading: boolean = false;
 
-  constructor() { }
+  constructor(private readingListService: ReadingListService) { }
 
   ngOnInit(): void {
+    this.loading = true;
+    this.readingListService.getReadingLists(false).subscribe(lists => {
+      this.lists = lists;
+      this.loading = false;
+    });
   }
 
   close() {
+
+  }
+
+  addToList(readingList: ReadingList) {
 
   }
 

--- a/UI/Web/src/app/reading-list/_modals/add-to-list-modal/add-to-list-modal.component.ts
+++ b/UI/Web/src/app/reading-list/_modals/add-to-list-modal/add-to-list-modal.component.ts
@@ -63,12 +63,18 @@ export class AddToListModalComponent implements OnInit, AfterViewInit {
   }
 
   create() {
-
-    this.modal.close();
+    this.readingListService.createList(this.listForm.value.title).subscribe(list => {
+      this.addToList(list);
+    });
   }
 
   addToList(readingList: ReadingList) {
-    this.modal.close();
+    if (this.type === ADD_FLOW.Series && this.seriesId != undefined) {
+      this.readingListService.updateBySeries(readingList.id, this.seriesId).subscribe(() => {
+        this.modal.close();
+      });
+    }
+    
   }
 
 }

--- a/UI/Web/src/app/reading-list/_modals/edit-reading-list-modal/edit-reading-list-modal.component.html
+++ b/UI/Web/src/app/reading-list/_modals/edit-reading-list-modal/edit-reading-list-modal.component.html
@@ -6,6 +6,10 @@
     </button>
 </div>
 <div class="modal-body">
+    <p>
+        This list is currently {{readingList?.promoted ? 'promoted' : 'not promoted'}} (<i class="fa fa-angle-double-up" aria-hidden="true"></i>). 
+        Promotion means that the list can be seen server-wide, not just for admin users. All series that are within this list will still have user-access restrictions placed on them.
+    </p>
     <form [formGroup]="reviewGroup">
         <div class="form-group">
             <label for="title">Name</label>
@@ -20,6 +24,7 @@
 </div>
 <div class="modal-footer">
     <button type="button" class="btn btn-secondary" (click)="close()">Close</button>
+    <button type="button" class="btn btn-info" (click)="togglePromotion()">{{readingList.promoted ? 'Demote' : 'Promote'}}</button>
     <button type="submit" class="btn btn-primary" [disabled]="reviewGroup.get('title')?.value.trim().length === 0" (click)="save()">Save</button>
 </div>
 

--- a/UI/Web/src/app/reading-list/_modals/edit-reading-list-modal/edit-reading-list-modal.component.html
+++ b/UI/Web/src/app/reading-list/_modals/edit-reading-list-modal/edit-reading-list-modal.component.html
@@ -1,0 +1,26 @@
+
+<div class="modal-header">
+    <h4 class="modal-title" id="modal-basic-title">Edit {{readingList.title}} Reading List</h4>
+    <button type="button" class="close" aria-label="Close" (click)="close()">
+    <span aria-hidden="true">&times;</span>
+    </button>
+</div>
+<div class="modal-body">
+    <form [formGroup]="reviewGroup">
+        <div class="form-group">
+            <label for="title">Name</label>
+            <input id="title" class="form-control" formControlName="title" type="text">
+        </div>
+
+        <div class="form-group">
+            <label for="summary">Summary</label>
+            <textarea id="summary" class="form-control" formControlName="summary" rows="3"></textarea>
+        </div>
+    </form>
+</div>
+<div class="modal-footer">
+    <button type="button" class="btn btn-secondary" (click)="close()">Close</button>
+    <button type="submit" class="btn btn-primary" [disabled]="reviewGroup.get('title')?.value.trim().length === 0" (click)="save()">Save</button>
+</div>
+
+

--- a/UI/Web/src/app/reading-list/_modals/edit-reading-list-modal/edit-reading-list-modal.component.ts
+++ b/UI/Web/src/app/reading-list/_modals/edit-reading-list-modal/edit-reading-list-modal.component.ts
@@ -1,0 +1,35 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { FormGroup, FormControl, Validators } from '@angular/forms';
+import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
+import { ReadingList } from 'src/app/_models/reading-list';
+
+@Component({
+  selector: 'app-edit-reading-list-modal',
+  templateUrl: './edit-reading-list-modal.component.html',
+  styleUrls: ['./edit-reading-list-modal.component.scss']
+})
+export class EditReadingListModalComponent implements OnInit {
+
+  @Input() readingList!: ReadingList;
+  reviewGroup!: FormGroup;
+
+  constructor(private ngModal: NgbActiveModal) { }
+
+  ngOnInit(): void {
+    this.reviewGroup = new FormGroup({
+      title: new FormControl(this.readingList.title, [Validators.required]),
+      summary: new FormControl(this.readingList.summary, [])
+    });
+  }
+
+  close() {
+    this.ngModal.dismiss(undefined);
+  }
+
+  save() {
+    if (this.reviewGroup.value.title.trim() === '') return;
+    
+    this.ngModal.close(this.readingList);
+  }
+
+}

--- a/UI/Web/src/app/reading-list/_modals/edit-reading-list-modal/edit-reading-list-modal.component.ts
+++ b/UI/Web/src/app/reading-list/_modals/edit-reading-list-modal/edit-reading-list-modal.component.ts
@@ -2,6 +2,7 @@ import { Component, Input, OnInit } from '@angular/core';
 import { FormGroup, FormControl, Validators } from '@angular/forms';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { ReadingList } from 'src/app/_models/reading-list';
+import { ReadingListService } from 'src/app/_services/reading-list.service';
 
 @Component({
   selector: 'app-edit-reading-list-modal',
@@ -13,7 +14,7 @@ export class EditReadingListModalComponent implements OnInit {
   @Input() readingList!: ReadingList;
   reviewGroup!: FormGroup;
 
-  constructor(private ngModal: NgbActiveModal) { }
+  constructor(private ngModal: NgbActiveModal, private readingListService: ReadingListService) { }
 
   ngOnInit(): void {
     this.reviewGroup = new FormGroup({
@@ -28,8 +29,24 @@ export class EditReadingListModalComponent implements OnInit {
 
   save() {
     if (this.reviewGroup.value.title.trim() === '') return;
-    
-    this.ngModal.close(this.readingList);
+    const model = {...this.reviewGroup.value, readingListId: this.readingList.id, promoted: this.readingList.promoted};
+
+    this.readingListService.update(model).subscribe(() => {
+      this.readingList.title = model.title;
+      this.readingList.summary = model.summary;
+      this.ngModal.close(this.readingList);
+    });
+  }
+
+  togglePromotion() {
+    const originalPromotion = this.readingList.promoted;
+    this.readingList.promoted = !this.readingList.promoted;
+    const model = {readingListId: this.readingList.id, promoted: this.readingList.promoted};
+    this.readingListService.update(model).subscribe(res => {
+      /* No Operation */
+    }, err => {
+      this.readingList.promoted = originalPromotion;
+    });
   }
 
 }

--- a/UI/Web/src/app/reading-list/dragable-ordered-list/dragable-ordered-list.component.html
+++ b/UI/Web/src/app/reading-list/dragable-ordered-list/dragable-ordered-list.component.html
@@ -1,4 +1,4 @@
-<div cdkDropList class="example-list" (cdkDropListDropped)="drop($event)">
+<div cdkDropList class="{{items.length > 0 ? 'example-list' : ''}}" (cdkDropListDropped)="drop($event)">
     <div class="example-box" *ngFor="let item of items; index as i" cdkDrag [cdkDragData]="item" cdkDragBoundary=".example-list">
         <div>
             <i class="fa fa-grip-vertical drag-handle" aria-hidden="true" cdkDragHandle></i>

--- a/UI/Web/src/app/reading-list/dragable-ordered-list/dragable-ordered-list.component.html
+++ b/UI/Web/src/app/reading-list/dragable-ordered-list/dragable-ordered-list.component.html
@@ -3,7 +3,7 @@
         <div>
             <i class="fa fa-grip-vertical drag-handle" aria-hidden="true" cdkDragHandle></i>
             <label for="reorder-{{i}}" class="sr-only">Reorder</label>
-            <input id="reorder-{{i}}" type="number" [value]="i" style="width: 40px" (keydown.enter)="updateIndex(i)" aria-describedby="instructions">
+            <input id="reorder-{{i}}" type="number" [value]="i" style="width: 40px" (keydown.enter)="updateIndex(i, item)" aria-describedby="instructions">
         </div>
 
         <ng-container  style="display: inline-block" [ngTemplateOutlet]="itemTemplate" [ngTemplateOutletContext]="{ $implicit: item, idx: i }"></ng-container>

--- a/UI/Web/src/app/reading-list/dragable-ordered-list/dragable-ordered-list.component.html
+++ b/UI/Web/src/app/reading-list/dragable-ordered-list/dragable-ordered-list.component.html
@@ -1,0 +1,12 @@
+<div cdkDropList class="example-list" (cdkDropListDropped)="drop($event)">
+    <div class="example-box" *ngFor="let item of items; index as i" cdkDrag [cdkDragData]="item" cdkDragBoundary=".example-list">
+        <div>
+            <i class="fa fa-grip-vertical drag-handle" aria-hidden="true" cdkDragHandle></i>
+            <label for="reorder-{{i}}" class="sr-only">Reorder</label>
+            <input id="reorder-{{i}}" type="number" [value]="i" style="width: 40px" (keydown.enter)="updateIndex(i)">
+        </div>
+
+        <ng-container  style="display: inline-block" [ngTemplateOutlet]="itemTemplate" [ngTemplateOutletContext]="{ $implicit: item, idx: i }"></ng-container>
+    </div>
+</div>
+  

--- a/UI/Web/src/app/reading-list/dragable-ordered-list/dragable-ordered-list.component.html
+++ b/UI/Web/src/app/reading-list/dragable-ordered-list/dragable-ordered-list.component.html
@@ -3,7 +3,7 @@
         <div>
             <i class="fa fa-grip-vertical drag-handle" aria-hidden="true" cdkDragHandle></i>
             <label for="reorder-{{i}}" class="sr-only">Reorder</label>
-            <input id="reorder-{{i}}" type="number" [value]="i" style="width: 40px" (keydown.enter)="updateIndex(i, item)" aria-describedby="instructions">
+            <input id="reorder-{{i}}" type="number" min="0" [max]="items.length - 1" [value]="i" style="width: 40px" (keydown.enter)="updateIndex(i, item)" aria-describedby="instructions">
         </div>
 
         <ng-container  style="display: inline-block" [ngTemplateOutlet]="itemTemplate" [ngTemplateOutletContext]="{ $implicit: item, idx: i }"></ng-container>

--- a/UI/Web/src/app/reading-list/dragable-ordered-list/dragable-ordered-list.component.html
+++ b/UI/Web/src/app/reading-list/dragable-ordered-list/dragable-ordered-list.component.html
@@ -1,9 +1,9 @@
-<div cdkDropList class="{{items.length > 0 ? 'example-list' : ''}}" (cdkDropListDropped)="drop($event)">
+<div cdkDropList class="{{items.length > 0 ? 'example-list list-group-flush' : ''}}" (cdkDropListDropped)="drop($event)">
     <div class="example-box" *ngFor="let item of items; index as i" cdkDrag [cdkDragData]="item" cdkDragBoundary=".example-list">
-        <div>
+        <div class="mr-3 align-middle">
             <i class="fa fa-grip-vertical drag-handle" aria-hidden="true" cdkDragHandle></i>
             <label for="reorder-{{i}}" class="sr-only">Reorder</label>
-            <input id="reorder-{{i}}" type="number" min="0" [max]="items.length - 1" [value]="i" style="width: 40px" (keydown.enter)="updateIndex(i, item)" aria-describedby="instructions">
+            <input *ngIf="accessibilityMode" id="reorder-{{i}}" type="number" min="0" [max]="items.length - 1" [value]="i" style="width: 40px" (keydown.enter)="updateIndex(i, item)" aria-describedby="instructions">
         </div>
 
         <ng-container  style="display: inline-block" [ngTemplateOutlet]="itemTemplate" [ngTemplateOutletContext]="{ $implicit: item, idx: i }"></ng-container>

--- a/UI/Web/src/app/reading-list/dragable-ordered-list/dragable-ordered-list.component.html
+++ b/UI/Web/src/app/reading-list/dragable-ordered-list/dragable-ordered-list.component.html
@@ -7,6 +7,11 @@
         </div>
 
         <ng-container  style="display: inline-block" [ngTemplateOutlet]="itemTemplate" [ngTemplateOutletContext]="{ $implicit: item, idx: i }"></ng-container>
+
+        <button class="btn btn-icon pull-right" (click)="removeItem(item, i)">
+            <i class="fa fa-times" aria-hidden="true"></i>
+            <span class="sr-only" attr.aria-labelledby="item.id--{{i}}">Remove item</span>
+          </button>
     </div>
 </div>
 

--- a/UI/Web/src/app/reading-list/dragable-ordered-list/dragable-ordered-list.component.html
+++ b/UI/Web/src/app/reading-list/dragable-ordered-list/dragable-ordered-list.component.html
@@ -3,10 +3,13 @@
         <div>
             <i class="fa fa-grip-vertical drag-handle" aria-hidden="true" cdkDragHandle></i>
             <label for="reorder-{{i}}" class="sr-only">Reorder</label>
-            <input id="reorder-{{i}}" type="number" [value]="i" style="width: 40px" (keydown.enter)="updateIndex(i)">
+            <input id="reorder-{{i}}" type="number" [value]="i" style="width: 40px" (keydown.enter)="updateIndex(i)" aria-describedby="instructions">
         </div>
 
         <ng-container  style="display: inline-block" [ngTemplateOutlet]="itemTemplate" [ngTemplateOutletContext]="{ $implicit: item, idx: i }"></ng-container>
     </div>
 </div>
-  
+
+<p class="sr-only" id="instructions">
+
+</p>

--- a/UI/Web/src/app/reading-list/dragable-ordered-list/dragable-ordered-list.component.scss
+++ b/UI/Web/src/app/reading-list/dragable-ordered-list/dragable-ordered-list.component.scss
@@ -1,5 +1,5 @@
 .example-list {
-    width: 500px;
+    min-width: 500px;
     max-width: 100%;
     border: solid 1px #ccc;
     min-height: 60px;
@@ -23,6 +23,7 @@
 
     .drag-handle {
         cursor: move;
+        font-size: 24px;
     }
   }
   

--- a/UI/Web/src/app/reading-list/dragable-ordered-list/dragable-ordered-list.component.scss
+++ b/UI/Web/src/app/reading-list/dragable-ordered-list/dragable-ordered-list.component.scss
@@ -1,7 +1,7 @@
 .example-list {
     min-width: 500px;
     max-width: 100%;
-    border: solid 1px #ccc;
+    //border: solid 1px #ccc;
     min-height: 60px;
     display: block;
     //background: white;
@@ -24,6 +24,7 @@
     .drag-handle {
         cursor: move;
         font-size: 24px;
+        margin-top: 215%;
     }
   }
   

--- a/UI/Web/src/app/reading-list/dragable-ordered-list/dragable-ordered-list.component.scss
+++ b/UI/Web/src/app/reading-list/dragable-ordered-list/dragable-ordered-list.component.scss
@@ -1,0 +1,51 @@
+.example-list {
+    width: 500px;
+    max-width: 100%;
+    border: solid 1px #ccc;
+    min-height: 60px;
+    display: block;
+    //background: white;
+    border-radius: 4px;
+    overflow: hidden;
+  }
+  
+  .example-box {
+    padding: 20px 10px;
+    border-bottom: solid 1px #ccc;
+    //color: rgba(0, 0, 0, 0.87);
+    display: flex;
+    flex-direction: row;
+    //align-items: center;
+    //justify-content: space-between;
+    box-sizing: border-box;
+    //background: white;
+    font-size: 14px;
+
+    .drag-handle {
+        cursor: move;
+    }
+  }
+  
+  .cdk-drag-preview {
+    box-sizing: border-box;
+    border-radius: 4px;
+    box-shadow: 0 5px 5px -3px rgba(0, 0, 0, 0.2),
+                0 8px 10px 1px rgba(0, 0, 0, 0.14),
+                0 3px 14px 2px rgba(0, 0, 0, 0.12);
+  }
+  
+  .cdk-drag-placeholder {
+    opacity: 0;
+  }
+  
+  .cdk-drag-animating {
+    transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
+  }
+  
+  .example-box:last-child {
+    border: none;
+  }
+  
+  .example-list.cdk-drop-list-dragging .example-box:not(.cdk-drag-placeholder) {
+    transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
+  }

--- a/UI/Web/src/app/reading-list/dragable-ordered-list/dragable-ordered-list.component.ts
+++ b/UI/Web/src/app/reading-list/dragable-ordered-list/dragable-ordered-list.component.ts
@@ -1,5 +1,5 @@
 import { CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
-import { Component, ContentChild, Input, OnInit, TemplateRef } from '@angular/core';
+import { Component, ContentChild, Input, OnInit, Output, TemplateRef } from '@angular/core';
 
 @Component({
   selector: 'app-dragable-ordered-list',
@@ -9,6 +9,7 @@ import { Component, ContentChild, Input, OnInit, TemplateRef } from '@angular/co
 export class DragableOrderedListComponent implements OnInit {
 
   @Input() items: Array<any> = [];
+  //@Output() orderUpdated = 
   @ContentChild('draggableItem') itemTemplate!: TemplateRef<any>;
 
   constructor() { }

--- a/UI/Web/src/app/reading-list/dragable-ordered-list/dragable-ordered-list.component.ts
+++ b/UI/Web/src/app/reading-list/dragable-ordered-list/dragable-ordered-list.component.ts
@@ -7,6 +7,11 @@ export interface IndexUpdateEvent {
   item: any;
 }
 
+export interface ItemRemoveEvent {
+  position: number;
+  item: any;
+}
+
 @Component({
   selector: 'app-dragable-ordered-list',
   templateUrl: './dragable-ordered-list.component.html',
@@ -17,6 +22,7 @@ export class DragableOrderedListComponent implements OnInit {
   @Input() accessibilityMode: boolean = false;
   @Input() items: Array<any> = [];
   @Output() orderUpdated: EventEmitter<IndexUpdateEvent> = new EventEmitter<IndexUpdateEvent>();
+  @Output() itemRemove: EventEmitter<ItemRemoveEvent> = new EventEmitter<ItemRemoveEvent>();
   @ContentChild('draggableItem') itemTemplate!: TemplateRef<any>;
 
   constructor() { }
@@ -44,6 +50,13 @@ export class DragableOrderedListComponent implements OnInit {
       fromPosition: previousIndex,
       toPosition: newIndex,
       item: this.items[newIndex]
+    });
+  }
+
+  removeItem(item: any, position: number) {
+    this.itemRemove.emit({
+      position,
+      item
     });
   }
 

--- a/UI/Web/src/app/reading-list/dragable-ordered-list/dragable-ordered-list.component.ts
+++ b/UI/Web/src/app/reading-list/dragable-ordered-list/dragable-ordered-list.component.ts
@@ -14,6 +14,7 @@ export interface IndexUpdateEvent {
 })
 export class DragableOrderedListComponent implements OnInit {
 
+  @Input() accessibilityMode: boolean = false;
   @Input() items: Array<any> = [];
   @Output() orderUpdated: EventEmitter<IndexUpdateEvent> = new EventEmitter<IndexUpdateEvent>();
   @ContentChild('draggableItem') itemTemplate!: TemplateRef<any>;
@@ -24,6 +25,7 @@ export class DragableOrderedListComponent implements OnInit {
   }
 
   drop(event: CdkDragDrop<string[]>) {
+    if (event.previousIndex === event.currentIndex)  return;
     moveItemInArray(this.items, event.previousIndex, event.currentIndex);
     this.orderUpdated.emit({
       fromPosition: event.previousIndex,
@@ -36,6 +38,7 @@ export class DragableOrderedListComponent implements OnInit {
     // get the new value of the input 
     var inputElem = <HTMLInputElement>document.querySelector('#reorder-' + previousIndex);
     const newIndex = parseInt(inputElem.value, 10);
+    if (previousIndex === newIndex)  return;
     moveItemInArray(this.items, previousIndex, newIndex);
     this.orderUpdated.emit({
       fromPosition: previousIndex,

--- a/UI/Web/src/app/reading-list/dragable-ordered-list/dragable-ordered-list.component.ts
+++ b/UI/Web/src/app/reading-list/dragable-ordered-list/dragable-ordered-list.component.ts
@@ -1,5 +1,11 @@
 import { CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
-import { Component, ContentChild, Input, OnInit, Output, TemplateRef } from '@angular/core';
+import { Component, ContentChild, EventEmitter, Input, OnInit, Output, TemplateRef } from '@angular/core';
+
+export interface IndexUpdateEvent {
+  fromPosition: number;
+  toPosition: number;
+  item: any;
+}
 
 @Component({
   selector: 'app-dragable-ordered-list',
@@ -9,7 +15,7 @@ import { Component, ContentChild, Input, OnInit, Output, TemplateRef } from '@an
 export class DragableOrderedListComponent implements OnInit {
 
   @Input() items: Array<any> = [];
-  //@Output() orderUpdated = 
+  @Output() orderUpdated: EventEmitter<IndexUpdateEvent> = new EventEmitter<IndexUpdateEvent>();
   @ContentChild('draggableItem') itemTemplate!: TemplateRef<any>;
 
   constructor() { }
@@ -19,13 +25,23 @@ export class DragableOrderedListComponent implements OnInit {
 
   drop(event: CdkDragDrop<string[]>) {
     moveItemInArray(this.items, event.previousIndex, event.currentIndex);
+    this.orderUpdated.emit({
+      fromPosition: event.previousIndex,
+      toPosition: event.currentIndex,
+      item: this.items[event.currentIndex]
+    });
   }
 
-  updateIndex(previousIndex: number) {
+  updateIndex(previousIndex: number, item: any) {
     // get the new value of the input 
     var inputElem = <HTMLInputElement>document.querySelector('#reorder-' + previousIndex);
     const newIndex = parseInt(inputElem.value, 10);
     moveItemInArray(this.items, previousIndex, newIndex);
+    this.orderUpdated.emit({
+      fromPosition: previousIndex,
+      toPosition: newIndex,
+      item: this.items[newIndex]
+    });
   }
 
 }

--- a/UI/Web/src/app/reading-list/dragable-ordered-list/dragable-ordered-list.component.ts
+++ b/UI/Web/src/app/reading-list/dragable-ordered-list/dragable-ordered-list.component.ts
@@ -1,0 +1,30 @@
+import { CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
+import { Component, ContentChild, Input, OnInit, TemplateRef } from '@angular/core';
+
+@Component({
+  selector: 'app-dragable-ordered-list',
+  templateUrl: './dragable-ordered-list.component.html',
+  styleUrls: ['./dragable-ordered-list.component.scss']
+})
+export class DragableOrderedListComponent implements OnInit {
+
+  @Input() items: Array<any> = [];
+  @ContentChild('draggableItem') itemTemplate!: TemplateRef<any>;
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+  drop(event: CdkDragDrop<string[]>) {
+    moveItemInArray(this.items, event.previousIndex, event.currentIndex);
+  }
+
+  updateIndex(previousIndex: number) {
+    // get the new value of the input 
+    var inputElem = <HTMLInputElement>document.querySelector('#reorder-' + previousIndex);
+    const newIndex = parseInt(inputElem.value, 10);
+    moveItemInArray(this.items, previousIndex, newIndex);
+  }
+
+}

--- a/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.html
+++ b/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.html
@@ -13,7 +13,7 @@
             </div>
             <div class="row no-gutters">
                 <div>
-                    <button class="btn btn-primary">
+                    <button class="btn btn-primary" (click)="removeRead()">
                         <span>
                             <i class="fa fa-book"></i>
                         </span>

--- a/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.html
+++ b/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.html
@@ -1,15 +1,58 @@
-<div class="container-fluid">
-    <h2>Reading List (name here)</h2>
-    <p>Informaation about how to use controls?</p>
+<div class="container-fluid mt-2" *ngIf="readingList">
+  <div class="row mb-3">
+        <div class="col-md-10 col-xs-8 col-sm-6">
+            <div class="row no-gutters">
+                
+              <h2 style="display: inline-block">
+                <span *ngIf="actions.length > 0">
+                    <app-card-actionables (actionHandler)="performAction($event)" [actions]="actions" [labelBy]="readingList.title"></app-card-actionables>
+                </span>
+                &nbsp;{{readingList.title}}&nbsp;
+                <span class="badge badge-primary badge-pill" attr.aria-label="{{items.length}} total items">{{items.length}}</span>
+              </h2>
+            </div>
+            <div class="row no-gutters">
+                <div>
+                    <button class="btn btn-primary">
+                        <span>
+                            <i class="fa fa-book"></i>
+                        </span>
+                        <span class="read-btn--text">&nbsp;</span>
+                    </button>
+                </div>
+                <div class="ml-2">
+                    <button class="btn btn-secondary" title="Edit Series information">
+                        <span>
+                            <i class="fa fa-pen" aria-hidden="true"></i>
+                        </span>
+                    </button>
+                </div>
+                <!-- <div class="ml-2">
+                    <div class="card-actions">
+                        <app-card-actionables [disabled]="actionInProgress" (actionHandler)="performAction($event)" [actions]="seriesActions" [labelBy]="series.name" iconClass="fa-ellipsis-h" btnClass="btn-secondary"></app-card-actionables>
+                    </div>
+                </div> -->
+            </div>
+            <p>{{readingList.summary}}</p>
+        </div>
+    </div>
 
-    <app-dragable-ordered-list [items]="chapters">
+    <div *ngIf="items.length === 0">
+      No chapters added
+    </div>    
+
+    <app-dragable-ordered-list [items]="items">
         <ng-template #draggableItem let-item let-position="idx">
             <div class="media">
                 <div class="media-body">
-                  <h5 class="mt-0 mb-1">Chapter {{item.chapterNumber}}</h5>
-                  <a href="javascript:void(0)">{{item.seriesName}}</a>
+                  <h5 class="mt-0 mb-1">{{formatTitle(item)}}</h5>
+                  <i class="fa {{utilityService.mangaFormatIcon(item.seriesFormat)}}" aria-hidden="true" *ngIf="item.seriesFormat != MangaFormat.UNKNOWN" title="{{utilityService.mangaFormat(item.seriesFormat)}}"></i><span class="sr-only">{{utilityService.mangaFormat(item.seriesFormat)}}</span>&nbsp;<a href="javascript:void(0)">{{item.seriesName}}</a>
+                  <span *ngIf="item.promoted">
+                    <i class="fa fa-angle-double-up" aria-hidden="true"></i>
+                  </span>
+                  
                 </div>
-                <div *ngIf="item.read"><i class="fa fa-check-square" aria-label="Read"></i></div>
+                <div *ngIf="item.pagesRead === item.totalPages"><i class="fa fa-check-square" aria-label="Read"></i></div>
               </div>
         </ng-template> 
     </app-dragable-ordered-list>

--- a/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.html
+++ b/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.html
@@ -42,7 +42,7 @@
     </div>    
 
     <!-- NOTE: It might be nice to have a switch for the accessibility toggle -->
-    <app-dragable-ordered-list [items]="items" >
+    <app-dragable-ordered-list [items]="items" (orderUpdated)="orderUpdated($event)">
         <ng-template #draggableItem let-item let-position="idx">
             <div class="media">
                 <img width="74px" style="width: 74px;" class="img-top lazyload mr-3" [src]="imageService.placeholderImage" [attr.data-src]="imageService.getChapterCoverImage(item.chapterId)" 

--- a/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.html
+++ b/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.html
@@ -17,7 +17,7 @@
                         <span>
                             <i class="fa fa-book"></i>
                         </span>
-                        <span class="read-btn--text">&nbsp;</span>
+                        <span class="read-btn--text">&nbsp;Remove Read</span>
                     </button>
                 </div>
                 <div class="ml-2">

--- a/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.html
+++ b/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.html
@@ -51,7 +51,7 @@
                 <img width="74px" style="width: 74px;" class="img-top lazyload mr-3" [src]="imageService.placeholderImage" [attr.data-src]="imageService.getChapterCoverImage(item.chapterId)" 
                 (error)="imageService.updateErroredImage($event)">
                 <div class="media-body">
-                  <h5 class="mt-0 mb-1" id="item.id--{{position}}">{{formatTitle(item)}}  ({{item.chapterId}})</h5>
+                  <h5 class="mt-0 mb-1" id="item.id--{{position}}">{{formatTitle(item)}}</h5>
                   <i class="fa {{utilityService.mangaFormatIcon(item.seriesFormat)}}" aria-hidden="true" *ngIf="item.seriesFormat != MangaFormat.UNKNOWN" title="{{utilityService.mangaFormat(item.seriesFormat)}}"></i><span class="sr-only">{{utilityService.mangaFormat(item.seriesFormat)}}</span>&nbsp;
                   <a href="/library/{{item.libraryId}}/series/{{item.seriesId}}">{{item.seriesName}}</a>
                   <span *ngIf="item.promoted">

--- a/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.html
+++ b/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.html
@@ -12,27 +12,20 @@
               </h2>
             </div>
             <div class="row no-gutters">
-                <div>
-                    <button class="btn btn-secondary" (click)="removeRead()">
-                        <span>
-                            <i class="fa fa-check"></i>
-                        </span>
-                        <span class="read-btn--text">&nbsp;Remove Read</span>
-                    </button>
-                </div>
-                <div class="ml-2">
-                    <button class="btn btn-secondary" title="Edit Series information">
-                        <span>
-                            <i class="fa fa-pen" aria-hidden="true"></i>
-                        </span>
-                    </button>
-                </div>
-                <div class="ml-2">
-                  <button class="btn btn-primary" title="Read" (click)="read()">
+              <div class="mr-2">
+                <button class="btn btn-primary" title="Read" (click)="read()">
+                    <span>
+                        <i class="fa fa-book-open" aria-hidden="true"></i>
+                        <span class="read-btn--text">&nbsp;Read</span>
+                    </span>
+                </button>
+              </div>
+              <div>
+                  <button class="btn btn-secondary" (click)="removeRead()">
                       <span>
-                          <i class="fa fa-book-open" aria-hidden="true"></i>
-                          <span class="read-btn--text">&nbsp;Read</span>
+                          <i class="fa fa-check"></i>
                       </span>
+                      <span class="read-btn--text">&nbsp;Remove Read</span>
                   </button>
               </div>
             </div>
@@ -45,9 +38,9 @@
     </div>    
 
     <!-- NOTE: It might be nice to have a switch for the accessibility toggle -->
-    <app-dragable-ordered-list [items]="items" (orderUpdated)="orderUpdated($event)">
+    <app-dragable-ordered-list [items]="items" (orderUpdated)="orderUpdated($event)" (itemRemove)="itemRemoved($event)">
         <ng-template #draggableItem let-item let-position="idx">
-            <div class="media">
+            <div class="media" style="width: 100%;">
                 <img width="74px" style="width: 74px;" class="img-top lazyload mr-3" [src]="imageService.placeholderImage" [attr.data-src]="imageService.getChapterCoverImage(item.chapterId)" 
                 (error)="imageService.updateErroredImage($event)">
                 <div class="media-body">
@@ -57,12 +50,6 @@
                   <span *ngIf="item.promoted">
                     <i class="fa fa-angle-double-up" aria-hidden="true"></i>
                   </span>
-
-                  <button class="btn btn-icon" (click)="removeItem(item, position)">
-                    <i class="fa fa-times" aria-hidden="true"></i>
-                    <span class="sr-only" attr.aria-labelledby="item.id--{{position}}">Remove item</span>
-                  </button>
-                  
                 </div>
                 <div class="pull-right" *ngIf="item.pagesRead === item.pagesTotal"><i class="fa fa-check-square" aria-label="Read"></i></div>
               </div>

--- a/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.html
+++ b/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.html
@@ -27,11 +27,6 @@
                         </span>
                     </button>
                 </div>
-                <!-- <div class="ml-2">
-                    <div class="card-actions">
-                        <app-card-actionables [disabled]="actionInProgress" (actionHandler)="performAction($event)" [actions]="seriesActions" [labelBy]="series.name" iconClass="fa-ellipsis-h" btnClass="btn-secondary"></app-card-actionables>
-                    </div>
-                </div> -->
             </div>
             <p>{{readingList.summary}}</p>
         </div>
@@ -48,12 +43,17 @@
                 <img width="74px" style="width: 74px;" class="img-top lazyload mr-3" [src]="imageService.placeholderImage" [attr.data-src]="imageService.getChapterCoverImage(item.chapterId)" 
                 (error)="imageService.updateErroredImage($event)">
                 <div class="media-body">
-                  <h5 class="mt-0 mb-1">{{formatTitle(item)}}</h5>
+                  <h5 class="mt-0 mb-1" id="item.id--{{position}}">{{formatTitle(item)}}</h5>
                   <i class="fa {{utilityService.mangaFormatIcon(item.seriesFormat)}}" aria-hidden="true" *ngIf="item.seriesFormat != MangaFormat.UNKNOWN" title="{{utilityService.mangaFormat(item.seriesFormat)}}"></i><span class="sr-only">{{utilityService.mangaFormat(item.seriesFormat)}}</span>&nbsp;
                   <a href="/library/{{item.libraryId}}/series/{{item.seriesId}}">{{item.seriesName}}</a>
                   <span *ngIf="item.promoted">
                     <i class="fa fa-angle-double-up" aria-hidden="true"></i>
                   </span>
+
+                  <button class="btn btn-icon" (click)="removeItem(item, position)">
+                    <i class="fa fa-times" aria-hidden="true"></i>
+                    <span class="sr-only" attr.aria-labelledby="item.id--{{position}}">Remove item</span>
+                  </button>
                   
                 </div>
                 <div class="pull-right" *ngIf="item.pagesRead === item.pagesTotal"><i class="fa fa-check-square" aria-label="Read"></i></div>

--- a/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.html
+++ b/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.html
@@ -1,4 +1,4 @@
-<div class="container-fluid mt-2" *ngIf="readingList">
+<div class="container mt-2" *ngIf="readingList">
   <div class="row mb-3">
         <div class="col-md-10 col-xs-8 col-sm-6">
             <div class="row no-gutters">

--- a/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.html
+++ b/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.html
@@ -46,7 +46,8 @@
             <div class="media">
                 <div class="media-body">
                   <h5 class="mt-0 mb-1">{{formatTitle(item)}}</h5>
-                  <i class="fa {{utilityService.mangaFormatIcon(item.seriesFormat)}}" aria-hidden="true" *ngIf="item.seriesFormat != MangaFormat.UNKNOWN" title="{{utilityService.mangaFormat(item.seriesFormat)}}"></i><span class="sr-only">{{utilityService.mangaFormat(item.seriesFormat)}}</span>&nbsp;<a href="javascript:void(0)">{{item.seriesName}}</a>
+                  <i class="fa {{utilityService.mangaFormatIcon(item.seriesFormat)}}" aria-hidden="true" *ngIf="item.seriesFormat != MangaFormat.UNKNOWN" title="{{utilityService.mangaFormat(item.seriesFormat)}}"></i><span class="sr-only">{{utilityService.mangaFormat(item.seriesFormat)}}</span>&nbsp;
+                  <a href="/library/{{item.libraryId}}/series/{{item.seriesId}}">{{item.seriesName}}</a>
                   <span *ngIf="item.promoted">
                     <i class="fa fa-angle-double-up" aria-hidden="true"></i>
                   </span>

--- a/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.html
+++ b/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.html
@@ -51,7 +51,7 @@
                 <img width="74px" style="width: 74px;" class="img-top lazyload mr-3" [src]="imageService.placeholderImage" [attr.data-src]="imageService.getChapterCoverImage(item.chapterId)" 
                 (error)="imageService.updateErroredImage($event)">
                 <div class="media-body">
-                  <h5 class="mt-0 mb-1" id="item.id--{{position}}">{{formatTitle(item)}}</h5>
+                  <h5 class="mt-0 mb-1" id="item.id--{{position}}">{{formatTitle(item)}}  ({{item.chapterId}})</h5>
                   <i class="fa {{utilityService.mangaFormatIcon(item.seriesFormat)}}" aria-hidden="true" *ngIf="item.seriesFormat != MangaFormat.UNKNOWN" title="{{utilityService.mangaFormat(item.seriesFormat)}}"></i><span class="sr-only">{{utilityService.mangaFormat(item.seriesFormat)}}</span>&nbsp;
                   <a href="/library/{{item.libraryId}}/series/{{item.seriesId}}">{{item.seriesName}}</a>
                   <span *ngIf="item.promoted">

--- a/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.html
+++ b/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.html
@@ -1,0 +1,16 @@
+<div class="container-fluid">
+    <h2>Reading List (name here)</h2>
+    <p>Informaation about how to use controls?</p>
+
+    <app-dragable-ordered-list [items]="chapters">
+        <ng-template #draggableItem let-item let-position="idx">
+            <div class="media">
+                <div class="media-body">
+                  <h5 class="mt-0 mb-1">Chapter {{item.chapterNumber}}</h5>
+                  <a href="javascript:void(0)">{{item.seriesName}}</a>
+                </div>
+                <div *ngIf="item.read"><i class="fa fa-check-square" aria-label="Read"></i></div>
+              </div>
+        </ng-template> 
+    </app-dragable-ordered-list>
+</div>

--- a/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.html
+++ b/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.html
@@ -5,9 +5,9 @@
                 
               <h2 style="display: inline-block">
                 <span *ngIf="actions.length > 0">
-                    <app-card-actionables (actionHandler)="performAction($event)" [actions]="actions" [labelBy]="readingList.title"></app-card-actionables>
+                    <app-card-actionables (actionHandler)="performAction($event)" [actions]="actions" [labelBy]="readingList.title"></app-card-actionables>&nbsp;
                 </span>
-                &nbsp;{{readingList.title}}&nbsp;
+                {{readingList.title}}&nbsp;<span *ngIf="readingList?.promoted">(<i class="fa fa-angle-double-up" aria-hidden="true"></i>)</span>&nbsp;
                 <span class="badge badge-primary badge-pill" attr.aria-label="{{items.length}} total items">{{items.length}}</span>
               </h2>
             </div>
@@ -21,7 +21,7 @@
                 </button>
               </div>
               <div>
-                  <button class="btn btn-secondary" (click)="removeRead()">
+                  <button class="btn btn-secondary" (click)="removeRead()" [disabled]="readingList?.promoted && !this.isAdmin">
                       <span>
                           <i class="fa fa-check"></i>
                       </span>
@@ -29,7 +29,7 @@
                   </button>
               </div>
             </div>
-            <p>{{readingList.summary}}</p>
+            <p class="mt-2" *ngIf="readingList.summary.length > 0">{{readingList.summary}}</p>
         </div>
     </div>
 

--- a/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.html
+++ b/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.html
@@ -13,9 +13,9 @@
             </div>
             <div class="row no-gutters">
                 <div>
-                    <button class="btn btn-primary" (click)="removeRead()">
+                    <button class="btn btn-secondary" (click)="removeRead()">
                         <span>
-                            <i class="fa fa-book"></i>
+                            <i class="fa fa-check"></i>
                         </span>
                         <span class="read-btn--text">&nbsp;Remove Read</span>
                     </button>
@@ -27,6 +27,14 @@
                         </span>
                     </button>
                 </div>
+                <div class="ml-2">
+                  <button class="btn btn-primary" title="Read" (click)="read()">
+                      <span>
+                          <i class="fa fa-book-open" aria-hidden="true"></i>
+                          <span class="read-btn--text">&nbsp;Read</span>
+                      </span>
+                  </button>
+              </div>
             </div>
             <p>{{readingList.summary}}</p>
         </div>

--- a/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.html
+++ b/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.html
@@ -41,9 +41,12 @@
       No chapters added
     </div>    
 
-    <app-dragable-ordered-list [items]="items">
+    <!-- NOTE: It might be nice to have a switch for the accessibility toggle -->
+    <app-dragable-ordered-list [items]="items" >
         <ng-template #draggableItem let-item let-position="idx">
             <div class="media">
+                <img width="74px" style="width: 74px;" class="img-top lazyload mr-3" [src]="imageService.placeholderImage" [attr.data-src]="imageService.getChapterCoverImage(item.chapterId)" 
+                (error)="imageService.updateErroredImage($event)">
                 <div class="media-body">
                   <h5 class="mt-0 mb-1">{{formatTitle(item)}}</h5>
                   <i class="fa {{utilityService.mangaFormatIcon(item.seriesFormat)}}" aria-hidden="true" *ngIf="item.seriesFormat != MangaFormat.UNKNOWN" title="{{utilityService.mangaFormat(item.seriesFormat)}}"></i><span class="sr-only">{{utilityService.mangaFormat(item.seriesFormat)}}</span>&nbsp;
@@ -53,7 +56,7 @@
                   </span>
                   
                 </div>
-                <div *ngIf="item.pagesRead === item.totalPages"><i class="fa fa-check-square" aria-label="Read"></i></div>
+                <div class="pull-right" *ngIf="item.pagesRead === item.pagesTotal"><i class="fa fa-check-square" aria-label="Read"></i></div>
               </div>
         </ng-template> 
     </app-dragable-ordered-list>

--- a/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.ts
+++ b/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.ts
@@ -1,0 +1,37 @@
+import { Component, OnInit } from '@angular/core';
+import { Chapter } from 'src/app/_models/chapter';
+
+@Component({
+  selector: 'app-reading-list-detail',
+  templateUrl: './reading-list-detail.component.html',
+  styleUrls: ['./reading-list-detail.component.scss']
+})
+export class ReadingListDetailComponent implements OnInit {
+
+  chapters: Array<{
+    seriesName: string,
+    chapterNumber: number,
+    volumeNumber: number,
+    read: boolean,
+    order: number
+  }> = [];
+  constructor( ) { }
+
+  ngOnInit(): void {
+    this.chapters.push(this.createChapter('Death Note', 0));
+    this.chapters.push(this.createChapter('Death Note', 1));
+    this.chapters.push(this.createChapter('Aria', 2));
+    this.chapters.push(this.createChapter('Btooom!', 3));
+  }
+
+  createChapter(title: string, order: number) {
+    return {
+      seriesName: title,
+      chapterNumber: Math.round(Math.random() * 100 + 1),
+      volumeNumber: 0,
+      read: Math.random() > 0.5,
+      order
+    };
+  }
+
+}

--- a/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.ts
+++ b/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.ts
@@ -60,7 +60,7 @@ export class ReadingListDetailComponent implements OnInit {
           this.isAdmin = this.accountService.hasAdminRole(user);
           
           this.actions = this.actionFactoryService.getReadingListActions(this.handleReadingListActionCallback.bind(this)).filter(actions => {
-            if (actions.action === Action.Edit && this.readingList?.promoted && !this.isAdmin) return false;
+            if (this.readingList?.promoted && !this.isAdmin) return false;
             return true;
           });
         }

--- a/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.ts
+++ b/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.ts
@@ -3,13 +3,13 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { ToastrService } from 'ngx-toastr';
 import { take } from 'rxjs/operators';
 import { UtilityService } from 'src/app/shared/_services/utility.service';
-import { Chapter } from 'src/app/_models/chapter';
 import { MangaFormat } from 'src/app/_models/manga-format';
 import { ReadingList, ReadingListItem } from 'src/app/_models/reading-list';
 import { AccountService } from 'src/app/_services/account.service';
 import { Action, ActionFactoryService, ActionItem } from 'src/app/_services/action-factory.service';
 import { ActionService } from 'src/app/_services/action.service';
 import { ImageService } from 'src/app/_services/image.service';
+import { ReaderService } from 'src/app/_services/reader.service';
 import { ReadingListService } from 'src/app/_services/reading-list.service';
 import { IndexUpdateEvent } from '../dragable-ordered-list/dragable-ordered-list.component';
 
@@ -33,7 +33,7 @@ export class ReadingListDetailComponent implements OnInit {
 
   constructor(private route: ActivatedRoute, private router: Router, private readingListService: ReadingListService,
     private actionService: ActionService, private actionFactoryService: ActionFactoryService, public utilityService: UtilityService,
-    public imageService: ImageService, private accountService: AccountService, private toastr: ToastrService) {}
+    public imageService: ImageService, private accountService: AccountService, private toastr: ToastrService, private readerService: ReaderService) {}
 
   ngOnInit(): void {
     const listId = this.route.snapshot.paramMap.get('id');
@@ -126,6 +126,19 @@ export class ReadingListDetailComponent implements OnInit {
   }
 
   read() {
-    
+    let currentlyReadingChapter = this.items[0];
+    for (let i = 0; i < this.items.length; i++) {
+      if (this.items[i].pagesRead >= this.items[i].pagesTotal) {
+        continue;
+      }
+      currentlyReadingChapter = this.items[i];
+      break;
+    }
+
+    if (currentlyReadingChapter.seriesFormat === MangaFormat.EPUB) {
+      this.router.navigate(['library', currentlyReadingChapter.libraryId, 'series', currentlyReadingChapter.seriesId, 'book', currentlyReadingChapter.chapterId], {queryParams: {readingListId: this.readingList.id}});
+    } else {
+      this.router.navigate(['library', currentlyReadingChapter.libraryId, 'series', currentlyReadingChapter.seriesId, 'manga', currentlyReadingChapter.chapterId], {queryParams: {readingListId: this.readingList.id}});
+    }
   }
 }

--- a/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.ts
+++ b/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.ts
@@ -6,6 +6,7 @@ import { MangaFormat } from 'src/app/_models/manga-format';
 import { ReadingList, ReadingListItem } from 'src/app/_models/reading-list';
 import { Action, ActionFactoryService, ActionItem } from 'src/app/_services/action-factory.service';
 import { ActionService } from 'src/app/_services/action.service';
+import { ImageService } from 'src/app/_services/image.service';
 import { ReadingListService } from 'src/app/_services/reading-list.service';
 
 @Component({
@@ -25,7 +26,8 @@ export class ReadingListDetailComponent implements OnInit {
   }
 
   constructor(private route: ActivatedRoute, private router: Router, private readingListService: ReadingListService,
-    private actionService: ActionService, private actionFactoryService: ActionFactoryService, public utilityService: UtilityService) {}
+    private actionService: ActionService, private actionFactoryService: ActionFactoryService, public utilityService: UtilityService,
+    public imageService: ImageService) {}
 
   ngOnInit(): void {
     const listId = this.route.snapshot.paramMap.get('id');

--- a/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.ts
+++ b/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.ts
@@ -113,7 +113,7 @@ export class ReadingListDetailComponent implements OnInit {
 
   removeItem(item: ReadingListItem, position: number) {
     this.readingListService.deleteItem(this.readingList.id, item.id).subscribe(() => {
-      this.items.splice(position);
+      this.items.splice(position, 1);
       this.toastr.success('Item removed');
     });
   }

--- a/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.ts
+++ b/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.ts
@@ -108,9 +108,13 @@ export class ReadingListDetailComponent implements OnInit {
   }
 
   orderUpdated(event: IndexUpdateEvent) {
-    // TODO: Buffer events so backend can process them all at the same time.
-    this.readingListService.updatePosition(this.readingList.id, event.item.id, event.fromPosition, event.toPosition).subscribe(() => {
+    this.readingListService.updatePosition(this.readingList.id, event.item.id, event.fromPosition, event.toPosition).subscribe(() => { /* No Operation */ });
+  }
 
+  removeItem(item: ReadingListItem, position: number) {
+    this.readingListService.deleteItem(this.readingList.id, item.id).subscribe(() => {
+      this.items.splice(position);
+      this.toastr.success('Item removed');
     });
   }
 

--- a/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.ts
+++ b/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.ts
@@ -90,7 +90,7 @@ export class ReadingListDetailComponent implements OnInit {
       case Action.Delete:
         this.readingListService.delete(readingList.id).subscribe(() => {
           this.toastr.success('Reading list deleted');
-          this.router.navigateByUrl('library');
+          this.router.navigateByUrl('library#lists');
         });
     }
   }

--- a/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.ts
+++ b/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.ts
@@ -25,6 +25,7 @@ export class ReadingListDetailComponent implements OnInit {
   readingList!: ReadingList;
   actions: Array<ActionItem<any>> = [];
   isAdmin: boolean = false;
+  isLoading: boolean = false;
 
   get MangaFormat(): typeof MangaFormat {
     return MangaFormat;
@@ -66,11 +67,15 @@ export class ReadingListDetailComponent implements OnInit {
         }
       });
     });
+    this.getListItems();
+  }
 
+  getListItems() {
+    this.isLoading = true;
     this.readingListService.getListItems(this.listId).subscribe(items => {
       this.items = items;
+      this.isLoading = false;
     });
-    
   }
 
   performAction(action: ActionItem<any>) {
@@ -106,6 +111,13 @@ export class ReadingListDetailComponent implements OnInit {
     // TODO: Buffer events so backend can process them all at the same time.
     this.readingListService.updatePosition(this.readingList.id, event.item.id, event.fromPosition, event.toPosition).subscribe(() => {
 
-    })
+    });
+  }
+
+  removeRead() {
+    this.isLoading = true;
+    this.readingListService.removeRead(this.readingList.id).subscribe(() => {
+      this.getListItems();
+    });
   }
 }

--- a/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.ts
+++ b/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.ts
@@ -11,6 +11,7 @@ import { Action, ActionFactoryService, ActionItem } from 'src/app/_services/acti
 import { ActionService } from 'src/app/_services/action.service';
 import { ImageService } from 'src/app/_services/image.service';
 import { ReadingListService } from 'src/app/_services/reading-list.service';
+import { IndexUpdateEvent } from '../dragable-ordered-list/dragable-ordered-list.component';
 
 @Component({
   selector: 'app-reading-list-detail',
@@ -99,5 +100,12 @@ export class ReadingListDetailComponent implements OnInit {
     }
 
     return 'Chapter ' + item.chapterNumber;
+  }
+
+  orderUpdated(event: IndexUpdateEvent) {
+    // TODO: Buffer events so backend can process them all at the same time.
+    this.readingListService.updatePosition(this.readingList.id, event.item.id, event.fromPosition, event.toPosition).subscribe(() => {
+
+    })
   }
 }

--- a/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.ts
+++ b/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.ts
@@ -1,9 +1,12 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
+import { ToastrService } from 'ngx-toastr';
+import { take } from 'rxjs/operators';
 import { UtilityService } from 'src/app/shared/_services/utility.service';
 import { Chapter } from 'src/app/_models/chapter';
 import { MangaFormat } from 'src/app/_models/manga-format';
 import { ReadingList, ReadingListItem } from 'src/app/_models/reading-list';
+import { AccountService } from 'src/app/_services/account.service';
 import { Action, ActionFactoryService, ActionItem } from 'src/app/_services/action-factory.service';
 import { ActionService } from 'src/app/_services/action.service';
 import { ImageService } from 'src/app/_services/image.service';
@@ -20,6 +23,7 @@ export class ReadingListDetailComponent implements OnInit {
   listId!: number;
   readingList!: ReadingList;
   actions: Array<ActionItem<any>> = [];
+  isAdmin: boolean = false;
 
   get MangaFormat(): typeof MangaFormat {
     return MangaFormat;
@@ -27,7 +31,7 @@ export class ReadingListDetailComponent implements OnInit {
 
   constructor(private route: ActivatedRoute, private router: Router, private readingListService: ReadingListService,
     private actionService: ActionService, private actionFactoryService: ActionFactoryService, public utilityService: UtilityService,
-    public imageService: ImageService) {}
+    public imageService: ImageService, private accountService: AccountService, private toastr: ToastrService) {}
 
   ngOnInit(): void {
     const listId = this.route.snapshot.paramMap.get('id');
@@ -40,22 +44,49 @@ export class ReadingListDetailComponent implements OnInit {
     this.listId = parseInt(listId, 10);
 
     this.readingListService.getReadingList(this.listId).subscribe(readingList => {
+      if (readingList == null) {
+        // The list doesn't exist
+        this.toastr.error('This list doesn\'t exist.');
+        this.router.navigateByUrl('library');
+        return;
+      }
       this.readingList = readingList;
+
+      this.accountService.currentUser$.pipe(take(1)).subscribe(user => {
+        if (user) {
+          this.isAdmin = this.accountService.hasAdminRole(user);
+          
+          this.actions = this.actionFactoryService.getReadingListActions(this.handleReadingListActionCallback.bind(this)).filter(actions => {
+            if (actions.action != Action.Edit) return true;
+            else if (this.readingList?.promoted && this.isAdmin) return true;
+            return false;
+            //return actions.action != Action.Edit || (actions.action === Action.Edit && this.readingList.promoted && this.isAdmin);
+          });
+        }
+      });
     });
 
     this.readingListService.getListItems(this.listId).subscribe(items => {
       this.items = items;
     });
-
-    this.actions = this.actionFactoryService.getReadingListActions(this.handleReadingListActionCallback.bind(this));
+    
   }
 
-  performAction(event: any) {
-
+  performAction(action: ActionItem<any>) {
+    // TODO: Try to move performAction into the actionables component. (have default handler in the component, allow for overridding to pass additional context)
+    if (typeof action.callback === 'function') {
+      action.callback(action.action, this.readingList);
+    }
   }
 
   handleReadingListActionCallback(action: Action, readingList: ReadingList) {
-
+    switch(action) {
+      case Action.Delete:
+        this.readingListService.delete(readingList.id).subscribe(() => {
+          this.toastr.success('Reading list deleted');
+          this.router.navigateByUrl('library');
+        });
+    }
   }
 
   formatTitle(item: ReadingListItem) {

--- a/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.ts
+++ b/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.ts
@@ -59,10 +59,7 @@ export class ReadingListDetailComponent implements OnInit {
         if (user) {
           this.isAdmin = this.accountService.hasAdminRole(user);
           
-          this.actions = this.actionFactoryService.getReadingListActions(this.handleReadingListActionCallback.bind(this)).filter(actions => {
-            if (this.readingList?.promoted && !this.isAdmin) return false;
-            return true;
-          });
+          this.actions = this.actionFactoryService.getReadingListActions(this.handleReadingListActionCallback.bind(this)).filter(action => this.readingListService.actionListFilter(action, readingList, this.isAdmin));
         }
       });
     });

--- a/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.ts
+++ b/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.ts
@@ -124,4 +124,8 @@ export class ReadingListDetailComponent implements OnInit {
       this.getListItems();
     });
   }
+
+  read() {
+    
+  }
 }

--- a/UI/Web/src/app/reading-list/reading-list.module.ts
+++ b/UI/Web/src/app/reading-list/reading-list.module.ts
@@ -8,6 +8,7 @@ import { AddToListModalComponent } from './_modals/add-to-list-modal/add-to-list
 import { ReactiveFormsModule } from '@angular/forms';
 import { CardsModule } from '../cards/cards.module';
 import { ReadingListsComponent } from './reading-lists/reading-lists.component';
+import { EditReadingListModalComponent } from './_modals/edit-reading-list-modal/edit-reading-list-modal.component';
 
 
 
@@ -16,7 +17,8 @@ import { ReadingListsComponent } from './reading-lists/reading-lists.component';
     DragableOrderedListComponent,
     ReadingListDetailComponent,
     AddToListModalComponent,
-    ReadingListsComponent
+    ReadingListsComponent,
+    EditReadingListModalComponent
   ],
   imports: [
     CommonModule,
@@ -27,7 +29,8 @@ import { ReadingListsComponent } from './reading-lists/reading-lists.component';
   ],
   exports: [
     AddToListModalComponent,
-    ReadingListsComponent
+    ReadingListsComponent,
+    EditReadingListModalComponent
   ]
 })
 export class ReadingListModule { }

--- a/UI/Web/src/app/reading-list/reading-list.module.ts
+++ b/UI/Web/src/app/reading-list/reading-list.module.ts
@@ -5,6 +5,7 @@ import { ReadingListDetailComponent } from './reading-list-detail/reading-list-d
 import { ReadingListRoutingModule } from './reading-list.router.module';
 import {DragDropModule} from '@angular/cdk/drag-drop';
 import { AddToListModalComponent } from './_modals/add-to-list-modal/add-to-list-modal.component';
+import { ReactiveFormsModule } from '@angular/forms';
 
 
 
@@ -17,6 +18,7 @@ import { AddToListModalComponent } from './_modals/add-to-list-modal/add-to-list
   imports: [
     CommonModule,
     ReadingListRoutingModule,
+    ReactiveFormsModule,
     DragDropModule,
   ],
   exports: [

--- a/UI/Web/src/app/reading-list/reading-list.module.ts
+++ b/UI/Web/src/app/reading-list/reading-list.module.ts
@@ -4,18 +4,23 @@ import { DragableOrderedListComponent } from './dragable-ordered-list/dragable-o
 import { ReadingListDetailComponent } from './reading-list-detail/reading-list-detail.component';
 import { ReadingListRoutingModule } from './reading-list.router.module';
 import {DragDropModule} from '@angular/cdk/drag-drop';
+import { AddToListModalComponent } from './_modals/add-to-list-modal/add-to-list-modal.component';
 
 
 
 @NgModule({
   declarations: [
     DragableOrderedListComponent,
-    ReadingListDetailComponent
+    ReadingListDetailComponent,
+    AddToListModalComponent
   ],
   imports: [
     CommonModule,
     ReadingListRoutingModule,
     DragDropModule,
+  ],
+  exports: [
+    AddToListModalComponent
   ]
 })
 export class ReadingListModule { }

--- a/UI/Web/src/app/reading-list/reading-list.module.ts
+++ b/UI/Web/src/app/reading-list/reading-list.module.ts
@@ -1,0 +1,21 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { DragableOrderedListComponent } from './dragable-ordered-list/dragable-ordered-list.component';
+import { ReadingListDetailComponent } from './reading-list-detail/reading-list-detail.component';
+import { ReadingListRoutingModule } from './reading-list.router.module';
+import {DragDropModule} from '@angular/cdk/drag-drop';
+
+
+
+@NgModule({
+  declarations: [
+    DragableOrderedListComponent,
+    ReadingListDetailComponent
+  ],
+  imports: [
+    CommonModule,
+    ReadingListRoutingModule,
+    DragDropModule,
+  ]
+})
+export class ReadingListModule { }

--- a/UI/Web/src/app/reading-list/reading-list.module.ts
+++ b/UI/Web/src/app/reading-list/reading-list.module.ts
@@ -6,6 +6,7 @@ import { ReadingListRoutingModule } from './reading-list.router.module';
 import {DragDropModule} from '@angular/cdk/drag-drop';
 import { AddToListModalComponent } from './_modals/add-to-list-modal/add-to-list-modal.component';
 import { ReactiveFormsModule } from '@angular/forms';
+import { CardsModule } from '../cards/cards.module';
 
 
 
@@ -20,6 +21,7 @@ import { ReactiveFormsModule } from '@angular/forms';
     ReadingListRoutingModule,
     ReactiveFormsModule,
     DragDropModule,
+    CardsModule
   ],
   exports: [
     AddToListModalComponent

--- a/UI/Web/src/app/reading-list/reading-list.module.ts
+++ b/UI/Web/src/app/reading-list/reading-list.module.ts
@@ -7,6 +7,7 @@ import {DragDropModule} from '@angular/cdk/drag-drop';
 import { AddToListModalComponent } from './_modals/add-to-list-modal/add-to-list-modal.component';
 import { ReactiveFormsModule } from '@angular/forms';
 import { CardsModule } from '../cards/cards.module';
+import { ReadingListsComponent } from './reading-lists/reading-lists.component';
 
 
 
@@ -14,7 +15,8 @@ import { CardsModule } from '../cards/cards.module';
   declarations: [
     DragableOrderedListComponent,
     ReadingListDetailComponent,
-    AddToListModalComponent
+    AddToListModalComponent,
+    ReadingListsComponent
   ],
   imports: [
     CommonModule,
@@ -24,7 +26,8 @@ import { CardsModule } from '../cards/cards.module';
     CardsModule
   ],
   exports: [
-    AddToListModalComponent
+    AddToListModalComponent,
+    ReadingListsComponent
   ]
 })
 export class ReadingListModule { }

--- a/UI/Web/src/app/reading-list/reading-list.router.module.ts
+++ b/UI/Web/src/app/reading-list/reading-list.router.module.ts
@@ -1,0 +1,23 @@
+import { NgModule } from "@angular/core";
+import { Routes, RouterModule } from "@angular/router";
+import { AuthGuard } from "../_guards/auth.guard";
+import { ReadingListDetailComponent } from "./reading-list-detail/reading-list-detail.component";
+
+const routes: Routes = [
+  {
+    path: '', 
+    runGuardsAndResolvers: 'always',
+    canActivate: [AuthGuard],
+    children: [
+        {path: '', component: ReadingListDetailComponent, pathMatch: 'full'},
+        // {path: ':id', component: CollectionDetailComponent},
+    ]
+  }
+];
+
+
+@NgModule({
+  imports: [RouterModule.forChild(routes), ],
+  exports: [RouterModule]
+})
+export class ReadingListRoutingModule { }

--- a/UI/Web/src/app/reading-list/reading-list.router.module.ts
+++ b/UI/Web/src/app/reading-list/reading-list.router.module.ts
@@ -7,9 +7,10 @@ const routes: Routes = [
   {
     path: '', 
     runGuardsAndResolvers: 'always',
-    canActivate: [AuthGuard],
+    canActivate: [AuthGuard], // TODO: Add a guard if they have access to said :id
     children: [
         {path: '', component: ReadingListDetailComponent, pathMatch: 'full'},
+        {path: ':id', component: ReadingListDetailComponent, pathMatch: 'full'},
         // {path: ':id', component: CollectionDetailComponent},
     ]
   }
@@ -17,7 +18,7 @@ const routes: Routes = [
 
 
 @NgModule({
-  imports: [RouterModule.forChild(routes), ],
+  imports: [RouterModule.forChild(routes)],
   exports: [RouterModule]
 })
 export class ReadingListRoutingModule { }

--- a/UI/Web/src/app/reading-list/reading-lists/reading-lists.component.html
+++ b/UI/Web/src/app/reading-list/reading-lists/reading-lists.component.html
@@ -6,6 +6,6 @@
     (pageChange)="onPageChange($event)"
     >
     <ng-template #cardItem let-item let-position="idx">
-        <app-card-item [title]="item.title" [entity]="item" [actions]="actions" [supressLibraryLink]="true" [imageUrl]="imageService.placeholderImage" (clicked)="handleClick()"></app-card-item>
+        <app-card-item [title]="item.title" [entity]="item" [actions]="getActions(item)" [supressLibraryLink]="true" [imageUrl]="imageService.placeholderImage" (clicked)="handleClick(item)"></app-card-item>
     </ng-template>
 </app-card-detail-layout>

--- a/UI/Web/src/app/reading-list/reading-lists/reading-lists.component.html
+++ b/UI/Web/src/app/reading-list/reading-lists/reading-lists.component.html
@@ -1,1 +1,12 @@
-<p>reading-lists works!</p>
+<app-card-detail-layout header="Reading Lists" 
+    [isLoading]="loadingLists"
+    [items]="lists"
+    [actions]="actions"
+    [pagination]="pagination"
+    (pageChange)="onPageChange($event)"
+    >
+    <ng-template #cardItem let-item let-position="idx">
+        <!-- <app-series-card [data]="item" [libraryId]="libraryId" [suppressLibraryLink]="true" (reload)="loadPage()"></app-series-card> -->
+        {{item.title}}
+    </ng-template>
+</app-card-detail-layout>

--- a/UI/Web/src/app/reading-list/reading-lists/reading-lists.component.html
+++ b/UI/Web/src/app/reading-list/reading-lists/reading-lists.component.html
@@ -1,0 +1,1 @@
+<p>reading-lists works!</p>

--- a/UI/Web/src/app/reading-list/reading-lists/reading-lists.component.html
+++ b/UI/Web/src/app/reading-list/reading-lists/reading-lists.component.html
@@ -6,7 +6,6 @@
     (pageChange)="onPageChange($event)"
     >
     <ng-template #cardItem let-item let-position="idx">
-        <!-- <app-series-card [data]="item" [libraryId]="libraryId" [suppressLibraryLink]="true" (reload)="loadPage()"></app-series-card> -->
-        {{item.title}}
+        <app-card-item [title]="item.title" [entity]="item" [actions]="actions" [supressLibraryLink]="true" [imageUrl]="imageService.placeholderImage" (clicked)="handleClick()"></app-card-item>
     </ng-template>
 </app-card-detail-layout>

--- a/UI/Web/src/app/reading-list/reading-lists/reading-lists.component.ts
+++ b/UI/Web/src/app/reading-list/reading-lists/reading-lists.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-reading-lists',
+  templateUrl: './reading-lists.component.html',
+  styleUrls: ['./reading-lists.component.scss']
+})
+export class ReadingListsComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/UI/Web/src/app/reading-list/reading-lists/reading-lists.component.ts
+++ b/UI/Web/src/app/reading-list/reading-lists/reading-lists.component.ts
@@ -3,6 +3,7 @@ import { take } from 'rxjs/operators';
 import { Pagination } from 'src/app/_models/pagination';
 import { ReadingList } from 'src/app/_models/reading-list';
 import { ActionItem } from 'src/app/_services/action-factory.service';
+import { ImageService } from 'src/app/_services/image.service';
 import { ReadingListService } from 'src/app/_services/reading-list.service';
 
 @Component({
@@ -17,7 +18,7 @@ export class ReadingListsComponent implements OnInit {
   pagination!: Pagination;
   actions: ActionItem<ReadingList>[] = [];
 
-  constructor(private readingListService: ReadingListService) { }
+  constructor(private readingListService: ReadingListService, public imageService: ImageService) { }
 
   ngOnInit(): void {
     this.loadPage();
@@ -46,6 +47,10 @@ export class ReadingListsComponent implements OnInit {
   onPageChange(pagination: Pagination) {
     window.history.replaceState(window.location.href, '', window.location.href.split('?')[0] + '?page=' + this.pagination.currentPage);
     this.loadPage();
+  }
+
+  handleClick() {
+
   }
 
 }

--- a/UI/Web/src/app/reading-list/reading-lists/reading-lists.component.ts
+++ b/UI/Web/src/app/reading-list/reading-lists/reading-lists.component.ts
@@ -1,4 +1,9 @@
 import { Component, OnInit } from '@angular/core';
+import { take } from 'rxjs/operators';
+import { Pagination } from 'src/app/_models/pagination';
+import { ReadingList } from 'src/app/_models/reading-list';
+import { ActionItem } from 'src/app/_services/action-factory.service';
+import { ReadingListService } from 'src/app/_services/reading-list.service';
 
 @Component({
   selector: 'app-reading-lists',
@@ -7,9 +12,40 @@ import { Component, OnInit } from '@angular/core';
 })
 export class ReadingListsComponent implements OnInit {
 
-  constructor() { }
+  lists: ReadingList[] = [];
+  loadingLists = false;
+  pagination!: Pagination;
+  actions: ActionItem<ReadingList>[] = [];
+
+  constructor(private readingListService: ReadingListService) { }
 
   ngOnInit(): void {
+    this.loadPage();
+  }
+
+  getPage() {
+    const urlParams = new URLSearchParams(window.location.search);
+    return urlParams.get('page');
+  }
+
+  loadPage() {
+    const page = this.getPage();
+    if (page != null) {
+      this.pagination.currentPage = parseInt(page, 10);
+    }
+    this.loadingLists = true;
+
+    this.readingListService.getReadingLists(true, this.pagination?.currentPage, this.pagination?.itemsPerPage).pipe(take(1)).subscribe(readingLists => {
+      this.lists = readingLists.result;
+      this.pagination = readingLists.pagination;
+      this.loadingLists = false;
+      window.scrollTo(0, 0);
+    });
+  }
+
+  onPageChange(pagination: Pagination) {
+    window.history.replaceState(window.location.href, '', window.location.href.split('?')[0] + '?page=' + this.pagination.currentPage);
+    this.loadPage();
   }
 
 }

--- a/UI/Web/src/app/reading-list/reading-lists/reading-lists.component.ts
+++ b/UI/Web/src/app/reading-list/reading-lists/reading-lists.component.ts
@@ -1,8 +1,11 @@
 import { Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
+import { ToastrService } from 'ngx-toastr';
 import { take } from 'rxjs/operators';
 import { Pagination } from 'src/app/_models/pagination';
 import { ReadingList } from 'src/app/_models/reading-list';
-import { ActionItem } from 'src/app/_services/action-factory.service';
+import { AccountService } from 'src/app/_services/account.service';
+import { Action, ActionFactoryService, ActionItem } from 'src/app/_services/action-factory.service';
 import { ImageService } from 'src/app/_services/image.service';
 import { ReadingListService } from 'src/app/_services/reading-list.service';
 
@@ -17,11 +20,45 @@ export class ReadingListsComponent implements OnInit {
   loadingLists = false;
   pagination!: Pagination;
   actions: ActionItem<ReadingList>[] = [];
+  isAdmin: boolean = false;
 
-  constructor(private readingListService: ReadingListService, public imageService: ImageService) { }
+  constructor(private readingListService: ReadingListService, public imageService: ImageService, private actionFactoryService: ActionFactoryService,
+    private accountService: AccountService, private toastr: ToastrService, private router: Router) { }
 
   ngOnInit(): void {
     this.loadPage();
+
+    this.accountService.currentUser$.pipe(take(1)).subscribe(user => {
+      if (user) {
+        this.isAdmin = this.accountService.hasAdminRole(user);
+      }
+    });
+  }
+
+  getActions(readingList: ReadingList) {
+    return this.actionFactoryService.getReadingListActions(this.handleReadingListActionCallback.bind(this)).filter(actions => {
+      if (actions.action != Action.Edit) return true;
+      else if (readingList?.promoted && this.isAdmin) return true;
+      return false;
+      //return actions.action != Action.Edit || (actions.action === Action.Edit && this.readingList.promoted && this.isAdmin);
+    });
+  }
+
+  performAction(action: ActionItem<any>, readingList: ReadingList) {
+    // TODO: Try to move performAction into the actionables component. (have default handler in the component, allow for overridding to pass additional context)
+    if (typeof action.callback === 'function') {
+      action.callback(action.action, readingList);
+    }
+  }
+
+  handleReadingListActionCallback(action: Action, readingList: ReadingList) {
+    switch(action) {
+      case Action.Delete:
+        this.readingListService.delete(readingList.id).subscribe(() => {
+          this.toastr.success('Reading list deleted');
+          this.loadPage();
+        });
+    }
   }
 
   getPage() {
@@ -49,8 +86,8 @@ export class ReadingListsComponent implements OnInit {
     this.loadPage();
   }
 
-  handleClick() {
-
+  handleClick(list: ReadingList) {
+    this.router.navigateByUrl('lists/' + list.id);
   }
 
 }

--- a/UI/Web/src/app/reading-list/reading-lists/reading-lists.component.ts
+++ b/UI/Web/src/app/reading-list/reading-lists/reading-lists.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { ToastrService } from 'ngx-toastr';
 import { take } from 'rxjs/operators';
-import { Pagination } from 'src/app/_models/pagination';
+import { PaginatedResult, Pagination } from 'src/app/_models/pagination';
 import { ReadingList } from 'src/app/_models/reading-list';
 import { AccountService } from 'src/app/_services/account.service';
 import { Action, ActionFactoryService, ActionItem } from 'src/app/_services/action-factory.service';
@@ -73,7 +73,7 @@ export class ReadingListsComponent implements OnInit {
     }
     this.loadingLists = true;
 
-    this.readingListService.getReadingLists(true, this.pagination?.currentPage, this.pagination?.itemsPerPage).pipe(take(1)).subscribe(readingLists => {
+    this.readingListService.getReadingLists(true, this.pagination?.currentPage, this.pagination?.itemsPerPage).pipe(take(1)).subscribe((readingLists: PaginatedResult<ReadingList[]>) => {
       this.lists = readingLists.result;
       this.pagination = readingLists.pagination;
       this.loadingLists = false;

--- a/UI/Web/src/app/reading-list/reading-lists/reading-lists.component.ts
+++ b/UI/Web/src/app/reading-list/reading-lists/reading-lists.component.ts
@@ -36,12 +36,7 @@ export class ReadingListsComponent implements OnInit {
   }
 
   getActions(readingList: ReadingList) {
-    return this.actionFactoryService.getReadingListActions(this.handleReadingListActionCallback.bind(this)).filter(actions => {
-      if (actions.action != Action.Edit) return true;
-      else if (readingList?.promoted && this.isAdmin) return true;
-      return false;
-      //return actions.action != Action.Edit || (actions.action === Action.Edit && this.readingList.promoted && this.isAdmin);
-    });
+    return this.actionFactoryService.getReadingListActions(this.handleReadingListActionCallback.bind(this)).filter(action => this.readingListService.actionListFilter(action, readingList, this.isAdmin));
   }
 
   performAction(action: ActionItem<any>, readingList: ReadingList) {

--- a/UI/Web/src/app/series-detail/series-detail.component.html
+++ b/UI/Web/src/app/series-detail/series-detail.component.html
@@ -99,7 +99,7 @@
 
 
     <div>
-        <ul ngbNav #nav="ngbNav" [(activeId)]="activeTabId" class="nav-tabs" [destroyOnHide]="false">
+        <ul ngbNav #nav="ngbNav" [(activeId)]="activeTabId" class="nav-tabs nav-pills" [destroyOnHide]="false">
             <li [ngbNavItem]="1" *ngIf="hasSpecials">
               <a ngbNavLink>Specials</a>
               <ng-template ngbNavContent>

--- a/UI/Web/src/app/series-detail/series-detail.component.ts
+++ b/UI/Web/src/app/series-detail/series-detail.component.ts
@@ -179,7 +179,7 @@ export class SeriesDetailComponent implements OnInit {
         this.openViewInfo(volume);
         break;
       case(Action.AddToReadingList):
-        this.actionService.addVolumeToReadingList(volume, () => {/* No Operation */ });
+        this.actionService.addVolumeToReadingList(volume, this.series.id, () => {/* No Operation */ });
         break;
       default:
         break;
@@ -198,7 +198,7 @@ export class SeriesDetailComponent implements OnInit {
         this.openViewInfo(chapter);
         break;
       case(Action.AddToReadingList):
-        this.actionService.addChapterToReadingList(chapter, () => {/* No Operation */ });
+        this.actionService.addChapterToReadingList(chapter, this.series.id, () => {/* No Operation */ });
         break;
       default:
         break;

--- a/UI/Web/src/app/series-detail/series-detail.component.ts
+++ b/UI/Web/src/app/series-detail/series-detail.component.ts
@@ -159,6 +159,9 @@ export class SeriesDetailComponent implements OnInit {
       case(Action.Bookmarks):
         this.actionService.openBookmarkModal(series, () => this.actionInProgress = false);
         break;
+      case(Action.AddToReadingList):
+        this.actionService.addSeriesToReadingList(series, () => this.actionInProgress = false);
+        break;
       default:
         break;
     }
@@ -175,6 +178,9 @@ export class SeriesDetailComponent implements OnInit {
       case(Action.Edit):
         this.openViewInfo(volume);
         break;
+      case(Action.AddToReadingList):
+        this.actionService.addVolumeToReadingList(volume, () => {/* No Operation */ });
+        break;
       default:
         break;
     }
@@ -190,6 +196,9 @@ export class SeriesDetailComponent implements OnInit {
         break;
       case(Action.Edit):
         this.openViewInfo(chapter);
+        break;
+      case(Action.AddToReadingList):
+        this.actionService.addChapterToReadingList(chapter, () => {/* No Operation */ });
         break;
       default:
         break;

--- a/UI/Web/src/app/shared/shared.module.ts
+++ b/UI/Web/src/app/shared/shared.module.ts
@@ -13,7 +13,6 @@ import { ShowIfScrollbarDirective } from './show-if-scrollbar.directive';
 import { A11yClickDirective } from './a11y-click.directive';
 import { SeriesFormatComponent } from './series-format/series-format.component';
 import { UpdateNotificationModalComponent } from './update-notification/update-notification-modal.component';
-import { SAVER, getSaver } from './_providers/saver.provider';
 import { CircularLoaderComponent } from './circular-loader/circular-loader.component';
 import { NgCircleProgressModule } from 'ng-circle-progress';
 
@@ -51,6 +50,5 @@ import { NgCircleProgressModule } from 'ng-circle-progress';
     TagBadgeComponent,
     CircularLoaderComponent,
   ],
-  //providers: [{provide: SAVER, useFactory: getSaver}]
 })
 export class SharedModule { }

--- a/UI/Web/src/app/user-settings/user-preferences/user-preferences.component.html
+++ b/UI/Web/src/app/user-settings/user-preferences/user-preferences.component.html
@@ -9,8 +9,14 @@
                     These are global settings that are bound to your account. 
                 </p>
                 
-                <ngb-accordion [closeOthers]="true" activeIds="site-panel">
+                <ngb-accordion [closeOthers]="true" activeIds="site-panel" #acc="ngbAccordion">
                         <ngb-panel id="site-panel" title="Site">
+                            <ng-template ngbPanelHeader>
+                                <div class="d-flex align-items-center justify-content-between">
+                                  <button ngbPanelToggle class="btn container-fluid text-left pl-0 accordion-header">Site</button>
+                                  <span class="pull-right"><i class="fa fa-angle-{{acc.isExpanded('site-panel') ? 'down' : 'up'}}" aria-hidden="true"></i></span>  
+                                </div>
+                              </ng-template>
                             <ng-template ngbPanelContent>
                                 <form [formGroup]="settingsForm" *ngIf="user !== undefined">
                                     <div class="form-group">
@@ -34,6 +40,12 @@
                             </ng-template>
                         </ngb-panel>
                         <ngb-panel id="reading-panel" title="Reading">
+                            <ng-template ngbPanelHeader>
+                                <div class="d-flex align-items-center justify-content-between">
+                                  <button ngbPanelToggle class="btn container-fluid text-left pl-0 accordion-header">Reading</button>
+                                  <span class="pull-right"><i class="fa fa-angle-{{acc.isExpanded('reading-panel') ? 'down' : 'up'}}" aria-hidden="true"></i></span>  
+                                </div>
+                              </ng-template>
                             <ng-template ngbPanelContent>
                                 <form [formGroup]="settingsForm" *ngIf="user !== undefined">
                                     <h3 id="manga-header">Manga</h3>
@@ -156,6 +168,12 @@
                     
     
                     <ngb-panel id="password-panel" title="Password">
+                        <ng-template ngbPanelHeader>
+                            <div class="d-flex align-items-center justify-content-between">
+                              <button ngbPanelToggle class="btn container-fluid text-left pl-0 accordion-header">Password</button>
+                              <span class="pull-right"><i class="fa fa-angle-{{acc.isExpanded('password-panel') ? 'down' : 'up'}}" aria-hidden="true"></i></span>  
+                            </div>
+                          </ng-template>
                         <ng-template ngbPanelContent>
                             <p>Change your Password</p>
                             <div class="alert alert-danger" role="alert" *ngIf="resetPasswordErrors.length > 0">
@@ -191,6 +209,12 @@
                         </ng-template>
                     </ngb-panel>
                     <ngb-panel id="api-panel" title="OPDS">
+                        <ng-template ngbPanelHeader>
+                            <div class="d-flex align-items-center justify-content-between">
+                              <button ngbPanelToggle class="btn container-fluid text-left pl-0 accordion-header">OPDS</button>
+                              <span class="pull-right"><i class="fa fa-angle-{{acc.isExpanded('api-panel') ? 'down' : 'up'}}" aria-hidden="true"></i></span>  
+                            </div>
+                          </ng-template>
                         <ng-template ngbPanelContent>
                             <p class="alert alert-danger" role="alert" *ngIf="!opdsEnabled">
                                 OPDS is not enabled on this server!

--- a/UI/Web/src/app/user-settings/user-preferences/user-preferences.component.html
+++ b/UI/Web/src/app/user-settings/user-preferences/user-preferences.component.html
@@ -1,6 +1,6 @@
 <div class="container">
     <h2>User Dashboard</h2>
-    <ul ngbNav #nav="ngbNav" [(activeId)]="active" class="nav-tabs">
+    <ul ngbNav #nav="ngbNav" [(activeId)]="active" class="nav-tabs nav-pills">
         <li *ngFor="let tab of tabs" [ngbNavItem]="tab">
             <a ngbNavLink routerLink="." [fragment]="tab.fragment">{{ tab.title | titlecase }}</a>
             <ng-template ngbNavContent>

--- a/UI/Web/src/assets/themes/dark.scss
+++ b/UI/Web/src/assets/themes/dark.scss
@@ -30,6 +30,11 @@ $dark-item-accent-bg: #292d32;
     color: white;
   }
 
+  .accordion-header {
+    font-weight: bold;
+    color: $dark-primary-color;
+  }
+
 
   .accent {
     background-color: $dark-form-background !important;


### PR DESCRIPTION
# Added
- Added: Reading Lists can now be created by adding any series, volume, or chapter to an existing or new reading list. Lists can be promoted so all users on the server can read them (RBS still applies, like collection tags). You can read through a reading list (continuous reading support), remove all read items in bulk, and order your items however you want with drag and drop. (Closes #268)
- Added: Continuous Reading for books! Books when on first or last page, will now show a double arrow to indicate that you can move to the next book (if it's in that series). 
- Added: Continuous Reading between different readers! What if you have a reading list of mixed media, some archives and some epubs? No problem, go ahead and press read and the readers will make sure to move you to the correct ones without leaving the reading interface. 
- Added: OPDS support updated with Reading Lists
- Added: Incognito mode is now implemented in the book reader as well
- Added: Added a parser case for 'Series - - Vol. 03 Ch. 023.5 - Volume 3 Extras.cbz' which is a common name from FMD2

# Fixed
- Fixed: Fixed a bug where marking a volume as unread would actually mark it as read
- Fixed: Fixed a bug where pressing save on edit series modal could clear out tags if you didn't interact with tags, like just updating cover image (Fixes #561)

# Changed
- Changed: (Performance) Huge performance improvement to GetChapterIdsForSeriesAsync() by reducing a Join and interation loop. Improvement went from 2 seconds -> 200ms.
- Changed: (Performance) Updated all APIs to use a lighter, faster GetUser call to minimize extra memory pressure where not needed. 
- Changed: Added some extra help information for users on directory picker, since linux users were getting confused (Fixes #559)
- Changed: After adding a new library, we now show a toast informing user a scan has been scheduled (Closes #542)
- Changed: (UX) Changed the design of accordions to match more of my style, with dedicated chevrons (Closes #543)
- Changed: (UX) Home page now has libraries at the bottom and tag list to quickly jump between Home, Lists, and Collections
- Changed: (UX) Updated tabs to use a pill shape, rather than normal tab set (Closes #551)
- Changed: (UX) Cleaned up some extra spaces when actionables (overflow dots) isn't shown to the left of titles.