### PR TITLE
Bugs, Enhancements, and Performance

### DIFF
--- a/API.Tests/API.Tests.csproj
+++ b/API.Tests/API.Tests.csproj
@@ -30,4 +30,8 @@
       <Folder Include="Services\Test Data\ScannerService\Manga" />
     </ItemGroup>
 
+    <ItemGroup>
+      <None Remove="Extensions\Test Data\modified on run.txt" />
+    </ItemGroup>
+
 </Project>

--- a/API.Tests/Extensions/Test Data/modified on run.txt
+++ b/API.Tests/Extensions/Test Data/modified on run.txt
@@ -1,3 +1,0 @@
-This file should be modified by the unit test08/20/2021 10:26:03
-08/20/2021 10:26:29
-08/22/2021 12:39:58

--- a/API.Tests/Parser/ComicParserTests.cs
+++ b/API.Tests/Parser/ComicParserTests.cs
@@ -49,6 +49,7 @@ namespace API.Tests.Parser
         [InlineData("Superman v1 024 (09-10 1943)", "1")]
         [InlineData("Amazing Man Comics chapter 25", "0")]
         [InlineData("Invincible 033.5 - Marvel Team-Up 14 (2006) (digital) (Minutemen-Slayer)", "0")]
+        [InlineData("Cyberpunk 2077 - Trauma Team 04.cbz", "0")]
         public void ParseComicVolumeTest(string filename, string expected)
         {
             Assert.Equal(expected, API.Parser.Parser.ParseComicVolume(filename));

--- a/API.Tests/Parser/ComicParserTests.cs
+++ b/API.Tests/Parser/ComicParserTests.cs
@@ -27,6 +27,7 @@ namespace API.Tests.Parser
         [InlineData("Batman Beyond - Return of the Joker (2001)", "Batman Beyond - Return of the Joker")]
         [InlineData("Invincible 033.5 - Marvel Team-Up 14 (2006) (digital) (Minutemen-Slayer)", "Invincible")]
         [InlineData("Batman Wayne Family Adventures - Ep. 001 - Moving In", "Batman Wayne Family Adventures")]
+        [InlineData("Saga 001 (2012) (Digital) (Empire-Zone).cbr", "Saga")]
         public void ParseComicSeriesTest(string filename, string expected)
         {
             Assert.Equal(expected, API.Parser.Parser.ParseComicSeries(filename));
@@ -74,6 +75,7 @@ namespace API.Tests.Parser
         [InlineData("Amazing Man Comics chapter 25", "25")]
         [InlineData("Invincible 033.5 - Marvel Team-Up 14 (2006) (digital) (Minutemen-Slayer)", "33.5")]
         [InlineData("Batman Wayne Family Adventures - Ep. 014 - Moving In", "14")]
+        [InlineData("Saga 001 (2012) (Digital) (Empire-Zone)", "1")]
         public void ParseComicChapterTest(string filename, string expected)
         {
             Assert.Equal(expected, API.Parser.Parser.ParseComicChapter(filename));

--- a/API.Tests/Parser/ComicParserTests.cs
+++ b/API.Tests/Parser/ComicParserTests.cs
@@ -25,27 +25,29 @@ namespace API.Tests.Parser
         [InlineData("Teen Titans v1 038 (1972) (c2c).cbr", "Teen Titans")]
         [InlineData("Batman Beyond 02 (of 6) (1999)", "Batman Beyond")]
         [InlineData("Batman Beyond - Return of the Joker (2001)", "Batman Beyond - Return of the Joker")]
+        [InlineData("Invincible 033.5 - Marvel Team-Up 14 (2006) (digital) (Minutemen-Slayer)", "Invincible")]
         public void ParseComicSeriesTest(string filename, string expected)
         {
             Assert.Equal(expected, API.Parser.Parser.ParseComicSeries(filename));
         }
 
         [Theory]
-        [InlineData("01 Spider-Man & Wolverine 01.cbr", "1")]
-        [InlineData("04 - Asterix the Gladiator (1964) (Digital-Empire) (WebP by Doc MaKS)", "4")]
+        [InlineData("01 Spider-Man & Wolverine 01.cbr", "0")]
+        [InlineData("04 - Asterix the Gladiator (1964) (Digital-Empire) (WebP by Doc MaKS)", "0")]
         [InlineData("The First Asterix Frieze (WebP by Doc MaKS)", "0")]
-        [InlineData("Batman & Catwoman - Trail of the Gun 01", "1")]
+        [InlineData("Batman & Catwoman - Trail of the Gun 01", "0")]
         [InlineData("Batman & Daredevil - King of New York", "0")]
-        [InlineData("Batman & Grendel (1996) 01 - Devil's Bones", "1")]
+        [InlineData("Batman & Grendel (1996) 01 - Devil's Bones", "0")]
         [InlineData("Batman & Robin the Teen Wonder #0", "0")]
         [InlineData("Batman & Wildcat (1 of 3)", "0")]
-        [InlineData("Batman And Superman World's Finest #01", "1")]
-        [InlineData("Babe 01", "1")]
-        [InlineData("Scott Pilgrim 01 - Scott Pilgrim's Precious Little Life (2004)", "1")]
+        [InlineData("Batman And Superman World's Finest #01", "0")]
+        [InlineData("Babe 01", "0")]
+        [InlineData("Scott Pilgrim 01 - Scott Pilgrim's Precious Little Life (2004)", "0")]
         [InlineData("Teen Titans v1 001 (1966-02) (digital) (OkC.O.M.P.U.T.O.-Novus)", "1")]
-        [InlineData("Scott Pilgrim 02 - Scott Pilgrim vs. The World (2005)", "2")]
+        [InlineData("Scott Pilgrim 02 - Scott Pilgrim vs. The World (2005)", "0")]
         [InlineData("Superman v1 024 (09-10 1943)", "1")]
         [InlineData("Amazing Man Comics chapter 25", "0")]
+        [InlineData("Invincible 033.5 - Marvel Team-Up 14 (2006) (digital) (Minutemen-Slayer)", "0")]
         public void ParseComicVolumeTest(string filename, string expected)
         {
             Assert.Equal(expected, API.Parser.Parser.ParseComicVolume(filename));
@@ -68,6 +70,7 @@ namespace API.Tests.Parser
         [InlineData("Superman v1 024 (09-10 1943)", "24")]
         [InlineData("Invincible 070.5 - Invincible Returns 1 (2010) (digital) (Minutemen-InnerDemons).cbr", "70.5")]
         [InlineData("Amazing Man Comics chapter 25", "25")]
+        [InlineData("Invincible 033.5 - Marvel Team-Up 14 (2006) (digital) (Minutemen-Slayer)", "33.5")]
         public void ParseComicChapterTest(string filename, string expected)
         {
             Assert.Equal(expected, API.Parser.Parser.ParseComicChapter(filename));

--- a/API.Tests/Parser/ComicParserTests.cs
+++ b/API.Tests/Parser/ComicParserTests.cs
@@ -26,6 +26,7 @@ namespace API.Tests.Parser
         [InlineData("Batman Beyond 02 (of 6) (1999)", "Batman Beyond")]
         [InlineData("Batman Beyond - Return of the Joker (2001)", "Batman Beyond - Return of the Joker")]
         [InlineData("Invincible 033.5 - Marvel Team-Up 14 (2006) (digital) (Minutemen-Slayer)", "Invincible")]
+        [InlineData("Batman Wayne Family Adventures - Ep. 001 - Moving In", "Batman Wayne Family Adventures")]
         public void ParseComicSeriesTest(string filename, string expected)
         {
             Assert.Equal(expected, API.Parser.Parser.ParseComicSeries(filename));
@@ -71,6 +72,7 @@ namespace API.Tests.Parser
         [InlineData("Invincible 070.5 - Invincible Returns 1 (2010) (digital) (Minutemen-InnerDemons).cbr", "70.5")]
         [InlineData("Amazing Man Comics chapter 25", "25")]
         [InlineData("Invincible 033.5 - Marvel Team-Up 14 (2006) (digital) (Minutemen-Slayer)", "33.5")]
+        [InlineData("Batman Wayne Family Adventures - Ep. 014 - Moving In", "14")]
         public void ParseComicChapterTest(string filename, string expected)
         {
             Assert.Equal(expected, API.Parser.Parser.ParseComicChapter(filename));

--- a/API.Tests/Parser/ComicParserTests.cs
+++ b/API.Tests/Parser/ComicParserTests.cs
@@ -23,6 +23,8 @@ namespace API.Tests.Parser
         [InlineData("Amazing Man Comics chapter 25", "Amazing Man Comics")]
         [InlineData("Amazing Man Comics issue #25", "Amazing Man Comics")]
         [InlineData("Teen Titans v1 038 (1972) (c2c).cbr", "Teen Titans")]
+        [InlineData("Batman Beyond 02 (of 6) (1999)", "Batman Beyond")]
+        [InlineData("Batman Beyond - Return of the Joker (2001)", "Batman Beyond - Return of the Joker")]
         public void ParseComicSeriesTest(string filename, string expected)
         {
             Assert.Equal(expected, API.Parser.Parser.ParseComicSeries(filename));

--- a/API.Tests/Parser/MangaParserTests.cs
+++ b/API.Tests/Parser/MangaParserTests.cs
@@ -159,6 +159,7 @@ namespace API.Tests.Parser
         [InlineData("Hentai Ouji to Warawanai Neko. - Vol. 06 Ch. 034.5", "Hentai Ouji to Warawanai Neko.")]
         [InlineData("The 100 Girlfriends Who Really, Really, Really, Really, Really Love You - Vol. 03 Ch. 023.5 - Volume 3 Extras.cbz", "The 100 Girlfriends Who Really, Really, Really, Really, Really Love You")]
         [InlineData("Kimi no Koto ga Daidaidaidaidaisuki na 100-nin no Kanojo Chapter 1-10", "Kimi no Koto ga Daidaidaidaidaisuki na 100-nin no Kanojo")]
+        [InlineData("The Duke of Death and His Black Maid - Ch. 177 - The Ball (3).cbz", "The Duke of Death and His Black Maid")]
         public void ParseSeriesTest(string filename, string expected)
         {
             Assert.Equal(expected, API.Parser.Parser.ParseSeries(filename));

--- a/API.Tests/Parser/MangaParserTests.cs
+++ b/API.Tests/Parser/MangaParserTests.cs
@@ -131,7 +131,7 @@ namespace API.Tests.Parser
         [InlineData("[dmntsf.net] One Piece - Digital Colored Comics Vol. 20 Ch. 177 - 30 Million vs 81 Million.cbz", "One Piece - Digital Colored Comics")]
         [InlineData("Corpse Party -The Anthology- Sachikos game of love Hysteric Birthday 2U Chapter 01", "Corpse Party -The Anthology- Sachikos game of love Hysteric Birthday 2U")]
         [InlineData("Vol03_ch15-22.rar", "")]
-        [InlineData("Love Hina - Special.cbz", "Love Hina")] // This has to be a fallback case
+        [InlineData("Love Hina - Special.cbz", "")] // This has to be a fallback case
         [InlineData("Ani-Hina Art Collection.cbz", "")] // This has to be a fallback case
         [InlineData("Magi - Ch.252-005.cbz", "Magi")]
         [InlineData("Umineko no Naku Koro ni - Episode 1 - Legend of the Golden Witch #1", "Umineko no Naku Koro ni")]
@@ -163,6 +163,9 @@ namespace API.Tests.Parser
         [InlineData("A Compendium of Ghosts - 031 - The Third Story_ Part 12 (Digital) (Cobalt001)", "A Compendium of Ghosts")]
         [InlineData("The Duke of Death and His Black Maid - Vol. 04 Ch. 054.5 - V4 Omake", "The Duke of Death and His Black Maid")]
         [InlineData("Vol. 04 Ch. 054.5", "")]
+        [InlineData("Great_Teacher_Onizuka_v16[TheSpectrum]", "Great Teacher Onizuka")]
+        [InlineData("[Renzokusei]_Kimi_wa_Midara_na_Boku_no_Joou_Ch5_Final_Chapter", "Kimi wa Midara na Boku no Joou")]
+        [InlineData("Battle Royale, v01 (2000) [TokyoPop] [Manga-Sketchbook]", "Battle Royale")]
         public void ParseSeriesTest(string filename, string expected)
         {
             Assert.Equal(expected, API.Parser.Parser.ParseSeries(filename));

--- a/API.Tests/Parser/MangaParserTests.cs
+++ b/API.Tests/Parser/MangaParserTests.cs
@@ -426,6 +426,14 @@ namespace API.Tests.Parser
               FullFilePath = filepath, IsSpecial = false
             });
 
+            filepath = @"E:\Manga\Toukyou Akazukin\Vol. 01 Ch. 001.cbz";
+            expected.Add(filepath, new ParserInfo
+            {
+              Series = "Toukyou Akazukin", Volumes = "1", Edition = "",
+              Chapters = "1", Filename = "Vol. 01 Ch. 001.cbz", Format = MangaFormat.Archive,
+              FullFilePath = filepath, IsSpecial = false
+            });
+
             // If an image is cover exclusively, ignore it
             filepath = @"E:\Manga\Seraph of the End\cover.png";
             expected.Add(filepath, null);

--- a/API.Tests/Parser/MangaParserTests.cs
+++ b/API.Tests/Parser/MangaParserTests.cs
@@ -131,7 +131,7 @@ namespace API.Tests.Parser
         [InlineData("[dmntsf.net] One Piece - Digital Colored Comics Vol. 20 Ch. 177 - 30 Million vs 81 Million.cbz", "One Piece - Digital Colored Comics")]
         [InlineData("Corpse Party -The Anthology- Sachikos game of love Hysteric Birthday 2U Chapter 01", "Corpse Party -The Anthology- Sachikos game of love Hysteric Birthday 2U")]
         [InlineData("Vol03_ch15-22.rar", "")]
-        [InlineData("Love Hina - Special.cbz", "")] // This has to be a fallback case
+        [InlineData("Love Hina - Special.cbz", "Love Hina")] // This has to be a fallback case
         [InlineData("Ani-Hina Art Collection.cbz", "")] // This has to be a fallback case
         [InlineData("Magi - Ch.252-005.cbz", "Magi")]
         [InlineData("Umineko no Naku Koro ni - Episode 1 - Legend of the Golden Witch #1", "Umineko no Naku Koro ni")]
@@ -161,6 +161,8 @@ namespace API.Tests.Parser
         [InlineData("Kimi no Koto ga Daidaidaidaidaisuki na 100-nin no Kanojo Chapter 1-10", "Kimi no Koto ga Daidaidaidaidaisuki na 100-nin no Kanojo")]
         [InlineData("The Duke of Death and His Black Maid - Ch. 177 - The Ball (3).cbz", "The Duke of Death and His Black Maid")]
         [InlineData("A Compendium of Ghosts - 031 - The Third Story_ Part 12 (Digital) (Cobalt001)", "A Compendium of Ghosts")]
+        [InlineData("The Duke of Death and His Black Maid - Vol. 04 Ch. 054.5 - V4 Omake", "The Duke of Death and His Black Maid")]
+        [InlineData("Vol. 04 Ch. 054.5", "")]
         public void ParseSeriesTest(string filename, string expected)
         {
             Assert.Equal(expected, API.Parser.Parser.ParseSeries(filename));
@@ -410,6 +412,14 @@ namespace API.Tests.Parser
             {
               Series = "Seraph of the End - Vampire Reign", Volumes = "0", Edition = "",
               Chapters = "93", Filename = "Seraph of the End - Vampire Reign 093 (2020) (Digital) (LuCaZ).cbz", Format = MangaFormat.Archive,
+              FullFilePath = filepath, IsSpecial = false
+            });
+
+            filepath = @"E:\Manga\Kono Subarashii Sekai ni Bakuen wo!\Vol. 00 Ch. 000.cbz";
+            expected.Add(filepath, new ParserInfo
+            {
+              Series = "Kono Subarashii Sekai ni Bakuen wo!", Volumes = "0", Edition = "",
+              Chapters = "0", Filename = "Vol. 00 Ch. 000.cbz", Format = MangaFormat.Archive,
               FullFilePath = filepath, IsSpecial = false
             });
 

--- a/API.Tests/Services/DirectoryServiceTests.cs
+++ b/API.Tests/Services/DirectoryServiceTests.cs
@@ -91,7 +91,6 @@ namespace API.Tests.Services
 
         [Theory]
         [InlineData(new string[] {"C:/Manga/"}, new string[] {"C:/Manga/Love Hina/Vol. 01.cbz"}, "C:/Manga/Love Hina")]
-        [InlineData(new string[] {@"M:\"}, new string[] {@"M:\Toukyou Akazukin\Vol. 01 Ch. 001.cbz"}, @"M:\")]
         public void FindHighestDirectoriesFromFilesTest(string[] rootDirectories, string[] folders, string expectedDirectory)
         {
             var actual = DirectoryService.FindHighestDirectoriesFromFiles(rootDirectories, folders);

--- a/API.Tests/Services/DirectoryServiceTests.cs
+++ b/API.Tests/Services/DirectoryServiceTests.cs
@@ -90,6 +90,16 @@ namespace API.Tests.Services
         }
 
         [Theory]
+        [InlineData(new string[] {"C:/Manga/"}, new string[] {"C:/Manga/Love Hina/Vol. 01.cbz"}, "C:/Manga/Love Hina")]
+        [InlineData(new string[] {@"M:\"}, new string[] {@"M:\Toukyou Akazukin\Vol. 01 Ch. 001.cbz"}, @"M:\")]
+        public void FindHighestDirectoriesFromFilesTest(string[] rootDirectories, string[] folders, string expectedDirectory)
+        {
+            var actual = DirectoryService.FindHighestDirectoriesFromFiles(rootDirectories, folders);
+            var expected = new Dictionary<string, string> {{expectedDirectory, ""}};
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
         [InlineData("C:/Manga/", "C:/Manga/Love Hina/Specials/Omake/", "Omake,Specials,Love Hina")]
         [InlineData("C:/Manga/", "C:/Manga/Love Hina/Specials/Omake", "Omake,Specials,Love Hina")]
         [InlineData("C:/Manga", "C:/Manga/Love Hina/Specials/Omake/", "Omake,Specials,Love Hina")]
@@ -102,6 +112,7 @@ namespace API.Tests.Services
         [InlineData(@"C:/", @"C://Btooom!/Vol.1 Chapter 2/1.cbz", "Vol.1 Chapter 2,Btooom!")]
         [InlineData(@"C:\\", @"C://Btooom!/Vol.1 Chapter 2/1.cbz", "Vol.1 Chapter 2,Btooom!")]
         [InlineData(@"C://mount/gdrive/Library/Test Library/Comics", @"C://mount/gdrive/Library/Test Library/Comics/Dragon Age/Test", "Test,Dragon Age")]
+        [InlineData(@"M:\", @"M:\Toukyou Akazukin\Vol. 01 Ch. 005.cbz", @"Toukyou Akazukin")]
         public void GetFoldersTillRoot_Test(string rootPath, string fullpath, string expectedArray)
         {
             var expected = expectedArray.Split(",");

--- a/API.Tests/Services/MetadataServiceTests.cs
+++ b/API.Tests/Services/MetadataServiceTests.cs
@@ -4,6 +4,8 @@ using API.Entities;
 using API.Interfaces;
 using API.Interfaces.Services;
 using API.Services;
+using API.SignalR;
+using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using Xunit;
@@ -19,10 +21,11 @@ namespace API.Tests.Services
         private readonly IBookService _bookService = Substitute.For<IBookService>();
         private readonly IArchiveService _archiveService = Substitute.For<IArchiveService>();
         private readonly ILogger<MetadataService> _logger = Substitute.For<ILogger<MetadataService>>();
+        private readonly IHubContext<MessageHub> _messageHub = Substitute.For<IHubContext<MessageHub>>();
 
         public MetadataServiceTests()
         {
-            _metadataService = new MetadataService(_unitOfWork, _logger, _archiveService, _bookService, _imageService);
+            _metadataService = new MetadataService(_unitOfWork, _logger, _archiveService, _bookService, _imageService, _messageHub);
         }
 
         [Fact]

--- a/API.Tests/Services/MetadataServiceTests.cs
+++ b/API.Tests/Services/MetadataServiceTests.cs
@@ -113,12 +113,13 @@ namespace API.Tests.Services
         }
 
         [Fact]
+
         public void ShouldUpdateCoverImage_OnSecondRun_HasCoverImage_NoForceUpdate_NoLock()
         {
             Assert.False(MetadataService.ShouldUpdateCoverImage(new byte[] {1}, new MangaFile()
             {
                 FilePath = Path.Join(_testDirectory, "file in folder.zip"),
-                LastModified = new DateTime(2021, 9, 14, 3, 21, 32, DateTimeKind.Local)
+                LastModified = DateTime.Now
             }, false, false));
         }
     }

--- a/API.Tests/Services/MetadataServiceTests.cs
+++ b/API.Tests/Services/MetadataServiceTests.cs
@@ -111,5 +111,15 @@ namespace API.Tests.Services
                 LastModified = new FileInfo(Path.Join(_testDirectory, "file in folder.zip")).LastWriteTime
             }, false, false));
         }
+
+        [Fact]
+        public void ShouldUpdateCoverImage_OnSecondRun_HasCoverImage_NoForceUpdate_NoLock()
+        {
+            Assert.False(MetadataService.ShouldUpdateCoverImage(new byte[] {1}, new MangaFile()
+            {
+                FilePath = Path.Join(_testDirectory, "file in folder.zip"),
+                LastModified = new DateTime(2021, 9, 14, 3, 21, 32, DateTimeKind.Local)
+            }, false, false));
+        }
     }
 }

--- a/API.Tests/Services/ScannerServiceTests.cs
+++ b/API.Tests/Services/ScannerServiceTests.cs
@@ -55,7 +55,7 @@ namespace API.Tests.Services
             IUnitOfWork unitOfWork = new UnitOfWork(_context, Substitute.For<IMapper>(), null);
 
 
-            IMetadataService metadataService = Substitute.For<MetadataService>(unitOfWork, _metadataLogger, _archiveService, _bookService, _imageService);
+            IMetadataService metadataService = Substitute.For<MetadataService>(unitOfWork, _metadataLogger, _archiveService, _bookService, _imageService, _messageHub);
             _scannerService = new ScannerService(unitOfWork, _logger, _archiveService, metadataService, _bookService, _cacheService, _messageHub);
         }
 

--- a/API.Tests/Services/ScannerServiceTests.cs
+++ b/API.Tests/Services/ScannerServiceTests.cs
@@ -14,8 +14,10 @@ using API.Parser;
 using API.Services;
 using API.Services.Tasks;
 using API.Services.Tasks.Scanner;
+using API.SignalR;
 using API.Tests.Helpers;
 using AutoMapper;
+using Microsoft.AspNetCore.SignalR;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -34,6 +36,7 @@ namespace API.Tests.Services
         private readonly IImageService _imageService = Substitute.For<IImageService>();
         private readonly ILogger<MetadataService> _metadataLogger = Substitute.For<ILogger<MetadataService>>();
         private readonly ICacheService _cacheService = Substitute.For<ICacheService>();
+        private readonly IHubContext<MessageHub> _messageHub = Substitute.For<IHubContext<MessageHub>>();
 
         private readonly DbConnection _connection;
         private readonly DataContext _context;
@@ -53,7 +56,7 @@ namespace API.Tests.Services
 
 
             IMetadataService metadataService = Substitute.For<MetadataService>(unitOfWork, _metadataLogger, _archiveService, _bookService, _imageService);
-            _scannerService = new ScannerService(unitOfWork, _logger, _archiveService, metadataService, _bookService, _cacheService);
+            _scannerService = new ScannerService(unitOfWork, _logger, _archiveService, metadataService, _bookService, _cacheService, _messageHub);
         }
 
         private async Task<bool> SeedDb()
@@ -110,6 +113,7 @@ namespace API.Tests.Services
 
             Assert.Empty(_scannerService.FindSeriesNotOnDisk(existingSeries, infos));
         }
+
 
         // TODO: Figure out how to do this with ParseScannedFiles
         // [Theory]

--- a/API/Comparators/NaturalSortComparer.cs
+++ b/API/Comparators/NaturalSortComparer.cs
@@ -33,6 +33,7 @@ namespace API.Comparators
             if (!_table.TryGetValue(y ?? Empty, out var y1))
             {
                 y1 = Regex.Split(y ?? Empty, "([0-9]+)");
+                // BUG: EXCEPTION: An item with the same key has already been added. Key: M:\Girls of the Wild's\Girls of the Wild's - Ep. 083 (Season 1) [LINE Webtoon].cbz
                 _table.Add(y ?? Empty, y1);
             }
 

--- a/API/Comparators/NaturalSortComparer.cs
+++ b/API/Comparators/NaturalSortComparer.cs
@@ -23,7 +23,7 @@ namespace API.Comparators
         {
             if (x == y) return 0;
 
-            // BUG: Operations that change non-concurrent collections must have exclusive access. A concurrent update was performed on this collection and corrupted its state. The collection's state is no longer correct.
+            // Should be fixed: Operations that change non-concurrent collections must have exclusive access. A concurrent update was performed on this collection and corrupted its state. The collection's state is no longer correct.
             if (!_table.TryGetValue(x ?? Empty, out var x1))
             {
                 x1 = Regex.Split(x ?? Empty, "([0-9]+)");
@@ -33,7 +33,7 @@ namespace API.Comparators
             if (!_table.TryGetValue(y ?? Empty, out var y1))
             {
                 y1 = Regex.Split(y ?? Empty, "([0-9]+)");
-                // BUG: EXCEPTION: An item with the same key has already been added. Key: M:\Girls of the Wild's\Girls of the Wild's - Ep. 083 (Season 1) [LINE Webtoon].cbz
+                // Should be fixed: EXCEPTION: An item with the same key has already been added. Key: M:\Girls of the Wild's\Girls of the Wild's - Ep. 083 (Season 1) [LINE Webtoon].cbz
                 _table.Add(y ?? Empty, y1);
             }
 

--- a/API/Controllers/PluginController.cs
+++ b/API/Controllers/PluginController.cs
@@ -1,0 +1,45 @@
+﻿using System.Threading.Tasks;
+using API.DTOs;
+using API.Interfaces;
+using API.Interfaces.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace API.Controllers
+{
+    public class PluginController : BaseApiController
+    {
+        private readonly IUnitOfWork _unitOfWork;
+        private readonly ITokenService _tokenService;
+        private readonly ILogger<PluginController> _logger;
+
+        public PluginController(IUnitOfWork unitOfWork, ITokenService tokenService, ILogger<PluginController> logger)
+        {
+            _unitOfWork = unitOfWork;
+            _tokenService = tokenService;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Authenticate with the Server given an apiKey. This will log you in by returning the user object and the JWT token.
+        /// </summary>
+        /// <param name="apiKey"></param>
+        /// <param name="pluginName">Name of the Plugin</param>
+        /// <returns></returns>
+        [HttpPost("authenticate")]
+        public async Task<ActionResult<UserDto>> Authenticate(string apiKey, string pluginName)
+        {
+            // NOTE: In order to log information about plugins, we need some Plugin Description information for each request
+            // Should log into access table so we can tell the user
+            var userId = await _unitOfWork.UserRepository.GetUserIdByApiKeyAsync(apiKey);
+            var user = await _unitOfWork.UserRepository.GetUserByIdAsync(userId);
+            _logger.LogInformation("Plugin {PluginName} has authenticated with {UserName} ({UserId})'s API Key", pluginName, user.UserName, userId);
+            return new UserDto
+            {
+                Username = user.UserName,
+                Token = await _tokenService.CreateToken(user),
+                ApiKey = user.ApiKey,
+            };
+        }
+    }
+}

--- a/API/Controllers/ReaderController.cs
+++ b/API/Controllers/ReaderController.cs
@@ -332,7 +332,6 @@ namespace API.Controllers
 
             if (await _readerService.SaveReadingProgress(progressDto, user.Id)) return Ok(true);
 
-            //return Ok(true);
             return BadRequest("Could not save progress");
         }
 

--- a/API/Controllers/ReaderController.cs
+++ b/API/Controllers/ReaderController.cs
@@ -332,6 +332,7 @@ namespace API.Controllers
 
             if (await _readerService.SaveReadingProgress(progressDto, user.Id)) return Ok(true);
 
+            //return Ok(true);
             return BadRequest("Could not save progress");
         }
 

--- a/API/Controllers/ReaderController.cs
+++ b/API/Controllers/ReaderController.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using API.Comparators;
 using API.Data.Repositories;
 using API.DTOs;
 using API.DTOs.Reader;
@@ -21,17 +20,15 @@ namespace API.Controllers
     /// </summary>
     public class ReaderController : BaseApiController
     {
-        private readonly IDirectoryService _directoryService;
         private readonly ICacheService _cacheService;
         private readonly IUnitOfWork _unitOfWork;
         private readonly ILogger<ReaderController> _logger;
         private readonly IReaderService _readerService;
 
         /// <inheritdoc />
-        public ReaderController(IDirectoryService directoryService, ICacheService cacheService,
+        public ReaderController(ICacheService cacheService,
             IUnitOfWork unitOfWork, ILogger<ReaderController> logger, IReaderService readerService)
         {
-            _directoryService = directoryService;
             _cacheService = cacheService;
             _unitOfWork = unitOfWork;
             _logger = logger;

--- a/API/Controllers/ReaderController.cs
+++ b/API/Controllers/ReaderController.cs
@@ -55,14 +55,15 @@ namespace API.Controllers
             {
                 var (path, _) = await _cacheService.GetCachedPagePath(chapter, page);
                 if (string.IsNullOrEmpty(path) || !System.IO.File.Exists(path)) return BadRequest($"No such image for page {page}");
-
-                var content = await _directoryService.ReadFileAsync(path);
+                // TODO: Try out this new code. We don't cache but we also don't load the byte[] into memory.
+                //var content = await _directoryService.ReadFileAsync(path);
                 var format = Path.GetExtension(path).Replace(".", "");
 
                 // Calculates SHA1 Hash for byte[]
-                Response.AddCacheHeader(content);
-
-                return File(content, "image/" + format);
+                //Response.AddCacheHeader(content);
+                //Response.Headers.Add("ETag", string.Concat(sha1.ComputeHash(content).Select(x => x.ToString("X2"))));
+                return PhysicalFile(path, "image/" + format);
+                //return File(content, "image/" + format);
             }
             catch (Exception)
             {

--- a/API/Controllers/ReaderController.cs
+++ b/API/Controllers/ReaderController.cs
@@ -55,15 +55,9 @@ namespace API.Controllers
             {
                 var (path, _) = await _cacheService.GetCachedPagePath(chapter, page);
                 if (string.IsNullOrEmpty(path) || !System.IO.File.Exists(path)) return BadRequest($"No such image for page {page}");
-                // TODO: Try out this new code. We don't cache but we also don't load the byte[] into memory.
-                //var content = await _directoryService.ReadFileAsync(path);
                 var format = Path.GetExtension(path).Replace(".", "");
 
-                // Calculates SHA1 Hash for byte[]
-                //Response.AddCacheHeader(content);
-                //Response.Headers.Add("ETag", string.Concat(sha1.ComputeHash(content).Select(x => x.ToString("X2"))));
                 return PhysicalFile(path, "image/" + format);
-                //return File(content, "image/" + format);
             }
             catch (Exception)
             {

--- a/API/Controllers/UploadController.cs
+++ b/API/Controllers/UploadController.cs
@@ -190,7 +190,7 @@ namespace API.Controllers
                 if (_unitOfWork.HasChanges())
                 {
                     await _unitOfWork.CommitAsync();
-                    _taskScheduler.RefreshSeriesMetadata(series.LibraryId, series.Id);
+                    _taskScheduler.RefreshSeriesMetadata(series.LibraryId, series.Id, true);
                     return Ok();
                 }
 

--- a/API/Data/Repositories/SeriesRepository.cs
+++ b/API/Data/Repositories/SeriesRepository.cs
@@ -117,11 +117,12 @@ namespace API.Data.Repositories
             return volumes;
         }
 
-        private void SortSpecialChapters(IEnumerable<VolumeDto> volumes)
+        private static void SortSpecialChapters(IEnumerable<VolumeDto> volumes)
         {
+            var sorter = new NaturalSortComparer();
             foreach (var v in volumes.Where(vDto => vDto.Number == 0))
             {
-                v.Chapters = v.Chapters.OrderBy(x => x.Range, new NaturalSortComparer()).ToList();
+                v.Chapters = v.Chapters.OrderBy(x => x.Range, sorter).ToList();
             }
         }
 

--- a/API/Data/Repositories/SeriesRepository.cs
+++ b/API/Data/Repositories/SeriesRepository.cs
@@ -18,7 +18,6 @@ namespace API.Data.Repositories
     {
         private readonly DataContext _context;
         private readonly IMapper _mapper;
-        private readonly NaturalSortComparer _naturalSortComparer = new ();
         public SeriesRepository(DataContext context, IMapper mapper)
         {
             _context = context;
@@ -122,7 +121,7 @@ namespace API.Data.Repositories
         {
             foreach (var v in volumes.Where(vDto => vDto.Number == 0))
             {
-                v.Chapters = v.Chapters.OrderBy(x => x.Range, _naturalSortComparer).ToList();
+                v.Chapters = v.Chapters.OrderBy(x => x.Range, new NaturalSortComparer()).ToList();
             }
         }
 

--- a/API/Entities/AppUserProgress.cs
+++ b/API/Entities/AppUserProgress.cs
@@ -55,16 +55,5 @@ namespace API.Entities
         /// Last date this was updated
         /// </summary>
         public DateTime LastModified { get; set; }
-
-        // /// <inheritdoc />
-        // [ConcurrencyCheck]
-        // public uint RowVersion { get; private set; }
-        //
-        //
-        // /// <inheritdoc />
-        // public void OnSavingChanges()
-        // {
-        //     RowVersion++;
-        // }
     }
 }

--- a/API/Entities/AppUserProgress.cs
+++ b/API/Entities/AppUserProgress.cs
@@ -9,7 +9,7 @@ namespace API.Entities
     /// Represents the progress a single user has on a given Chapter.
     /// </summary>
     //[Index(nameof(SeriesId), nameof(VolumeId), nameof(ChapterId), nameof(AppUserId), IsUnique = true)]
-    public class AppUserProgress : IEntityDate, IHasConcurrencyToken
+    public class AppUserProgress : IEntityDate
     {
         /// <summary>
         /// Id of Entity
@@ -56,15 +56,15 @@ namespace API.Entities
         /// </summary>
         public DateTime LastModified { get; set; }
 
-        /// <inheritdoc />
-        [ConcurrencyCheck]
-        public uint RowVersion { get; private set; }
-
-
-        /// <inheritdoc />
-        public void OnSavingChanges()
-        {
-            RowVersion++;
-        }
+        // /// <inheritdoc />
+        // [ConcurrencyCheck]
+        // public uint RowVersion { get; private set; }
+        //
+        //
+        // /// <inheritdoc />
+        // public void OnSavingChanges()
+        // {
+        //     RowVersion++;
+        // }
     }
 }

--- a/API/Entities/MangaFile.cs
+++ b/API/Entities/MangaFile.cs
@@ -30,9 +30,13 @@ namespace API.Entities
         public int ChapterId { get; set; }
 
         // Methods
+        /// <summary>
+        /// If the File on disk's last modified time is after what is stored in MangaFile
+        /// </summary>
+        /// <returns></returns>
         public bool HasFileBeenModified()
         {
-            return !File.GetLastWriteTime(FilePath).Equals(LastModified);
+            return File.GetLastWriteTime(FilePath) > LastModified;
         }
     }
 }

--- a/API/Interfaces/ITaskScheduler.cs
+++ b/API/Interfaces/ITaskScheduler.cs
@@ -14,7 +14,7 @@ namespace API.Interfaces
         void CleanupChapters(int[] chapterIds);
         void RefreshMetadata(int libraryId, bool forceUpdate = true);
         void CleanupTemp();
-        void RefreshSeriesMetadata(int libraryId, int seriesId);
+        void RefreshSeriesMetadata(int libraryId, int seriesId, bool forceUpdate = false);
         void ScanSeries(int libraryId, int seriesId, bool forceUpdate = false);
         void CancelStatsTasks();
         void RunStatCollection();

--- a/API/Interfaces/Services/IMetadataService.cs
+++ b/API/Interfaces/Services/IMetadataService.cs
@@ -12,9 +12,9 @@ namespace API.Interfaces.Services
         /// <param name="forceUpdate"></param>
         void RefreshMetadata(int libraryId, bool forceUpdate = false);
 
-        public void UpdateMetadata(Chapter chapter, bool forceUpdate);
-        public void UpdateMetadata(Volume volume, bool forceUpdate);
-        public void UpdateMetadata(Series series, bool forceUpdate);
+        public bool UpdateMetadata(Chapter chapter, bool forceUpdate);
+        public bool UpdateMetadata(Volume volume, bool forceUpdate);
+        public bool UpdateMetadata(Series series, bool forceUpdate);
         /// <summary>
         /// Performs a forced refresh of metatdata just for a series and it's nested entities
         /// </summary>

--- a/API/Interfaces/Services/IMetadataService.cs
+++ b/API/Interfaces/Services/IMetadataService.cs
@@ -1,4 +1,5 @@
-﻿using API.Entities;
+﻿using System.Threading.Tasks;
+using API.Entities;
 
 namespace API.Interfaces.Services
 {
@@ -19,6 +20,6 @@ namespace API.Interfaces.Services
         /// </summary>
         /// <param name="libraryId"></param>
         /// <param name="seriesId"></param>
-        void RefreshMetadataForSeries(int libraryId, int seriesId);
+        Task RefreshMetadataForSeries(int libraryId, int seriesId, bool forceUpdate = false);
     }
 }

--- a/API/Interfaces/Services/IScannerService.cs
+++ b/API/Interfaces/Services/IScannerService.cs
@@ -13,7 +13,7 @@ namespace API.Interfaces.Services
         /// <param name="libraryId">Library to scan against</param>
         /// <param name="forceUpdate">Force overwriting for cover images</param>
         Task ScanLibrary(int libraryId, bool forceUpdate);
-        void ScanLibraries();
+        Task ScanLibraries();
         Task ScanSeries(int libraryId, int seriesId, bool forceUpdate, CancellationToken token);
     }
 }

--- a/API/Interfaces/Services/IScannerService.cs
+++ b/API/Interfaces/Services/IScannerService.cs
@@ -12,7 +12,7 @@ namespace API.Interfaces.Services
         /// </summary>
         /// <param name="libraryId">Library to scan against</param>
         /// <param name="forceUpdate">Force overwriting for cover images</param>
-        void ScanLibrary(int libraryId, bool forceUpdate);
+        Task ScanLibrary(int libraryId, bool forceUpdate);
         void ScanLibraries();
         Task ScanSeries(int libraryId, int seriesId, bool forceUpdate, CancellationToken token);
     }

--- a/API/Interfaces/Services/ReaderService.cs
+++ b/API/Interfaces/Services/ReaderService.cs
@@ -74,15 +74,17 @@ namespace API.Interfaces.Services
                     return true;
                 }
             }
-            catch (DBConcurrencyException exception)
-            {
-                // Swallow exception, nothing happened
-                _logger.LogError(exception, "Could not save progress due to data being updated since this was called");
-                return true;
-            }
+            // catch (DBConcurrencyException exception)
+            // {
+            //     // Swallow exception, nothing happened
+            //     _logger.LogError(exception, "Could not save progress due to data being updated since this was called");
+            //     return true;
+            // }
             catch (Exception exception)
             {
+                // TODO: Figure out why this sometimes fails when updating too fast
                 // When opening a fresh chapter, this seems to fail (sometimes)
+                // This issue is that the data updates while we are saving. It usually occurs from the webtoon reader when scrolling fast.
                 _logger.LogError(exception, "Could not save progress");
                 await _unitOfWork.RollbackAsync();
             }

--- a/API/Interfaces/Services/ReaderService.cs
+++ b/API/Interfaces/Services/ReaderService.cs
@@ -74,17 +74,8 @@ namespace API.Interfaces.Services
                     return true;
                 }
             }
-            // catch (DBConcurrencyException exception)
-            // {
-            //     // Swallow exception, nothing happened
-            //     _logger.LogError(exception, "Could not save progress due to data being updated since this was called");
-            //     return true;
-            // }
             catch (Exception exception)
             {
-                // TODO: Figure out why this sometimes fails when updating too fast
-                // When opening a fresh chapter, this seems to fail (sometimes)
-                // This issue is that the data updates while we are saving. It usually occurs from the webtoon reader when scrolling fast.
                 _logger.LogError(exception, "Could not save progress");
                 await _unitOfWork.RollbackAsync();
             }

--- a/API/Interfaces/Services/ReaderService.cs
+++ b/API/Interfaces/Services/ReaderService.cs
@@ -18,7 +18,6 @@ namespace API.Interfaces.Services
         private readonly ILogger<ReaderService> _logger;
         private readonly ChapterSortComparer _chapterSortComparer = new ChapterSortComparer();
         private readonly ChapterSortComparerZeroFirst _chapterSortComparerForInChapterSorting = new ChapterSortComparerZeroFirst();
-        private readonly NaturalSortComparer _naturalSortComparer = new NaturalSortComparer();
 
         public ReaderService(IUnitOfWork unitOfWork, ILogger<ReaderService> logger)
         {
@@ -119,7 +118,7 @@ namespace API.Interfaces.Services
             if (currentVolume.Number == 0)
             {
                 // Handle specials by sorting on their Filename aka Range
-                var chapterId = GetNextChapterId(currentVolume.Chapters.OrderBy(x => x.Range, _naturalSortComparer), currentChapter.Number);
+                var chapterId = GetNextChapterId(currentVolume.Chapters.OrderBy(x => x.Range, new NaturalSortComparer()), currentChapter.Number);
                 if (chapterId > 0) return chapterId;
             }
 
@@ -170,7 +169,7 @@ namespace API.Interfaces.Services
 
             if (currentVolume.Number == 0)
             {
-                var chapterId = GetNextChapterId(currentVolume.Chapters.OrderBy(x => x.Range, _naturalSortComparer).Reverse(), currentChapter.Number);
+                var chapterId = GetNextChapterId(currentVolume.Chapters.OrderBy(x => x.Range, new NaturalSortComparer()).Reverse(), currentChapter.Number);
                 if (chapterId > 0) return chapterId;
             }
 

--- a/API/Interfaces/Services/ReaderService.cs
+++ b/API/Interfaces/Services/ReaderService.cs
@@ -1,6 +1,7 @@
 ﻿
 using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Linq;
 using System.Threading.Tasks;
 using API.Comparators;
@@ -44,7 +45,8 @@ namespace API.Interfaces.Services
                 if (userProgress == null)
                 {
                     // Create a user object
-                    var userWithProgress = await _unitOfWork.UserRepository.GetUserByIdAsync(userId, AppUserIncludes.Progress);
+                    var userWithProgress =
+                        await _unitOfWork.UserRepository.GetUserByIdAsync(userId, AppUserIncludes.Progress);
                     userWithProgress.Progresses ??= new List<AppUserProgress>();
                     userWithProgress.Progresses.Add(new AppUserProgress
                     {
@@ -71,6 +73,12 @@ namespace API.Interfaces.Services
                 {
                     return true;
                 }
+            }
+            catch (DBConcurrencyException exception)
+            {
+                // Swallow exception, nothing happened
+                _logger.LogError(exception, "Could not save progress due to data being updated since this was called");
+                return true;
             }
             catch (Exception exception)
             {

--- a/API/Parser/Parser.cs
+++ b/API/Parser/Parser.cs
@@ -294,6 +294,11 @@ namespace API.Parser
                 @"^(?<Series>.*)(?: |_)i(ssue) #\d+",
                 RegexOptions.IgnoreCase | RegexOptions.Compiled,
             RegexTimeout),
+            // Batman Wayne Family Adventures - Ep. 001 - Moving In
+            new Regex(
+                @"^(?<Series>.+?)(\s|_|-)?(?:Ep\.?)(\s|_|-)+\d+",
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+                RegexTimeout),
             // Batman & Catwoman - Trail of the Gun 01, Batman & Grendel (1996) 01 - Devil's Bones, Teen Titans v1 001 (1966-02) (digital) (OkC.O.M.P.U.T.O.-Novus)
             new Regex(
                 @"^(?<Series>.+?)(?: \d+)",

--- a/API/Parser/Parser.cs
+++ b/API/Parser/Parser.cs
@@ -323,41 +323,44 @@ namespace API.Parser
 
         private static readonly Regex[] ComicVolumeRegex = new[]
         {
-            // 04 - Asterix the Gladiator (1964) (Digital-Empire) (WebP by Doc MaKS)
-            new Regex(
-                @"^(?<Volume>\d+) (- |_)?(?<Series>.*(\d{4})?)( |_)(\(|\d+)",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled,
-            RegexTimeout),
-            // 01 Spider-Man & Wolverine 01.cbr
-            new Regex(
-                @"^(?<Volume>\d+) (?:- )?(?<Series>.*) (\d+)?",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled,
-            RegexTimeout),
-            // Batman & Wildcat (1 of 3)
-            new Regex(
-                @"(?<Series>.*(\d{4})?)( |_)(?:\((?<Chapter>\d+) of \d+)",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled,
-            RegexTimeout),
+            // // 04 - Asterix the Gladiator (1964) (Digital-Empire) (WebP by Doc MaKS)
+            // new Regex(
+            //     @"^(?<Volume>\d+) (- |_)?(?<Series>.*(\d{4})?)( |_)(\(|\d+)",
+            //     RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            // RegexTimeout),
+            // // 01 Spider-Man & Wolverine 01.cbr
+            // new Regex(
+            //     @"^(?<Volume>\d+) (?:- )?(?<Series>.*) (\d+)?",
+            //     RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            // RegexTimeout),
+            // // Batman & Wildcat (1 of 3)
+            // new Regex(
+            //     @"(?<Series>.*(\d{4})?)( |_)(?:\((?<Chapter>\d+) of \d+)",
+            //     RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            // RegexTimeout),
             // Teen Titans v1 001 (1966-02) (digital) (OkC.O.M.P.U.T.O.-Novus)
             new Regex(
                 @"^(?<Series>.*)(?: |_)v(?<Volume>\d+)",
                 RegexOptions.IgnoreCase | RegexOptions.Compiled,
             RegexTimeout),
             // Scott Pilgrim 02 - Scott Pilgrim vs. The World (2005)
-            new Regex(
-                @"^(?<Series>.*)(?<!c(hapter)|i(ssue))(?<!of)(?: |_)(?<!of )(?<Volume>\d+)",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled,
-            RegexTimeout),
+            // BUG: Negative lookbehind has to be fixed width
+            // NOTE: The case this is built for does not make much sense.
+            // new Regex(
+            //     @"^(?<Series>.+?)(?<!c(hapter)|i(ssue))(?<!of)(?: |_)(?<!of )(?<Volume>\d+)",
+            //     RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            // RegexTimeout),
+
             // Batman & Catwoman - Trail of the Gun 01, Batman & Grendel (1996) 01 - Devil's Bones, Teen Titans v1 001 (1966-02) (digital) (OkC.O.M.P.U.T.O.-Novus)
-            new Regex(
-                @"^(?<Series>.*)(?<!c(hapter)|i(ssue))(?<!of)(?: (?<Volume>\d+))",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled,
-            RegexTimeout),
-            // Batman & Robin the Teen Wonder #0
-            new Regex(
-                @"^(?<Series>.*)(?: |_)#(?<Volume>\d+)",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled,
-            RegexTimeout),
+            // new Regex(
+            //     @"^(?<Series>.+?)(?<!c(hapter)|i(ssue))(?<!of)(?: (?<Volume>\d+))",
+            //     RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            // RegexTimeout),
+            // // Batman & Robin the Teen Wonder #0
+            // new Regex(
+            //     @"^(?<Series>.*)(?: |_)#(?<Volume>\d+)",
+            //     RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            // RegexTimeout),
         };
 
         private static readonly Regex[] ComicChapterRegex = new[]

--- a/API/Parser/Parser.cs
+++ b/API/Parser/Parser.cs
@@ -102,11 +102,17 @@ namespace API.Parser
                 @"^(?<Series>.*)( |_)Vol\.?(\d+|tbd)",
                 RegexOptions.IgnoreCase | RegexOptions.Compiled,
             RegexTimeout),
+            // Mad Chimera World - Volume 005 - Chapter 026.cbz (couldn't figure out how to get Volume negative lookaround working on below regex),
+            // The Duke of Death and His Black Maid - Vol. 04 Ch. 054.5 - V4 Omake
+            new Regex(
+                @"(?<Series>.+?)(\s|_|-)+(?:Vol(ume|\.)?(\s|_|-)+\d+)(\s|_|-)+(?:(Ch|Chapter|Ch)\.?)(\s|_|-)+(?<Chapter>\d+)",
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+                RegexTimeout),
             // Ichiban_Ushiro_no_Daimaou_v04_ch34_[VISCANS].zip, VanDread-v01-c01.zip
             new Regex(
-            @"(?<Series>.*)(\b|_)v(?<Volume>\d+-?\d*)(\s|_|-)",
-            RegexOptions.IgnoreCase | RegexOptions.Compiled,
-            RegexTimeout),
+                @"(?<Series>.*)(\b|_)v(?<Volume>\d+-?\d*)(\s|_|-)",
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+                RegexTimeout),
             // Gokukoku no Brynhildr - c001-008 (v01) [TrinityBAKumA], Black Bullet - v4 c17 [batoto]
             new Regex(
                 @"(?<Series>.*)( - )(?:v|vo|c)\d",
@@ -115,11 +121,6 @@ namespace API.Parser
             // Kedouin Makoto - Corpse Party Musume, Chapter 19 [Dametrans].zip
             new Regex(
                 @"(?<Series>.*)(?:, Chapter )(?<Chapter>\d+)",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled,
-            RegexTimeout),
-            // Mad Chimera World - Volume 005 - Chapter 026.cbz (couldn't figure out how to get Volume negative lookaround working on below regex)
-            new Regex(
-                @"(?<Series>.*)(\s|_|-)(?:Volume(\s|_|-)+\d+)(\s|_|-)+(?:Chapter)(\s|_|-)(?<Chapter>\d+)",
                 RegexOptions.IgnoreCase | RegexOptions.Compiled,
             RegexTimeout),
             // Please Go Home, Akutsu-San! - Chapter 038.5 - Volume Announcement.cbz
@@ -149,7 +150,7 @@ namespace API.Parser
             RegexTimeout),
             // Momo The Blood Taker - Chapter 027 Violent Emotion.cbz, Grand Blue Dreaming - SP02 Extra (2019) (Digital) (danke-Empire).cbz
             new Regex(
-                @"(?<Series>.*)(\b|_|-|\s)(?:(ch(apter|\.)(\b|_|-|\s))|sp)\d",
+                @"^(?<Series>(?!Vol).+?)(?:(ch(apter|\.)(\b|_|-|\s))|sp)",
                 RegexOptions.IgnoreCase | RegexOptions.Compiled,
             RegexTimeout),
             // Historys Strongest Disciple Kenichi_v11_c90-98.zip, Killing Bites Vol. 0001 Ch. 0001 - Galactica Scanlations (gb)

--- a/API/Parser/Parser.cs
+++ b/API/Parser/Parser.cs
@@ -296,7 +296,7 @@ namespace API.Parser
             RegexTimeout),
             // Batman & Catwoman - Trail of the Gun 01, Batman & Grendel (1996) 01 - Devil's Bones, Teen Titans v1 001 (1966-02) (digital) (OkC.O.M.P.U.T.O.-Novus)
             new Regex(
-                @"^(?<Series>.*)(?: \d+)",
+                @"^(?<Series>.+?)(?: \d+)",
                 RegexOptions.IgnoreCase | RegexOptions.Compiled,
             RegexTimeout),
             // Batman & Robin the Teen Wonder #0

--- a/API/Parser/Parser.cs
+++ b/API/Parser/Parser.cs
@@ -149,7 +149,7 @@ namespace API.Parser
             RegexTimeout),
             // Momo The Blood Taker - Chapter 027 Violent Emotion.cbz, Grand Blue Dreaming - SP02 Extra (2019) (Digital) (danke-Empire).cbz
             new Regex(
-                @"(?<Series>.*)(\b|_|-|\s)(?:(chapter(\b|_|-|\s))|sp)\d",
+                @"(?<Series>.*)(\b|_|-|\s)(?:(ch(apter|\.)(\b|_|-|\s))|sp)\d",
                 RegexOptions.IgnoreCase | RegexOptions.Compiled,
             RegexTimeout),
             // Historys Strongest Disciple Kenichi_v11_c90-98.zip, Killing Bites Vol. 0001 Ch. 0001 - Galactica Scanlations (gb)

--- a/API/Parser/Parser.cs
+++ b/API/Parser/Parser.cs
@@ -150,7 +150,7 @@ namespace API.Parser
             RegexTimeout),
             // Momo The Blood Taker - Chapter 027 Violent Emotion.cbz, Grand Blue Dreaming - SP02 Extra (2019) (Digital) (danke-Empire).cbz
             new Regex(
-                @"^(?<Series>(?!Vol).+?)(?:(ch(apter|\.)(\b|_|-|\s))|sp)",
+                @"^(?<Series>(?!Vol).+?)(?:(ch(apter|\.)(\b|_|-|\s))|sp)\d",
                 RegexOptions.IgnoreCase | RegexOptions.Compiled,
             RegexTimeout),
             // Historys Strongest Disciple Kenichi_v11_c90-98.zip, Killing Bites Vol. 0001 Ch. 0001 - Galactica Scanlations (gb)
@@ -939,6 +939,9 @@ namespace API.Parser
 
         /// <summary>
         /// Translates _ -> spaces, trims front and back of string, removes release groups
+        /// <example>
+        /// Hippos_the_Great [Digital], -> Hippos the Great
+        /// </example>
         /// </summary>
         /// <param name="title"></param>
         /// <returns></returns>
@@ -951,7 +954,7 @@ namespace API.Parser
             title = RemoveSpecialTags(title);
 
             title = title.Replace("_", " ").Trim();
-            if (title.EndsWith("-"))
+            if (title.EndsWith("-") || title.EndsWith(","))
             {
                 title = title.Substring(0, title.Length - 1);
             }

--- a/API/Parser/Parser.cs
+++ b/API/Parser/Parser.cs
@@ -396,6 +396,11 @@ namespace API.Parser
                 @"^(?<Series>.*)(?: |_)(c? ?)(?<Chapter>(\d+(\.\d)?)-?(\d+(\.\d)?)?)(c? ?)-",
                 RegexOptions.IgnoreCase | RegexOptions.Compiled,
             RegexTimeout),
+            // Saga 001 (2012) (Digital) (Empire-Zone)
+            new Regex(
+                @"(?<Series>.+?)(?: |_)(c? ?)(?<Chapter>(\d+(\.\d)?)-?(\d+(\.\d)?)?)\s\(\d{4}",
+                RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout),
             // Amazing Man Comics chapter 25
             new Regex(
                 @"^(?!Vol)(?<Series>.*)( |_)c(hapter)( |_)(?<Chapter>\d*)",

--- a/API/Services/DirectoryService.cs
+++ b/API/Services/DirectoryService.cs
@@ -306,6 +306,44 @@ namespace API.Services
 
 
        /// <summary>
+       /// Finds the highest directories from a set of MangaFiles
+       /// </summary>
+       /// <param name="libraryFolders">List of top level folders which files belong to</param>
+       /// <param name="filePaths">List of file paths that belong to libraryFolders</param>
+       /// <returns></returns>
+       public static Dictionary<string, string> FindHighestDirectoriesFromFiles(IEnumerable<string> libraryFolders, IList<string> filePaths)
+       {
+           var stopLookingForDirectories = false;
+           var dirs = new Dictionary<string, string>();
+           foreach (var folder in libraryFolders)
+           {
+               if (stopLookingForDirectories) break;
+               foreach (var file in filePaths)
+               {
+                   if (!file.Contains(folder)) continue;
+
+                   var parts = GetFoldersTillRoot(folder, file).ToList();
+                   if (parts.Count == 0)
+                   {
+                       // Break from all loops, we done, just scan folder.Path (library root)
+                       dirs.Add(folder, string.Empty);
+                       stopLookingForDirectories = true;
+                       break;
+                   }
+
+                   var fullPath = Path.Join(folder, parts.Last());
+                   if (!dirs.ContainsKey(fullPath))
+                   {
+                       dirs.Add(fullPath, string.Empty);
+                   }
+               }
+           }
+
+           return dirs;
+       }
+
+
+       /// <summary>
        /// Recursively scans files and applies an action on them. This uses as many cores the underlying PC has to speed
        /// up processing.
        /// </summary>

--- a/API/Services/ImageService.cs
+++ b/API/Services/ImageService.cs
@@ -14,13 +14,11 @@ namespace API.Services
   {
     private readonly ILogger<ImageService> _logger;
     private readonly IDirectoryService _directoryService;
-    private readonly NaturalSortComparer _naturalSortComparer;
 
     public ImageService(ILogger<ImageService> logger, IDirectoryService directoryService)
     {
       _logger = logger;
       _directoryService = directoryService;
-      _naturalSortComparer = new NaturalSortComparer();
     }
 
     /// <summary>
@@ -38,7 +36,7 @@ namespace API.Services
       }
 
       var firstImage = _directoryService.GetFilesWithExtension(directory, Parser.Parser.ImageFileExtensions)
-        .OrderBy(f => f, _naturalSortComparer).FirstOrDefault();
+        .OrderBy(f => f, new NaturalSortComparer()).FirstOrDefault();
 
       return firstImage;
     }

--- a/API/Services/MetadataService.cs
+++ b/API/Services/MetadataService.cs
@@ -223,10 +223,10 @@ namespace API.Services
             {
                 foreach (var chapter in volume.Chapters)
                 {
-                    UpdateMetadata(chapter, true);
+                    UpdateMetadata(chapter, false);
                 }
 
-                UpdateMetadata(volume, true);
+                UpdateMetadata(volume, false);
             }
 
             UpdateMetadata(series, true);

--- a/API/Services/MetadataService.cs
+++ b/API/Services/MetadataService.cs
@@ -159,10 +159,13 @@ namespace API.Services
             if (firstFile == null || (!forceUpdate && !firstFile.HasFileBeenModified())) return;
             if (Parser.Parser.IsPdf(firstFile.FilePath)) return;
 
-            var summary = Parser.Parser.IsEpub(firstFile.FilePath) ? _bookService.GetSummaryInfo(firstFile.FilePath) : _archiveService.GetSummaryInfo(firstFile.FilePath);
-            if (string.IsNullOrEmpty(series.Summary))
+            if (series.Format is MangaFormat.Archive or MangaFormat.Epub)
             {
-                series.Summary = summary;
+                var summary = Parser.Parser.IsEpub(firstFile.FilePath) ? _bookService.GetSummaryInfo(firstFile.FilePath) : _archiveService.GetSummaryInfo(firstFile.FilePath);
+                if (string.IsNullOrEmpty(series.Summary))
+                {
+                    series.Summary = summary;
+                }
             }
 
             firstFile.LastModified = DateTime.Now;

--- a/API/Services/TaskScheduler.cs
+++ b/API/Services/TaskScheduler.cs
@@ -176,5 +176,6 @@ namespace API.Services
         {
             await _metadataService.RefreshMetadataForSeries(libraryId, seriesId, forceUpdate);
         }
+
     }
 }

--- a/API/Services/TaskScheduler.cs
+++ b/API/Services/TaskScheduler.cs
@@ -144,7 +144,7 @@ namespace API.Services
         public void RefreshSeriesMetadata(int libraryId, int seriesId, bool forceUpdate = false)
         {
             _logger.LogInformation("Enqueuing series metadata refresh for: {SeriesId}", seriesId);
-            BackgroundJob.Enqueue(() => RefreshMetadataForSeries(libraryId, seriesId, forceUpdate));
+            BackgroundJob.Enqueue(() => _metadataService.RefreshMetadataForSeries(libraryId, seriesId, forceUpdate));
         }
 
         public void ScanSeries(int libraryId, int seriesId, bool forceUpdate = false)
@@ -167,15 +167,5 @@ namespace API.Services
             var update = await _versionUpdaterService.CheckForUpdate();
             await _versionUpdaterService.PushUpdate(update);
         }
-
-        /// <summary>
-        /// Not an external call. Only public so that we can call this for a Task
-        /// </summary>
-        // ReSharper disable once MemberCanBePrivate.Global
-        public async Task RefreshMetadataForSeries(int libraryId, int seriesId, bool forceUpdate = false)
-        {
-            await _metadataService.RefreshMetadataForSeries(libraryId, seriesId, forceUpdate);
-        }
-
     }
 }

--- a/API/Services/TaskScheduler.cs
+++ b/API/Services/TaskScheduler.cs
@@ -141,10 +141,10 @@ namespace API.Services
             BackgroundJob.Enqueue(() => DirectoryService.ClearDirectory(tempDirectory));
         }
 
-        public void RefreshSeriesMetadata(int libraryId, int seriesId)
+        public void RefreshSeriesMetadata(int libraryId, int seriesId, bool forceUpdate = false)
         {
             _logger.LogInformation("Enqueuing series metadata refresh for: {SeriesId}", seriesId);
-            BackgroundJob.Enqueue(() => _metadataService.RefreshMetadataForSeries(libraryId, seriesId));
+            BackgroundJob.Enqueue(() => RefreshMetadataForSeries(libraryId, seriesId, forceUpdate));
         }
 
         public void ScanSeries(int libraryId, int seriesId, bool forceUpdate = false)
@@ -166,6 +166,15 @@ namespace API.Services
         {
             var update = await _versionUpdaterService.CheckForUpdate();
             await _versionUpdaterService.PushUpdate(update);
+        }
+
+        /// <summary>
+        /// Not an external call. Only public so that we can call this for a Task
+        /// </summary>
+        // ReSharper disable once MemberCanBePrivate.Global
+        public async Task RefreshMetadataForSeries(int libraryId, int seriesId, bool forceUpdate = false)
+        {
+            await _metadataService.RefreshMetadataForSeries(libraryId, seriesId, forceUpdate);
         }
     }
 }

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -78,17 +78,10 @@ namespace API.Services.Tasks
                     totalFiles, parsedSeries.Keys.Count, sw.ElapsedMilliseconds + scanElapsedTime, series.Name);
 
                 CleanupDbEntities();
-                BackgroundJob.Enqueue(() => _metadataService.RefreshMetadataForSeries(libraryId, seriesId));
+                BackgroundJob.Enqueue(() => _metadataService.RefreshMetadataForSeries(libraryId, seriesId, false));
                 BackgroundJob.Enqueue(() => _cacheService.CleanupChapters(chapterIds));
-                // TODO: Tell UI that this series is done
-                await _messageHub.Clients.All.SendAsync("ScanSeries", new SignalRMessage
-                {
-                    Name = "ScanSeries",
-                    Body = new
-                    {
-                        SeriesId = seriesId
-                    }
-                }, cancellationToken: token);
+                // Tell UI that this series is done
+                await _messageHub.Clients.All.SendAsync(SignalREvents.ScanSeries, MessageFactory.ScanSeriesEvent(seriesId), cancellationToken: token);
             }
             else
             {

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -126,12 +126,12 @@ namespace API.Services.Tasks
 
        [DisableConcurrentExecution(timeoutInSeconds: 360)]
        [AutomaticRetry(Attempts = 0, OnAttemptsExceeded = AttemptsExceededAction.Delete)]
-       public void ScanLibraries()
+       public async Task ScanLibraries()
        {
           var libraries = Task.Run(() => _unitOfWork.LibraryRepository.GetLibrariesAsync()).Result.ToList();
           foreach (var lib in libraries)
           {
-             ScanLibrary(lib.Id, false);
+             await ScanLibrary(lib.Id, false);
           }
 
        }

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -51,7 +51,7 @@ namespace API.Services.Tasks
            var files = await _unitOfWork.SeriesRepository.GetFilesForSeries(seriesId);
            var series = await _unitOfWork.SeriesRepository.GetSeriesByIdAsync(seriesId);
            var library = await _unitOfWork.LibraryRepository.GetFullLibraryForIdAsync(libraryId, seriesId);
-           var dirs = FindHighestDirectoriesFromFiles(library, files);
+           var dirs = DirectoryService.FindHighestDirectoriesFromFiles(library.Folders.Select(f => f.Path), files.Select(f => f.FilePath).ToList());
            var chapterIds = await _unitOfWork.SeriesRepository.GetChapterIdsForSeriesAsync(new []{ seriesId });
 
            _logger.LogInformation("Beginning file scan on {SeriesName}", series.Name);
@@ -67,6 +67,37 @@ namespace API.Services.Tasks
                parsedSeries.Remove(key);
            }
 
+           if (parsedSeries.Count == 0)
+           {
+               // We need to do an additional check for an edge case: If the scan ran and the files do not match the existing Series name, then it is very likely,
+               // the files have crap naming and if we don't correct, the series will get deleted due to the parser not being able to fallback onto folder parsing as the root
+               // is the series folder.
+               var existingFolder = dirs.Keys.FirstOrDefault(key => key.Contains(series.OriginalName));
+               if (dirs.Keys.Count == 1 && !string.IsNullOrEmpty(existingFolder))
+               {
+                   dirs = new Dictionary<string, string>();
+                   var path = Path.GetPathRoot(existingFolder);
+                   if (!string.IsNullOrEmpty(path))
+                   {
+                       dirs[path] = string.Empty;
+                   }
+               }
+               _logger.LogDebug("{SeriesName} has bad naming convention, forcing rescan at a higher directory.", series.OriginalName);
+               scanner = new ParseScannedFiles(_bookService, _logger);
+               parsedSeries = scanner.ScanLibrariesForSeries(library.Type, dirs.Keys, out var totalFiles2, out var scanElapsedTime2);
+               totalFiles += totalFiles2;
+               scanElapsedTime += scanElapsedTime2;
+
+               // If a root level folder scan occurs, then multiple series gets passed in and thus we get a unique constraint issue
+               // Hence we clear out anything but what we selected for
+               firstSeries = library.Series.FirstOrDefault();
+               keys = parsedSeries.Keys;
+               foreach (var key in keys.Where(key => !firstSeries.NameInParserInfo(parsedSeries[key].FirstOrDefault()) || firstSeries?.Format != key.Format))
+               {
+                   parsedSeries.Remove(key);
+               }
+           }
+
            var sw = new Stopwatch();
            UpdateLibrary(library, parsedSeries);
 
@@ -78,7 +109,7 @@ namespace API.Services.Tasks
                     totalFiles, parsedSeries.Keys.Count, sw.ElapsedMilliseconds + scanElapsedTime, series.Name);
 
                 CleanupDbEntities();
-                BackgroundJob.Enqueue(() => _metadataService.RefreshMetadataForSeries(libraryId, seriesId, false));
+                BackgroundJob.Enqueue(() => _metadataService.RefreshMetadataForSeries(libraryId, seriesId, forceUpdate));
                 BackgroundJob.Enqueue(() => _cacheService.CleanupChapters(chapterIds));
                 // Tell UI that this series is done
                 await _messageHub.Clients.All.SendAsync(SignalREvents.ScanSeries, MessageFactory.ScanSeriesEvent(seriesId), cancellationToken: token);
@@ -98,37 +129,37 @@ namespace API.Services.Tasks
        /// <param name="library"></param>
        /// <param name="files"></param>
        /// <returns></returns>
-       private static Dictionary<string, string> FindHighestDirectoriesFromFiles(Library library, IList<MangaFile> files)
-       {
-          var stopLookingForDirectories = false;
-          var dirs = new Dictionary<string, string>();
-          foreach (var folder in library.Folders)
-          {
-             if (stopLookingForDirectories) break;
-             foreach (var file in files)
-             {
-                if (!file.FilePath.Contains(folder.Path)) continue;
-
-                var parts = DirectoryService.GetFoldersTillRoot(folder.Path, file.FilePath).ToList();
-                if (parts.Count == 0)
-                {
-                   // Break from all loops, we done, just scan folder.Path (library root)
-                   dirs.Add(folder.Path, string.Empty);
-                   stopLookingForDirectories = true;
-                   break;
-                }
-
-                var fullPath = Path.Join(folder.Path, parts.Last());
-                if (!dirs.ContainsKey(fullPath))
-                {
-                   dirs.Add(fullPath, string.Empty);
-                }
-             }
-          }
-
-          return dirs;
-       }
-
+       // private static Dictionary<string, string> FindHighestDirectoriesFromFiles(Library library, IList<MangaFile> files)
+       // {
+       //    var stopLookingForDirectories = false;
+       //    var dirs = new Dictionary<string, string>();
+       //    foreach (var folder in library.Folders)
+       //    {
+       //       if (stopLookingForDirectories) break;
+       //       foreach (var file in files)
+       //       {
+       //          if (!file.FilePath.Contains(folder.Path)) continue;
+       //
+       //          var parts = DirectoryService.GetFoldersTillRoot(folder.Path, file.FilePath).ToList();
+       //          if (parts.Count == 0)
+       //          {
+       //             // Break from all loops, we done, just scan folder.Path (library root)
+       //             dirs.Add(folder.Path, string.Empty);
+       //             stopLookingForDirectories = true;
+       //             break;
+       //          }
+       //
+       //          var fullPath = Path.Join(folder.Path, parts.Last());
+       //          if (!dirs.ContainsKey(fullPath))
+       //          {
+       //             dirs.Add(fullPath, string.Empty);
+       //          }
+       //       }
+       //    }
+       //
+       //    return dirs;
+       // }
+       //
 
        [DisableConcurrentExecution(timeoutInSeconds: 360)]
        [AutomaticRetry(Attempts = 0, OnAttemptsExceeded = AttemptsExceededAction.Delete)]

--- a/API/Services/Tasks/VersionUpdaterService.cs
+++ b/API/Services/Tasks/VersionUpdaterService.cs
@@ -140,11 +140,7 @@ namespace API.Services.Tasks
                 connections.AddRange(await _tracker.GetConnectionsForUser(admin));
             }
 
-            await _messageHub.Clients.Users(admins).SendAsync("UpdateAvailable", new SignalRMessage
-            {
-                Name = "UpdateAvailable",
-                Body = update
-            });
+            await _messageHub.Clients.Users(admins).SendAsync(SignalREvents.UpdateVersion, MessageFactory.UpdateVersionEvent(update));
         }
 
 

--- a/API/SignalR/MessageFactory.cs
+++ b/API/SignalR/MessageFactory.cs
@@ -1,0 +1,42 @@
+﻿using System.Threading;
+using API.DTOs.Update;
+
+namespace API.SignalR
+{
+    public static class MessageFactory
+    {
+        public static SignalRMessage ScanSeriesEvent(int seriesId)
+        {
+            return new SignalRMessage()
+            {
+                Name = SignalREvents.ScanSeries,
+                Body = new
+                {
+                    SeriesId = seriesId
+                }
+            };
+        }
+
+        public static SignalRMessage RefreshMetadataEvent(int libraryId, int seriesId)
+        {
+            return new SignalRMessage()
+            {
+                Name = SignalREvents.RefreshMetadata,
+                Body = new
+                {
+                    SeriesId = seriesId,
+                    LibraryId = libraryId
+                }
+            };
+        }
+
+        public static SignalRMessage UpdateVersionEvent(UpdateNotificationDto update)
+        {
+            return new SignalRMessage
+            {
+                Name = SignalREvents.UpdateVersion,
+                Body = update
+            };
+        }
+    }
+}

--- a/API/SignalR/MessageFactory.cs
+++ b/API/SignalR/MessageFactory.cs
@@ -17,6 +17,19 @@ namespace API.SignalR
             };
         }
 
+        public static SignalRMessage ScanLibraryEvent(int libraryId, string stage)
+        {
+            return new SignalRMessage()
+            {
+                Name = SignalREvents.ScanLibrary,
+                Body = new
+                {
+                    LibraryId = libraryId,
+                    Stage = stage
+                }
+            };
+        }
+
         public static SignalRMessage RefreshMetadataEvent(int libraryId, int seriesId)
         {
             return new SignalRMessage()
@@ -38,5 +51,6 @@ namespace API.SignalR
                 Body = update
             };
         }
+
     }
 }

--- a/API/SignalR/SignalREvents.cs
+++ b/API/SignalR/SignalREvents.cs
@@ -1,0 +1,10 @@
+﻿namespace API.SignalR
+{
+    public static class SignalREvents
+    {
+        public const string UpdateVersion = "UpdateVersion";
+        public const string ScanSeries = "ScanSeries";
+        public const string RefreshMetadata = "RefreshMetadata";
+
+    }
+}

--- a/API/SignalR/SignalREvents.cs
+++ b/API/SignalR/SignalREvents.cs
@@ -5,6 +5,7 @@
         public const string UpdateVersion = "UpdateVersion";
         public const string ScanSeries = "ScanSeries";
         public const string RefreshMetadata = "RefreshMetadata";
+        public const string ScanLibrary = "ScanLibrary";
 
     }
 }

--- a/UI/Web/src/app/_guards/admin.guard.ts
+++ b/UI/Web/src/app/_guards/admin.guard.ts
@@ -19,7 +19,7 @@ export class AdminGuard implements CanActivate {
         if (this.accountService.hasAdminRole(user)) {
           return true;
         }
-
+        
         this.toastr.error('You are not authorized to view this page.');
         return false;
       })

--- a/UI/Web/src/app/_guards/auth.guard.ts
+++ b/UI/Web/src/app/_guards/auth.guard.ts
@@ -19,7 +19,9 @@ export class AuthGuard implements CanActivate {
         if (user) {
           return true;
         }
-        this.toastr.error('You are not authorized to view this page.');
+        if (this.toastr.toasts.filter(toast => toast.message === 'Unauthorized' || toast.message === 'You are not authorized to view this page.').length === 0) {
+          this.toastr.error('You are not authorized to view this page.');
+        }
         localStorage.setItem(this.urlKey, window.location.pathname);
         this.router.navigateByUrl('/libraries');
         return false;

--- a/UI/Web/src/app/_models/events/scan-library-event.ts
+++ b/UI/Web/src/app/_models/events/scan-library-event.ts
@@ -1,0 +1,4 @@
+export interface ScanLibraryEvent {
+    libraryId: number;
+    stage: 'complete';
+}

--- a/UI/Web/src/app/_models/events/scan-series-event.ts
+++ b/UI/Web/src/app/_models/events/scan-series-event.ts
@@ -1,0 +1,3 @@
+export interface ScanSeriesEvent {
+    seriesId: number;
+}

--- a/UI/Web/src/app/_services/action-factory.service.ts
+++ b/UI/Web/src/app/_services/action-factory.service.ts
@@ -260,6 +260,12 @@ export class ActionFactoryService {
         requiresAdmin: false
       },
       {
+        action: Action.IncognitoRead,
+        title: 'Read in Incognito',
+        callback: this.dummyCallback,
+        requiresAdmin: false
+      },
+      {
         action: Action.AddToReadingList,
         title: 'Add to Reading List',
         callback: this.dummyCallback,

--- a/UI/Web/src/app/_services/message-hub.service.ts
+++ b/UI/Web/src/app/_services/message-hub.service.ts
@@ -5,11 +5,14 @@ import { User } from '@sentry/angular';
 import { BehaviorSubject, ReplaySubject } from 'rxjs';
 import { environment } from 'src/environments/environment';
 import { UpdateNotificationModalComponent } from '../shared/update-notification/update-notification-modal.component';
+import { ScanLibraryEvent } from '../_models/events/scan-library-event';
 import { ScanSeriesEvent } from '../_models/events/scan-series-event';
 
 export enum EVENTS {
   UpdateAvailable = 'UpdateAvailable',
   ScanSeries = 'ScanSeries',
+  ScanLibrary = 'ScanLibrary',
+  RefreshMetadata = 'RefreshMetadata',
 }
 
 export interface Message<T> {
@@ -29,6 +32,7 @@ export class MessageHubService {
   public messages$ = this.messagesSource.asObservable();
 
   public scanSeries: EventEmitter<ScanSeriesEvent> = new EventEmitter<ScanSeriesEvent>();
+  public scanLibrary: EventEmitter<ScanLibraryEvent> = new EventEmitter<ScanLibraryEvent>();
 
   constructor(private modalService: NgbModal) { }
 
@@ -54,6 +58,17 @@ export class MessageHubService {
         payload: resp.body
       });
       this.scanSeries.emit(resp.body);
+    });
+
+    this.hubConnection.on(EVENTS.ScanLibrary, resp => {
+      this.messagesSource.next({
+        event: EVENTS.ScanLibrary,
+        payload: resp.body
+      });
+      this.scanLibrary.emit(resp.body);
+      // if ((resp.body as ScanLibraryEvent).stage === 'complete') {
+      //   this.toastr.
+      // }
     });
 
     this.hubConnection.on(EVENTS.UpdateAvailable, resp => {

--- a/UI/Web/src/app/manga-reader/_models/reader-enums.ts
+++ b/UI/Web/src/app/manga-reader/_models/reader-enums.ts
@@ -2,21 +2,21 @@ export enum FITTING_OPTION {
     HEIGHT = 'full-height',
     WIDTH = 'full-width',
     ORIGINAL = 'original'
-  }
+}
   
 export enum SPLIT_PAGE_PART {
     NO_SPLIT = 'none',
     LEFT_PART = 'left',
     RIGHT_PART = 'right'
-  }
+}
   
 export enum PAGING_DIRECTION {
     FORWARD = 1,
     BACKWARDS = -1,
-  }
+}
   
 export enum COLOR_FILTER {
     NONE = '',
     SEPIA = 'filter-sepia',
     DARK = 'filter-dark'
-  }
+}

--- a/UI/Web/src/app/manga-reader/infinite-scroller/infinite-scroller.component.html
+++ b/UI/Web/src/app/manga-reader/infinite-scroller/infinite-scroller.component.html
@@ -1,5 +1,5 @@
 
-<div class="fixed-top overlay" *ngIf="debug">
+<div class="fixed-top overlay" *ngIf="showDebugBar()">
     <strong>Captures Scroll Events:</strong> {{!this.isScrolling && this.allImagesLoaded}}
     <strong>Is Scrolling:</strong> {{isScrollingForwards() ? 'Forwards' : 'Backwards'}} {{this.isScrolling}}
     <strong>All Images Loaded:</strong> {{this.allImagesLoaded}}
@@ -26,7 +26,7 @@
     </div>
 </div>
 <ng-container *ngFor="let item of webtoonImages | async; let index = index;">
-    <img src="{{item.src}}" style="display: block" class="mx-auto {{pageNum === item.page && debug ? 'active': ''}}" *ngIf="pageNum >= pageNum - bufferPages && pageNum <= pageNum + bufferPages" rel="nofollow" alt="image" (load)="onImageLoad($event)" id="page-{{item.page}}" [attr.page]="item.page" ondragstart="return false;" onselectstart="return false;">
+    <img src="{{item.src}}" style="display: block" class="mx-auto {{pageNum === item.page && showDebugOutline() ? 'active': ''}}" *ngIf="pageNum >= pageNum - bufferPages && pageNum <= pageNum + bufferPages" rel="nofollow" alt="image" (load)="onImageLoad($event)" id="page-{{item.page}}" [attr.page]="item.page" ondragstart="return false;" onselectstart="return false;">
 </ng-container>
 <div *ngIf="atBottom" class="spacer bottom" role="alert" (click)="loadPrevChapter.emit()">
     <div>

--- a/UI/Web/src/app/manga-reader/infinite-scroller/infinite-scroller.component.html
+++ b/UI/Web/src/app/manga-reader/infinite-scroller/infinite-scroller.component.html
@@ -4,12 +4,12 @@
     <strong>Is Scrolling:</strong> {{isScrollingForwards() ? 'Forwards' : 'Backwards'}} {{this.isScrolling}}
     <strong>All Images Loaded:</strong> {{this.allImagesLoaded}}
     <strong>Prefetched</strong> {{minPageLoaded}}-{{maxPageLoaded}} 
-    <strong>Current Page:</strong>{{pageNum}}
-    <strong>Width:</strong> {{webtoonImageWidth}}
     <strong>Pages:</strong> {{pageNum}} / {{totalPages}}
     <strong>At Top:</strong> {{atTop}}
     <strong>At Bottom:</strong> {{atBottom}}
-
+    <strong>Total Height:</strong> {{getTotalHeight()}}
+    <strong>Total Scroll:</strong> {{getTotalScroll()}}
+    <strong>Scroll Top:</strong> {{getScrollTop()}}
 </div>
 
 <div *ngIf="atTop" class="spacer top" role="alert" (click)="loadPrevChapter.emit()">

--- a/UI/Web/src/app/manga-reader/infinite-scroller/infinite-scroller.component.ts
+++ b/UI/Web/src/app/manga-reader/infinite-scroller/infinite-scroller.component.ts
@@ -412,15 +412,15 @@ export class InfiniteScrollerComponent implements OnInit, OnChanges, OnDestroy {
     let startingIndex = 0;
     let endingIndex = 0;
     if (this.isScrollingForwards()) {
-      startingIndex = Math.min(Math.max(this.pageNum - this.bufferPages, 0), this.totalPages + 1);
-      endingIndex = Math.min(Math.max(this.pageNum + this.bufferPages, 0), this.totalPages + 1);
+      startingIndex = Math.min(Math.max(this.pageNum - this.bufferPages, 0), this.totalPages);
+      endingIndex = Math.min(Math.max(this.pageNum + this.bufferPages, 0), this.totalPages);
 
-      if (startingIndex === this.totalPages + 1) {
+      if (startingIndex === this.totalPages) {
         return [0, 0];
       }
     } else {
-      startingIndex = Math.min(Math.max(this.pageNum - this.bufferPages, 0), this.totalPages + 1);
-      endingIndex = Math.min(Math.max(this.pageNum + this.bufferPages, 0), this.totalPages + 1);
+      startingIndex = Math.min(Math.max(this.pageNum - this.bufferPages, 0), this.totalPages);
+      endingIndex = Math.min(Math.max(this.pageNum + this.bufferPages, 0), this.totalPages);
     }
 
 
@@ -442,7 +442,7 @@ export class InfiniteScrollerComponent implements OnInit, OnChanges, OnDestroy {
     if (startingIndex === 0 && endingIndex === 0) { return; }
 
     this.debugLog('\t[PREFETCH] prefetching pages: ' + startingIndex + ' to ' + endingIndex);
-    for(let i = startingIndex; i < endingIndex; i++) {
+    for(let i = startingIndex; i <= endingIndex; i++) {
       this.loadWebtoonImage(i);
     }
 

--- a/UI/Web/src/app/manga-reader/infinite-scroller/infinite-scroller.component.ts
+++ b/UI/Web/src/app/manga-reader/infinite-scroller/infinite-scroller.component.ts
@@ -234,12 +234,12 @@ export class InfiniteScrollerComponent implements OnInit, OnChanges, OnDestroy {
       // < 5 because debug mode and FF (mobile) can report non 0, despite being at 0
       if (this.getScrollTop() < 5 && this.pageNum === 0 && !this.atTop) {
         this.atBottom = false;
+
         this.atTop = true; 
-        // Scroll user back to original location (FF Mobile: This is causing jank)
+        // Scroll user back to original location
         this.previousScrollHeightMinusTop = document.documentElement.scrollHeight - document.documentElement.scrollTop;
         requestAnimationFrame(() => window.scrollTo(0, SPACER_SCROLL_INTO_PX));
-      }
-      if (this.atTop) {
+      } else if (this.getScrollTop() < 5 && this.pageNum === 0 && this.atTop) {
         // If already at top, then we moving on
         this.loadPrevChapter.emit();
       }
@@ -271,7 +271,6 @@ export class InfiniteScrollerComponent implements OnInit, OnChanges, OnDestroy {
     this.imagesLoaded = {};
     this.webtoonImages.next([]);
     this.atBottom = false;
-    //this.atTop = document.documentElement.scrollTop === 0 && this.pageNum === 0;
     this.checkIfShouldTriggerContinuousReader();
 
     const [startingIndex, endingIndex] = this.calculatePrefetchIndecies();

--- a/UI/Web/src/app/manga-reader/infinite-scroller/infinite-scroller.component.ts
+++ b/UI/Web/src/app/manga-reader/infinite-scroller/infinite-scroller.component.ts
@@ -117,7 +117,7 @@ export class InfiniteScrollerComponent implements OnInit, OnChanges, OnDestroy {
   /**
    * Debug mode. Will show extra information. Use bitwise (|) operators between different modes to enable different output
    */
-  debugMode: DEBUG_MODES = DEBUG_MODES.None;// DEBUG_MODES.Logs | DEBUG_MODES.ActionBar | DEBUG_MODES.Outline;
+  debugMode: DEBUG_MODES = DEBUG_MODES.None;
 
   get minPageLoaded() {
     return Math.min(...Object.values(this.imagesLoaded));
@@ -215,44 +215,33 @@ export class InfiniteScrollerComponent implements OnInit, OnChanges, OnDestroy {
       const totalHeight = this.getTotalHeight();
       const totalScroll = this.getTotalScroll();
 
-      console.log('down: totalScroll: ', totalScroll + (this.debugMode & DEBUG_MODES.None ? 1 : 0));
-      console.log('down: totalHeight: ', totalHeight);
-
       // If we were at top but have started scrolling down past page 0, remove top spacer
       if (this.atTop && this.pageNum > 0) {
         this.atTop = false;
       }
       // debug mode will add an extra pixel from the image border + (this.debug ? 1 : 0) 
-      if (totalScroll === totalHeight && !this.atBottom) { // totalScroll === totalHeight, totalScroll - totalHeight <= 1
+      if (totalScroll === totalHeight && !this.atBottom) {
         this.atBottom = true;
         this.setPageNum(this.totalPages);
         // Scroll user back to original location
         this.previousScrollHeightMinusTop = document.documentElement.scrollTop;
-        console.log('down: this.previousScrollHeightMinusTop: ', this.previousScrollHeightMinusTop);
-        console.log('down: new scroll top: ', this.previousScrollHeightMinusTop + (SPACER_SCROLL_INTO_PX / 2));
-        setTimeout(() => document.documentElement.scrollTop = this.previousScrollHeightMinusTop + (SPACER_SCROLL_INTO_PX / 2), 10);
+        requestAnimationFrame(() => document.documentElement.scrollTop = this.previousScrollHeightMinusTop + (SPACER_SCROLL_INTO_PX / 2));
       } else if (totalScroll >= totalHeight + SPACER_SCROLL_INTO_PX && this.atBottom) { 
         // This if statement will fire once we scroll into the spacer at all
-        //this.loadNextChapter.emit();
+        this.loadNextChapter.emit();
       }
     } else {
-      console.log('up: totalScroll: ', document.documentElement.scrollTop);
       // < 5 because debug mode and FF (mobile) can report non 0, despite being at 0
-      if (this.getScrollTop() < 5 && this.pageNum === 0 && !this.atTop) { // document.documentElement.scrollTop === 0
+      if (this.getScrollTop() < 5 && this.pageNum === 0 && !this.atTop) {
         this.atBottom = false;
         this.atTop = true; 
         // Scroll user back to original location (FF Mobile: This is causing jank)
         this.previousScrollHeightMinusTop = document.documentElement.scrollHeight - document.documentElement.scrollTop;
-        console.log('up: this.previousScrollHeightMinusTop: ', this.previousScrollHeightMinusTop);
-        console.log('up: new scroll top (old): ', document.documentElement.scrollHeight - this.previousScrollHeightMinusTop - (SPACER_SCROLL_INTO_PX / 2));
-        console.log('up: new scroll top (new): ', (SPACER_SCROLL_INTO_PX * 2));
-
-        // This might work, but not sure. I think it's happenening too fast
-        setTimeout(() => document.documentElement.scrollTop = (SPACER_SCROLL_INTO_PX / 2), 100); // document.documentElement.scrollHeight - this.previousScrollHeightMinusTop - (SPACER_SCROLL_INTO_PX / 2)
+        requestAnimationFrame(() => window.scrollTo(0, SPACER_SCROLL_INTO_PX));
       }
       if (this.atTop) {
         // If already at top, then we moving on
-        //this.loadPrevChapter.emit();
+        this.loadPrevChapter.emit();
       }
     }
 

--- a/UI/Web/src/app/manga-reader/infinite-scroller/infinite-scroller.component.ts
+++ b/UI/Web/src/app/manga-reader/infinite-scroller/infinite-scroller.component.ts
@@ -412,15 +412,15 @@ export class InfiniteScrollerComponent implements OnInit, OnChanges, OnDestroy {
     let startingIndex = 0;
     let endingIndex = 0;
     if (this.isScrollingForwards()) {
-      startingIndex = Math.min(Math.max(this.pageNum - this.bufferPages, 0), this.totalPages);
-      endingIndex = Math.min(Math.max(this.pageNum + this.bufferPages, 0), this.totalPages);
+      startingIndex = Math.min(Math.max(this.pageNum - this.bufferPages, 0), this.totalPages + 1);
+      endingIndex = Math.min(Math.max(this.pageNum + this.bufferPages, 0), this.totalPages + 1);
 
-      if (startingIndex === this.totalPages) {
+      if (startingIndex === this.totalPages + 1) {
         return [0, 0];
       }
     } else {
-      startingIndex = Math.min(Math.max(this.pageNum - this.bufferPages, 0), this.totalPages);
-      endingIndex = Math.min(Math.max(this.pageNum + this.bufferPages, 0), this.totalPages);
+      startingIndex = Math.min(Math.max(this.pageNum - this.bufferPages, 0), this.totalPages + 1);
+      endingIndex = Math.min(Math.max(this.pageNum + this.bufferPages, 0), this.totalPages + 1);
     }
 
 

--- a/UI/Web/src/app/manga-reader/infinite-scroller/infinite-scroller.component.ts
+++ b/UI/Web/src/app/manga-reader/infinite-scroller/infinite-scroller.component.ts
@@ -212,7 +212,7 @@ export class InfiniteScrollerComponent implements OnInit, OnChanges, OnDestroy {
         this.atTop = false;
       }
       // debug mode will add an extra pixel from the image border + (this.debug ? 1 : 0) 
-      if (totalScroll - totalHeight <= 1) { // totalScroll === totalHeight
+      if (totalScroll === totalHeight && !this.atBottom) { // totalScroll === totalHeight, totalScroll - totalHeight <= 1
         this.atBottom = true;
         this.setPageNum(this.totalPages);
         // Scroll user back to original location

--- a/UI/Web/src/app/manga-reader/infinite-scroller/infinite-scroller.component.ts
+++ b/UI/Web/src/app/manga-reader/infinite-scroller/infinite-scroller.component.ts
@@ -117,7 +117,7 @@ export class InfiniteScrollerComponent implements OnInit, OnChanges, OnDestroy {
   /**
    * Debug mode. Will show extra information. Use bitwise (|) operators between different modes to enable different output
    */
-  debugMode: DEBUG_MODES = DEBUG_MODES.Logs | DEBUG_MODES.ActionBar | DEBUG_MODES.Outline;
+  debugMode: DEBUG_MODES = DEBUG_MODES.None;// DEBUG_MODES.Logs | DEBUG_MODES.ActionBar | DEBUG_MODES.Outline;
 
   get minPageLoaded() {
     return Math.min(...Object.values(this.imagesLoaded));
@@ -244,8 +244,11 @@ export class InfiniteScrollerComponent implements OnInit, OnChanges, OnDestroy {
         // Scroll user back to original location (FF Mobile: This is causing jank)
         this.previousScrollHeightMinusTop = document.documentElement.scrollHeight - document.documentElement.scrollTop;
         console.log('up: this.previousScrollHeightMinusTop: ', this.previousScrollHeightMinusTop);
-        console.log('up: new scroll top: ', document.documentElement.scrollHeight - this.previousScrollHeightMinusTop - (SPACER_SCROLL_INTO_PX / 2));
-        setTimeout(() => document.documentElement.scrollTop = document.documentElement.scrollHeight - this.previousScrollHeightMinusTop - (SPACER_SCROLL_INTO_PX / 2), 10);
+        console.log('up: new scroll top (old): ', document.documentElement.scrollHeight - this.previousScrollHeightMinusTop - (SPACER_SCROLL_INTO_PX / 2));
+        console.log('up: new scroll top (new): ', (SPACER_SCROLL_INTO_PX * 2));
+
+        // This might work, but not sure. I think it's happenening too fast
+        setTimeout(() => document.documentElement.scrollTop = (SPACER_SCROLL_INTO_PX / 2), 100); // document.documentElement.scrollHeight - this.previousScrollHeightMinusTop - (SPACER_SCROLL_INTO_PX / 2)
       }
       if (this.atTop) {
         // If already at top, then we moving on

--- a/UI/Web/src/app/manga-reader/manga-reader.component.html
+++ b/UI/Web/src/app/manga-reader/manga-reader.component.html
@@ -30,7 +30,7 @@
         <div class="webtoon-images" *ngIf="readerMode === READER_MODE.WEBTOON && !isLoading">
             <app-infinite-scroller [pageNum]="pageNum" [bufferPages]="5" [goToPage]="goToPageEvent" (pageNumberChange)="handleWebtoonPageChange($event)" [totalPages]="maxPages - 1" [urlProvider]="getPageUrl" (loadNextChapter)="loadNextChapter()" (loadPrevChapter)="loadPrevChapter()"></app-infinite-scroller>
         </div>
-        <ng-container *ngIf="readerMode === READER_MODE.MANGA_LR || readerMode === READER_MODE.MANGA_UD"> <!--; else webtoonClickArea; See if people want this mode WEBTOON_WITH_CLICKS-->
+        <ng-container *ngIf="readerMode === READER_MODE.MANGA_LR || readerMode === READER_MODE.MANGA_UD">
             <div class="{{readerMode === READER_MODE.MANGA_LR ? 'right' : 'top'}} {{clickOverlayClass('right')}}" (click)="handlePageChange($event, 'right')"></div>
             <div class="{{readerMode === READER_MODE.MANGA_LR ? 'left' : 'bottom'}} {{clickOverlayClass('left')}}" (click)="handlePageChange($event, 'left')"></div>
         </ng-container>
@@ -64,7 +64,7 @@
         </div>
         <div class="row pt-4 ml-2 mr-2">
             <div class="col">
-                <button class="btn btn-icon" (click)="setReadingDirection();resetMenuCloseTimer();" [disabled]="readerMode === READER_MODE.WEBTOON" aria-describedby="reading-direction" title="Reading Direction: {{readingDirection === ReadingDirection.LeftToRight ? 'Left to Right' : 'Right to Left'}}">
+                <button class="btn btn-icon" (click)="setReadingDirection();resetMenuCloseTimer();" [disabled]="readerMode === READER_MODE.WEBTOON || readerMode === READER_MODE.MANGA_UD" aria-describedby="reading-direction" title="Reading Direction: {{readingDirection === ReadingDirection.LeftToRight ? 'Left to Right' : 'Right to Left'}}">
                     <i class="fa fa-angle-double-{{readingDirection === ReadingDirection.LeftToRight ? 'right' : 'left'}}" aria-hidden="true"></i>
                     <span id="reading-direction" class="sr-only">{{readingDirection === ReadingDirection.LeftToRight ? 'Left to Right' : 'Right to Left'}}</span>
                 </button>

--- a/UI/Web/src/app/manga-reader/manga-reader.component.html
+++ b/UI/Web/src/app/manga-reader/manga-reader.component.html
@@ -43,14 +43,19 @@
     </div>
     
     <div class="fixed-bottom overlay" *ngIf="menuOpen" [@slideFromBottom]="menuOpen">
-        <div class="form-group" *ngIf="pageOptions != undefined && pageOptions.ceil != undefined && pageOptions.ceil > 0">
+        <div class="form-group" *ngIf="pageOptions != undefined && pageOptions.ceil != undefined">
             <span class="sr-only" id="slider-info"></span>
             <div class="row no-gutters">
                 <button class="btn btn-small btn-icon col-1" [disabled]="prevChapterDisabled" (click)="loadPrevChapter();resetMenuCloseTimer();" title="Prev Chapter/Volume"><i class="fa fa-fast-backward" aria-hidden="true"></i></button>
                 <button class="btn btn-small btn-icon col-1" [disabled]="prevPageDisabled || pageNum === 0" (click)="goToPage(0);resetMenuCloseTimer();" title="First Page"><i class="fa fa-step-backward" aria-hidden="true"></i></button>
-                <div class="col custom-slider">
+                <div class="col custom-slider" *ngIf="pageOptions.ceil > 0; else noSlider">
                     <ngx-slider [options]="pageOptions" [value]="pageNum" aria-describedby="slider-info" [manualRefresh]="refreshSlider" (userChangeEnd)="sliderPageUpdate($event);startMenuCloseTimer()" (userChangeStart)="cancelMenuCloseTimer();"></ngx-slider>
                 </div>
+                <ng-template #noSlider>
+                    <div class="col custom-slider">
+                        <ngx-slider [options]="pageOptions" [value]="pageNum" aria-describedby="slider-info" (userChangeEnd)="startMenuCloseTimer()" (userChangeStart)="cancelMenuCloseTimer();"></ngx-slider>
+                    </div>
+                </ng-template>
                 <button class="btn btn-small btn-icon col-2" [disabled]="nextPageDisabled || pageNum >= maxPages - 1" (click)="goToPage(this.maxPages);resetMenuCloseTimer();" title="Last Page"><i class="fa fa-step-forward" aria-hidden="true"></i></button>
                 <button class="btn btn-small btn-icon col-1" [disabled]="nextChapterDisabled" (click)="loadNextChapter();resetMenuCloseTimer();" title="Next Chapter/Volume"><i class="fa fa-fast-forward" aria-hidden="true"></i></button>
             </div>

--- a/UI/Web/src/app/manga-reader/manga-reader.component.scss
+++ b/UI/Web/src/app/manga-reader/manga-reader.component.scss
@@ -92,20 +92,6 @@ canvas {
 }
 
 
-.center-menu {
-    position: fixed;
-    top: 10px;
-    left: $side-width;
-    width: $center-width;
-    border-bottom: $dash-width dashed $secondary-color;
-    text-align: center;
-    z-index: 2;
-    padding-bottom: 10px;
-    padding-left: 10px;
-    padding-right: 10px;
-}
-
-
 .right {
     position: fixed;
     right: 0px;

--- a/UI/Web/src/app/manga-reader/manga-reader.component.ts
+++ b/UI/Web/src/app/manga-reader/manga-reader.component.ts
@@ -442,7 +442,7 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
         }
       });
 
-      // ! Should I move the prefetching code if we start in webtoon reader mode? 
+
       const images = [];
       for (let i = 0; i < PREFETCH_PAGES + 2; i++) {
         images.push(new Image());
@@ -982,6 +982,7 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   saveSettings() {
+    // NOTE: This is not called anywhere
     if (this.user === undefined) return;
 
     const data: Preferences = {

--- a/UI/Web/src/app/manga-reader/manga-reader.component.ts
+++ b/UI/Web/src/app/manga-reader/manga-reader.component.ts
@@ -347,11 +347,26 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
 
   @HostListener('window:keyup', ['$event'])
   handleKeyPress(event: KeyboardEvent) {
-    if (event.key === KEY_CODES.RIGHT_ARROW || event.key === KEY_CODES.DOWN_ARROW) {
-      this.readingDirection === ReadingDirection.LeftToRight ? this.nextPage() : this.prevPage();
-    } else if (event.key === KEY_CODES.LEFT_ARROW || event.key === KEY_CODES.UP_ARROW) {
-      this.readingDirection === ReadingDirection.LeftToRight ? this.prevPage() : this.nextPage();
-    } else if (event.key === KEY_CODES.ESC_KEY) {
+
+    switch (this.readerMode) {
+      case READER_MODE.MANGA_LR:
+        if (event.key === KEY_CODES.RIGHT_ARROW) {
+          this.readingDirection === ReadingDirection.LeftToRight ? this.nextPage() : this.prevPage();
+        } else if (event.key === KEY_CODES.LEFT_ARROW) {
+          this.readingDirection === ReadingDirection.LeftToRight ? this.prevPage() : this.nextPage();
+        }
+        break;
+      case READER_MODE.MANGA_UD:
+      case READER_MODE.WEBTOON:
+        if (event.key === KEY_CODES.DOWN_ARROW) {
+          this.nextPage()
+        } else if (event.key === KEY_CODES.UP_ARROW) {
+          this.prevPage()
+        }
+        break;
+    }
+
+    if (event.key === KEY_CODES.ESC_KEY) {
       if (this.menuOpen) {
         this.toggleMenu();
         event.stopPropagation();
@@ -1008,6 +1023,7 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
    * Bookmarks the current page for the chapter
    */
   bookmarkPage() {
+    // TODO: Show some sort of UI visual to show that a page was bookmarked
     const pageNum = this.pageNum;
     if (this.pageBookmarked) {
       this.readerService.unbookmark(this.seriesId, this.volumeId, this.chapterId, pageNum).pipe(take(1)).subscribe(() => {

--- a/UI/Web/src/app/nav-header/nav-header.component.html
+++ b/UI/Web/src/app/nav-header/nav-header.component.html
@@ -2,7 +2,7 @@
     <div class="container-fluid">
       <a class="sr-only sr-only-focusable focus-visible" href="javascript:void(0);" (click)="moveFocus()">Skip to main content</a>
       <a class="navbar-brand" routerLink="/library" routerLinkActive="active"><img class="logo" src="../../assets/images/logo.png" alt="kavita icon" aria-hidden="true"/><span class="phone-hidden"> Kavita</span></a>
-      <ul class="navbar-nav mr-auto">
+      <ul class="navbar-nav col mr-auto">
         
         <div class="nav-item" *ngIf="(accountService.currentUser$ | async) as user">
           <div>

--- a/UI/Web/src/app/reading-list/dragable-ordered-list/dragable-ordered-list.component.html
+++ b/UI/Web/src/app/reading-list/dragable-ordered-list/dragable-ordered-list.component.html
@@ -2,16 +2,19 @@
     <div class="example-box" *ngFor="let item of items; index as i" cdkDrag [cdkDragData]="item" cdkDragBoundary=".example-list">
         <div class="mr-3 align-middle">
             <i class="fa fa-grip-vertical drag-handle" aria-hidden="true" cdkDragHandle></i>
-            <label for="reorder-{{i}}" class="sr-only">Reorder</label>
-            <input *ngIf="accessibilityMode" id="reorder-{{i}}" type="number" min="0" [max]="items.length - 1" [value]="i" style="width: 40px" (keydown.enter)="updateIndex(i, item)" aria-describedby="instructions">
         </div>
 
         <ng-container  style="display: inline-block" [ngTemplateOutlet]="itemTemplate" [ngTemplateOutletContext]="{ $implicit: item, idx: i }"></ng-container>
 
+        <div class="align-middle" style="padding-top: 40px">
+            <label for="reorder-{{i}}" class="sr-only">Reorder</label>
+                    <input *ngIf="accessibilityMode" id="reorder-{{i}}" type="number" min="0" [max]="items.length - 1" [value]="i" style="width: 40px" (focusout)="updateIndex(i, item)" (keydown.enter)="updateIndex(i, item)" aria-describedby="instructions">
+        </div>
         <button class="btn btn-icon pull-right" (click)="removeItem(item, i)">
             <i class="fa fa-times" aria-hidden="true"></i>
             <span class="sr-only" attr.aria-labelledby="item.id--{{i}}">Remove item</span>
-          </button>
+        </button>
+        
     </div>
 </div>
 

--- a/UI/Web/src/app/reading-list/dragable-ordered-list/dragable-ordered-list.component.scss
+++ b/UI/Web/src/app/reading-list/dragable-ordered-list/dragable-ordered-list.component.scss
@@ -1,10 +1,8 @@
 .example-list {
     min-width: 500px;
     max-width: 100%;
-    //border: solid 1px #ccc;
     min-height: 60px;
     display: block;
-    //background: white;
     border-radius: 4px;
     overflow: hidden;
   }
@@ -12,13 +10,9 @@
   .example-box {
     padding: 20px 10px;
     border-bottom: solid 1px #ccc;
-    //color: rgba(0, 0, 0, 0.87);
     display: flex;
     flex-direction: row;
-    //align-items: center;
-    //justify-content: space-between;
     box-sizing: border-box;
-    //background: white;
     font-size: 14px;
 
     .drag-handle {

--- a/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.html
+++ b/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.html
@@ -28,6 +28,12 @@
                       <span class="read-btn--text">&nbsp;Remove Read</span>
                   </button>
               </div>
+              <div class="ml-2 mt-2">
+                <div class="form-check form-check-inline">
+                  <input class="form-check-input" type="checkbox" id="accessibilit-mode" [value]="accessibilityMode" (change)="accessibilityMode = !accessibilityMode">
+                  <label class="form-check-label" for="accessibilit-mode">Show Order Numbers</label>
+                </div>
+              </div>
             </div>
             <div class="row no-gutters mt-2">
               <app-read-more [text]="readingList.summary" [maxLength]="250"></app-read-more>
@@ -39,8 +45,7 @@
       No chapters added
     </div>    
 
-    <!-- NOTE: It might be nice to have a switch for the accessibility toggle -->
-    <app-dragable-ordered-list [items]="items" (orderUpdated)="orderUpdated($event)" (itemRemove)="itemRemoved($event)">
+    <app-dragable-ordered-list [items]="items" (orderUpdated)="orderUpdated($event)" (itemRemove)="itemRemoved($event)" [accessibilityMode]="accessibilityMode">
         <ng-template #draggableItem let-item let-position="idx">
             <div class="media" style="width: 100%;">
                 <img width="74px" style="width: 74px;" class="img-top lazyload mr-3" [src]="imageService.placeholderImage" [attr.data-src]="imageService.getChapterCoverImage(item.chapterId)" 

--- a/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.html
+++ b/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.html
@@ -1,44 +1,45 @@
-<div class="container mt-2" *ngIf="readingList">
-  <div class="row mb-3">
-        <div class="col-md-10 col-xs-8 col-sm-6">
-            <div class="row no-gutters">
+<div class="container-sm mt-2" *ngIf="readingList">
+  <div class="mb-3">
+    <!-- Title row-->
+    <div class="row no-gutters">
                 
-              <h2 style="display: inline-block">
-                <span *ngIf="actions.length > 0">
-                    <app-card-actionables (actionHandler)="performAction($event)" [actions]="actions" [labelBy]="readingList.title"></app-card-actionables>&nbsp;
-                </span>
-                {{readingList.title}}&nbsp;<span *ngIf="readingList?.promoted">(<i class="fa fa-angle-double-up" aria-hidden="true"></i>)</span>&nbsp;
-                <span class="badge badge-primary badge-pill" attr.aria-label="{{items.length}} total items">{{items.length}}</span>
-              </h2>
-            </div>
-            <div class="row no-gutters">
-              <div class="mr-2">
-                <button class="btn btn-primary" title="Read" (click)="read()">
-                    <span>
-                        <i class="fa fa-book-open" aria-hidden="true"></i>
-                        <span class="read-btn--text">&nbsp;Read</span>
-                    </span>
-                </button>
-              </div>
-              <div>
-                  <button class="btn btn-secondary" (click)="removeRead()" [disabled]="readingList?.promoted && !this.isAdmin">
-                      <span>
-                          <i class="fa fa-check"></i>
-                      </span>
-                      <span class="read-btn--text">&nbsp;Remove Read</span>
-                  </button>
-              </div>
-              <div class="ml-2 mt-2">
-                <div class="form-check form-check-inline">
-                  <input class="form-check-input" type="checkbox" id="accessibilit-mode" [value]="accessibilityMode" (change)="accessibilityMode = !accessibilityMode">
-                  <label class="form-check-label" for="accessibilit-mode">Show Order Numbers</label>
-                </div>
-              </div>
-            </div>
-            <div class="row no-gutters mt-2">
-              <app-read-more [text]="readingList.summary" [maxLength]="250"></app-read-more>
-            </div>
+      <h2 style="display: inline-block">
+        <span *ngIf="actions.length > 0">
+            <app-card-actionables (actionHandler)="performAction($event)" [actions]="actions" [labelBy]="readingList.title"></app-card-actionables>&nbsp;
+        </span>
+        {{readingList.title}}&nbsp;<span *ngIf="readingList?.promoted">(<i class="fa fa-angle-double-up" aria-hidden="true"></i>)</span>&nbsp;
+        <span class="badge badge-primary badge-pill" attr.aria-label="{{items.length}} total items">{{items.length}}</span>
+      </h2>
+    </div>
+    <!-- Action row-->
+    <div class="row no-gutters">
+      <div class="mr-2">
+        <button class="btn btn-primary" title="Read" (click)="read()">
+            <span>
+                <i class="fa fa-book-open" aria-hidden="true"></i>
+                <span class="read-btn--text">&nbsp;Read</span>
+            </span>
+        </button>
+      </div>
+      <div>
+          <button class="btn btn-secondary" (click)="removeRead()" [disabled]="readingList?.promoted && !this.isAdmin">
+              <span>
+                  <i class="fa fa-check"></i>
+              </span>
+              <span class="read-btn--text">&nbsp;Remove Read</span>
+          </button>
+      </div>
+      <div class="ml-2 mt-2" *ngIf="!(readingList?.promoted && !this.isAdmin)">
+        <div class="form-check form-check-inline">
+          <input class="form-check-input" type="checkbox" id="accessibilit-mode" [value]="accessibilityMode" (change)="accessibilityMode = !accessibilityMode">
+          <label class="form-check-label" for="accessibilit-mode">Order Numbers</label>
         </div>
+      </div>
+    </div>
+    <!-- Summary row-->
+    <div class="row no-gutters mt-2">
+      <app-read-more [text]="readingList.summary" [maxLength]="250"></app-read-more>
+    </div>
     </div>
 
     <div *ngIf="items.length === 0">

--- a/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.scss
+++ b/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.scss
@@ -1,0 +1,4 @@
+.container-sm {
+    padding-left: 0px;
+    padding-right: 0px;
+}

--- a/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.ts
+++ b/UI/Web/src/app/reading-list/reading-list-detail/reading-list-detail.component.ts
@@ -26,6 +26,7 @@ export class ReadingListDetailComponent implements OnInit {
   actions: Array<ActionItem<any>> = [];
   isAdmin: boolean = false;
   isLoading: boolean = false;
+  accessibilityMode: boolean = false;
 
   // Downloading
   hasDownloadingRole: boolean = false;

--- a/UI/Web/src/app/series-detail/series-detail.component.html
+++ b/UI/Web/src/app/series-detail/series-detail.component.html
@@ -95,8 +95,6 @@
             </div>
         </div>
     </div>
-    <hr>
-
 
     <div>
         <ul ngbNav #nav="ngbNav" [(activeId)]="activeTabId" class="nav-tabs nav-pills" [destroyOnHide]="false">

--- a/UI/Web/src/app/series-detail/series-detail.component.ts
+++ b/UI/Web/src/app/series-detail/series-detail.component.ts
@@ -124,6 +124,8 @@ export class SeriesDetailComponent implements OnInit, OnDestroy {
     this.messageHub.scanSeries.pipe(takeUntil(this.onDestroy)).subscribe((event: ScanSeriesEvent) => {
       if (event.seriesId == this.series.id)
       this.loadSeries(seriesId);
+      this.seriesImage = this.imageService.randomize(this.imageService.getSeriesCoverImage(this.series.id));
+      this.toastr.success('Scan series completed');
     });
 
     const seriesId = parseInt(routeId, 10);

--- a/UI/Web/src/app/series-detail/series-detail.component.ts
+++ b/UI/Web/src/app/series-detail/series-detail.component.ts
@@ -140,12 +140,6 @@ export class SeriesDetailComponent implements OnInit, OnDestroy {
     this.onDestroy.complete();
   }
 
-  loadSeriesMetadata(seriesId: number) {
-    this.seriesService.getMetadata(seriesId).subscribe(metadata => {
-      this.seriesMetadata = metadata;
-    });
-  }
-
   handleSeriesActionCallback(action: Action, series: Series) {
     this.actionInProgress = true;
     switch(action) {
@@ -436,7 +430,6 @@ export class SeriesDetailComponent implements OnInit, OnDestroy {
       window.scrollTo(0, 0);
       if (closeResult.success) {
         this.loadSeries(this.series.id);
-        this.loadSeriesMetadata(this.series.id);
         if (closeResult.coverImageUpdate) {
           // Random triggers a load change without any problems with API
           this.seriesImage = this.imageService.randomize(this.imageService.getSeriesCoverImage(this.series.id));

--- a/UI/Web/src/app/series-detail/series-detail.component.ts
+++ b/UI/Web/src/app/series-detail/series-detail.component.ts
@@ -1,9 +1,10 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 import { ActivatedRoute, Router } from '@angular/router';
 import { NgbModal, NgbRatingConfig } from '@ng-bootstrap/ng-bootstrap';
 import { ToastrService } from 'ngx-toastr';
-import { finalize, take, takeWhile } from 'rxjs/operators';
+import { Subject } from 'rxjs';
+import { finalize, take, takeUntil, takeWhile } from 'rxjs/operators';
 import { CardDetailsModalComponent } from '../cards/_modals/card-details-modal/card-details-modal.component';
 import { EditSeriesModalComponent } from '../cards/_modals/edit-series-modal/edit-series-modal.component';
 import { ConfirmConfig } from '../shared/confirm-dialog/_models/confirm-config';
@@ -13,6 +14,7 @@ import { DownloadService } from '../shared/_services/download.service';
 import { UtilityService } from '../shared/_services/utility.service';
 import { ReviewSeriesModalComponent } from '../_modals/review-series-modal/review-series-modal.component';
 import { Chapter } from '../_models/chapter';
+import { ScanSeriesEvent } from '../_models/events/scan-series-event';
 import { LibraryType } from '../_models/library';
 import { MangaFormat } from '../_models/manga-format';
 import { Series } from '../_models/series';
@@ -23,6 +25,7 @@ import { ActionItem, ActionFactoryService, Action } from '../_services/action-fa
 import { ActionService } from '../_services/action.service';
 import { ImageService } from '../_services/image.service';
 import { LibraryService } from '../_services/library.service';
+import { MessageHubService } from '../_services/message-hub.service';
 import { ReaderService } from '../_services/reader.service';
 import { SeriesService } from '../_services/series.service';
 
@@ -32,7 +35,7 @@ import { SeriesService } from '../_services/series.service';
   templateUrl: './series-detail.component.html',
   styleUrls: ['./series-detail.component.scss']
 })
-export class SeriesDetailComponent implements OnInit {
+export class SeriesDetailComponent implements OnInit, OnDestroy {
 
   series!: Series;
   volumes: Volume[] = [];
@@ -76,6 +79,8 @@ export class SeriesDetailComponent implements OnInit {
    */
   actionInProgress: boolean = false;
 
+  private onDestroy: Subject<void> = new Subject();
+
 
   get LibraryType(): typeof LibraryType {
     return LibraryType;
@@ -97,7 +102,7 @@ export class SeriesDetailComponent implements OnInit {
               private actionFactoryService: ActionFactoryService, private libraryService: LibraryService,
               private confirmService: ConfirmService, private titleService: Title,
               private downloadService: DownloadService, private actionService: ActionService,
-              public imageSerivce: ImageService) {
+              public imageSerivce: ImageService, private messageHub: MessageHubService) {
     ratingConfig.max = 5;
     this.router.routeReuseStrategy.shouldReuseRoute = () => false;
     this.accountService.currentUser$.pipe(take(1)).subscribe(user => {
@@ -116,14 +121,23 @@ export class SeriesDetailComponent implements OnInit {
       return;
     }
 
+    this.messageHub.scanSeries.pipe(takeUntil(this.onDestroy)).subscribe((event: ScanSeriesEvent) => {
+      if (event.seriesId == this.series.id)
+      this.loadSeries(seriesId);
+    });
+
     const seriesId = parseInt(routeId, 10);
     this.libraryId = parseInt(libraryId, 10);
     this.seriesImage = this.imageService.getSeriesCoverImage(seriesId);
-    this.loadSeriesMetadata(seriesId);
     this.libraryService.getLibraryType(this.libraryId).subscribe(type => {
       this.libraryType = type;
       this.loadSeries(seriesId);
     });
+  }
+
+  ngOnDestroy() {
+    this.onDestroy.next();
+    this.onDestroy.complete();
   }
 
   loadSeriesMetadata(seriesId: number) {

--- a/UI/Web/src/app/user-settings/user-preferences/user-preferences.component.html
+++ b/UI/Web/src/app/user-settings/user-preferences/user-preferences.component.html
@@ -142,20 +142,20 @@
                                     </div>
                                     <div class="form-group">
                                         <label id="font-size">Font Size</label>
-                                        <ngx-slider [options]="bookReaderFontSizeOptions" formControlName="bookReaderFontSize" aria-labelledby="font-size"></ngx-slider>
+                                        <div class="custom-slider"><ngx-slider [options]="bookReaderFontSizeOptions" formControlName="bookReaderFontSize" aria-labelledby="font-size"></ngx-slider></div>
                                     </div>
                                     <div class="form-group">
                                         <label>Line Height</label>&nbsp;<i class="fa fa-info-circle" aria-hidden="true" placement="right" [ngbTooltip]="bookLineHeightOptionTooltip" role="button" tabindex="0"></i>
                                         <ng-template #bookLineHeightOptionTooltip>How much spacing between the lines of the book</ng-template>
                                         <span class="sr-only" id="settings-booklineheight-option-help">How much spacing between the lines of the book</span>
-                                        <ngx-slider [options]="bookReaderLineSpacingOptions" formControlName="bookReaderLineSpacing" aria-describedby="settings-booklineheight-option-help"></ngx-slider>
+                                        <div class="custom-slider"><ngx-slider [options]="bookReaderLineSpacingOptions" formControlName="bookReaderLineSpacing" aria-describedby="settings-booklineheight-option-help"></ngx-slider></div>
                                     </div>
     
                                     <div class="form-group">
                                         <label>Margin</label>&nbsp;<i class="fa fa-info-circle" aria-hidden="true" placement="right" [ngbTooltip]="bookReaderMarginOptionTooltip" role="button" tabindex="0"></i>
                                         <ng-template #bookReaderMarginOptionTooltip>How much spacing on each side of the screen. This will override to 0 on mobile devices regardless of this setting.</ng-template>
                                         <span class="sr-only" id="settings-bookmargin-option-help">How much spacing on each side of the screen. This will override to 0 on mobile devices regardless of this setting.</span>
-                                        <ngx-slider [options]="bookReaderMarginOptions" formControlName="bookReaderMargin" aria-describedby="bookmargin"></ngx-slider>
+                                        <div class="custom-slider"><ngx-slider [options]="bookReaderMarginOptions" formControlName="bookReaderMargin" aria-describedby="bookmargin"></ngx-slider></div>
                                     </div>
     
                                     <div class="float-right mb-3">

--- a/UI/Web/src/app/user-settings/user-preferences/user-preferences.component.scss
+++ b/UI/Web/src/app/user-settings/user-preferences/user-preferences.component.scss
@@ -1,3 +1,55 @@
+@import '../../../theme/colors';
+
 .invalid-feedback {
     display: inline-block !important;
 }
+
+// Slider handle override
+::ng-deep {
+    .custom-slider .ngx-slider .ngx-slider-bar {
+      background: #545a52;
+      height: 2px;
+    }
+    .custom-slider .ngx-slider .ngx-slider-selection {
+      background: $primary-color;
+    }
+  
+    .custom-slider .ngx-slider .ngx-slider-pointer {
+      width: 8px;
+      height: 16px;
+      top: auto; /* to remove the default positioning */
+      bottom: 0;
+      background-color: $primary-color; // #333;
+      border-top-left-radius: 3px;
+      border-top-right-radius: 3px;
+    }
+  
+    .custom-slider .ngx-slider .ngx-slider-pointer:after {
+      display: none;
+    }
+  
+    .custom-slider .ngx-slider .ngx-slider-bubble {
+      bottom: 14px;
+      font-weight: bold;
+    }
+  
+    .custom-slider .ngx-slider .ngx-slider-limit {
+      font-weight: bold;
+      color: white !important;
+  
+    }
+  
+  
+    .custom-slider .ngx-slider .ngx-slider-tick {
+      width: 1px;
+      height: 10px;
+      margin-left: 4px;
+      border-radius: 0;
+      background: #ffe4d1;
+      top: -1px;
+    }
+  
+    .custom-slider .ngx-slider .ngx-slider-tick.ngx-slider-selected {
+      background: $primary-color;
+    }
+  }

--- a/UI/Web/src/app/user-settings/user-preferences/user-preferences.component.scss
+++ b/UI/Web/src/app/user-settings/user-preferences/user-preferences.component.scss
@@ -19,7 +19,7 @@
       height: 16px;
       top: auto; /* to remove the default positioning */
       bottom: 0;
-      background-color: $primary-color; // #333;
+      background-color: $primary-color;
       border-top-left-radius: 3px;
       border-top-right-radius: 3px;
     }

--- a/UI/Web/src/assets/themes/dark.scss
+++ b/UI/Web/src/assets/themes/dark.scss
@@ -5,6 +5,7 @@ $dark-primary-color: rgba(74, 198, 148, 0.9);
 $dark-text-color: #efefef;
 $dark-hover-color: #4ac694;
 $dark-form-background: rgba(1, 4, 9, 0.5);
+$dark-form-background-no-opacity: rgb(1, 4, 9);
 $dark-form-placeholder: #efefef;
 $dark-link-color: rgb(88, 166, 255);
 $dark-icon-color: white;
@@ -126,6 +127,7 @@ $dark-item-accent-bg: #292d32;
   
 
   .dropdown-menu {
+    background-color: #171719db;
     .dropdown-item:hover, .dropdown-item:focus {
         color: $dark-text-color;
         background-color: $dark-hover-color;

--- a/UI/Web/src/assets/themes/dark.scss
+++ b/UI/Web/src/assets/themes/dark.scss
@@ -127,7 +127,7 @@ $dark-item-accent-bg: #292d32;
   
 
   .dropdown-menu {
-    background-color: #171719db;
+    background-color: #171719;
     .dropdown-item:hover, .dropdown-item:focus {
         color: $dark-text-color;
         background-color: $dark-hover-color;

--- a/UI/Web/src/styles.scss
+++ b/UI/Web/src/styles.scss
@@ -51,54 +51,6 @@ body {
   cursor: pointer;
 }
 
-// Slider handle override
-::ng-deep {
-  .custom-slider .ngx-slider .ngx-slider-bar {
-    background: #ffe4d1;
-    height: 2px;
-  }
-  .custom-slider .ngx-slider .ngx-slider-selection {
-    background: orange;
-  }
-
-  .custom-slider .ngx-slider .ngx-slider-pointer {
-    width: 8px;
-    height: 16px;
-    top: auto; /* to remove the default positioning */
-    bottom: 0;
-    background-color: #333;
-    border-top-left-radius: 3px;
-    border-top-right-radius: 3px;
-  }
-
-  .custom-slider .ngx-slider .ngx-slider-pointer:after {
-    display: none;
-  }
-
-  .custom-slider .ngx-slider .ngx-slider-bubble {
-    bottom: 14px;
-  }
-
-  .custom-slider .ngx-slider .ngx-slider-limit {
-    font-weight: bold;
-    color: orange;
-  }
-
-  .custom-slider .ngx-slider .ngx-slider-tick {
-    width: 1px;
-    height: 10px;
-    margin-left: 4px;
-    border-radius: 0;
-    background: #ffe4d1;
-    top: -1px;
-  }
-
-  .custom-slider .ngx-slider .ngx-slider-tick.ngx-slider-selected {
-    background: orange;
-  }
-}
-
-
 
 // Utiliities
 @include media-breakpoint-down(xs, (xs: 0, sm: 576px, md: 768px, lg: 992px, xl: 1200px)) {

--- a/UI/Web/tsconfig.json
+++ b/UI/Web/tsconfig.json
@@ -4,6 +4,7 @@
   "compilerOptions": {
     "baseUrl": "./",
     "outDir": "./dist/out-tsc",
+    "removeComments": true /* Do not emit comments to output. */,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitReturns": true,


### PR DESCRIPTION
This misc branch of goodies has a large effort focus on performance, some parsing improvements, and getting the webtoon reader working much more reliably on all devices. 

# Added
- Added: Added parser case for 'The Duke of Death and His Black Maid - Ch. 177 - The Ball (3).cbz'
- Added: Added a way for external scripts to use a user api key to authenticate (this essentially allows 3rd party scripts to interact with Kavita).
- Added: Implemented the ability to automatically refresh after a series scan based on when server finishes. This will push the event to the user and if they are on series detail, the page will automatically update to reflect new status on backend
- Added: Added many more manga and comic parsing cases which leads to catching more file naming conventions


# Fixed
- Fixed: Fixed a bad parser case for 'Batman Beyond 02 (of 6) (1999)' which was consuming too many characters
- Fixed: Fixed an issue if the manga only had one page, the bottom menu would be missing page and chapter controls.
- Fixed: Fixed a bug where on small phones, nav bar could overflow due to scroll to top
- Fixed: Don't force metadata refresh on Scan Series, only on refresh metadata
- Fixed: Fixed a bug when really poorly named files are within a folder that contains the series name, fallback couldn't occur due to it being taken as root folder and would delete the series. Now we detect said condition and will go one level higher, resulting in potentially more I/O, but the series will not be deleted.
- Fixed: Added the Read in Incognito context item for Chapter cards
- Fixed: Fixed an issue where cover image generation could occur due to a bad check on LastWriteTime on the underlying file.
- Fixed: (Webtoon reader) Ensure prefetching uses totalPages + 1 since we pass in totalPages as - 1 from manga reader
- Fixed: (Webtoon reader) Fixed issue where last page of webtoon wouldn't be prefetched due to a < instead of <= on prefetching code
- Fixed: Fixed alignment on phones for reading lists with long titles causing overflow (Fixes #575 )

# Changed
- Changed: Webtoon reader with continuous reading now works on mobile (develop)
- Changed: Removed a lot of Volume parsing for Comics that don't make sense
- Changed: Reworked a lot of parsing cases for comics based on naming conventions observed from releases found online.
- Changed: Tweaked a lot of regex for manga parsing to handle some cases where poorly named files, like 'Vol. 03 Ch. 21' would end up parsing as Series 'Vol. 03'.
- Changed: Dropdown menus now have a darker background
- Changed: Fixed how keyboard presses for up/down/left/right work with MANGA_UD reading mode. Up/down only work when using Up/Down mode.  (Fixes #579)
- Changed: All sliders in the app (user preferences) now use the same style
- Changed: Auth guard will now check if an existing toast is present giving same message before popping the toast.
- Changed: Moved sorters so they aren't reused between multiple threads. Slightly higher memory footprint. There was a rare exception thrown in the sort code due to concurrent access.

# Performance
- Removed some duplicate API calls from series detail page
- Performance: Performance improvement on metadata service. Now when we scan for cover image changes, we emit when a change occurs and only then do we update parent entities (array copy)
- Implemented ability to send images from archives to the UI without incurring any extra memory pressure.
- Performance: Huge updates to metadata refresh. On 650GB, 12k file DB, metadata refresh now only takes 2.2 seconds to check all files to updates to cover images, summary, etc. 
