### PR TITLE
WebP Support

### DIFF
--- a/API.Tests/Parser/ParserTest.cs
+++ b/API.Tests/Parser/ParserTest.cs
@@ -156,6 +156,7 @@ namespace API.Tests.Parser
         [InlineData("test.png", true)]
         [InlineData(".test.jpg", false)]
         [InlineData("!test.jpg", false)]
+        [InlineData("test.webp", true)]
         public void IsImageTest(string filename, bool expected)
         {
             Assert.Equal(expected, IsImage(filename));

--- a/API/Interfaces/Services/IMetadataService.cs
+++ b/API/Interfaces/Services/IMetadataService.cs
@@ -10,7 +10,7 @@ namespace API.Interfaces.Services
         /// </summary>
         /// <param name="libraryId"></param>
         /// <param name="forceUpdate"></param>
-        void RefreshMetadata(int libraryId, bool forceUpdate = false);
+        Task RefreshMetadata(int libraryId, bool forceUpdate = false);
 
         public bool UpdateMetadata(Chapter chapter, bool forceUpdate);
         public bool UpdateMetadata(Volume volume, bool forceUpdate);

--- a/API/Parser/Parser.cs
+++ b/API/Parser/Parser.cs
@@ -13,7 +13,7 @@ namespace API.Parser
         public const string DefaultVolume = "0";
         private static readonly TimeSpan RegexTimeout = TimeSpan.FromMilliseconds(500);
 
-        public const string ImageFileExtensions = @"^(\.png|\.jpeg|\.jpg)";
+        public const string ImageFileExtensions = @"^(\.png|\.jpeg|\.jpg|\.webp)";
         public const string ArchiveFileExtensions = @"\.cbz|\.zip|\.rar|\.cbr|\.tar.gz|\.7zip|\.7z|\.cb7|\.cbt";
         public const string BookFileExtensions = @"\.epub|\.pdf";
         public const string MacOsMetadataFileStartsWith = @"._";

--- a/API/Services/MetadataService.cs
+++ b/API/Services/MetadataService.cs
@@ -187,10 +187,10 @@ namespace API.Services
         /// <remarks>This can be heavy on memory first run</remarks>
         /// <param name="libraryId"></param>
         /// <param name="forceUpdate">Force updating cover image even if underlying file has not been modified or chapter already has a cover image</param>
-        public void RefreshMetadata(int libraryId, bool forceUpdate = false)
+        public async Task RefreshMetadata(int libraryId, bool forceUpdate = false)
         {
             var sw = Stopwatch.StartNew();
-            var library = Task.Run(() => _unitOfWork.LibraryRepository.GetFullLibraryForIdAsync(libraryId)).GetAwaiter().GetResult();
+            var library = await _unitOfWork.LibraryRepository.GetFullLibraryForIdAsync(libraryId);
 
             // PERF: See if we can break this up into multiple threads that process 20 series at a time then save so we can reduce amount of memory used
             _logger.LogInformation("Beginning metadata refresh of {LibraryName}", library.Name);
@@ -213,7 +213,7 @@ namespace API.Services
             }
 
 
-            if (_unitOfWork.HasChanges() && Task.Run(() => _unitOfWork.CommitAsync()).Result)
+            if (_unitOfWork.HasChanges() && await _unitOfWork.CommitAsync())
             {
                 _logger.LogInformation("Updated metadata for {LibraryName} in {ElapsedMilliseconds} milliseconds", library.Name, sw.ElapsedMilliseconds);
             }
@@ -228,7 +228,7 @@ namespace API.Services
         public async Task RefreshMetadataForSeries(int libraryId, int seriesId, bool forceUpdate = false)
         {
             var sw = Stopwatch.StartNew();
-            var library = Task.Run(() => _unitOfWork.LibraryRepository.GetFullLibraryForIdAsync(libraryId)).GetAwaiter().GetResult();
+            var library = await _unitOfWork.LibraryRepository.GetFullLibraryForIdAsync(libraryId);
 
             var series = library.Series.SingleOrDefault(s => s.Id == seriesId);
             if (series == null)

--- a/UI/Web/src/app/_services/action-factory.service.ts
+++ b/UI/Web/src/app/_services/action-factory.service.ts
@@ -113,17 +113,10 @@ export class ActionFactoryService {
     
         this.chapterActions.push({
           action: Action.Edit,
-          title: 'Edit',
+          title: 'Info',
           callback: this.dummyCallback,
           requiresAdmin: false
         });
-
-        // this.readingListActions.push({
-        //   action: Action.Promote, // Should I just use CollectionTag modal-like instead?
-        //   title: 'Delete',
-        //   callback: this.dummyCallback,
-        //   requiresAdmin: true
-        // });
       }
 
       if (this.hasDownloadRole || this.isAdmin) {
@@ -145,33 +138,39 @@ export class ActionFactoryService {
   }
 
   getLibraryActions(callback: (action: Action, library: Library) => void) {
-    this.libraryActions.forEach(action => action.callback = callback);
-    return this.libraryActions;
+    const actions = this.libraryActions.map(a => {return {...a}});
+    actions.forEach(action => action.callback = callback);
+    return actions;
   }
 
   getSeriesActions(callback: (action: Action, series: Series) => void) {
-    this.seriesActions.forEach(action => action.callback = callback);
-    return this.seriesActions;
+    const actions = this.seriesActions.map(a => {return {...a}});
+    actions.forEach(action => action.callback = callback);
+    return actions;
   }
 
   getVolumeActions(callback: (action: Action, volume: Volume) => void) {
-    this.volumeActions.forEach(action => action.callback = callback);
-    return this.volumeActions;
+    const actions = this.volumeActions.map(a => {return {...a}});
+    actions.forEach(action => action.callback = callback);
+    return actions;
   }
 
   getChapterActions(callback: (action: Action, chapter: Chapter) => void) {
-    this.chapterActions.forEach(action => action.callback = callback);
-    return this.chapterActions;
+    const actions = this.chapterActions.map(a => {return {...a}});
+    actions.forEach(action => action.callback = callback);
+    return actions;
   }
 
   getCollectionTagActions(callback: (action: Action, collectionTag: CollectionTag) => void) {
-    this.collectionTagActions.forEach(action => action.callback = callback);
-    return this.collectionTagActions;
+    const actions = this.collectionTagActions.map(a => {return {...a}});
+    actions.forEach(action => action.callback = callback);
+    return actions;
   }
 
   getReadingListActions(callback: (action: Action, readingList: ReadingList) => void) {
-    this.readingListActions.forEach(action => action.callback = callback);
-    return this.readingListActions;
+    const actions = this.readingListActions.map(a => {return {...a}});
+    actions.forEach(action => action.callback = callback);
+    return actions;
   }
 
   filterBookmarksForFormat(action: ActionItem<Series>, series: Series) {

--- a/UI/Web/src/app/_services/action.service.ts
+++ b/UI/Web/src/app/_services/action.service.ts
@@ -1,8 +1,8 @@
 import { Injectable, OnDestroy } from '@angular/core';
 import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import { ToastrService } from 'ngx-toastr';
-import { forkJoin, Subject } from 'rxjs';
-import { take, takeUntil } from 'rxjs/operators';
+import { Subject } from 'rxjs';
+import { take } from 'rxjs/operators';
 import { BookmarksModalComponent } from '../cards/_modals/bookmarks-modal/bookmarks-modal.component';
 import { AddToListModalComponent, ADD_FLOW } from '../reading-list/_modals/add-to-list-modal/add-to-list-modal.component';
 import { EditReadingListModalComponent } from '../reading-list/_modals/edit-reading-list-modal/edit-reading-list-modal.component';

--- a/UI/Web/src/app/_services/reader.service.ts
+++ b/UI/Web/src/app/_services/reader.service.ts
@@ -150,6 +150,7 @@ export class ReaderService {
     return newRoute;
   }
 
+
   getQueryParamsObject(incognitoMode: boolean = false, readingListMode: boolean = false, readingListId: number = -1) {
     let params: {[key: string]: any} = {};
     if (incognitoMode) {

--- a/UI/Web/src/app/admin/changelog/changelog.component.html
+++ b/UI/Web/src/app/admin/changelog/changelog.component.html
@@ -2,10 +2,8 @@
     <div class="card w-100 mb-2" style="width: 18rem;">
         <div class="card-body">
           <h5 class="card-title">{{update.updateTitle}}&nbsp;
-              <span class="badge badge-secondary" *ngIf="update.updateVersion <= update.currentVersion; else available">Installed</span>
-              <ng-template #available>
-                  <span class="badge badge-secondary">Available</span>
-              </ng-template>
+              <span class="badge badge-secondary" *ngIf="update.updateVersion === update.currentVersion">Installed</span>
+              <span class="badge badge-secondary" *ngIf="update.updateVersion > update.currentVersion">Available</span>
           </h5>
           <pre class="card-text update-body" [innerHtml]="update.updateBody | safeHtml"></pre>
           <a *ngIf="!update.isDocker" href="{{update.updateUrl}}" class="btn btn-{{indx === 0 ? 'primary' : 'secondary'}} float-right" target="_blank">Download</a>

--- a/UI/Web/src/app/book-reader/book-reader/book-reader.component.ts
+++ b/UI/Web/src/app/book-reader/book-reader/book-reader.component.ts
@@ -479,10 +479,10 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
     if (this.nextChapterId === CHAPTER_ID_NOT_FETCHED || this.nextChapterId === this.chapterId) {
       this.readerService.getNextChapter(this.seriesId, this.volumeId, this.chapterId, this.readingListId).pipe(take(1)).subscribe(chapterId => {
         this.nextChapterId = chapterId;
-        this.loadChapter(chapterId, 'next');
+        this.loadChapter(chapterId, 'Next');
       });
     } else {
-      this.loadChapter(this.nextChapterId, 'next');
+      this.loadChapter(this.nextChapterId, 'Next');
     }
   }
 
@@ -502,14 +502,14 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
     if (this.prevChapterId === CHAPTER_ID_NOT_FETCHED || this.prevChapterId === this.chapterId) {
       this.readerService.getPrevChapter(this.seriesId, this.volumeId, this.chapterId, this.readingListId).pipe(take(1)).subscribe(chapterId => {
         this.prevChapterId = chapterId;
-        this.loadChapter(chapterId, 'prev');
+        this.loadChapter(chapterId, 'Prev');
       });
     } else {
-      this.loadChapter(this.prevChapterId, 'prev');
+      this.loadChapter(this.prevChapterId, 'Prev');
     }
   }
 
-  loadChapter(chapterId: number, direction: 'next' | 'prev') {
+  loadChapter(chapterId: number, direction: 'Next' | 'Prev') {
     if (chapterId >= 0) {
       this.chapterId = chapterId;
       this.continuousChaptersStack.push(chapterId); 
@@ -517,11 +517,12 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       const newRoute = this.readerService.getNextChapterUrl(this.router.url, this.chapterId, this.incognitoMode, this.readingListMode, this.readingListId);
       window.history.replaceState({}, '', newRoute);
       this.init();
+      this.toastr.info(direction + ' chapter loaded', '', {timeOut: 3000});
     } else {
       // This will only happen if no actual chapter can be found
       this.toastr.warning('Could not find ' + direction + ' chapter');
       this.isLoading = false;
-      if (direction === 'prev') {
+      if (direction === 'Prev') {
         this.prevPageDisabled = true;
       } else {
         this.nextPageDisabled = true;

--- a/UI/Web/src/app/book-reader/book-reader/book-reader.component.ts
+++ b/UI/Web/src/app/book-reader/book-reader/book-reader.component.ts
@@ -172,8 +172,6 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
    */
   lastSeenScrollPartPath: string = '';
 
-
-
   /**
    * Hack: Override background color for reader and restore it onDestroy
    */
@@ -536,7 +534,11 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   closeReader() {
-    this.location.back();
+    if (this.readingListMode) {
+      this.router.navigateByUrl('lists/' + this.readingListId);
+    } else {
+      this.location.back();
+    }
   }
 
   resetSettings() {

--- a/UI/Web/src/app/cards/_modals/edit-series-modal/edit-series-modal.component.html
+++ b/UI/Web/src/app/cards/_modals/edit-series-modal/edit-series-modal.component.html
@@ -6,13 +6,13 @@
             <span aria-hidden="true">&times;</span>
         </button>
     </div>
-    <div class="modal-body scrollable-modal">
-        <form [formGroup]="editSeriesForm">
-            <ul ngbNav #nav="ngbNav" [(activeId)]="active" class="nav-tabs">
+    <div class="modal-body scrollable-modal {{utilityService.getActiveBreakpoint() === Breakpoint.Mobile ? '' : 'd-flex'}}">
+        
+            <ul ngbNav #nav="ngbNav" [(activeId)]="active" class="nav-pills" orientation="{{utilityService.getActiveBreakpoint() === Breakpoint.Mobile ? 'horizontal' : 'vertical'}}" style="min-width: 135px;">
                 <li [ngbNavItem]="tabs[0]">
                   <a ngbNavLink>{{tabs[0]}}</a>
                   <ng-template ngbNavContent>
-
+                    <form [formGroup]="editSeriesForm">
                     <div class="row no-gutters">
                         <div class="form-group" style="width: 100%">
                             <label for="name">Name</label>
@@ -77,6 +77,7 @@
                             <textarea id="summary" class="form-control" formControlName="summary" rows="4"></textarea>
                         </div>
                     </div>
+                    </form>
 
                   </ng-template>
                 </li>
@@ -151,9 +152,8 @@
                   </ng-template>
                 </li>
             </ul>
-        </form>
         
-        <div [ngbNavOutlet]="nav" class="mt-3"></div>
+            <div [ngbNavOutlet]="nav" class="tab-content {{utilityService.getActiveBreakpoint() === Breakpoint.Mobile ? 'mt-3' : 'ml-4 flex-fill'}}"></div>
     </div>
     <div class="modal-footer">
         <button type="button" class="btn btn-secondary" (click)="close()">Close</button>

--- a/UI/Web/src/app/cards/_modals/edit-series-modal/edit-series-modal.component.ts
+++ b/UI/Web/src/app/cards/_modals/edit-series-modal/edit-series-modal.component.ts
@@ -3,7 +3,7 @@ import { FormBuilder, FormControl, FormGroup } from '@angular/forms';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { forkJoin, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
-import { UtilityService } from 'src/app/shared/_services/utility.service';
+import { Breakpoint, UtilityService } from 'src/app/shared/_services/utility.service';
 import { TypeaheadSettings } from 'src/app/typeahead/typeahead-settings';
 import { Chapter } from 'src/app/_models/chapter';
 import { CollectionTag } from 'src/app/_models/collection-tag';
@@ -42,6 +42,10 @@ export class EditSeriesModalComponent implements OnInit, OnDestroy {
    * Selected Cover for uploading
    */
   selectedCover: string = '';
+
+  get Breakpoint(): typeof Breakpoint {
+    return Breakpoint;
+  }
 
   constructor(public modal: NgbActiveModal,
               private seriesService: SeriesService,

--- a/UI/Web/src/app/cards/series-card/series-card.component.ts
+++ b/UI/Web/src/app/cards/series-card/series-card.component.ts
@@ -94,7 +94,6 @@ export class SeriesCardComponent implements OnInit, OnChanges {
       if (closeResult.success) {
         if (closeResult.coverImageUpdate) {
           this.imageUrl = this.imageService.randomize(this.imageService.getSeriesCoverImage(closeResult.series.id));
-          console.log('image url: ', this.imageUrl);
         }
         this.seriesService.getSeries(data.id).subscribe(series => {
           this.data = series;

--- a/UI/Web/src/app/manga-reader/manga-reader.component.ts
+++ b/UI/Web/src/app/manga-reader/manga-reader.component.ts
@@ -468,7 +468,11 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   closeReader() {
-    this.location.back();
+    if (this.readingListMode) {
+      this.router.navigateByUrl('lists/' + this.readingListId);
+    } else {
+      this.location.back();
+    }
   }
 
   updateTitle(chapterInfo: ChapterInfo) {

--- a/UI/Web/src/app/series-detail/series-detail.component.html
+++ b/UI/Web/src/app/series-detail/series-detail.component.html
@@ -102,8 +102,8 @@
               <a ngbNavLink>Specials</a>
               <ng-template ngbNavContent>
                 <div class="row">
-                    <div *ngFor="let chapter of specials">
-                        <app-card-item class="col-auto" *ngIf="chapter.isSpecial"  [entity]="chapter" [title]="chapter.title || chapter.range" (click)="openChapter(chapter)"
+                    <div *ngFor="let chapter of specials; trackBy: trackByChapterIdentity">
+                        <app-card-item class="col-auto" *ngIf="chapter.isSpecial" [entity]="chapter" [title]="chapter.title || chapter.range" (click)="openChapter(chapter)"
                         [imageUrl]="imageService.getChapterCoverImage(chapter.id)"
                         [read]="chapter.pagesRead" [total]="chapter.pages" [actions]="chapterActions"></app-card-item>
                     </div>
@@ -114,12 +114,12 @@
               <a ngbNavLink>Volumes/Chapters</a>
               <ng-template ngbNavContent>
                   <div class="row">
-                    <div *ngFor="let volume of volumes; trackby: trackByVolumeIdentity">
+                    <div *ngFor="let volume of volumes; trackBy: trackByVolumeIdentity">
                         <app-card-item class="col-auto" *ngIf="volume.number != 0" [entity]="volume" [title]="'Volume ' + volume.name" (click)="openVolume(volume)"
                             [imageUrl]="imageService.getVolumeCoverImage(volume.id) + '&offset=' + coverImageOffset"
                             [read]="volume.pagesRead" [total]="volume.pages" [actions]="volumeActions"></app-card-item>
                     </div>
-                    <div *ngFor="let chapter of chapters; trackby: trackByChapterIdentity">
+                    <div *ngFor="let chapter of chapters; trackBy: trackByChapterIdentity">
                         <app-card-item class="col-auto" *ngIf="!chapter.isSpecial" [entity]="chapter" [title]="'Chapter ' + chapter.range" (click)="openChapter(chapter)"
                         [imageUrl]="imageService.getChapterCoverImage(chapter.id) + '&offset=' + coverImageOffset"
                         [read]="chapter.pagesRead" [total]="chapter.pages" [actions]="chapterActions"></app-card-item>

--- a/UI/Web/src/app/series-detail/series-detail.component.html
+++ b/UI/Web/src/app/series-detail/series-detail.component.html
@@ -114,12 +114,12 @@
               <a ngbNavLink>Volumes/Chapters</a>
               <ng-template ngbNavContent>
                   <div class="row">
-                    <div *ngFor="let volume of volumes">
+                    <div *ngFor="let volume of volumes; trackby: trackByVolumeIdentity">
                         <app-card-item class="col-auto" *ngIf="volume.number != 0" [entity]="volume" [title]="'Volume ' + volume.name" (click)="openVolume(volume)"
                             [imageUrl]="imageService.getVolumeCoverImage(volume.id) + '&offset=' + coverImageOffset"
                             [read]="volume.pagesRead" [total]="volume.pages" [actions]="volumeActions"></app-card-item>
                     </div>
-                    <div *ngFor="let chapter of chapters">
+                    <div *ngFor="let chapter of chapters; trackby: trackByChapterIdentity">
                         <app-card-item class="col-auto" *ngIf="!chapter.isSpecial" [entity]="chapter" [title]="'Chapter ' + chapter.range" (click)="openChapter(chapter)"
                         [imageUrl]="imageService.getChapterCoverImage(chapter.id) + '&offset=' + coverImageOffset"
                         [read]="chapter.pagesRead" [total]="chapter.pages" [actions]="chapterActions"></app-card-item>

--- a/UI/Web/src/app/series-detail/series-detail.component.ts
+++ b/UI/Web/src/app/series-detail/series-detail.component.ts
@@ -305,6 +305,11 @@ export class SeriesDetailComponent implements OnInit, OnDestroy {
           this.hasNonSpecialVolumeChapters = false;
         }
 
+        // If an update occured and we were on specials, re-activate Volumes/Chapters 
+        if (!this.hasSpecials && this.activeTabId != 2) {
+          this.activeTabId = 2;
+        }
+
         this.isLoading = false;
       });
     }, err => {

--- a/UI/Web/src/app/series-detail/series-detail.component.ts
+++ b/UI/Web/src/app/series-detail/series-detail.component.ts
@@ -79,6 +79,15 @@ export class SeriesDetailComponent implements OnInit, OnDestroy {
    */
   actionInProgress: boolean = false;
 
+  /**
+   * Track by function for Volume to tell when to refresh card data
+   */
+  trackByVolumeIdentity = (index: number, item: Volume) => `${item.name}_${item.pagesRead}`;
+  /**
+   * Track by function for Chapter to tell when to refresh card data
+   */
+  trackByChapterIdentity = (index: number, item: Chapter) => `${item.title}_${item.number}_${item.pagesRead}`;
+
   private onDestroy: Subject<void> = new Subject();
 
 

--- a/UI/Web/src/app/shared/_services/utility.service.ts
+++ b/UI/Web/src/app/shared/_services/utility.service.ts
@@ -18,6 +18,13 @@ export enum KEY_CODES {
   DELETE = 'Delete'
 }
 
+export enum Breakpoint {
+  Mobile = 768,
+  Tablet = 1280,
+  Desktop = 1440
+}
+
+
 @Injectable({
   providedIn: 'root'
 })
@@ -109,6 +116,14 @@ export class UtilityService {
 
   asSeries(d: any) {
     return <Series>d;
+  }
+
+  getActiveBreakpoint(): Breakpoint {
+    if (window.innerWidth <= Breakpoint.Mobile) return Breakpoint.Mobile;
+    else if (window.innerWidth > Breakpoint.Mobile && window.innerWidth <= Breakpoint.Tablet) return Breakpoint.Tablet;
+    else if (window.innerWidth > Breakpoint.Tablet) return Breakpoint.Desktop
+    
+    return Breakpoint.Desktop;
   }
 
 }


### PR DESCRIPTION
# Added
- Added: WebP support. This will work with all browsers except Safari on MacOS < Big Sur 11. Those users will need to use a different browser. 
- Added: When you cross a chapter boundary via continuous reading in book reader, a toast will show up

# Fixed
- Fixed: When doing a scan series and receiving an event from server once done, volume/chapters wouldn't refresh their names
- Fixed: When reading using a reading list and navigating between manga and book readers, close will now go back to the reading list page
- Fixed: Fixed an issue where after opening a volume's info modal from series detail trying to open a chapter info modal, it wouldn't work
- Fixed: Fixed an issue where older releases would show as Available

# Changed
- Changed: Tabs within modals are now vertical, unless you are on mobile