### PR TITLE
Foundational Cover Image Rework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -500,3 +500,4 @@ _output/
 API/stats/
 UI/Web/dist/
 /API.Tests/Extensions/Test Data/modified on run.txt
+/API/covers/

--- a/API.Benchmark/ArchiveSerivceBenchmark.cs
+++ b/API.Benchmark/ArchiveSerivceBenchmark.cs
@@ -1,0 +1,8 @@
+﻿namespace API.Benchmark
+{
+    public class ArchiveSerivceBenchmark
+    {
+        // Benchmark to test default GetNumberOfPages from archive
+        // vs a new method where I try to open the archive and return said stream
+    }
+}

--- a/API.Tests/Parser/MangaParserTests.cs
+++ b/API.Tests/Parser/MangaParserTests.cs
@@ -236,6 +236,7 @@ namespace API.Tests.Parser
         [InlineData("Kedouin Makoto - Corpse Party Musume, Chapter 09.cbz", "9")]
         [InlineData("Hentai Ouji to Warawanai Neko. - Vol. 06 Ch. 034.5", "34.5")]
         [InlineData("Kimi no Koto ga Daidaidaidaidaisuki na 100-nin no Kanojo Chapter 1-10", "1-10")]
+        [InlineData("Deku_&_Bakugo_-_Rising_v1_c1.1.cbz", "1.1")]
         public void ParseChaptersTest(string filename, string expected)
         {
             Assert.Equal(expected, API.Parser.Parser.ParseChapter(filename));

--- a/API.Tests/Services/ArchiveServiceTests.cs
+++ b/API.Tests/Services/ArchiveServiceTests.cs
@@ -50,7 +50,7 @@ namespace API.Tests.Services
             var testDirectory = Path.Join(Directory.GetCurrentDirectory(), "../../../Services/Test Data/ArchiveService/Archives");
             Assert.Equal(expected, _archiveService.IsValidArchive(Path.Join(testDirectory, archivePath)));
         }
-        
+
         [Theory]
         [InlineData("non existent file.zip", 0)]
         [InlineData("winrar.rar", 0)]
@@ -69,7 +69,7 @@ namespace API.Tests.Services
             Assert.Equal(expected, _archiveService.GetNumberOfPagesFromArchive(Path.Join(testDirectory, archivePath)));
             _testOutputHelper.WriteLine($"Processed Original in {sw.ElapsedMilliseconds} ms");
         }
-        
+
 
 
         [Theory]
@@ -84,12 +84,12 @@ namespace API.Tests.Services
         {
             var sw = Stopwatch.StartNew();
             var testDirectory = Path.Join(Directory.GetCurrentDirectory(), "../../../Services/Test Data/ArchiveService/Archives");
-            
+
             Assert.Equal(expected, _archiveService.CanOpen(Path.Join(testDirectory, archivePath)));
             _testOutputHelper.WriteLine($"Processed Original in {sw.ElapsedMilliseconds} ms");
         }
-        
-        
+
+
         [Theory]
         [InlineData("non existent file.zip", 0)]
         [InlineData("winrar.rar", 0)]
@@ -100,18 +100,18 @@ namespace API.Tests.Services
         [InlineData("file in folder_alt.zip", 1)]
         public void CanExtractArchive(string archivePath, int expectedFileCount)
         {
-            
+
             var testDirectory = Path.Join(Directory.GetCurrentDirectory(), "../../../Services/Test Data/ArchiveService/Archives");
             var extractDirectory = Path.Join(Directory.GetCurrentDirectory(), "../../../Services/Test Data/ArchiveService/Archives/Extraction");
 
             DirectoryService.ClearAndDeleteDirectory(extractDirectory);
-            
+
             Stopwatch sw = Stopwatch.StartNew();
             _archiveService.ExtractArchive(Path.Join(testDirectory, archivePath), extractDirectory);
             var di1 = new DirectoryInfo(extractDirectory);
             Assert.Equal(expectedFileCount, di1.Exists ? di1.GetFiles().Length : 0);
             _testOutputHelper.WriteLine($"Processed in {sw.ElapsedMilliseconds} ms");
-            
+
             DirectoryService.ClearAndDeleteDirectory(extractDirectory);
         }
 
@@ -142,9 +142,9 @@ namespace API.Tests.Services
             var foundFile = _archiveService.FirstFileEntry(files);
             Assert.Equal(expected, string.IsNullOrEmpty(foundFile) ? "" : foundFile);
         }
-        
-        
-        
+
+
+
         [Theory]
         [InlineData("v10.cbz", "v10.expected.jpg")]
         [InlineData("v10 - with folder.cbz", "v10 - with folder.expected.jpg")]
@@ -160,11 +160,11 @@ namespace API.Tests.Services
             var expectedBytes = File.ReadAllBytes(Path.Join(testDirectory, expectedOutputFile));
             archiveService.Configure().CanOpen(Path.Join(testDirectory, inputFile)).Returns(ArchiveLibrary.Default);
             Stopwatch sw = Stopwatch.StartNew();
-            Assert.Equal(expectedBytes, archiveService.GetCoverImage(Path.Join(testDirectory, inputFile)));
+            Assert.Equal(expectedBytes, File.ReadAllBytes(archiveService.GetCoverImage(Path.Join(testDirectory, inputFile), Path.GetFileNameWithoutExtension(inputFile) + "_output")));
             _testOutputHelper.WriteLine($"Processed in {sw.ElapsedMilliseconds} ms");
         }
-        
-        
+
+
         [Theory]
         [InlineData("v10.cbz", "v10.expected.jpg")]
         [InlineData("v10 - with folder.cbz", "v10 - with folder.expected.jpg")]
@@ -178,10 +178,10 @@ namespace API.Tests.Services
             var archiveService =  Substitute.For<ArchiveService>(_logger, new DirectoryService(_directoryServiceLogger));
             var testDirectory = Path.Join(Directory.GetCurrentDirectory(), "../../../Services/Test Data/ArchiveService/CoverImages");
             var expectedBytes = File.ReadAllBytes(Path.Join(testDirectory, expectedOutputFile));
-            
+
             archiveService.Configure().CanOpen(Path.Join(testDirectory, inputFile)).Returns(ArchiveLibrary.SharpCompress);
             Stopwatch sw = Stopwatch.StartNew();
-            Assert.Equal(expectedBytes, archiveService.GetCoverImage(Path.Join(testDirectory, inputFile)));
+            Assert.Equal(expectedBytes, File.ReadAllBytes(archiveService.GetCoverImage(Path.Join(testDirectory, inputFile), Path.GetFileNameWithoutExtension(inputFile) + "_output")));
             _testOutputHelper.WriteLine($"Processed in {sw.ElapsedMilliseconds} ms");
         }
 
@@ -191,7 +191,7 @@ namespace API.Tests.Services
         public void CanParseCoverImage(string inputFile)
         {
             var testDirectory = Path.Join(Directory.GetCurrentDirectory(), "../../../Services/Test Data/ArchiveService/");
-            Assert.NotEmpty(_archiveService.GetCoverImage(Path.Join(testDirectory, inputFile)));
+            Assert.NotEmpty(File.ReadAllBytes(_archiveService.GetCoverImage(Path.Join(testDirectory, inputFile), Path.GetFileNameWithoutExtension(inputFile) + "_output")));
         }
 
         [Fact]
@@ -200,7 +200,7 @@ namespace API.Tests.Services
             var testDirectory = Path.Join(Directory.GetCurrentDirectory(), "../../../Services/Test Data/ArchiveService/ComicInfos");
             var archive = Path.Join(testDirectory, "file in folder.zip");
             var summaryInfo = "By all counts, Ryouta Sakamoto is a loser when he's not holed up in his room, bombing things into oblivion in his favorite online action RPG. But his very own uneventful life is blown to pieces when he's abducted and taken to an uninhabited island, where he soon learns the hard way that he's being pitted against others just like him in a explosives-riddled death match! How could this be happening? Who's putting them up to this? And why!? The name, not to mention the objective, of this very real survival game is eerily familiar to Ryouta, who has mastered its virtual counterpart-BTOOOM! Can Ryouta still come out on top when he's playing for his life!?";
-            
+
             Assert.Equal(summaryInfo, _archiveService.GetSummaryInfo(archive));
 
         }

--- a/API.Tests/Services/MetadataServiceTests.cs
+++ b/API.Tests/Services/MetadataServiceTests.cs
@@ -15,19 +15,19 @@ namespace API.Tests.Services
     public class MetadataServiceTests
     {
         private readonly string _testDirectory = Path.Join(Directory.GetCurrentDirectory(), "../../../Services/Test Data/ArchiveService/Archives");
-        private readonly string _testCoverImageFile = "thumbnail.jpg";
-        private readonly string _testCoverImageDirectory = Path.Join(Directory.GetCurrentDirectory(), @"..\..\..\Services\Test Data\ArchiveService\CoverImages");
-        private readonly MetadataService _metadataService;
-        private readonly IUnitOfWork _unitOfWork = Substitute.For<IUnitOfWork>();
-        private readonly IImageService _imageService = Substitute.For<IImageService>();
-        private readonly IBookService _bookService = Substitute.For<IBookService>();
-        private readonly IArchiveService _archiveService = Substitute.For<IArchiveService>();
-        private readonly ILogger<MetadataService> _logger = Substitute.For<ILogger<MetadataService>>();
-        private readonly IHubContext<MessageHub> _messageHub = Substitute.For<IHubContext<MessageHub>>();
+        private const string TestCoverImageFile = "thumbnail.jpg";
+        private readonly string _testCoverImageDirectory = Path.Join(Directory.GetCurrentDirectory(), @"../../../Services/Test Data/ArchiveService/CoverImages");
+        //private readonly MetadataService _metadataService;
+        // private readonly IUnitOfWork _unitOfWork = Substitute.For<IUnitOfWork>();
+        // private readonly IImageService _imageService = Substitute.For<IImageService>();
+        // private readonly IBookService _bookService = Substitute.For<IBookService>();
+        // private readonly IArchiveService _archiveService = Substitute.For<IArchiveService>();
+        // private readonly ILogger<MetadataService> _logger = Substitute.For<ILogger<MetadataService>>();
+        // private readonly IHubContext<MessageHub> _messageHub = Substitute.For<IHubContext<MessageHub>>();
 
         public MetadataServiceTests()
         {
-            _metadataService = new MetadataService(_unitOfWork, _logger, _archiveService, _bookService, _imageService, _messageHub);
+            //_metadataService = new MetadataService(_unitOfWork, _logger, _archiveService, _bookService, _imageService, _messageHub);
         }
 
         [Fact]
@@ -107,7 +107,7 @@ namespace API.Tests.Services
         public void ShouldNotUpdateCoverImage_OnSecondRun_CoverImageSet()
         {
             // Represents first run
-            Assert.False(MetadataService.ShouldUpdateCoverImage(_testCoverImageFile, new MangaFile()
+            Assert.False(MetadataService.ShouldUpdateCoverImage(TestCoverImageFile, new MangaFile()
             {
                 FilePath = Path.Join(_testDirectory, "file in folder.zip"),
                 LastModified = new FileInfo(Path.Join(_testDirectory, "file in folder.zip")).LastWriteTime
@@ -118,7 +118,7 @@ namespace API.Tests.Services
         public void ShouldNotUpdateCoverImage_OnSecondRun_HasCoverImage_NoForceUpdate_NoLock()
         {
 
-            Assert.False(MetadataService.ShouldUpdateCoverImage(_testCoverImageFile, new MangaFile()
+            Assert.False(MetadataService.ShouldUpdateCoverImage(TestCoverImageFile, new MangaFile()
             {
                 FilePath = Path.Join(_testDirectory, "file in folder.zip"),
                 LastModified = DateTime.Now

--- a/API.Tests/Services/MetadataServiceTests.cs
+++ b/API.Tests/Services/MetadataServiceTests.cs
@@ -115,7 +115,7 @@ namespace API.Tests.Services
         }
 
         [Fact]
-        public void ShouldNoteUpdateCoverImage_OnSecondRun_HasCoverImage_NoForceUpdate_NoLock()
+        public void ShouldNotUpdateCoverImage_OnSecondRun_HasCoverImage_NoForceUpdate_NoLock()
         {
 
             Assert.False(MetadataService.ShouldUpdateCoverImage(_testCoverImageFile, new MangaFile()

--- a/API.Tests/Services/MetadataServiceTests.cs
+++ b/API.Tests/Services/MetadataServiceTests.cs
@@ -16,7 +16,7 @@ namespace API.Tests.Services
     {
         private readonly string _testDirectory = Path.Join(Directory.GetCurrentDirectory(), "../../../Services/Test Data/ArchiveService/Archives");
         private readonly string _testCoverImageFile = "thumbnail.jpg";
-        private readonly string _testCoverImageDirectory = Path.Join(Directory.GetCurrentDirectory(), @"..\..\..\Services\Test Data\ArchiveService\CoverImages\");
+        private readonly string _testCoverImageDirectory = Path.Join(Directory.GetCurrentDirectory(), @"..\..\..\Services\Test Data\ArchiveService\CoverImages");
         private readonly MetadataService _metadataService;
         private readonly IUnitOfWork _unitOfWork = Substitute.For<IUnitOfWork>();
         private readonly IImageService _imageService = Substitute.For<IImageService>();
@@ -25,7 +25,6 @@ namespace API.Tests.Services
         private readonly ILogger<MetadataService> _logger = Substitute.For<ILogger<MetadataService>>();
         private readonly IHubContext<MessageHub> _messageHub = Substitute.For<IHubContext<MessageHub>>();
 
-        // TODO: Uncomment this (bytes)
         public MetadataServiceTests()
         {
             _metadataService = new MetadataService(_unitOfWork, _logger, _archiveService, _bookService, _imageService, _messageHub);
@@ -130,11 +129,11 @@ namespace API.Tests.Services
         public void ShouldUpdateCoverImage_OnSecondRun_HasCoverImage_NoForceUpdate_HasLock_CoverImageDoesntExist()
         {
 
-            Assert.True(MetadataService.ShouldUpdateCoverImage(Path.Join(Directory.GetCurrentDirectory(), Path.Join(Directory.GetCurrentDirectory(), "../../../Services/Test Data/ArchiveService/CoverImages/doesn'texist.jpg")), new MangaFile()
+            Assert.True(MetadataService.ShouldUpdateCoverImage(@"doesn't_exist.jpg", new MangaFile()
             {
                 FilePath = Path.Join(_testDirectory, "file in folder.zip"),
                 LastModified = DateTime.Now
-            }, false, true));
+            }, false, true, _testCoverImageDirectory));
         }
     }
 }

--- a/API.Tests/Services/MetadataServiceTests.cs
+++ b/API.Tests/Services/MetadataServiceTests.cs
@@ -23,104 +23,105 @@ namespace API.Tests.Services
         private readonly ILogger<MetadataService> _logger = Substitute.For<ILogger<MetadataService>>();
         private readonly IHubContext<MessageHub> _messageHub = Substitute.For<IHubContext<MessageHub>>();
 
-        public MetadataServiceTests()
-        {
-            _metadataService = new MetadataService(_unitOfWork, _logger, _archiveService, _bookService, _imageService, _messageHub);
-        }
-
-        [Fact]
-        public void ShouldUpdateCoverImage_OnFirstRun()
-        {
-            // Represents first run
-            Assert.True(MetadataService.ShouldUpdateCoverImage(null, new MangaFile()
-            {
-                FilePath = Path.Join(_testDirectory, "file in folder.zip"),
-                LastModified = DateTime.Now
-            }, false, false));
-        }
-
-        [Fact]
-        public void ShouldUpdateCoverImage_OnFirstRunSeries()
-        {
-            // Represents first run
-            Assert.True(MetadataService.ShouldUpdateCoverImage(null,null, false, false));
-        }
-
-        [Fact]
-        public void ShouldUpdateCoverImage_OnSecondRun_FileModified()
-        {
-            // Represents first run
-            Assert.True(MetadataService.ShouldUpdateCoverImage(null, new MangaFile()
-            {
-                FilePath = Path.Join(_testDirectory, "file in folder.zip"),
-                LastModified = new FileInfo(Path.Join(_testDirectory, "file in folder.zip")).LastWriteTime.Subtract(TimeSpan.FromDays(1))
-            }, false, false));
-        }
-
-        [Fact]
-        public void ShouldUpdateCoverImage_OnSecondRun_CoverImageLocked()
-        {
-            // Represents first run
-            Assert.False(MetadataService.ShouldUpdateCoverImage(null, new MangaFile()
-            {
-                FilePath = Path.Join(_testDirectory, "file in folder.zip"),
-                LastModified = new FileInfo(Path.Join(_testDirectory, "file in folder.zip")).LastWriteTime
-            }, false, true));
-        }
-
-        [Fact]
-        public void ShouldUpdateCoverImage_OnSecondRun_ForceUpdate()
-        {
-            // Represents first run
-            Assert.True(MetadataService.ShouldUpdateCoverImage(null, new MangaFile()
-            {
-                FilePath = Path.Join(_testDirectory, "file in folder.zip"),
-                LastModified = new FileInfo(Path.Join(_testDirectory, "file in folder.zip")).LastWriteTime
-            }, true, false));
-        }
-
-        [Fact]
-        public void ShouldUpdateCoverImage_OnSecondRun_NoFileChangeButNoCoverImage()
-        {
-            // Represents first run
-            Assert.True(MetadataService.ShouldUpdateCoverImage(null, new MangaFile()
-            {
-                FilePath = Path.Join(_testDirectory, "file in folder.zip"),
-                LastModified = new FileInfo(Path.Join(_testDirectory, "file in folder.zip")).LastWriteTime
-            }, false, false));
-        }
-
-        [Fact]
-        public void ShouldUpdateCoverImage_OnSecondRun_FileChangeButNoCoverImage()
-        {
-            // Represents first run
-            Assert.True(MetadataService.ShouldUpdateCoverImage(null, new MangaFile()
-            {
-                FilePath = Path.Join(_testDirectory, "file in folder.zip"),
-                LastModified = new FileInfo(Path.Join(_testDirectory, "file in folder.zip")).LastWriteTime + TimeSpan.FromDays(1)
-            }, false, false));
-        }
-
-        [Fact]
-        public void ShouldUpdateCoverImage_OnSecondRun_CoverImageSet()
-        {
-            // Represents first run
-            Assert.False(MetadataService.ShouldUpdateCoverImage(new byte[] {1}, new MangaFile()
-            {
-                FilePath = Path.Join(_testDirectory, "file in folder.zip"),
-                LastModified = new FileInfo(Path.Join(_testDirectory, "file in folder.zip")).LastWriteTime
-            }, false, false));
-        }
-
-        [Fact]
-
-        public void ShouldUpdateCoverImage_OnSecondRun_HasCoverImage_NoForceUpdate_NoLock()
-        {
-            Assert.False(MetadataService.ShouldUpdateCoverImage(new byte[] {1}, new MangaFile()
-            {
-                FilePath = Path.Join(_testDirectory, "file in folder.zip"),
-                LastModified = DateTime.Now
-            }, false, false));
-        }
+        // TODO: Uncomment this (bytes)
+        // public MetadataServiceTests()
+        // {
+        //     _metadataService = new MetadataService(_unitOfWork, _logger, _archiveService, _bookService, _imageService, _messageHub);
+        // }
+        //
+        // [Fact]
+        // public void ShouldUpdateCoverImage_OnFirstRun()
+        // {
+        //     // Represents first run
+        //     Assert.True(MetadataService.ShouldUpdateCoverImage(null, new MangaFile()
+        //     {
+        //         FilePath = Path.Join(_testDirectory, "file in folder.zip"),
+        //         LastModified = DateTime.Now
+        //     }, false, false));
+        // }
+        //
+        // [Fact]
+        // public void ShouldUpdateCoverImage_OnFirstRunSeries()
+        // {
+        //     // Represents first run
+        //     Assert.True(MetadataService.ShouldUpdateCoverImage(null,null, false, false));
+        // }
+        //
+        // [Fact]
+        // public void ShouldUpdateCoverImage_OnSecondRun_FileModified()
+        // {
+        //     // Represents first run
+        //     Assert.True(MetadataService.ShouldUpdateCoverImage(null, new MangaFile()
+        //     {
+        //         FilePath = Path.Join(_testDirectory, "file in folder.zip"),
+        //         LastModified = new FileInfo(Path.Join(_testDirectory, "file in folder.zip")).LastWriteTime.Subtract(TimeSpan.FromDays(1))
+        //     }, false, false));
+        // }
+        //
+        // [Fact]
+        // public void ShouldUpdateCoverImage_OnSecondRun_CoverImageLocked()
+        // {
+        //     // Represents first run
+        //     Assert.False(MetadataService.ShouldUpdateCoverImage(null, new MangaFile()
+        //     {
+        //         FilePath = Path.Join(_testDirectory, "file in folder.zip"),
+        //         LastModified = new FileInfo(Path.Join(_testDirectory, "file in folder.zip")).LastWriteTime
+        //     }, false, true));
+        // }
+        //
+        // [Fact]
+        // public void ShouldUpdateCoverImage_OnSecondRun_ForceUpdate()
+        // {
+        //     // Represents first run
+        //     Assert.True(MetadataService.ShouldUpdateCoverImage(null, new MangaFile()
+        //     {
+        //         FilePath = Path.Join(_testDirectory, "file in folder.zip"),
+        //         LastModified = new FileInfo(Path.Join(_testDirectory, "file in folder.zip")).LastWriteTime
+        //     }, true, false));
+        // }
+        //
+        // [Fact]
+        // public void ShouldUpdateCoverImage_OnSecondRun_NoFileChangeButNoCoverImage()
+        // {
+        //     // Represents first run
+        //     Assert.True(MetadataService.ShouldUpdateCoverImage(null, new MangaFile()
+        //     {
+        //         FilePath = Path.Join(_testDirectory, "file in folder.zip"),
+        //         LastModified = new FileInfo(Path.Join(_testDirectory, "file in folder.zip")).LastWriteTime
+        //     }, false, false));
+        // }
+        //
+        // [Fact]
+        // public void ShouldUpdateCoverImage_OnSecondRun_FileChangeButNoCoverImage()
+        // {
+        //     // Represents first run
+        //     Assert.True(MetadataService.ShouldUpdateCoverImage(null, new MangaFile()
+        //     {
+        //         FilePath = Path.Join(_testDirectory, "file in folder.zip"),
+        //         LastModified = new FileInfo(Path.Join(_testDirectory, "file in folder.zip")).LastWriteTime + TimeSpan.FromDays(1)
+        //     }, false, false));
+        // }
+        //
+        // [Fact]
+        // public void ShouldUpdateCoverImage_OnSecondRun_CoverImageSet()
+        // {
+        //     // Represents first run
+        //     Assert.False(MetadataService.ShouldUpdateCoverImage(new byte[] {1}, new MangaFile()
+        //     {
+        //         FilePath = Path.Join(_testDirectory, "file in folder.zip"),
+        //         LastModified = new FileInfo(Path.Join(_testDirectory, "file in folder.zip")).LastWriteTime
+        //     }, false, false));
+        // }
+        //
+        // [Fact]
+        //
+        // public void ShouldUpdateCoverImage_OnSecondRun_HasCoverImage_NoForceUpdate_NoLock()
+        // {
+        //     Assert.False(MetadataService.ShouldUpdateCoverImage(new byte[] {1}, new MangaFile()
+        //     {
+        //         FilePath = Path.Join(_testDirectory, "file in folder.zip"),
+        //         LastModified = DateTime.Now
+        //     }, false, false));
+        // }
     }
 }

--- a/API.Tests/Services/MetadataServiceTests.cs
+++ b/API.Tests/Services/MetadataServiceTests.cs
@@ -15,6 +15,7 @@ namespace API.Tests.Services
     public class MetadataServiceTests
     {
         private readonly string _testDirectory = Path.Join(Directory.GetCurrentDirectory(), "../../../Services/Test Data/ArchiveService/Archives");
+        private readonly string _testCoverImageFile = Path.Join(Directory.GetCurrentDirectory(), @"..\..\..\Services\Test Data\ArchiveService\CoverImages\thumbnail.jpg");
         private readonly MetadataService _metadataService;
         private readonly IUnitOfWork _unitOfWork = Substitute.For<IUnitOfWork>();
         private readonly IImageService _imageService = Substitute.For<IImageService>();
@@ -24,104 +25,115 @@ namespace API.Tests.Services
         private readonly IHubContext<MessageHub> _messageHub = Substitute.For<IHubContext<MessageHub>>();
 
         // TODO: Uncomment this (bytes)
-        // public MetadataServiceTests()
-        // {
-        //     _metadataService = new MetadataService(_unitOfWork, _logger, _archiveService, _bookService, _imageService, _messageHub);
-        // }
-        //
-        // [Fact]
-        // public void ShouldUpdateCoverImage_OnFirstRun()
-        // {
-        //     // Represents first run
-        //     Assert.True(MetadataService.ShouldUpdateCoverImage(null, new MangaFile()
-        //     {
-        //         FilePath = Path.Join(_testDirectory, "file in folder.zip"),
-        //         LastModified = DateTime.Now
-        //     }, false, false));
-        // }
-        //
-        // [Fact]
-        // public void ShouldUpdateCoverImage_OnFirstRunSeries()
-        // {
-        //     // Represents first run
-        //     Assert.True(MetadataService.ShouldUpdateCoverImage(null,null, false, false));
-        // }
-        //
-        // [Fact]
-        // public void ShouldUpdateCoverImage_OnSecondRun_FileModified()
-        // {
-        //     // Represents first run
-        //     Assert.True(MetadataService.ShouldUpdateCoverImage(null, new MangaFile()
-        //     {
-        //         FilePath = Path.Join(_testDirectory, "file in folder.zip"),
-        //         LastModified = new FileInfo(Path.Join(_testDirectory, "file in folder.zip")).LastWriteTime.Subtract(TimeSpan.FromDays(1))
-        //     }, false, false));
-        // }
-        //
-        // [Fact]
-        // public void ShouldUpdateCoverImage_OnSecondRun_CoverImageLocked()
-        // {
-        //     // Represents first run
-        //     Assert.False(MetadataService.ShouldUpdateCoverImage(null, new MangaFile()
-        //     {
-        //         FilePath = Path.Join(_testDirectory, "file in folder.zip"),
-        //         LastModified = new FileInfo(Path.Join(_testDirectory, "file in folder.zip")).LastWriteTime
-        //     }, false, true));
-        // }
-        //
-        // [Fact]
-        // public void ShouldUpdateCoverImage_OnSecondRun_ForceUpdate()
-        // {
-        //     // Represents first run
-        //     Assert.True(MetadataService.ShouldUpdateCoverImage(null, new MangaFile()
-        //     {
-        //         FilePath = Path.Join(_testDirectory, "file in folder.zip"),
-        //         LastModified = new FileInfo(Path.Join(_testDirectory, "file in folder.zip")).LastWriteTime
-        //     }, true, false));
-        // }
-        //
-        // [Fact]
-        // public void ShouldUpdateCoverImage_OnSecondRun_NoFileChangeButNoCoverImage()
-        // {
-        //     // Represents first run
-        //     Assert.True(MetadataService.ShouldUpdateCoverImage(null, new MangaFile()
-        //     {
-        //         FilePath = Path.Join(_testDirectory, "file in folder.zip"),
-        //         LastModified = new FileInfo(Path.Join(_testDirectory, "file in folder.zip")).LastWriteTime
-        //     }, false, false));
-        // }
-        //
-        // [Fact]
-        // public void ShouldUpdateCoverImage_OnSecondRun_FileChangeButNoCoverImage()
-        // {
-        //     // Represents first run
-        //     Assert.True(MetadataService.ShouldUpdateCoverImage(null, new MangaFile()
-        //     {
-        //         FilePath = Path.Join(_testDirectory, "file in folder.zip"),
-        //         LastModified = new FileInfo(Path.Join(_testDirectory, "file in folder.zip")).LastWriteTime + TimeSpan.FromDays(1)
-        //     }, false, false));
-        // }
-        //
-        // [Fact]
-        // public void ShouldUpdateCoverImage_OnSecondRun_CoverImageSet()
-        // {
-        //     // Represents first run
-        //     Assert.False(MetadataService.ShouldUpdateCoverImage(new byte[] {1}, new MangaFile()
-        //     {
-        //         FilePath = Path.Join(_testDirectory, "file in folder.zip"),
-        //         LastModified = new FileInfo(Path.Join(_testDirectory, "file in folder.zip")).LastWriteTime
-        //     }, false, false));
-        // }
-        //
-        // [Fact]
-        //
-        // public void ShouldUpdateCoverImage_OnSecondRun_HasCoverImage_NoForceUpdate_NoLock()
-        // {
-        //     Assert.False(MetadataService.ShouldUpdateCoverImage(new byte[] {1}, new MangaFile()
-        //     {
-        //         FilePath = Path.Join(_testDirectory, "file in folder.zip"),
-        //         LastModified = DateTime.Now
-        //     }, false, false));
-        // }
+        public MetadataServiceTests()
+        {
+            _metadataService = new MetadataService(_unitOfWork, _logger, _archiveService, _bookService, _imageService, _messageHub);
+        }
+
+        [Fact]
+        public void ShouldUpdateCoverImage_OnFirstRun()
+        {
+            // Represents first run
+            Assert.True(MetadataService.ShouldUpdateCoverImage(null, new MangaFile()
+            {
+                FilePath = Path.Join(_testDirectory, "file in folder.zip"),
+                LastModified = DateTime.Now
+            }, false, false));
+        }
+
+        [Fact]
+        public void ShouldUpdateCoverImage_OnFirstRunSeries()
+        {
+            // Represents first run
+            Assert.True(MetadataService.ShouldUpdateCoverImage(null,null, false, false));
+        }
+
+        [Fact]
+        public void ShouldUpdateCoverImage_OnFirstRun_FileModified()
+        {
+            // Represents first run
+            Assert.True(MetadataService.ShouldUpdateCoverImage(null, new MangaFile()
+            {
+                FilePath = Path.Join(_testDirectory, "file in folder.zip"),
+                LastModified = new FileInfo(Path.Join(_testDirectory, "file in folder.zip")).LastWriteTime.Subtract(TimeSpan.FromDays(1))
+            }, false, false));
+        }
+
+        [Fact]
+        public void ShouldUpdateCoverImage_OnFirstRun_CoverImageLocked()
+        {
+            // Represents first run
+            Assert.True(MetadataService.ShouldUpdateCoverImage(null, new MangaFile()
+            {
+                FilePath = Path.Join(_testDirectory, "file in folder.zip"),
+                LastModified = new FileInfo(Path.Join(_testDirectory, "file in folder.zip")).LastWriteTime
+            }, false, true));
+        }
+
+        [Fact]
+        public void ShouldUpdateCoverImage_OnSecondRun_ForceUpdate()
+        {
+            // Represents first run
+            Assert.True(MetadataService.ShouldUpdateCoverImage(null, new MangaFile()
+            {
+                FilePath = Path.Join(_testDirectory, "file in folder.zip"),
+                LastModified = new FileInfo(Path.Join(_testDirectory, "file in folder.zip")).LastWriteTime
+            }, true, false));
+        }
+
+        [Fact]
+        public void ShouldUpdateCoverImage_OnSecondRun_NoFileChangeButNoCoverImage()
+        {
+            // Represents first run
+            Assert.True(MetadataService.ShouldUpdateCoverImage(null, new MangaFile()
+            {
+                FilePath = Path.Join(_testDirectory, "file in folder.zip"),
+                LastModified = new FileInfo(Path.Join(_testDirectory, "file in folder.zip")).LastWriteTime
+            }, false, false));
+        }
+
+        [Fact]
+        public void ShouldUpdateCoverImage_OnSecondRun_FileChangeButNoCoverImage()
+        {
+            // Represents first run
+            Assert.True(MetadataService.ShouldUpdateCoverImage(null, new MangaFile()
+            {
+                FilePath = Path.Join(_testDirectory, "file in folder.zip"),
+                LastModified = new FileInfo(Path.Join(_testDirectory, "file in folder.zip")).LastWriteTime + TimeSpan.FromDays(1)
+            }, false, false));
+        }
+
+        [Fact]
+        public void ShouldNotUpdateCoverImage_OnSecondRun_CoverImageSet()
+        {
+            // Represents first run
+            Assert.False(MetadataService.ShouldUpdateCoverImage(_testCoverImageFile, new MangaFile()
+            {
+                FilePath = Path.Join(_testDirectory, "file in folder.zip"),
+                LastModified = new FileInfo(Path.Join(_testDirectory, "file in folder.zip")).LastWriteTime
+            }, false, false));
+        }
+
+        [Fact]
+        public void ShouldNoteUpdateCoverImage_OnSecondRun_HasCoverImage_NoForceUpdate_NoLock()
+        {
+
+            Assert.False(MetadataService.ShouldUpdateCoverImage(_testCoverImageFile, new MangaFile()
+            {
+                FilePath = Path.Join(_testDirectory, "file in folder.zip"),
+                LastModified = DateTime.Now
+            }, false, false));
+        }
+
+        [Fact]
+        public void ShouldUpdateCoverImage_OnSecondRun_HasCoverImage_NoForceUpdate_HasLock_CoverImageDoesntExist()
+        {
+
+            Assert.True(MetadataService.ShouldUpdateCoverImage(Path.Join(Directory.GetCurrentDirectory(), Path.Join(Directory.GetCurrentDirectory(), "../../../Services/Test Data/ArchiveService/CoverImages/doesn'texist.jpg")), new MangaFile()
+            {
+                FilePath = Path.Join(_testDirectory, "file in folder.zip"),
+                LastModified = DateTime.Now
+            }, false, true));
+        }
     }
 }

--- a/API.Tests/Services/MetadataServiceTests.cs
+++ b/API.Tests/Services/MetadataServiceTests.cs
@@ -15,7 +15,8 @@ namespace API.Tests.Services
     public class MetadataServiceTests
     {
         private readonly string _testDirectory = Path.Join(Directory.GetCurrentDirectory(), "../../../Services/Test Data/ArchiveService/Archives");
-        private readonly string _testCoverImageFile = Path.Join(Directory.GetCurrentDirectory(), @"..\..\..\Services\Test Data\ArchiveService\CoverImages\thumbnail.jpg");
+        private readonly string _testCoverImageFile = "thumbnail.jpg";
+        private readonly string _testCoverImageDirectory = Path.Join(Directory.GetCurrentDirectory(), @"..\..\..\Services\Test Data\ArchiveService\CoverImages\");
         private readonly MetadataService _metadataService;
         private readonly IUnitOfWork _unitOfWork = Substitute.For<IUnitOfWork>();
         private readonly IImageService _imageService = Substitute.For<IImageService>();
@@ -111,7 +112,7 @@ namespace API.Tests.Services
             {
                 FilePath = Path.Join(_testDirectory, "file in folder.zip"),
                 LastModified = new FileInfo(Path.Join(_testDirectory, "file in folder.zip")).LastWriteTime
-            }, false, false));
+            }, false, false, _testCoverImageDirectory));
         }
 
         [Fact]
@@ -122,7 +123,7 @@ namespace API.Tests.Services
             {
                 FilePath = Path.Join(_testDirectory, "file in folder.zip"),
                 LastModified = DateTime.Now
-            }, false, false));
+            }, false, false, _testCoverImageDirectory));
         }
 
         [Fact]

--- a/API/API.csproj
+++ b/API/API.csproj
@@ -78,7 +78,6 @@
   <ItemGroup>
     <None Remove="Hangfire-log.db" />
     <None Remove="obj\**" />
-    <None Remove="wwwroot\**" />
     <None Remove="cache\**" />
     <None Remove="backups\**" />
     <None Remove="logs\**" />
@@ -91,7 +90,6 @@
   <ItemGroup>
     <Compile Remove="Interfaces\IMetadataService.cs" />
     <Compile Remove="obj\**" />
-    <Compile Remove="wwwroot\**" />
     <Compile Remove="cache\**" />
     <Compile Remove="backups\**" />
     <Compile Remove="logs\**" />
@@ -101,7 +99,6 @@
 
   <ItemGroup>
     <EmbeddedResource Remove="obj\**" />
-    <EmbeddedResource Remove="wwwroot\**" />
     <EmbeddedResource Remove="cache\**" />
     <EmbeddedResource Remove="backups\**" />
     <EmbeddedResource Remove="logs\**" />
@@ -111,7 +108,6 @@
 
   <ItemGroup>
     <Content Remove="obj\**" />
-    <Content Remove="wwwroot\**" />
     <Content Remove="cache\**" />
     <Content Remove="backups\**" />
     <Content Remove="logs\**" />
@@ -246,6 +242,48 @@
     <_ContentIncludedByDefault Remove="wwwroot\styles.4bd902bb3037f36f2c64.css.map" />
     <_ContentIncludedByDefault Remove="wwwroot\vendor.6b2a0912ae80e6fd297f.js" />
     <_ContentIncludedByDefault Remove="wwwroot\vendor.6b2a0912ae80e6fd297f.js.map" />
+    <_ContentIncludedByDefault Remove="wwwroot\10.b727db78581442412e9a.js" />
+    <_ContentIncludedByDefault Remove="wwwroot\10.b727db78581442412e9a.js.map" />
+    <_ContentIncludedByDefault Remove="wwwroot\2.fcc031071e80d6837012.js" />
+    <_ContentIncludedByDefault Remove="wwwroot\2.fcc031071e80d6837012.js.map" />
+    <_ContentIncludedByDefault Remove="wwwroot\7.c30da7d2e809fa05d1e3.js" />
+    <_ContentIncludedByDefault Remove="wwwroot\7.c30da7d2e809fa05d1e3.js.map" />
+    <_ContentIncludedByDefault Remove="wwwroot\8.d4c77a90c95e9861656a.js" />
+    <_ContentIncludedByDefault Remove="wwwroot\8.d4c77a90c95e9861656a.js.map" />
+    <_ContentIncludedByDefault Remove="wwwroot\9.489b177dd1a6beeb35ad.js" />
+    <_ContentIncludedByDefault Remove="wwwroot\9.489b177dd1a6beeb35ad.js.map" />
+    <_ContentIncludedByDefault Remove="wwwroot\assets\fonts\Spartan\OFL.txt" />
+    <_ContentIncludedByDefault Remove="wwwroot\assets\fonts\Spartan\Spartan-VariableFont_wght.ttf" />
+    <_ContentIncludedByDefault Remove="wwwroot\assets\icons\android-chrome-192x192.png" />
+    <_ContentIncludedByDefault Remove="wwwroot\assets\icons\android-chrome-256x256.png" />
+    <_ContentIncludedByDefault Remove="wwwroot\assets\icons\apple-touch-icon.png" />
+    <_ContentIncludedByDefault Remove="wwwroot\assets\icons\browserconfig.xml" />
+    <_ContentIncludedByDefault Remove="wwwroot\assets\icons\favicon-16x16.png" />
+    <_ContentIncludedByDefault Remove="wwwroot\assets\icons\favicon-32x32.png" />
+    <_ContentIncludedByDefault Remove="wwwroot\assets\icons\favicon.ico" />
+    <_ContentIncludedByDefault Remove="wwwroot\assets\icons\mstile-150x150.png" />
+    <_ContentIncludedByDefault Remove="wwwroot\assets\images\image-reset-cover-min.png" />
+    <_ContentIncludedByDefault Remove="wwwroot\assets\images\image-reset-cover.png" />
+    <_ContentIncludedByDefault Remove="wwwroot\assets\images\kavita-book-cropped.png" />
+    <_ContentIncludedByDefault Remove="wwwroot\assets\images\login-bg.jpg" />
+    <_ContentIncludedByDefault Remove="wwwroot\assets\images\logo.png" />
+    <_ContentIncludedByDefault Remove="wwwroot\common.fbf71de364f5a1f37413.js" />
+    <_ContentIncludedByDefault Remove="wwwroot\common.fbf71de364f5a1f37413.js.map" />
+    <_ContentIncludedByDefault Remove="wwwroot\login-bg.8860e6ff9d2a3598539c.jpg" />
+    <_ContentIncludedByDefault Remove="wwwroot\main.a3a1e647a39145accff3.js" />
+    <_ContentIncludedByDefault Remove="wwwroot\main.a3a1e647a39145accff3.js.map" />
+    <_ContentIncludedByDefault Remove="wwwroot\polyfills.3dda3bf3d087e5d131ba.js" />
+    <_ContentIncludedByDefault Remove="wwwroot\polyfills.3dda3bf3d087e5d131ba.js.map" />
+    <_ContentIncludedByDefault Remove="wwwroot\runtime.b9818dfc90f418b3f0a7.js" />
+    <_ContentIncludedByDefault Remove="wwwroot\runtime.b9818dfc90f418b3f0a7.js.map" />
+    <_ContentIncludedByDefault Remove="wwwroot\scripts.7d1c78b2763c483bb699.js" />
+    <_ContentIncludedByDefault Remove="wwwroot\scripts.7d1c78b2763c483bb699.js.map" />
+    <_ContentIncludedByDefault Remove="wwwroot\site.webmanifest" />
+    <_ContentIncludedByDefault Remove="wwwroot\Spartan-VariableFont_wght.0427aac0d980a12ae8ba.ttf" />
+    <_ContentIncludedByDefault Remove="wwwroot\styles.85a58cb3e4a4b1add864.css" />
+    <_ContentIncludedByDefault Remove="wwwroot\styles.85a58cb3e4a4b1add864.css.map" />
+    <_ContentIncludedByDefault Remove="wwwroot\vendor.54bf44a9aa720ff8881d.js" />
+    <_ContentIncludedByDefault Remove="wwwroot\vendor.54bf44a9aa720ff8881d.js.map" />
   </ItemGroup>
 
   <ItemGroup>

--- a/API/API.csproj
+++ b/API/API.csproj
@@ -85,6 +85,7 @@
     <None Remove="temp\**" />
     <None Remove="kavita.log" />
     <None Remove="kavita.db" />
+    <None Remove="covers\**" />
   </ItemGroup>
 
   <ItemGroup>
@@ -95,6 +96,7 @@
     <Compile Remove="backups\**" />
     <Compile Remove="logs\**" />
     <Compile Remove="temp\**" />
+    <Compile Remove="covers\**" />
   </ItemGroup>
 
   <ItemGroup>
@@ -104,6 +106,7 @@
     <EmbeddedResource Remove="backups\**" />
     <EmbeddedResource Remove="logs\**" />
     <EmbeddedResource Remove="temp\**" />
+    <EmbeddedResource Remove="covers\**" />
   </ItemGroup>
 
   <ItemGroup>
@@ -118,6 +121,7 @@
     <Content Update="appsettings.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Remove="covers\**" />
   </ItemGroup>
 
   <ItemGroup>

--- a/API/API.csproj
+++ b/API/API.csproj
@@ -58,7 +58,7 @@
     <PackageReference Include="NetVips.Native" Version="8.11.0" />
     <PackageReference Include="NReco.Logging.File" Version="1.1.2" />
     <PackageReference Include="Sentry.AspNetCore" Version="3.8.3" />
-    <PackageReference Include="SharpCompress" Version="0.28.3" />
+    <PackageReference Include="SharpCompress" Version="0.29.0" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="8.27.0.35380">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/API/API.csproj.DotSettings
+++ b/API/API.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=covers/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/API/Controllers/CollectionController.cs
+++ b/API/Controllers/CollectionController.cs
@@ -121,7 +121,7 @@ namespace API.Controllers
                 if (!updateSeriesForTagDto.Tag.CoverImageLocked)
                 {
                     tag.CoverImageLocked = false;
-                    tag.CoverImage = String.Empty;//Array.Empty<byte>();
+                    tag.CoverImage = string.Empty;
                     _unitOfWork.CollectionTagRepository.Update(tag);
                 }
 

--- a/API/Controllers/CollectionController.cs
+++ b/API/Controllers/CollectionController.cs
@@ -121,7 +121,7 @@ namespace API.Controllers
                 if (!updateSeriesForTagDto.Tag.CoverImageLocked)
                 {
                     tag.CoverImageLocked = false;
-                    tag.CoverImage = Array.Empty<byte>();
+                    tag.CoverImage = String.Empty;//Array.Empty<byte>();
                     _unitOfWork.CollectionTagRepository.Update(tag);
                 }
 

--- a/API/Controllers/ImageController.cs
+++ b/API/Controllers/ImageController.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.IO;
+using System.Threading.Tasks;
 using API.Extensions;
 using API.Interfaces;
 using Microsoft.AspNetCore.Mvc;
@@ -27,11 +28,18 @@ namespace API.Controllers
         [HttpGet("chapter-cover")]
         public async Task<ActionResult> GetChapterCoverImage(int chapterId)
         {
-            var content = await _unitOfWork.ChapterRepository.GetChapterCoverImageAsync(chapterId);
-            if (content == null) return BadRequest("No cover image");
+            var path =await _unitOfWork.ChapterRepository.GetChapterCoverImageAsync(chapterId);
+            if (string.IsNullOrEmpty(path) || !System.IO.File.Exists(path)) return BadRequest($"No cover image");
+            var format = Path.GetExtension(path).Replace(".", "");
 
-            Response.AddCacheHeader(content);
-            return File(content, "image/" + Format, $"{chapterId}");
+            // TODO: Need to figure out how to add ETAG caching on it
+            return PhysicalFile(path, "image/" + format);
+
+            // var content = await _unitOfWork.ChapterRepository.GetChapterCoverImageAsync(chapterId);
+            // if (content == null) return BadRequest("No cover image");
+            //
+            // Response.AddCacheHeader(content);
+            // return File(content, "image/" + Format, $"{chapterId}");
         }
 
         /// <summary>
@@ -42,11 +50,17 @@ namespace API.Controllers
         [HttpGet("volume-cover")]
         public async Task<ActionResult> GetVolumeCoverImage(int volumeId)
         {
-            var content = await _unitOfWork.VolumeRepository.GetVolumeCoverImageAsync(volumeId);
-            if (content == null) return BadRequest("No cover image");
+            var path = await _unitOfWork.VolumeRepository.GetVolumeCoverImageAsync(volumeId);
+            if (string.IsNullOrEmpty(path) || !System.IO.File.Exists(path)) return BadRequest($"No cover image");
+            var format = Path.GetExtension(path).Replace(".", "");
 
-            Response.AddCacheHeader(content);
-            return File(content, "image/" + Format, $"{volumeId}");
+            // TODO: Need to figure out how to add ETAG caching on it
+            return PhysicalFile(path, "image/" + format);
+            // var content = await _unitOfWork.VolumeRepository.GetVolumeCoverImageAsync(volumeId);
+            // if (content == null) return BadRequest("No cover image");
+            //
+            // Response.AddCacheHeader(content);
+            // return File(content, "image/" + Format, $"{volumeId}");
         }
 
         /// <summary>
@@ -57,11 +71,18 @@ namespace API.Controllers
         [HttpGet("series-cover")]
         public async Task<ActionResult> GetSeriesCoverImage(int seriesId)
         {
-            var content = await _unitOfWork.SeriesRepository.GetSeriesCoverImageAsync(seriesId);
-            if (content == null) return BadRequest("No cover image");
+            // var content = await _unitOfWork.SeriesRepository.GetSeriesCoverImageAsync(seriesId);
+            // if (content == null) return BadRequest("No cover image");
+            //
+            // Response.AddCacheHeader(content);
+            // return File(content, "image/" + Format, $"{seriesId}");
 
-            Response.AddCacheHeader(content);
-            return File(content, "image/" + Format, $"{seriesId}");
+            var path = await _unitOfWork.SeriesRepository.GetSeriesCoverImageAsync(seriesId);
+            if (string.IsNullOrEmpty(path) || !System.IO.File.Exists(path)) return BadRequest($"No cover image");
+            var format = Path.GetExtension(path).Replace(".", "");
+
+            // TODO: Need to figure out how to add ETAG caching on it
+            return PhysicalFile(path, "image/" + format);
         }
 
         /// <summary>
@@ -72,11 +93,18 @@ namespace API.Controllers
         [HttpGet("collection-cover")]
         public async Task<ActionResult> GetCollectionCoverImage(int collectionTagId)
         {
-            var content = await _unitOfWork.CollectionTagRepository.GetCoverImageAsync(collectionTagId);
-            if (content == null) return BadRequest("No cover image");
+            var path = await _unitOfWork.CollectionTagRepository.GetCoverImageAsync(collectionTagId);
+            if (string.IsNullOrEmpty(path) || !System.IO.File.Exists(path)) return BadRequest($"No cover image");
+            var format = Path.GetExtension(path).Replace(".", "");
 
-            Response.AddCacheHeader(content);
-            return File(content, "image/" + Format, $"{collectionTagId}");
+            // TODO: Need to figure out how to add ETAG caching on it
+            return PhysicalFile(path, "image/" + format);
+
+            // var content = await _unitOfWork.CollectionTagRepository.GetCoverImageAsync(collectionTagId);
+            // if (content == null) return BadRequest("No cover image");
+            //
+            // Response.AddCacheHeader(content);
+            // return File(content, "image/" + Format, $"{collectionTagId}");
         }
     }
 }

--- a/API/Controllers/ImageController.cs
+++ b/API/Controllers/ImageController.cs
@@ -1,8 +1,10 @@
 ﻿using System.IO;
 using System.Threading.Tasks;
+using API.Extensions;
 using API.Interfaces;
 using API.Services;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Net.Http.Headers;
 
 namespace API.Controllers
 {
@@ -40,6 +42,7 @@ namespace API.Controllers
         /// </summary>
         /// <param name="volumeId"></param>
         /// <returns></returns>
+        //[ResponseCache(Duration = 10, Location = ResponseCacheLocation.Any, NoStore = false)]
         [HttpGet("volume-cover")]
         public async Task<ActionResult> GetVolumeCoverImage(int volumeId)
         {
@@ -48,6 +51,7 @@ namespace API.Controllers
             var format = Path.GetExtension(path).Replace(".", "");
 
             // TODO: Need to figure out how to add ETAG caching on it
+            Response.AddCacheHeader(path);
             return PhysicalFile(path, "image/" + format);
         }
 

--- a/API/Controllers/ImageController.cs
+++ b/API/Controllers/ImageController.cs
@@ -33,7 +33,7 @@ namespace API.Controllers
             if (string.IsNullOrEmpty(path) || !System.IO.File.Exists(path)) return BadRequest($"No cover image");
             var format = Path.GetExtension(path).Replace(".", "");
 
-            // TODO: Need to figure out how to add ETAG caching on it
+            Response.AddCacheHeader(path);
             return PhysicalFile(path, "image/" + format);
         }
 
@@ -42,7 +42,6 @@ namespace API.Controllers
         /// </summary>
         /// <param name="volumeId"></param>
         /// <returns></returns>
-        //[ResponseCache(Duration = 10, Location = ResponseCacheLocation.Any, NoStore = false)]
         [HttpGet("volume-cover")]
         public async Task<ActionResult> GetVolumeCoverImage(int volumeId)
         {
@@ -50,7 +49,6 @@ namespace API.Controllers
             if (string.IsNullOrEmpty(path) || !System.IO.File.Exists(path)) return BadRequest($"No cover image");
             var format = Path.GetExtension(path).Replace(".", "");
 
-            // TODO: Need to figure out how to add ETAG caching on it
             Response.AddCacheHeader(path);
             return PhysicalFile(path, "image/" + format);
         }
@@ -83,7 +81,7 @@ namespace API.Controllers
             if (string.IsNullOrEmpty(path) || !System.IO.File.Exists(path)) return BadRequest($"No cover image");
             var format = Path.GetExtension(path).Replace(".", "");
 
-            // TODO: Need to figure out how to add ETAG caching on it
+            Response.AddCacheHeader(path);
             return PhysicalFile(path, "image/" + format);
         }
     }

--- a/API/Controllers/ImageController.cs
+++ b/API/Controllers/ImageController.cs
@@ -1,6 +1,5 @@
 ﻿using System.IO;
 using System.Threading.Tasks;
-using API.Extensions;
 using API.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 
@@ -11,7 +10,6 @@ namespace API.Controllers
     /// </summary>
     public class ImageController : BaseApiController
     {
-        private const string Format = "jpeg";
         private readonly IUnitOfWork _unitOfWork;
 
         /// <inheritdoc />

--- a/API/Controllers/ImageController.cs
+++ b/API/Controllers/ImageController.cs
@@ -65,7 +65,7 @@ namespace API.Controllers
             if (string.IsNullOrEmpty(path) || !System.IO.File.Exists(path)) return BadRequest($"No cover image");
             var format = Path.GetExtension(path).Replace(".", "");
 
-            // TODO: Need to figure out how to add ETAG caching on it
+            Response.AddCacheHeader(path);
             return PhysicalFile(path, "image/" + format);
         }
 

--- a/API/Controllers/ImageController.cs
+++ b/API/Controllers/ImageController.cs
@@ -34,12 +34,6 @@ namespace API.Controllers
 
             // TODO: Need to figure out how to add ETAG caching on it
             return PhysicalFile(path, "image/" + format);
-
-            // var content = await _unitOfWork.ChapterRepository.GetChapterCoverImageAsync(chapterId);
-            // if (content == null) return BadRequest("No cover image");
-            //
-            // Response.AddCacheHeader(content);
-            // return File(content, "image/" + Format, $"{chapterId}");
         }
 
         /// <summary>
@@ -56,11 +50,6 @@ namespace API.Controllers
 
             // TODO: Need to figure out how to add ETAG caching on it
             return PhysicalFile(path, "image/" + format);
-            // var content = await _unitOfWork.VolumeRepository.GetVolumeCoverImageAsync(volumeId);
-            // if (content == null) return BadRequest("No cover image");
-            //
-            // Response.AddCacheHeader(content);
-            // return File(content, "image/" + Format, $"{volumeId}");
         }
 
         /// <summary>
@@ -71,12 +60,6 @@ namespace API.Controllers
         [HttpGet("series-cover")]
         public async Task<ActionResult> GetSeriesCoverImage(int seriesId)
         {
-            // var content = await _unitOfWork.SeriesRepository.GetSeriesCoverImageAsync(seriesId);
-            // if (content == null) return BadRequest("No cover image");
-            //
-            // Response.AddCacheHeader(content);
-            // return File(content, "image/" + Format, $"{seriesId}");
-
             var path = await _unitOfWork.SeriesRepository.GetSeriesCoverImageAsync(seriesId);
             if (string.IsNullOrEmpty(path) || !System.IO.File.Exists(path)) return BadRequest($"No cover image");
             var format = Path.GetExtension(path).Replace(".", "");
@@ -99,12 +82,6 @@ namespace API.Controllers
 
             // TODO: Need to figure out how to add ETAG caching on it
             return PhysicalFile(path, "image/" + format);
-
-            // var content = await _unitOfWork.CollectionTagRepository.GetCoverImageAsync(collectionTagId);
-            // if (content == null) return BadRequest("No cover image");
-            //
-            // Response.AddCacheHeader(content);
-            // return File(content, "image/" + Format, $"{collectionTagId}");
         }
     }
 }

--- a/API/Controllers/ImageController.cs
+++ b/API/Controllers/ImageController.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO;
 using System.Threading.Tasks;
 using API.Interfaces;
+using API.Services;
 using Microsoft.AspNetCore.Mvc;
 
 namespace API.Controllers
@@ -26,7 +27,7 @@ namespace API.Controllers
         [HttpGet("chapter-cover")]
         public async Task<ActionResult> GetChapterCoverImage(int chapterId)
         {
-            var path =await _unitOfWork.ChapterRepository.GetChapterCoverImageAsync(chapterId);
+            var path = Path.Join(DirectoryService.CoverImageDirectory, await _unitOfWork.ChapterRepository.GetChapterCoverImageAsync(chapterId));
             if (string.IsNullOrEmpty(path) || !System.IO.File.Exists(path)) return BadRequest($"No cover image");
             var format = Path.GetExtension(path).Replace(".", "");
 
@@ -42,7 +43,7 @@ namespace API.Controllers
         [HttpGet("volume-cover")]
         public async Task<ActionResult> GetVolumeCoverImage(int volumeId)
         {
-            var path = await _unitOfWork.VolumeRepository.GetVolumeCoverImageAsync(volumeId);
+            var path = Path.Join(DirectoryService.CoverImageDirectory, await _unitOfWork.VolumeRepository.GetVolumeCoverImageAsync(volumeId));
             if (string.IsNullOrEmpty(path) || !System.IO.File.Exists(path)) return BadRequest($"No cover image");
             var format = Path.GetExtension(path).Replace(".", "");
 
@@ -58,7 +59,7 @@ namespace API.Controllers
         [HttpGet("series-cover")]
         public async Task<ActionResult> GetSeriesCoverImage(int seriesId)
         {
-            var path = await _unitOfWork.SeriesRepository.GetSeriesCoverImageAsync(seriesId);
+            var path = Path.Join(DirectoryService.CoverImageDirectory, await _unitOfWork.SeriesRepository.GetSeriesCoverImageAsync(seriesId));
             if (string.IsNullOrEmpty(path) || !System.IO.File.Exists(path)) return BadRequest($"No cover image");
             var format = Path.GetExtension(path).Replace(".", "");
 
@@ -74,7 +75,7 @@ namespace API.Controllers
         [HttpGet("collection-cover")]
         public async Task<ActionResult> GetCollectionCoverImage(int collectionTagId)
         {
-            var path = await _unitOfWork.CollectionTagRepository.GetCoverImageAsync(collectionTagId);
+            var path = Path.Join(DirectoryService.CoverImageDirectory, await _unitOfWork.CollectionTagRepository.GetCoverImageAsync(collectionTagId));
             if (string.IsNullOrEmpty(path) || !System.IO.File.Exists(path)) return BadRequest($"No cover image");
             var format = Path.GetExtension(path).Replace(".", "");
 

--- a/API/Controllers/ReaderController.cs
+++ b/API/Controllers/ReaderController.cs
@@ -300,7 +300,7 @@ namespace API.Controllers
                 SeriesId = 0
             };
             if (user.Progresses == null) return Ok(progressBookmark);
-            var progress = user.Progresses.SingleOrDefault(x => x.AppUserId == user.Id && x.ChapterId == chapterId);
+            var progress = user.Progresses.FirstOrDefault(x => x.AppUserId == user.Id && x.ChapterId == chapterId);
 
             if (progress != null)
             {

--- a/API/Controllers/ReadingListController.cs
+++ b/API/Controllers/ReadingListController.cs
@@ -21,6 +21,11 @@ namespace API.Controllers
             _unitOfWork = unitOfWork;
         }
 
+        /// <summary>
+        /// Fetches a single Reading List
+        /// </summary>
+        /// <param name="readingListId"></param>
+        /// <returns></returns>
         [HttpGet]
         public async Task<ActionResult<IEnumerable<ReadingListDto>>> GetList(int readingListId)
         {
@@ -86,6 +91,11 @@ namespace API.Controllers
             return BadRequest("Couldn't update position");
         }
 
+        /// <summary>
+        /// Deletes a list item from the list. Will reorder all item positions afterwards
+        /// </summary>
+        /// <param name="dto"></param>
+        /// <returns></returns>
         [HttpPost("delete-item")]
         public async Task<ActionResult> DeleteListItem(UpdateReadingListPosition dto)
         {
@@ -201,6 +211,11 @@ namespace API.Controllers
             return Ok(await _unitOfWork.ReadingListRepository.GetReadingListDtoByTitleAsync(dto.Title));
         }
 
+        /// <summary>
+        /// Update a
+        /// </summary>
+        /// <param name="dto"></param>
+        /// <returns></returns>
         [HttpPost("update")]
         public async Task<ActionResult> UpdateList(UpdateReadingListDto dto)
         {

--- a/API/Controllers/SeriesController.cs
+++ b/API/Controllers/SeriesController.cs
@@ -161,6 +161,7 @@ namespace API.Controllers
             {
                 // Trigger a refresh when we are moving from a locked image to a non-locked
                 needsRefreshMetadata = true;
+                // TODO: Do I need to clear out the coverImage here?
                 series.CoverImageLocked = updateSeries.CoverImageLocked;
             }
 

--- a/API/Controllers/SeriesController.cs
+++ b/API/Controllers/SeriesController.cs
@@ -157,6 +157,7 @@ namespace API.Controllers
             series.Summary = updateSeries.Summary?.Trim();
 
             var needsRefreshMetadata = false;
+            // This is when you hit Reset
             if (series.CoverImageLocked && !updateSeries.CoverImageLocked)
             {
                 // Trigger a refresh when we are moving from a locked image to a non-locked

--- a/API/Controllers/SeriesController.cs
+++ b/API/Controllers/SeriesController.cs
@@ -161,7 +161,7 @@ namespace API.Controllers
             {
                 // Trigger a refresh when we are moving from a locked image to a non-locked
                 needsRefreshMetadata = true;
-                // TODO: Do I need to clear out the coverImage here?
+                series.CoverImage = string.Empty;
                 series.CoverImageLocked = updateSeries.CoverImageLocked;
             }
 

--- a/API/Controllers/UploadController.cs
+++ b/API/Controllers/UploadController.cs
@@ -180,7 +180,8 @@ namespace API.Controllers
             try
             {
                 var chapter = await _unitOfWork.ChapterRepository.GetChapterAsync(uploadFileDto.Id);
-                chapter.CoverImage = string.Empty; //Array.Empty<byte>();
+                var originalFile = chapter.CoverImage;
+                chapter.CoverImage = string.Empty;
                 chapter.CoverImageLocked = false;
                 _unitOfWork.ChapterRepository.Update(chapter);
                 var volume = await _unitOfWork.SeriesRepository.GetVolumeAsync(chapter.VolumeId);
@@ -191,6 +192,7 @@ namespace API.Controllers
                 if (_unitOfWork.HasChanges())
                 {
                     await _unitOfWork.CommitAsync();
+                    System.IO.File.Delete(originalFile);
                     _taskScheduler.RefreshSeriesMetadata(series.LibraryId, series.Id, true);
                     return Ok();
                 }

--- a/API/Controllers/UploadController.cs
+++ b/API/Controllers/UploadController.cs
@@ -53,7 +53,7 @@ namespace API.Controllers
 
                 if (bytes.Length > 0)
                 {
-                    series.CoverImage = bytes;
+                    series.CoverImage = String.Empty; // TODO: Correct this (bytes)
                     series.CoverImageLocked = true;
                     _unitOfWork.SeriesRepository.Update(series);
                 }
@@ -98,7 +98,8 @@ namespace API.Controllers
 
                 if (bytes.Length > 0)
                 {
-                    tag.CoverImage = bytes;
+                    tag.CoverImage = String.Empty;
+                    ; //TODO: Fix bytes;
                     tag.CoverImageLocked = true;
                     _unitOfWork.CollectionTagRepository.Update(tag);
                 }
@@ -143,7 +144,7 @@ namespace API.Controllers
                 if (bytes.Length > 0)
                 {
                     var chapter = await _unitOfWork.ChapterRepository.GetChapterAsync(uploadFileDto.Id);
-                    chapter.CoverImage = bytes;
+                    chapter.CoverImage = string.Empty;// TODO: bytes;
                     chapter.CoverImageLocked = true;
                     _unitOfWork.ChapterRepository.Update(chapter);
                     var volume = await _unitOfWork.SeriesRepository.GetVolumeAsync(chapter.VolumeId);
@@ -179,7 +180,7 @@ namespace API.Controllers
             try
             {
                 var chapter = await _unitOfWork.ChapterRepository.GetChapterAsync(uploadFileDto.Id);
-                chapter.CoverImage = Array.Empty<byte>();
+                chapter.CoverImage = string.Empty; //Array.Empty<byte>();
                 chapter.CoverImageLocked = false;
                 _unitOfWork.ChapterRepository.Update(chapter);
                 var volume = await _unitOfWork.SeriesRepository.GetVolumeAsync(chapter.VolumeId);

--- a/API/Controllers/UploadController.cs
+++ b/API/Controllers/UploadController.cs
@@ -7,6 +7,7 @@ using API.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using NetVips;
 
 namespace API.Controllers
 {
@@ -49,7 +50,7 @@ namespace API.Controllers
 
             try
             {
-                var filePath = _imageService.CreateThumbnailFromBase64(uploadFileDto.Url, $"series{uploadFileDto.Id}");
+                var filePath = _imageService.CreateThumbnailFromBase64(uploadFileDto.Url, ImageService.GetSeriesFormat(uploadFileDto.Id));
                 var series = await _unitOfWork.SeriesRepository.GetSeriesByIdAsync(uploadFileDto.Id);
 
                 if (!string.IsNullOrEmpty(filePath))
@@ -94,7 +95,7 @@ namespace API.Controllers
 
             try
             {
-                var filePath = _imageService.CreateThumbnailFromBase64(uploadFileDto.Url, $"tag{uploadFileDto.Id}");
+                var filePath = _imageService.CreateThumbnailFromBase64(uploadFileDto.Url, $"{ImageService.GetCollectionTagFormat(uploadFileDto.Id)}");
                 var tag = await _unitOfWork.CollectionTagRepository.GetTagAsync(uploadFileDto.Id);
 
                 if (!string.IsNullOrEmpty(filePath))
@@ -140,7 +141,7 @@ namespace API.Controllers
             try
             {
                 var chapter = await _unitOfWork.ChapterRepository.GetChapterAsync(uploadFileDto.Id);
-                var filePath = _imageService.CreateThumbnailFromBase64(uploadFileDto.Url, $"v{chapter.VolumeId}_c{uploadFileDto.Id}");
+                var filePath = _imageService.CreateThumbnailFromBase64(uploadFileDto.Url, $"{ImageService.GetChapterFormat(uploadFileDto.Id, chapter.VolumeId)}");
 
                 if (!string.IsNullOrEmpty(filePath))
                 {

--- a/API/Controllers/UploadController.cs
+++ b/API/Controllers/UploadController.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using API.DTOs.Uploads;
 using API.Interfaces;
 using API.Interfaces.Services;
+using API.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -48,12 +49,12 @@ namespace API.Controllers
 
             try
             {
-                var bytes = _imageService.CreateThumbnailFromBase64(uploadFileDto.Url);
+                var filePath = _imageService.CreateThumbnailFromBase64(uploadFileDto.Url, $"series{uploadFileDto.Id}");
                 var series = await _unitOfWork.SeriesRepository.GetSeriesByIdAsync(uploadFileDto.Id);
 
-                if (bytes.Length > 0)
+                if (!string.IsNullOrEmpty(filePath))
                 {
-                    series.CoverImage = String.Empty; // TODO: Correct this (bytes)
+                    series.CoverImage = filePath;
                     series.CoverImageLocked = true;
                     _unitOfWork.SeriesRepository.Update(series);
                 }
@@ -93,13 +94,12 @@ namespace API.Controllers
 
             try
             {
-                var bytes = _imageService.CreateThumbnailFromBase64(uploadFileDto.Url);
+                var filePath = _imageService.CreateThumbnailFromBase64(uploadFileDto.Url, $"tag{uploadFileDto.Id}");
                 var tag = await _unitOfWork.CollectionTagRepository.GetTagAsync(uploadFileDto.Id);
 
-                if (bytes.Length > 0)
+                if (!string.IsNullOrEmpty(filePath))
                 {
-                    tag.CoverImage = String.Empty;
-                    ; //TODO: Fix bytes;
+                    tag.CoverImage = filePath;
                     tag.CoverImageLocked = true;
                     _unitOfWork.CollectionTagRepository.Update(tag);
                 }
@@ -139,12 +139,12 @@ namespace API.Controllers
 
             try
             {
-                var bytes = _imageService.CreateThumbnailFromBase64(uploadFileDto.Url);
+                var chapter = await _unitOfWork.ChapterRepository.GetChapterAsync(uploadFileDto.Id);
+                var filePath = _imageService.CreateThumbnailFromBase64(uploadFileDto.Url, $"v{chapter.VolumeId}_c{uploadFileDto.Id}");
 
-                if (bytes.Length > 0)
+                if (!string.IsNullOrEmpty(filePath))
                 {
-                    var chapter = await _unitOfWork.ChapterRepository.GetChapterAsync(uploadFileDto.Id);
-                    chapter.CoverImage = string.Empty;// TODO: bytes;
+                    chapter.CoverImage = filePath;
                     chapter.CoverImageLocked = true;
                     _unitOfWork.ChapterRepository.Update(chapter);
                     var volume = await _unitOfWork.SeriesRepository.GetVolumeAsync(chapter.VolumeId);

--- a/API/Data/MigrateCoverImages.cs
+++ b/API/Data/MigrateCoverImages.cs
@@ -9,6 +9,16 @@ using Microsoft.EntityFrameworkCore;
 namespace API.Data
 {
     /// <summary>
+    /// A data structure to migrate Cover Images from byte[] to files.
+    /// </summary>
+    internal class CoverMigration
+    {
+        public string Id { get; set; }
+        public byte[] CoverImage { get; set; }
+        public string ParentId { get; set; }
+    }
+
+    /// <summary>
     /// In v0.4.6, Cover Images were migrated from byte[] in the DB to external files. This migration handles that work.
     /// </summary>
     public static class MigrateCoverImages

--- a/API/Data/MigrateCoverImages.cs
+++ b/API/Data/MigrateCoverImages.cs
@@ -32,7 +32,7 @@ namespace API.Data
                 DirectoryService.ExistOrCreate(DirectoryService.CoverImageDirectory);
 
                 Console.WriteLine("Extracting cover images for Series");
-                var lockedSeries = SQLHelper.RawSqlQuery(context, "Select Id, CoverImage From Series where CoverImageLocked = true;", x =>
+                var lockedSeries = SqlHelper.RawSqlQuery(context, "Select Id, CoverImage From Series where CoverImageLocked = true;", x =>
                     new CoverMigration()
                     {
                         Id = x[0] + string.Empty,
@@ -58,7 +58,7 @@ namespace API.Data
                 }
 
                 Console.WriteLine("Extracting cover images for Chapters");
-                var chapters = SQLHelper.RawSqlQuery(context, "Select Id, CoverImage, VolumeId From Chapter;", x =>
+                var chapters = SqlHelper.RawSqlQuery(context, "Select Id, CoverImage, VolumeId From Chapter;", x =>
                     new CoverMigration()
                     {
                         Id = x[0] + string.Empty,
@@ -84,7 +84,7 @@ namespace API.Data
                 }
 
                 Console.WriteLine("Extracting cover images for Collection Tags");
-                var tags = SQLHelper.RawSqlQuery(context, "Select Id, CoverImage From CollectionTag Where CoverImage IS NOT NULL;", x =>
+                var tags = SqlHelper.RawSqlQuery(context, "Select Id, CoverImage From CollectionTag Where CoverImage IS NOT NULL;", x =>
                     new CoverMigration()
                     {
                         Id = x[0] + string.Empty,

--- a/API/Data/MigrateCoverImages.cs
+++ b/API/Data/MigrateCoverImages.cs
@@ -32,7 +32,7 @@ namespace API.Data
                 DirectoryService.ExistOrCreate(DirectoryService.CoverImageDirectory);
 
                 Console.WriteLine("Extracting cover images for Series");
-                var lockedSeries = SqlHelper.RawSqlQuery(context, "Select Id, CoverImage From Series where CoverImageLocked = true;", x =>
+                var lockedSeries = SqlHelper.RawSqlQuery(context, "Select Id, CoverImage From Series Where CoverImage IS NOT NULL", x =>
                     new CoverMigration()
                     {
                         Id = x[0] + string.Empty,
@@ -58,7 +58,7 @@ namespace API.Data
                 }
 
                 Console.WriteLine("Extracting cover images for Chapters");
-                var chapters = SqlHelper.RawSqlQuery(context, "Select Id, CoverImage, VolumeId From Chapter;", x =>
+                var chapters = SqlHelper.RawSqlQuery(context, "Select Id, CoverImage, VolumeId From Chapter Where CoverImage IS NOT NULL;", x =>
                     new CoverMigration()
                     {
                         Id = x[0] + string.Empty,

--- a/API/Data/MigrateCoverImages.cs
+++ b/API/Data/MigrateCoverImages.cs
@@ -116,8 +116,8 @@ namespace API.Data
         public static async Task UpdateDatabaseWithImages(DataContext context)
         {
             Console.WriteLine("Updating Series entities");
-            var lockedSeries = await context.Series.Where(s => s.CoverImageLocked).ToListAsync();
-            foreach (var series in lockedSeries)
+            var seriesCovers = await context.Series.Where(s => !string.IsNullOrEmpty(s.CoverImage)).ToListAsync();
+            foreach (var series in seriesCovers)
             {
                 if (!File.Exists(Path.Join(DirectoryService.CoverImageDirectory,
                     $"{ImageService.GetSeriesFormat(series.Id)}.png"))) continue;

--- a/API/Data/MigrateCoverImages.cs
+++ b/API/Data/MigrateCoverImages.cs
@@ -1,0 +1,150 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using API.Helpers;
+using API.Services;
+using Microsoft.EntityFrameworkCore;
+
+namespace API.Data
+{
+    /// <summary>
+    /// In v0.4.6, Cover Images were migrated from byte[] in the DB to external files. This migration handles that work.
+    /// </summary>
+    public static class MigrateCoverImages
+    {
+        /// <summary>
+        /// Run first. Will extract byte[]s from DB and write them to the cover directory.
+        /// </summary>
+        public static void ExtractToImages(DbContext context)
+        {
+                Console.WriteLine("Migrating Cover Images to disk. Expect delay.");
+                DirectoryService.ExistOrCreate(DirectoryService.CoverImageDirectory);
+
+                Console.WriteLine("Extracting cover images for Series");
+                var lockedSeries = SQLHelper.RawSqlQuery(context, "Select Id, CoverImage From Series where CoverImageLocked = true;", x =>
+                    new CoverMigration()
+                    {
+                        Id = x[0] + string.Empty,
+                        CoverImage = (byte[]) x[1],
+                        ParentId = "0"
+                    });
+                foreach (var series in lockedSeries)
+                {
+                    if (series.CoverImage == null || !series.CoverImage.Any()) continue;
+                    if (File.Exists(Path.Join(DirectoryService.CoverImageDirectory,
+                        $"series{series.Id}.png"))) continue;
+
+                    try
+                    {
+                        var stream = new MemoryStream(series.CoverImage);
+                        stream.Position = 0;
+                        ImageService.WriteCoverThumbnail(stream, $"series{series.Id}");
+                    }
+                    catch (Exception e)
+                    {
+                        Console.WriteLine(e);
+                    }
+                }
+
+                Console.WriteLine("Extracting cover images for Chapters");
+                var chapters = SQLHelper.RawSqlQuery(context, "Select Id, CoverImage, VolumeId From Chapter;", x =>
+                    new CoverMigration()
+                    {
+                        Id = x[0] + string.Empty,
+                        CoverImage = (byte[]) x[1],
+                        ParentId = x[2] + string.Empty
+                    });
+                foreach (var chapter in chapters)
+                {
+                    if (chapter.CoverImage == null || !chapter.CoverImage.Any()) continue;
+                    if (File.Exists(Path.Join(DirectoryService.CoverImageDirectory,
+                        $"v{chapter.ParentId}_c{chapter.Id}.png"))) continue;
+
+                    try
+                    {
+                        var stream = new MemoryStream(chapter.CoverImage);
+                        stream.Position = 0;
+                        ImageService.WriteCoverThumbnail(stream, $"v{chapter.ParentId}_c{chapter.Id}");
+                    }
+                    catch (Exception e)
+                    {
+                        Console.WriteLine(e);
+                    }
+                }
+
+                Console.WriteLine("Extracting cover images for Collection Tags");
+                var tags = SQLHelper.RawSqlQuery(context, "Select Id, CoverImage From CollectionTag Where CoverImage IS NOT NULL;", x =>
+                    new CoverMigration()
+                    {
+                        Id = x[0] + string.Empty,
+                        CoverImage = (byte[]) x[1] ,
+                        ParentId = "0"
+                    });
+                foreach (var tag in tags)
+                {
+                    if (tag.CoverImage == null || !tag.CoverImage.Any()) continue;
+                    if (File.Exists(Path.Join(DirectoryService.CoverImageDirectory,
+                        $"tag{tag.Id}.png"))) continue;
+                    try
+                    {
+                        var stream = new MemoryStream(tag.CoverImage);
+                        stream.Position = 0;
+                        ImageService.WriteCoverThumbnail(stream, $"tag{tag.Id}");
+                    }
+                    catch (Exception e)
+                    {
+                        Console.WriteLine(e);
+                    }
+                }
+        }
+
+        /// <summary>
+        /// Run after <see cref="ExtractToImages"/>. Will update the DB with names of files that were extracted.
+        /// </summary>
+        /// <param name="context"></param>
+        public static async Task UpdateDatabaseWithImages(DataContext context)
+        {
+            Console.WriteLine("Updating Series entities");
+            var lockedSeries = await context.Series.Where(s => s.CoverImageLocked).ToListAsync();
+            foreach (var series in lockedSeries)
+            {
+                if (!File.Exists(Path.Join(DirectoryService.CoverImageDirectory,
+                    $"series{series.Id}.png"))) continue;
+                series.CoverImage = $"series{series.Id}.png";
+            }
+
+            await context.SaveChangesAsync();
+
+            Console.WriteLine("Updating Chapter entities");
+            var chapters = await context.Chapter.ToListAsync();
+            foreach (var chapter in chapters)
+            {
+                if (File.Exists(Path.Join(DirectoryService.CoverImageDirectory,
+                    $"v{chapter.VolumeId}_c{chapter.Id}.png")))
+                {
+                    chapter.CoverImage = $"v{chapter.VolumeId}_c{chapter.Id}.png";
+                }
+
+            }
+
+            await context.SaveChangesAsync();
+
+            Console.WriteLine("Updating Collection Tag entities");
+            var tags = await context.CollectionTag.ToListAsync();
+            foreach (var tag in tags)
+            {
+                if (File.Exists(Path.Join(DirectoryService.CoverImageDirectory,
+                    $"tag{tag.Id}.png")))
+                {
+                    tag.CoverImage = $"tag{tag.Id}.png";
+                }
+
+            }
+
+            await context.SaveChangesAsync();
+            Console.WriteLine("Cover Image Migration completed");
+        }
+
+    }
+}

--- a/API/Data/MigrateCoverImages.cs
+++ b/API/Data/MigrateCoverImages.cs
@@ -33,13 +33,13 @@ namespace API.Data
                 {
                     if (series.CoverImage == null || !series.CoverImage.Any()) continue;
                     if (File.Exists(Path.Join(DirectoryService.CoverImageDirectory,
-                        $"series{series.Id}.png"))) continue;
+                        $"{ImageService.GetSeriesFormat(int.Parse(series.Id))}.png"))) continue;
 
                     try
                     {
                         var stream = new MemoryStream(series.CoverImage);
                         stream.Position = 0;
-                        ImageService.WriteCoverThumbnail(stream, $"series{series.Id}");
+                        ImageService.WriteCoverThumbnail(stream, ImageService.GetSeriesFormat(int.Parse(series.Id)));
                     }
                     catch (Exception e)
                     {
@@ -59,13 +59,13 @@ namespace API.Data
                 {
                     if (chapter.CoverImage == null || !chapter.CoverImage.Any()) continue;
                     if (File.Exists(Path.Join(DirectoryService.CoverImageDirectory,
-                        $"v{chapter.ParentId}_c{chapter.Id}.png"))) continue;
+                        $"{ImageService.GetChapterFormat(int.Parse(chapter.Id), int.Parse(chapter.ParentId))}.png"))) continue;
 
                     try
                     {
                         var stream = new MemoryStream(chapter.CoverImage);
                         stream.Position = 0;
-                        ImageService.WriteCoverThumbnail(stream, $"v{chapter.ParentId}_c{chapter.Id}");
+                        ImageService.WriteCoverThumbnail(stream, $"{ImageService.GetChapterFormat(int.Parse(chapter.Id), int.Parse(chapter.ParentId))}");
                     }
                     catch (Exception e)
                     {
@@ -85,12 +85,12 @@ namespace API.Data
                 {
                     if (tag.CoverImage == null || !tag.CoverImage.Any()) continue;
                     if (File.Exists(Path.Join(DirectoryService.CoverImageDirectory,
-                        $"tag{tag.Id}.png"))) continue;
+                        $"{ImageService.GetCollectionTagFormat(int.Parse(tag.Id))}.png"))) continue;
                     try
                     {
                         var stream = new MemoryStream(tag.CoverImage);
                         stream.Position = 0;
-                        ImageService.WriteCoverThumbnail(stream, $"tag{tag.Id}");
+                        ImageService.WriteCoverThumbnail(stream, $"{ImageService.GetCollectionTagFormat(int.Parse(tag.Id))}");
                     }
                     catch (Exception e)
                     {
@@ -110,8 +110,8 @@ namespace API.Data
             foreach (var series in lockedSeries)
             {
                 if (!File.Exists(Path.Join(DirectoryService.CoverImageDirectory,
-                    $"series{series.Id}.png"))) continue;
-                series.CoverImage = $"series{series.Id}.png";
+                    $"{ImageService.GetSeriesFormat(series.Id)}.png"))) continue;
+                series.CoverImage = $"{ImageService.GetSeriesFormat(series.Id)}.png";
             }
 
             await context.SaveChangesAsync();
@@ -121,9 +121,9 @@ namespace API.Data
             foreach (var chapter in chapters)
             {
                 if (File.Exists(Path.Join(DirectoryService.CoverImageDirectory,
-                    $"v{chapter.VolumeId}_c{chapter.Id}.png")))
+                    $"{ImageService.GetChapterFormat(chapter.Id, chapter.VolumeId)}.png")))
                 {
-                    chapter.CoverImage = $"v{chapter.VolumeId}_c{chapter.Id}.png";
+                    chapter.CoverImage = $"{ImageService.GetChapterFormat(chapter.Id, chapter.VolumeId)}.png";
                 }
 
             }
@@ -135,9 +135,9 @@ namespace API.Data
             foreach (var tag in tags)
             {
                 if (File.Exists(Path.Join(DirectoryService.CoverImageDirectory,
-                    $"tag{tag.Id}.png")))
+                    $"{ImageService.GetCollectionTagFormat(tag.Id)}.png")))
                 {
-                    tag.CoverImage = $"tag{tag.Id}.png";
+                    tag.CoverImage = $"{ImageService.GetCollectionTagFormat(tag.Id)}.png";
                 }
 
             }

--- a/API/Data/Migrations/20210916142418_EntityImageRefactor.Designer.cs
+++ b/API/Data/Migrations/20210916142418_EntityImageRefactor.Designer.cs
@@ -3,14 +3,16 @@ using System;
 using API.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace API.Data.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20210916142418_EntityImageRefactor")]
+    partial class EntityImageRefactor
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/API/Data/Migrations/20210916142418_EntityImageRefactor.cs
+++ b/API/Data/Migrations/20210916142418_EntityImageRefactor.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace API.Data.Migrations
+{
+    public partial class EntityImageRefactor : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "RowVersion",
+                table: "AppUserProgresses");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "CoverImage",
+                table: "Volume",
+                type: "TEXT",
+                nullable: true,
+                oldClrType: typeof(byte[]),
+                oldType: "BLOB",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "CoverImage",
+                table: "Series",
+                type: "TEXT",
+                nullable: true,
+                oldClrType: typeof(byte[]),
+                oldType: "BLOB",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "CoverImage",
+                table: "CollectionTag",
+                type: "TEXT",
+                nullable: true,
+                oldClrType: typeof(byte[]),
+                oldType: "BLOB",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "CoverImage",
+                table: "Chapter",
+                type: "TEXT",
+                nullable: true,
+                oldClrType: typeof(byte[]),
+                oldType: "BLOB",
+                oldNullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<byte[]>(
+                name: "CoverImage",
+                table: "Volume",
+                type: "BLOB",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "TEXT",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<byte[]>(
+                name: "CoverImage",
+                table: "Series",
+                type: "BLOB",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "TEXT",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<byte[]>(
+                name: "CoverImage",
+                table: "CollectionTag",
+                type: "BLOB",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "TEXT",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<byte[]>(
+                name: "CoverImage",
+                table: "Chapter",
+                type: "BLOB",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "TEXT",
+                oldNullable: true);
+
+            migrationBuilder.AddColumn<uint>(
+                name: "RowVersion",
+                table: "AppUserProgresses",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0u);
+        }
+    }
+}

--- a/API/Data/Migrations/20210916142418_EntityImageRefactor.cs
+++ b/API/Data/Migrations/20210916142418_EntityImageRefactor.cs
@@ -7,8 +7,6 @@ namespace API.Data.Migrations
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            //var query = migrationBuilder.Sql("Select Id, CoverImage, CoverImageLocked from Volume");
-
             migrationBuilder.DropColumn(
                 name: "RowVersion",
                 table: "AppUserProgresses");

--- a/API/Data/Migrations/20210916142418_EntityImageRefactor.cs
+++ b/API/Data/Migrations/20210916142418_EntityImageRefactor.cs
@@ -7,6 +7,8 @@ namespace API.Data.Migrations
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {
+            //var query = migrationBuilder.Sql("Select Id, CoverImage, CoverImageLocked from Volume");
+
             migrationBuilder.DropColumn(
                 name: "RowVersion",
                 table: "AppUserProgresses");

--- a/API/Data/Repositories/AppUserProgressRepository.cs
+++ b/API/Data/Repositories/AppUserProgressRepository.cs
@@ -73,7 +73,7 @@ namespace API.Data.Repositories
         {
             return await _context.AppUserProgresses
                 .Where(p => p.ChapterId == chapterId && p.AppUserId == userId)
-                .SingleOrDefaultAsync();
+                .FirstOrDefaultAsync();
         }
     }
 }

--- a/API/Data/Repositories/ChapterRepository.cs
+++ b/API/Data/Repositories/ChapterRepository.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using API.DTOs;
 using API.DTOs.Reader;
@@ -140,8 +142,9 @@ namespace API.Data.Repositories
         /// </summary>
         /// <param name="chapterId"></param>
         /// <returns></returns>
-        public async Task<byte[]> GetChapterCoverImageAsync(int chapterId)
+        public async Task<string> GetChapterCoverImageAsync(int chapterId)
         {
+
             return await _context.Chapter
                 .Where(c => c.Id == chapterId)
                 .Select(c => c.CoverImage)

--- a/API/Data/Repositories/ChapterRepository.cs
+++ b/API/Data/Repositories/ChapterRepository.cs
@@ -154,7 +154,11 @@ namespace API.Data.Repositories
 
         public async Task<IList<string>> GetAllCoverImagesAsync()
         {
-            return await _context.Chapter.Select(c => c.CoverImage).AsNoTracking().ToListAsync();
+            return await _context.Chapter
+                .Select(c => c.CoverImage)
+                .Where(t => !string.IsNullOrEmpty(t))
+                .AsNoTracking()
+                .ToListAsync();
         }
 
         /// <summary>

--- a/API/Data/Repositories/ChapterRepository.cs
+++ b/API/Data/Repositories/ChapterRepository.cs
@@ -162,9 +162,23 @@ namespace API.Data.Repositories
         }
 
         /// <summary>
-        /// Returns non-tracked files for a set of chapterIds
+        /// Returns cover images for locked chapters
         /// </summary>
-        /// <param name="chapterIds"></param>
+        /// <returns></returns>
+        public async Task<IEnumerable<string>> GetCoverImagesForLockedChaptersAsync()
+        {
+            return await _context.Chapter
+                .Where(c => c.CoverImageLocked)
+                .Select(c => c.CoverImage)
+                .Where(t => !string.IsNullOrEmpty(t))
+                .AsNoTracking()
+                .ToListAsync();
+        }
+
+        /// <summary>
+        /// Returns non-tracked files for a set of <paramref name="chapterIds"/>
+        /// </summary>
+        /// <param name="chapterIds">List of chapter Ids</param>
         /// <returns></returns>
         public async Task<IList<MangaFile>> GetFilesForChaptersAsync(IReadOnlyList<int> chapterIds)
         {

--- a/API/Data/Repositories/ChapterRepository.cs
+++ b/API/Data/Repositories/ChapterRepository.cs
@@ -152,6 +152,11 @@ namespace API.Data.Repositories
                 .SingleOrDefaultAsync();
         }
 
+        public async Task<IList<string>> GetAllCoverImagesAsync()
+        {
+            return await _context.Chapter.Select(c => c.CoverImage).AsNoTracking().ToListAsync();
+        }
+
         /// <summary>
         /// Returns non-tracked files for a set of chapterIds
         /// </summary>

--- a/API/Data/Repositories/CollectionTagRepository.cs
+++ b/API/Data/Repositories/CollectionTagRepository.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using API.DTOs;
@@ -100,9 +101,9 @@ namespace API.Data.Repositories
                 .ToListAsync();
         }
 
-        public Task<byte[]> GetCoverImageAsync(int collectionTagId)
+        public async Task<string> GetCoverImageAsync(int collectionTagId)
         {
-            return _context.CollectionTag
+            return await _context.CollectionTag
                 .Where(c => c.Id == collectionTagId)
                 .Select(c => c.CoverImage)
                 .AsNoTracking()

--- a/API/Data/Repositories/CollectionTagRepository.cs
+++ b/API/Data/Repositories/CollectionTagRepository.cs
@@ -49,8 +49,16 @@ namespace API.Data.Repositories
         public async Task<IEnumerable<CollectionTag>> GetAllTagsAsync()
         {
             return await _context.CollectionTag
-                .Select(c => c)
                 .OrderBy(c => c.NormalizedTitle)
+                .ToListAsync();
+        }
+
+        public async Task<IList<string>> GetAllCoverImagesAsync()
+        {
+            return await _context.CollectionTag
+                .Select(t => t.CoverImage)
+                .Where(t => !string.IsNullOrEmpty(t))
+                .AsNoTracking()
                 .ToListAsync();
         }
 

--- a/API/Data/Repositories/SeriesRepository.cs
+++ b/API/Data/Repositories/SeriesRepository.cs
@@ -447,7 +447,11 @@ namespace API.Data.Repositories
 
         public async Task<IList<string>> GetAllCoverImagesAsync()
         {
-            return await _context.Series.Select(s => s.CoverImage).AsNoTracking().ToListAsync();
+            return await _context.Series
+                .Select(s => s.CoverImage)
+                .Where(t => !string.IsNullOrEmpty(t))
+                .AsNoTracking()
+                .ToListAsync();
         }
     }
 }

--- a/API/Data/Repositories/SeriesRepository.cs
+++ b/API/Data/Repositories/SeriesRepository.cs
@@ -453,5 +453,14 @@ namespace API.Data.Repositories
                 .AsNoTracking()
                 .ToListAsync();
         }
+
+        public async Task<IEnumerable<string>> GetLockedCoverImagesAsync()
+        {
+            return await _context.Series
+                .Where(s => s.CoverImageLocked && !string.IsNullOrEmpty(s.CoverImage))
+                .Select(s => s.CoverImage)
+                .AsNoTracking()
+                .ToListAsync();
+        }
     }
 }

--- a/API/Data/Repositories/SeriesRepository.cs
+++ b/API/Data/Repositories/SeriesRepository.cs
@@ -444,5 +444,10 @@ namespace API.Data.Repositories
                 .AsSplitQuery()
                 .ToListAsync();
         }
+
+        public async Task<IList<string>> GetAllCoverImagesAsync()
+        {
+            return await _context.Series.Select(s => s.CoverImage).AsNoTracking().ToListAsync();
+        }
     }
 }

--- a/API/Data/Repositories/SeriesRepository.cs
+++ b/API/Data/Repositories/SeriesRepository.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using API.Comparators;
@@ -256,7 +257,7 @@ namespace API.Data.Repositories
             }
         }
 
-        public async Task<byte[]> GetSeriesCoverImageAsync(int seriesId)
+        public async Task<string> GetSeriesCoverImageAsync(int seriesId)
         {
             return await _context.Series
                 .Where(s => s.Id == seriesId)

--- a/API/Data/Repositories/VolumeRepository.cs
+++ b/API/Data/Repositories/VolumeRepository.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using API.DTOs;
@@ -35,9 +36,9 @@ namespace API.Data.Repositories
                 .ToListAsync();
         }
 
-        public async Task<byte[]> GetVolumeCoverImageAsync(int volumeId)
+        public async Task<string> GetVolumeCoverImageAsync(int volumeId)
         {
-            return await _context.Volume
+           return await _context.Volume
                 .Where(v => v.Id == volumeId)
                 .Select(v => v.CoverImage)
                 .AsNoTracking()

--- a/API/Entities/Chapter.cs
+++ b/API/Entities/Chapter.cs
@@ -23,7 +23,11 @@ namespace API.Entities
         public ICollection<MangaFile> Files { get; set; }
         public DateTime Created { get; set; }
         public DateTime LastModified { get; set; }
-        public byte[] CoverImage { get; set; }
+        /// <summary>
+        /// Absolute path to the (managed) image file
+        /// </summary>
+        /// <remarks>The file is managed internally to Kavita's APPDIR</remarks>
+        public string CoverImage { get; set; }
         public bool CoverImageLocked { get; set; }
         /// <summary>
         /// Total number of pages in all MangaFiles

--- a/API/Entities/CollectionTag.cs
+++ b/API/Entities/CollectionTag.cs
@@ -14,11 +14,11 @@ namespace API.Entities
         /// Visible title of the Tag
         /// </summary>
         public string Title { get; set; }
-
         /// <summary>
-        /// Cover Image for the collection tag
+        /// Absolute path to the (managed) image file
         /// </summary>
-        public byte[] CoverImage { get; set; }
+        /// <remarks>The file is managed internally to Kavita's APPDIR</remarks>
+        public string CoverImage { get; set; }
         /// <summary>
         /// Denotes if the CoverImage has been overridden by the user. If so, it will not be updated during normal scan operations.
         /// </summary>

--- a/API/Entities/Series.cs
+++ b/API/Entities/Series.cs
@@ -36,7 +36,11 @@ namespace API.Entities
         public string Summary { get; set; } // TODO: Migrate into SeriesMetdata (with Metadata update)
         public DateTime Created { get; set; }
         public DateTime LastModified { get; set; }
-        public byte[] CoverImage { get; set; }
+        /// <summary>
+        /// Absolute path to the (managed) image file
+        /// </summary>
+        /// <remarks>The file is managed internally to Kavita's APPDIR</remarks>
+        public string CoverImage { get; set; }
         /// <summary>
         /// Denotes if the CoverImage has been overridden by the user. If so, it will not be updated during normal scan operations.
         /// </summary>

--- a/API/Entities/Volume.cs
+++ b/API/Entities/Volume.cs
@@ -13,7 +13,11 @@ namespace API.Entities
         public IList<Chapter> Chapters { get; set; }
         public DateTime Created { get; set; }
         public DateTime LastModified { get; set; }
-        public byte[] CoverImage { get; set; }
+        /// <summary>
+        /// Absolute path to the (managed) image file
+        /// </summary>
+        /// <remarks>The file is managed internally to Kavita's APPDIR</remarks>
+        public string CoverImage { get; set; }
         public int Pages { get; set; }
 
 

--- a/API/Extensions/HttpExtensions.cs
+++ b/API/Extensions/HttpExtensions.cs
@@ -33,6 +33,11 @@ namespace API.Extensions
             response.Headers.Add("ETag", string.Concat(sha1.ComputeHash(content).Select(x => x.ToString("X2"))));
         }
 
+        /// <summary>
+        /// Calculates SHA256 hash for a cover image filename and sets as ETag. Ensures Cache-Control: private header is added.
+        /// </summary>
+        /// <param name="response"></param>
+        /// <param name="filename"></param>
         public static void AddCacheHeader(this HttpResponse response, string filename)
         {
             if (filename == null || filename.Length <= 0) return;

--- a/API/Extensions/HttpExtensions.cs
+++ b/API/Extensions/HttpExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using System.Text;
 using System.Text.Json;
 using API.Helpers;
 using Microsoft.AspNetCore.Http;
@@ -7,7 +8,7 @@ namespace API.Extensions
 {
     public static class HttpExtensions
     {
-        public static void AddPaginationHeader(this HttpResponse response, int currentPage, 
+        public static void AddPaginationHeader(this HttpResponse response, int currentPage,
             int itemsPerPage, int totalItems, int totalPages)
         {
             var paginationHeader = new PaginationHeader(currentPage, itemsPerPage, totalItems, totalPages);
@@ -15,7 +16,7 @@ namespace API.Extensions
             {
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase
             };
-            
+
             response.Headers.Add("Pagination", JsonSerializer.Serialize(paginationHeader, options));
             response.Headers.Add("Access-Control-Expose-Headers", "Pagination");
         }
@@ -31,6 +32,13 @@ namespace API.Extensions
             using var sha1 = new System.Security.Cryptography.SHA256CryptoServiceProvider();
             response.Headers.Add("ETag", string.Concat(sha1.ComputeHash(content).Select(x => x.ToString("X2"))));
         }
-        
+
+        public static void AddCacheHeader(this HttpResponse response, string filename)
+        {
+            if (filename == null || filename.Length <= 0) return;
+            using var sha1 = new System.Security.Cryptography.SHA256CryptoServiceProvider();
+            response.Headers.Add("ETag", string.Concat(sha1.ComputeHash(Encoding.UTF8.GetBytes(filename)).Select(x => x.ToString("X2"))));
+        }
+
     }
 }

--- a/API/Helpers/SQLHelper.cs
+++ b/API/Helpers/SQLHelper.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using Microsoft.EntityFrameworkCore;
+
+namespace API.Helpers
+{
+    public static class SQLHelper
+    {
+        public static List<T> RawSqlQuery<T>(DbContext context, string query, Func<DbDataReader, T> map)
+        {
+            //using var context = new DbContext();
+            using var command = context.Database.GetDbConnection().CreateCommand();
+            command.CommandText = query;
+            command.CommandType = CommandType.Text;
+
+            context.Database.OpenConnection();
+
+            using var result = command.ExecuteReader();
+            var entities = new List<T>();
+
+            while (result.Read())
+            {
+                entities.Add(map(result));
+            }
+
+            return entities;
+        }
+    }
+}

--- a/API/Helpers/SQLHelper.cs
+++ b/API/Helpers/SQLHelper.cs
@@ -6,11 +6,10 @@ using Microsoft.EntityFrameworkCore;
 
 namespace API.Helpers
 {
-    public static class SQLHelper
+    public static class SqlHelper
     {
         public static List<T> RawSqlQuery<T>(DbContext context, string query, Func<DbDataReader, T> map)
         {
-            //using var context = new DbContext();
             using var command = context.Database.GetDbConnection().CreateCommand();
             command.CommandText = query;
             command.CommandType = CommandType.Text;

--- a/API/Interfaces/Repositories/IChapterRepository.cs
+++ b/API/Interfaces/Repositories/IChapterRepository.cs
@@ -17,6 +17,6 @@ namespace API.Interfaces.Repositories
         Task<IList<MangaFile>> GetFilesForChapterAsync(int chapterId);
         Task<IList<Chapter>> GetChaptersAsync(int volumeId);
         Task<IList<MangaFile>> GetFilesForChaptersAsync(IReadOnlyList<int> chapterIds);
-        Task<byte[]> GetChapterCoverImageAsync(int chapterId);
+        Task<string> GetChapterCoverImageAsync(int chapterId);
     }
 }

--- a/API/Interfaces/Repositories/IChapterRepository.cs
+++ b/API/Interfaces/Repositories/IChapterRepository.cs
@@ -19,5 +19,6 @@ namespace API.Interfaces.Repositories
         Task<IList<MangaFile>> GetFilesForChaptersAsync(IReadOnlyList<int> chapterIds);
         Task<string> GetChapterCoverImageAsync(int chapterId);
         Task<IList<string>> GetAllCoverImagesAsync();
+        Task<IEnumerable<string>> GetCoverImagesForLockedChaptersAsync();
     }
 }

--- a/API/Interfaces/Repositories/IChapterRepository.cs
+++ b/API/Interfaces/Repositories/IChapterRepository.cs
@@ -18,5 +18,6 @@ namespace API.Interfaces.Repositories
         Task<IList<Chapter>> GetChaptersAsync(int volumeId);
         Task<IList<MangaFile>> GetFilesForChaptersAsync(IReadOnlyList<int> chapterIds);
         Task<string> GetChapterCoverImageAsync(int chapterId);
+        Task<IList<string>> GetAllCoverImagesAsync();
     }
 }

--- a/API/Interfaces/Repositories/ICollectionTagRepository.cs
+++ b/API/Interfaces/Repositories/ICollectionTagRepository.cs
@@ -10,7 +10,7 @@ namespace API.Interfaces.Repositories
         void Remove(CollectionTag tag);
         Task<IEnumerable<CollectionTagDto>> GetAllTagDtosAsync();
         Task<IEnumerable<CollectionTagDto>> SearchTagDtosAsync(string searchQuery);
-        Task<byte[]> GetCoverImageAsync(int collectionTagId);
+        Task<string> GetCoverImageAsync(int collectionTagId);
         Task<IEnumerable<CollectionTagDto>> GetAllPromotedTagDtosAsync();
         Task<CollectionTag> GetTagAsync(int tagId);
         Task<CollectionTag> GetFullTagAsync(int tagId);

--- a/API/Interfaces/Repositories/ICollectionTagRepository.cs
+++ b/API/Interfaces/Repositories/ICollectionTagRepository.cs
@@ -17,5 +17,6 @@ namespace API.Interfaces.Repositories
         void Update(CollectionTag tag);
         Task<int> RemoveTagsWithoutSeries();
         Task<IEnumerable<CollectionTag>> GetAllTagsAsync();
+        Task<IList<string>> GetAllCoverImagesAsync();
     }
 }

--- a/API/Interfaces/Repositories/ISeriesRepository.cs
+++ b/API/Interfaces/Repositories/ISeriesRepository.cs
@@ -64,5 +64,6 @@ namespace API.Interfaces.Repositories
         Task<PagedList<SeriesDto>> GetSeriesDtoForCollectionAsync(int collectionId, int userId, UserParams userParams);
         Task<IList<MangaFile>> GetFilesForSeries(int seriesId);
         Task<IEnumerable<SeriesDto>> GetSeriesDtoForIdsAsync(IEnumerable<int> seriesIds, int userId);
+        Task<IList<string>> GetAllCoverImagesAsync();
     }
 }

--- a/API/Interfaces/Repositories/ISeriesRepository.cs
+++ b/API/Interfaces/Repositories/ISeriesRepository.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using API.DTOs;
 using API.DTOs.Filtering;
@@ -65,5 +66,6 @@ namespace API.Interfaces.Repositories
         Task<IList<MangaFile>> GetFilesForSeries(int seriesId);
         Task<IEnumerable<SeriesDto>> GetSeriesDtoForIdsAsync(IEnumerable<int> seriesIds, int userId);
         Task<IList<string>> GetAllCoverImagesAsync();
+        Task<IEnumerable<string>> GetLockedCoverImagesAsync();
     }
 }

--- a/API/Interfaces/Repositories/ISeriesRepository.cs
+++ b/API/Interfaces/Repositories/ISeriesRepository.cs
@@ -57,7 +57,7 @@ namespace API.Interfaces.Repositories
         Task AddSeriesModifiers(int userId, List<SeriesDto> series);
 
 
-        Task<byte[]> GetSeriesCoverImageAsync(int seriesId);
+        Task<string> GetSeriesCoverImageAsync(int seriesId);
         Task<IEnumerable<SeriesDto>> GetInProgress(int userId, int libraryId, UserParams userParams, FilterDto filter);
         Task<PagedList<SeriesDto>> GetRecentlyAdded(int libraryId, int userId, UserParams userParams, FilterDto filter);
         Task<SeriesMetadataDto> GetSeriesMetadata(int seriesId);

--- a/API/Interfaces/Repositories/IVolumeRepository.cs
+++ b/API/Interfaces/Repositories/IVolumeRepository.cs
@@ -9,6 +9,6 @@ namespace API.Interfaces.Repositories
     {
         void Update(Volume volume);
         Task<IList<MangaFile>> GetFilesForVolume(int volumeId);
-        Task<byte[]> GetVolumeCoverImageAsync(int volumeId);
+        Task<string> GetVolumeCoverImageAsync(int volumeId);
     }
 }

--- a/API/Interfaces/Services/IArchiveService.cs
+++ b/API/Interfaces/Services/IArchiveService.cs
@@ -10,7 +10,7 @@ namespace API.Interfaces.Services
     {
         void ExtractArchive(string archivePath, string extractPath);
         int GetNumberOfPagesFromArchive(string archivePath);
-        byte[] GetCoverImage(string archivePath, bool createThumbnail = false);
+        string GetCoverImage(string archivePath, string fileName);
         bool IsValidArchive(string archivePath);
         string GetSummaryInfo(string archivePath);
         ArchiveLibrary CanOpen(string archivePath);

--- a/API/Interfaces/Services/IBackupService.cs
+++ b/API/Interfaces/Services/IBackupService.cs
@@ -1,11 +1,12 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 
 namespace API.Interfaces.Services
 {
     public interface IBackupService
     {
-        void BackupDatabase();
+        Task BackupDatabase();
         /// <summary>
         /// Returns a list of full paths of the logs files detailed in <see cref="IConfiguration"/>. 
         /// </summary>

--- a/API/Interfaces/Services/IBookService.cs
+++ b/API/Interfaces/Services/IBookService.cs
@@ -8,7 +8,7 @@ namespace API.Interfaces.Services
     public interface IBookService
     {
         int GetNumberOfPages(string filePath);
-        byte[] GetCoverImage(string fileFilePath, bool createThumbnail = true);
+        string GetCoverImage(string fileFilePath, string fileName);
         Task<Dictionary<string, int>> CreateKeyToPageMappingAsync(EpubBookRef book);
 
         /// <summary>

--- a/API/Interfaces/Services/ICleanupService.cs
+++ b/API/Interfaces/Services/ICleanupService.cs
@@ -1,7 +1,9 @@
-﻿namespace API.Interfaces.Services
+﻿using System.Threading.Tasks;
+
+namespace API.Interfaces.Services
 {
     public interface ICleanupService
     {
-        void Cleanup();
+        Task Cleanup();
     }
 }

--- a/API/Interfaces/Services/ICleanupService.cs
+++ b/API/Interfaces/Services/ICleanupService.cs
@@ -5,5 +5,6 @@ namespace API.Interfaces.Services
     public interface ICleanupService
     {
         Task Cleanup();
+        void CleanupCacheDirectory();
     }
 }

--- a/API/Interfaces/Services/IImageService.cs
+++ b/API/Interfaces/Services/IImageService.cs
@@ -1,4 +1,5 @@
 ﻿using API.Entities;
+using API.Services;
 
 namespace API.Interfaces.Services
 {
@@ -10,13 +11,13 @@ namespace API.Interfaces.Services
     /// Creates a Thumbnail version of an image
     /// </summary>
     /// <param name="path">Path to the image file</param>
-    /// <returns></returns>
+    /// <returns>File name with extension of the file. This will always write to <see cref="DirectoryService.CoverImageDirectory"/></returns>
     public string CreateThumbnail(string path, string fileName);
     /// <summary>
     /// Creates a Thumbnail version of a base64 image
     /// </summary>
     /// <param name="encodedImage">base64 encoded image</param>
-    /// <returns>Path to the file</returns>
+    /// <returns>File name with extension of the file. This will always write to <see cref="DirectoryService.CoverImageDirectory"/></returns>
     public string CreateThumbnailFromBase64(string encodedImage, string fileName);
   }
 }

--- a/API/Interfaces/Services/IImageService.cs
+++ b/API/Interfaces/Services/IImageService.cs
@@ -16,7 +16,7 @@ namespace API.Interfaces.Services
     /// Creates a Thumbnail version of a base64 image
     /// </summary>
     /// <param name="encodedImage">base64 encoded image</param>
-    /// <returns></returns>
-    public byte[] CreateThumbnailFromBase64(string encodedImage);
+    /// <returns>Path to the file</returns>
+    public string CreateThumbnailFromBase64(string encodedImage, string fileName);
   }
 }

--- a/API/Interfaces/Services/IImageService.cs
+++ b/API/Interfaces/Services/IImageService.cs
@@ -4,14 +4,14 @@ namespace API.Interfaces.Services
 {
   public interface IImageService
   {
-    byte[] GetCoverImage(string path, bool createThumbnail = false);
+    string GetCoverImage(string path, string fileName);
     string GetCoverFile(MangaFile file);
     /// <summary>
     /// Creates a Thumbnail version of an image
     /// </summary>
     /// <param name="path">Path to the image file</param>
     /// <returns></returns>
-    public byte[] CreateThumbnail(string path);
+    public string CreateThumbnail(string path, string fileName);
     /// <summary>
     /// Creates a Thumbnail version of a base64 image
     /// </summary>

--- a/API/Program.cs
+++ b/API/Program.cs
@@ -1,10 +1,14 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Security.Cryptography;
 using System.Threading;
+using System.Threading.Channels;
 using System.Threading.Tasks;
 using API.Data;
 using API.Entities;
+using API.Interfaces;
+using API.Services;
 using Kavita.Common;
 using Kavita.Common.EnvironmentInfo;
 using Microsoft.AspNetCore.Hosting;
@@ -14,6 +18,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using NetVips;
 using Sentry;
 
 namespace API
@@ -49,6 +54,13 @@ namespace API
          {
             var context = services.GetRequiredService<DataContext>();
             var roleManager = services.GetRequiredService<RoleManager<AppRole>>();
+
+            if (!Directory.Exists(DirectoryService.CoverImageDirectory))
+            {
+                Console.WriteLine("Migrating Cover Images to disk. Expect delay.");
+                DirectoryService.ExistOrCreate(DirectoryService.CoverImageDirectory);
+            }
+
             // Apply all migrations on startup
             await context.Database.MigrateAsync();
             await Seed.SeedRoles(roleManager);

--- a/API/Program.cs
+++ b/API/Program.cs
@@ -60,9 +60,17 @@ namespace API
             var roleManager = services.GetRequiredService<RoleManager<AppRole>>();
 
             var requiresCoverImageMigration = !Directory.Exists(DirectoryService.CoverImageDirectory);
-            if (requiresCoverImageMigration)
+            try
             {
-                MigrateCoverImages.ExtractToImages(context);
+                // If this is a new install, tables wont exist yet
+                if (requiresCoverImageMigration)
+                {
+                    MigrateCoverImages.ExtractToImages(context);
+                }
+            }
+            catch (Exception )
+            {
+                requiresCoverImageMigration = false;
             }
 
             // Apply all migrations on startup

--- a/API/Program.cs
+++ b/API/Program.cs
@@ -27,12 +27,6 @@ using Sentry;
 
 namespace API
 {
-    public class CoverMigration
-    {
-        public string Id { get; set; }
-        public byte[] CoverImage { get; set; }
-        public string ParentId { get; set; }
-    }
    public class Program
    {
       private static readonly int HttpPort = Configuration.Port;

--- a/API/Services/ArchiveService.cs
+++ b/API/Services/ArchiveService.cs
@@ -257,17 +257,9 @@ namespace API.Services
 
         private string CreateThumbnail(string entryName, Stream stream, string fileName)
         {
-            // if (!formatExtension.StartsWith("."))
-            // {
-            //     formatExtension = $".png";
-            // }
             try
             {
-                using var thumbnail = Image.ThumbnailStream(stream, MetadataService.ThumbnailWidth);
-                var filename = Path.Join(DirectoryService.CoverImageDirectory, fileName + ".png");
-                thumbnail.WriteToFile(filename);
-                return filename;
-                //return thumbnail.WriteToBuffer(formatExtension);
+                return ImageService.WriteCoverThumbnail(stream, fileName);
             }
             catch (Exception ex)
             {

--- a/API/Services/DirectoryService.cs
+++ b/API/Services/DirectoryService.cs
@@ -19,6 +19,7 @@ namespace API.Services
        public static readonly string TempDirectory = Path.Join(Directory.GetCurrentDirectory(), "temp");
        public static readonly string LogDirectory = Path.Join(Directory.GetCurrentDirectory(), "logs");
        public static readonly string CacheDirectory = Path.Join(Directory.GetCurrentDirectory(), "cache");
+       public static readonly string CoverImageDirectory = Path.Join(Directory.GetCurrentDirectory(), "covers");
 
        public DirectoryService(ILogger<DirectoryService> logger)
        {

--- a/API/Services/ImageService.cs
+++ b/API/Services/ImageService.cs
@@ -41,46 +41,51 @@ namespace API.Services
       return firstImage;
     }
 
-    public byte[] GetCoverImage(string path, bool createThumbnail = false)
+    public string GetCoverImage(string path, string fileName)
     {
-      if (string.IsNullOrEmpty(path)) return Array.Empty<byte>();
+      if (string.IsNullOrEmpty(path)) return String.Empty;
 
       try
       {
-        if (createThumbnail)
-        {
-            return CreateThumbnail(path);
-        }
-
-        using var img = Image.NewFromFile(path);
-        using var stream = new MemoryStream();
-        img.JpegsaveStream(stream);
-        stream.Position = 0;
-        return stream.ToArray();
+          return CreateThumbnail(path,  fileName);
       }
       catch (Exception ex)
       {
         _logger.LogWarning(ex, "[GetCoverImage] There was an error and prevented thumbnail generation on {ImageFile}. Defaulting to no cover image", path);
       }
 
-      return Array.Empty<byte>();
+      return String.Empty;
+    }
+
+    /// <summary>
+    /// Writes the bytes[] to the full path. Will overwrite if already exists
+    /// </summary>
+    /// <param name="image"></param>
+    /// <param name="path"></param>
+    /// <returns></returns>
+    public void WriteBytesToDisk(byte[] image, string path)
+    {
+        File.WriteAllBytesAsync(path, image);
     }
 
 
     /// <inheritdoc />
-    public byte[] CreateThumbnail(string path)
+    public string CreateThumbnail(string path, string fileName)
     {
         try
         {
             using var thumbnail = Image.Thumbnail(path, MetadataService.ThumbnailWidth);
-            return thumbnail.WriteToBuffer(".jpg");
+            var filename = Path.Join(DirectoryService.CoverImageDirectory, fileName + ".png");
+            thumbnail.WriteToFile(filename);
+            return filename;
+            //return thumbnail.WriteToBuffer(".jpg");
         }
         catch (Exception e)
         {
             _logger.LogError(e, "Error creating thumbnail from url");
         }
 
-        return Array.Empty<byte>();
+        return String.Empty;
     }
 
 

--- a/API/Services/ImageService.cs
+++ b/API/Services/ImageService.cs
@@ -115,5 +115,21 @@ namespace API.Services
 
         return string.Empty;
     }
+
+    public static string GetChapterFormat(int chapterId, int volumeId)
+    {
+        return $"v{volumeId}_c{chapterId}";
+    }
+
+
+    public static string GetSeriesFormat(int seriesId)
+    {
+        return $"series{seriesId}";
+    }
+
+    public static string GetCollectionTagFormat(int tagId)
+    {
+        return $"tag{tagId}";
+    }
   }
 }

--- a/API/Services/ImageService.cs
+++ b/API/Services/ImageService.cs
@@ -15,6 +15,11 @@ namespace API.Services
     private readonly ILogger<ImageService> _logger;
     private readonly IDirectoryService _directoryService;
 
+    /// <summary>
+    /// Width of the Thumbnail generation
+    /// </summary>
+    private const int ThumbnailWidth = 320;
+
     public ImageService(ILogger<ImageService> logger, IDirectoryService directoryService)
     {
       _logger = logger;
@@ -43,7 +48,7 @@ namespace API.Services
 
     public string GetCoverImage(string path, string fileName)
     {
-      if (string.IsNullOrEmpty(path)) return String.Empty;
+      if (string.IsNullOrEmpty(path)) return string.Empty;
 
       try
       {
@@ -54,27 +59,15 @@ namespace API.Services
         _logger.LogWarning(ex, "[GetCoverImage] There was an error and prevented thumbnail generation on {ImageFile}. Defaulting to no cover image", path);
       }
 
-      return String.Empty;
+      return string.Empty;
     }
-
-    /// <summary>
-    /// Writes the bytes[] to the full path. Will overwrite if already exists
-    /// </summary>
-    /// <param name="image"></param>
-    /// <param name="path"></param>
-    /// <returns></returns>
-    public void WriteBytesToDisk(byte[] image, string path)
-    {
-        File.WriteAllBytesAsync(path, image);
-    }
-
-
+    
     /// <inheritdoc />
     public string CreateThumbnail(string path, string fileName)
     {
         try
         {
-            using var thumbnail = Image.Thumbnail(path, MetadataService.ThumbnailWidth);
+            using var thumbnail = Image.Thumbnail(path, ThumbnailWidth);
             var filename = Path.Join(DirectoryService.CoverImageDirectory, fileName + ".png");
             thumbnail.WriteToFile(filename);
             return filename;
@@ -91,13 +84,12 @@ namespace API.Services
     /// Creates a thumbnail out of a memory stream and saves to <see cref="DirectoryService.CoverImageDirectory"/> with the passed
     /// fileName and .png extension.
     /// </summary>
-    /// <param name="stream">Stream to write to disk.</param>
+    /// <param name="stream">Stream to write to disk. Ensure this is rewinded.</param>
     /// <param name="fileName">filename to save as without extension</param>
     /// <returns>Full file path of saved file</returns>
     public static string WriteCoverThumbnail(Stream stream, string fileName)
     {
-        stream.Position = 0;
-        using var thumbnail = NetVips.Image.ThumbnailStream(stream, MetadataService.ThumbnailWidth);
+        using var thumbnail = NetVips.Image.ThumbnailStream(stream, ThumbnailWidth);
         // using var sha1 = new System.Security.Cryptography.SHA256CryptoServiceProvider();
         // string.Concat(sha1.ComputeHash(content).Select(x => x.ToString("X2")))
         var filename = Path.Join(DirectoryService.CoverImageDirectory, fileName + ".png");
@@ -111,7 +103,7 @@ namespace API.Services
     {
         try
         {
-            using var thumbnail = Image.ThumbnailBuffer(Convert.FromBase64String(encodedImage), MetadataService.ThumbnailWidth);
+            using var thumbnail = Image.ThumbnailBuffer(Convert.FromBase64String(encodedImage), ThumbnailWidth);
             var filename = Path.Join(DirectoryService.CoverImageDirectory, fileName + ".png");
             thumbnail.WriteToFile(filename);
             return filename;

--- a/API/Services/ImageService.cs
+++ b/API/Services/ImageService.cs
@@ -78,14 +78,31 @@ namespace API.Services
             var filename = Path.Join(DirectoryService.CoverImageDirectory, fileName + ".png");
             thumbnail.WriteToFile(filename);
             return filename;
-            //return thumbnail.WriteToBuffer(".jpg");
         }
         catch (Exception e)
         {
             _logger.LogError(e, "Error creating thumbnail from url");
         }
 
-        return String.Empty;
+        return string.Empty;
+    }
+
+    /// <summary>
+    /// Creates a thumbnail out of a memory stream and saves to <see cref="DirectoryService.CoverImageDirectory"/> with the passed
+    /// fileName and .png extension.
+    /// </summary>
+    /// <param name="stream">Stream to write to disk.</param>
+    /// <param name="fileName">filename to save as without extension</param>
+    /// <returns>Full file path of saved file</returns>
+    public static string WriteCoverThumbnail(Stream stream, string fileName)
+    {
+        stream.Position = 0;
+        using var thumbnail = NetVips.Image.ThumbnailStream(stream, MetadataService.ThumbnailWidth);
+        // using var sha1 = new System.Security.Cryptography.SHA256CryptoServiceProvider();
+        // string.Concat(sha1.ComputeHash(content).Select(x => x.ToString("X2")))
+        var filename = Path.Join(DirectoryService.CoverImageDirectory, fileName + ".png");
+        thumbnail.WriteToFile(filename);
+        return filename;
     }
 
 

--- a/API/Services/ImageService.cs
+++ b/API/Services/ImageService.cs
@@ -14,6 +14,10 @@ namespace API.Services
   {
     private readonly ILogger<ImageService> _logger;
     private readonly IDirectoryService _directoryService;
+    public const string ChapterCoverImageRegex = @"v\d+_c\d+";
+    public const string SeriesCoverImageRegex = @"seres\d+";
+    public const string CollectionTagCoverImageRegex = @"tag\d+";
+
 
     /// <summary>
     /// Width of the Thumbnail generation
@@ -116,17 +120,32 @@ namespace API.Services
         return string.Empty;
     }
 
+    /// <summary>
+    /// Returns the name format for a chapter cover image
+    /// </summary>
+    /// <param name="chapterId"></param>
+    /// <param name="volumeId"></param>
+    /// <returns></returns>
     public static string GetChapterFormat(int chapterId, int volumeId)
     {
         return $"v{volumeId}_c{chapterId}";
     }
 
-
+    /// <summary>
+    /// Returns the name format for a series cover image
+    /// </summary>
+    /// <param name="seriesId"></param>
+    /// <returns></returns>
     public static string GetSeriesFormat(int seriesId)
     {
         return $"series{seriesId}";
     }
 
+    /// <summary>
+    /// Returns the name format for a collection tag cover image
+    /// </summary>
+    /// <param name="tagId"></param>
+    /// <returns></returns>
     public static string GetCollectionTagFormat(int tagId)
     {
         return $"tag{tagId}";

--- a/API/Services/ImageService.cs
+++ b/API/Services/ImageService.cs
@@ -94,8 +94,6 @@ namespace API.Services
     public static string WriteCoverThumbnail(Stream stream, string fileName)
     {
         using var thumbnail = NetVips.Image.ThumbnailStream(stream, ThumbnailWidth);
-        // using var sha1 = new System.Security.Cryptography.SHA256CryptoServiceProvider();
-        // string.Concat(sha1.ComputeHash(content).Select(x => x.ToString("X2")))
         var filename = fileName + ".png";
         thumbnail.WriteToFile(Path.Join(DirectoryService.CoverImageDirectory, fileName + ".png"));
         return filename;

--- a/API/Services/ImageService.cs
+++ b/API/Services/ImageService.cs
@@ -107,19 +107,21 @@ namespace API.Services
 
 
     /// <inheritdoc />
-    public byte[] CreateThumbnailFromBase64(string encodedImage)
+    public string CreateThumbnailFromBase64(string encodedImage, string fileName)
     {
         try
         {
             using var thumbnail = Image.ThumbnailBuffer(Convert.FromBase64String(encodedImage), MetadataService.ThumbnailWidth);
-            return thumbnail.WriteToBuffer(".jpg");
+            var filename = Path.Join(DirectoryService.CoverImageDirectory, fileName + ".png");
+            thumbnail.WriteToFile(filename);
+            return filename;
         }
         catch (Exception e)
         {
             _logger.LogError(e, "Error creating thumbnail from url");
         }
 
-        return Array.Empty<byte>();
+        return string.Empty;
     }
   }
 }

--- a/API/Services/ImageService.cs
+++ b/API/Services/ImageService.cs
@@ -61,15 +61,15 @@ namespace API.Services
 
       return string.Empty;
     }
-    
+
     /// <inheritdoc />
     public string CreateThumbnail(string path, string fileName)
     {
         try
         {
             using var thumbnail = Image.Thumbnail(path, ThumbnailWidth);
-            var filename = Path.Join(DirectoryService.CoverImageDirectory, fileName + ".png");
-            thumbnail.WriteToFile(filename);
+            var filename = fileName + ".png";
+            thumbnail.WriteToFile(Path.Join(DirectoryService.CoverImageDirectory, fileName + ".png"));
             return filename;
         }
         catch (Exception e)
@@ -86,14 +86,14 @@ namespace API.Services
     /// </summary>
     /// <param name="stream">Stream to write to disk. Ensure this is rewinded.</param>
     /// <param name="fileName">filename to save as without extension</param>
-    /// <returns>Full file path of saved file</returns>
+    /// <returns>File name with extension of the file. This will always write to <see cref="DirectoryService.CoverImageDirectory"/></returns>
     public static string WriteCoverThumbnail(Stream stream, string fileName)
     {
         using var thumbnail = NetVips.Image.ThumbnailStream(stream, ThumbnailWidth);
         // using var sha1 = new System.Security.Cryptography.SHA256CryptoServiceProvider();
         // string.Concat(sha1.ComputeHash(content).Select(x => x.ToString("X2")))
-        var filename = Path.Join(DirectoryService.CoverImageDirectory, fileName + ".png");
-        thumbnail.WriteToFile(filename);
+        var filename = fileName + ".png";
+        thumbnail.WriteToFile(Path.Join(DirectoryService.CoverImageDirectory, fileName + ".png"));
         return filename;
     }
 
@@ -104,8 +104,8 @@ namespace API.Services
         try
         {
             using var thumbnail = Image.ThumbnailBuffer(Convert.FromBase64String(encodedImage), ThumbnailWidth);
-            var filename = Path.Join(DirectoryService.CoverImageDirectory, fileName + ".png");
-            thumbnail.WriteToFile(filename);
+            var filename = fileName + ".png";
+            thumbnail.WriteToFile(Path.Join(DirectoryService.CoverImageDirectory, fileName + ".png"));
             return filename;
         }
         catch (Exception e)

--- a/API/Services/MetadataService.cs
+++ b/API/Services/MetadataService.cs
@@ -28,7 +28,7 @@ namespace API.Services
         /// <summary>
         /// Width of the Thumbnail generation
         /// </summary>
-        public static readonly int ThumbnailWidth = 320; // 153w x 230h
+        //public static readonly int ThumbnailWidth = 320; // 153w x 230h
 
         public MetadataService(IUnitOfWork unitOfWork, ILogger<MetadataService> logger,
             IArchiveService archiveService, IBookService bookService, IImageService imageService, IHubContext<MessageHub> messageHub)

--- a/API/Services/MetadataService.cs
+++ b/API/Services/MetadataService.cs
@@ -65,19 +65,20 @@ namespace API.Services
 
         private string GetCoverImage(MangaFile file, int volumeId, int chapterId)
         {
+            // TODO: Think about a factory for naming convention & include format & hash
             file.LastModified = DateTime.Now;
             switch (file.Format)
             {
                 case MangaFormat.Pdf:
                 case MangaFormat.Epub:
-                    return _bookService.GetCoverImage(file.FilePath, $"v{volumeId}_c{chapterId}"); // TODO: Think about a factory for naming convention & include format & hash
+                    return _bookService.GetCoverImage(file.FilePath, $"v{volumeId}_c{chapterId}");
                 case MangaFormat.Image:
                     var coverImage = _imageService.GetCoverFile(file);
                     return _imageService.GetCoverImage(coverImage, $"v{volumeId}_c{chapterId}");
                 case MangaFormat.Archive:
                     return _archiveService.GetCoverImage(file.FilePath, $"v{volumeId}_c{chapterId}");
                 default:
-                    return String.Empty;
+                    return string.Empty;
             }
 
         }

--- a/API/Services/MetadataService.cs
+++ b/API/Services/MetadataService.cs
@@ -55,7 +55,6 @@ namespace API.Services
                 coverImageDirectory = DirectoryService.CoverImageDirectory;
             }
 
-            Console.WriteLine($"Checking if file exists at {Path.Join(coverImageDirectory, coverImage)}");
             var fileExists = File.Exists(Path.Join(coverImageDirectory, coverImage));
             if (isCoverLocked && fileExists) return false;
             if (forceUpdate) return true;

--- a/API/Services/MetadataService.cs
+++ b/API/Services/MetadataService.cs
@@ -71,12 +71,12 @@ namespace API.Services
             {
                 case MangaFormat.Pdf:
                 case MangaFormat.Epub:
-                    return _bookService.GetCoverImage(file.FilePath, $"v{volumeId}_c{chapterId}");
+                    return _bookService.GetCoverImage(file.FilePath, ImageService.GetChapterFormat(chapterId, volumeId));
                 case MangaFormat.Image:
                     var coverImage = _imageService.GetCoverFile(file);
-                    return _imageService.GetCoverImage(coverImage, $"v{volumeId}_c{chapterId}");
+                    return _imageService.GetCoverImage(coverImage, ImageService.GetChapterFormat(chapterId, volumeId));
                 case MangaFormat.Archive:
-                    return _archiveService.GetCoverImage(file.FilePath, $"v{volumeId}_c{chapterId}");
+                    return _archiveService.GetCoverImage(file.FilePath, ImageService.GetChapterFormat(chapterId, volumeId));
                 default:
                     return string.Empty;
             }

--- a/API/Services/MetadataService.cs
+++ b/API/Services/MetadataService.cs
@@ -53,7 +53,7 @@ namespace API.Services
         public static bool ShouldUpdateCoverImage(string coverImage, MangaFile firstFile, bool forceUpdate = false,
             bool isCoverLocked = false)
         {
-            var fileExists = File.Exists(coverImage);
+            var fileExists = File.Exists(Path.Join(DirectoryService.CoverImageDirectory, coverImage));
             if (isCoverLocked && fileExists) return false;
             if (forceUpdate) return true;
             return (firstFile != null && firstFile.HasFileBeenModified()) || !HasCoverImage(coverImage, fileExists);

--- a/API/Services/MetadataService.cs
+++ b/API/Services/MetadataService.cs
@@ -25,10 +25,6 @@ namespace API.Services
         private readonly IImageService _imageService;
         private readonly IHubContext<MessageHub> _messageHub;
         private readonly ChapterSortComparerZeroFirst _chapterSortComparerForInChapterSorting = new ChapterSortComparerZeroFirst();
-        /// <summary>
-        /// Width of the Thumbnail generation
-        /// </summary>
-        //public static readonly int ThumbnailWidth = 320; // 153w x 230h
 
         public MetadataService(IUnitOfWork unitOfWork, ILogger<MetadataService> logger,
             IArchiveService archiveService, IBookService bookService, IImageService imageService, IHubContext<MessageHub> messageHub)
@@ -49,11 +45,16 @@ namespace API.Services
         /// <param name="firstFile"></param>
         /// <param name="forceUpdate"></param>
         /// <param name="isCoverLocked"></param>
+        /// <param name="coverImageDirectory">Directory where cover images are. Defaults to <see cref="DirectoryService.CoverImageDirectory"/></param>
         /// <returns></returns>
         public static bool ShouldUpdateCoverImage(string coverImage, MangaFile firstFile, bool forceUpdate = false,
-            bool isCoverLocked = false)
+            bool isCoverLocked = false, string coverImageDirectory = null)
         {
-            var fileExists = File.Exists(Path.Join(DirectoryService.CoverImageDirectory, coverImage));
+            if (string.IsNullOrEmpty(coverImageDirectory))
+            {
+                coverImageDirectory = DirectoryService.CoverImageDirectory;
+            }
+            var fileExists = File.Exists(Path.Join(coverImageDirectory, coverImage));
             if (isCoverLocked && fileExists) return false;
             if (forceUpdate) return true;
             return (firstFile != null && firstFile.HasFileBeenModified()) || !HasCoverImage(coverImage, fileExists);

--- a/API/Services/MetadataService.cs
+++ b/API/Services/MetadataService.cs
@@ -72,7 +72,6 @@ namespace API.Services
 
         private string GetCoverImage(MangaFile file, int volumeId, int chapterId)
         {
-            // TODO: Think about a factory for naming convention & include format & hash
             file.LastModified = DateTime.Now;
             switch (file.Format)
             {

--- a/API/Services/MetadataService.cs
+++ b/API/Services/MetadataService.cs
@@ -42,8 +42,9 @@ namespace API.Services
         }
 
         /// <summary>
-        /// Determines whether an entity should regenerate cover image
+        /// Determines whether an entity should regenerate cover image.
         /// </summary>
+        /// <remarks>If a cover image is locked but the underlying file has been deleted, this will allow regenerating. </remarks>
         /// <param name="coverImage"></param>
         /// <param name="firstFile"></param>
         /// <param name="forceUpdate"></param>
@@ -52,15 +53,21 @@ namespace API.Services
         public static bool ShouldUpdateCoverImage(string coverImage, MangaFile firstFile, bool forceUpdate = false,
             bool isCoverLocked = false)
         {
-            if (isCoverLocked) return false;
+            var fileExists = File.Exists(coverImage);
+            if (isCoverLocked && fileExists) return false;
             if (forceUpdate) return true;
-            return (firstFile != null && firstFile.HasFileBeenModified()) || !HasCoverImage(coverImage);
+            return (firstFile != null && firstFile.HasFileBeenModified()) || !HasCoverImage(coverImage, fileExists);
         }
 
 
         private static bool HasCoverImage(string coverImage)
         {
-            return !string.IsNullOrEmpty(coverImage) && File.Exists(coverImage);
+            return HasCoverImage(coverImage, File.Exists(coverImage));
+        }
+
+        private static bool HasCoverImage(string coverImage, bool fileExists)
+        {
+            return !string.IsNullOrEmpty(coverImage) && fileExists;
         }
 
         private string GetCoverImage(MangaFile file, int volumeId, int chapterId)

--- a/API/Services/MetadataService.cs
+++ b/API/Services/MetadataService.cs
@@ -54,6 +54,8 @@ namespace API.Services
             {
                 coverImageDirectory = DirectoryService.CoverImageDirectory;
             }
+
+            Console.WriteLine($"Checking if file exists at {Path.Join(coverImageDirectory, coverImage)}");
             var fileExists = File.Exists(Path.Join(coverImageDirectory, coverImage));
             if (isCoverLocked && fileExists) return false;
             if (forceUpdate) return true;

--- a/API/Services/TaskScheduler.cs
+++ b/API/Services/TaskScheduler.cs
@@ -121,7 +121,7 @@ namespace API.Services
             _logger.LogInformation("Enqueuing library scan for: {LibraryId}", libraryId);
             BackgroundJob.Enqueue(() => _scannerService.ScanLibrary(libraryId, forceUpdate));
             // When we do a scan, force cache to re-unpack in case page numbers change
-            BackgroundJob.Enqueue(() => _cleanupService.Cleanup());
+            BackgroundJob.Enqueue(() => _cleanupService.CleanupCacheDirectory());
         }
 
         public void CleanupChapters(int[] chapterIds)

--- a/API/Services/Tasks/CleanupService.cs
+++ b/API/Services/Tasks/CleanupService.cs
@@ -1,7 +1,11 @@
 ﻿using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using API.Interfaces;
 using API.Interfaces.Services;
 using Hangfire;
 using Microsoft.Extensions.Logging;
+using NetVips;
 
 namespace API.Services.Tasks
 {
@@ -13,20 +17,26 @@ namespace API.Services.Tasks
         private readonly ICacheService _cacheService;
         private readonly ILogger<CleanupService> _logger;
         private readonly IBackupService _backupService;
+        private readonly IUnitOfWork _unitOfWork;
+        private readonly IDirectoryService _directoryService;
 
-        public CleanupService(ICacheService cacheService, ILogger<CleanupService> logger, IBackupService backupService)
+        public CleanupService(ICacheService cacheService, ILogger<CleanupService> logger,
+            IBackupService backupService, IUnitOfWork unitOfWork, IDirectoryService directoryService)
         {
             _cacheService = cacheService;
             _logger = logger;
             _backupService = backupService;
+            _unitOfWork = unitOfWork;
+            _directoryService = directoryService;
         }
 
         /// <summary>
-        /// Cleans up Temp, cache, and old database backups
+        /// Cleans up Temp, cache, deleted cover images,  and old database backups
         /// </summary>
         [AutomaticRetry(Attempts = 3, LogEvents = false, OnAttemptsExceeded = AttemptsExceededAction.Fail)]
-        public void Cleanup()
+        public async Task Cleanup()
         {
+            _logger.LogInformation("Starting Cleanup");
             _logger.LogInformation("Cleaning temp directory");
             var tempDirectory = Path.Join(Directory.GetCurrentDirectory(), "temp");
             DirectoryService.ClearDirectory(tempDirectory);
@@ -34,6 +44,34 @@ namespace API.Services.Tasks
             _cacheService.Cleanup();
             _logger.LogInformation("Cleaning old database backups");
             _backupService.CleanupBackups();
+            _logger.LogInformation("Cleaning deleted cover images");
+            await DeleteSeriesCoverImages();
+            await DeleteChapterCoverImages();
+            _logger.LogInformation("Cleanup finished");
+        }
+
+        private async Task DeleteSeriesCoverImages()
+        {
+            var images = await _unitOfWork.SeriesRepository.GetAllCoverImagesAsync();
+            var files = _directoryService.GetFiles(DirectoryService.CoverImageDirectory, @"seres\d+");
+            foreach (var file in files)
+            {
+                if (images.Contains(file)) continue;
+                File.Delete(file);
+
+            }
+        }
+
+        private async Task DeleteChapterCoverImages()
+        {
+            var images = await _unitOfWork.ChapterRepository.GetAllCoverImagesAsync();
+            var files = _directoryService.GetFiles(DirectoryService.CoverImageDirectory, @"v\d+_c\d+");
+            foreach (var file in files)
+            {
+                if (images.Contains(file)) continue;
+                File.Delete(file);
+
+            }
         }
     }
 }

--- a/API/Services/Tasks/CleanupService.cs
+++ b/API/Services/Tasks/CleanupService.cs
@@ -30,6 +30,12 @@ namespace API.Services.Tasks
             _directoryService = directoryService;
         }
 
+        public void CleanupCacheDirectory()
+        {
+            _logger.LogInformation("Cleaning cache directory");
+            _cacheService.Cleanup();
+        }
+
         /// <summary>
         /// Cleans up Temp, cache, deleted cover images,  and old database backups
         /// </summary>
@@ -40,8 +46,7 @@ namespace API.Services.Tasks
             _logger.LogInformation("Cleaning temp directory");
             var tempDirectory = Path.Join(Directory.GetCurrentDirectory(), "temp");
             DirectoryService.ClearDirectory(tempDirectory);
-            _logger.LogInformation("Cleaning cache directory");
-            _cacheService.Cleanup();
+            CleanupCacheDirectory();
             _logger.LogInformation("Cleaning old database backups");
             _backupService.CleanupBackups();
             _logger.LogInformation("Cleaning deleted cover images");

--- a/API/Services/Tasks/CleanupService.cs
+++ b/API/Services/Tasks/CleanupService.cs
@@ -54,10 +54,10 @@ namespace API.Services.Tasks
         private async Task DeleteSeriesCoverImages()
         {
             var images = await _unitOfWork.SeriesRepository.GetAllCoverImagesAsync();
-            var files = _directoryService.GetFiles(DirectoryService.CoverImageDirectory, @"seres\d+");
+            var files = _directoryService.GetFiles(DirectoryService.CoverImageDirectory, ImageService.SeriesCoverImageRegex);
             foreach (var file in files)
             {
-                if (images.Contains(file)) continue;
+                if (images.Contains(Path.GetFileName(file))) continue;
                 File.Delete(file);
 
             }
@@ -66,10 +66,10 @@ namespace API.Services.Tasks
         private async Task DeleteChapterCoverImages()
         {
             var images = await _unitOfWork.ChapterRepository.GetAllCoverImagesAsync();
-            var files = _directoryService.GetFiles(DirectoryService.CoverImageDirectory, @"v\d+_c\d+");
+            var files = _directoryService.GetFiles(DirectoryService.CoverImageDirectory, ImageService.ChapterCoverImageRegex);
             foreach (var file in files)
             {
-                if (images.Contains(file)) continue;
+                if (images.Contains(Path.GetFileName(file))) continue;
                 File.Delete(file);
 
             }
@@ -78,10 +78,10 @@ namespace API.Services.Tasks
         private async Task DeleteTagCoverImages()
         {
             var images = await _unitOfWork.CollectionTagRepository.GetAllCoverImagesAsync();
-            var files = _directoryService.GetFiles(DirectoryService.CoverImageDirectory, @"v\d+_c\d+");
+            var files = _directoryService.GetFiles(DirectoryService.CoverImageDirectory, ImageService.CollectionTagCoverImageRegex);
             foreach (var file in files)
             {
-                if (images.Contains(file)) continue;
+                if (images.Contains(Path.GetFileName(file))) continue;
                 File.Delete(file);
 
             }

--- a/API/Services/Tasks/CleanupService.cs
+++ b/API/Services/Tasks/CleanupService.cs
@@ -47,7 +47,7 @@ namespace API.Services.Tasks
             _logger.LogInformation("Cleaning deleted cover images");
             await DeleteSeriesCoverImages();
             await DeleteChapterCoverImages();
-            // TODO: Handle Tag Cover Images
+            await DeleteTagCoverImages();
             _logger.LogInformation("Cleanup finished");
         }
 
@@ -66,6 +66,18 @@ namespace API.Services.Tasks
         private async Task DeleteChapterCoverImages()
         {
             var images = await _unitOfWork.ChapterRepository.GetAllCoverImagesAsync();
+            var files = _directoryService.GetFiles(DirectoryService.CoverImageDirectory, @"v\d+_c\d+");
+            foreach (var file in files)
+            {
+                if (images.Contains(file)) continue;
+                File.Delete(file);
+
+            }
+        }
+
+        private async Task DeleteTagCoverImages()
+        {
+            var images = await _unitOfWork.CollectionTagRepository.GetAllCoverImagesAsync();
             var files = _directoryService.GetFiles(DirectoryService.CoverImageDirectory, @"v\d+_c\d+");
             foreach (var file in files)
             {

--- a/API/Services/Tasks/CleanupService.cs
+++ b/API/Services/Tasks/CleanupService.cs
@@ -47,6 +47,7 @@ namespace API.Services.Tasks
             _logger.LogInformation("Cleaning deleted cover images");
             await DeleteSeriesCoverImages();
             await DeleteChapterCoverImages();
+            // TODO: Handle Tag Cover Images
             _logger.LogInformation("Cleanup finished");
         }
 

--- a/API/Services/Tasks/Scanner/ParseScannedFiles.cs
+++ b/API/Services/Tasks/Scanner/ParseScannedFiles.cs
@@ -48,7 +48,7 @@ namespace API.Services.Tasks.Scanner
         public static IList<ParserInfo> GetInfosByName(Dictionary<ParsedSeries, List<ParserInfo>> parsedSeries, Series series)
         {
             var existingKey = parsedSeries.Keys.FirstOrDefault(ps =>
-                ps.Format == series.Format && ps.NormalizedName == Parser.Parser.Normalize(series.OriginalName));
+                ps.Format == series.Format && ps.NormalizedName.Equals(Parser.Parser.Normalize(series.OriginalName)));
 
             return existingKey != null ? parsedSeries[existingKey] : new List<ParserInfo>();
         }

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -277,6 +277,9 @@ namespace API.Services.Tasks
                 _logger.LogError(ex, "There was an exception updating volumes for {SeriesName}", series.Name);
              }
           });
+
+          // Last step, remove any series that have no pages
+          library.Series = library.Series.Where(s => s.Pages > 0).ToList();
        }
 
        public IEnumerable<Series> FindSeriesNotOnDisk(ICollection<Series> existingSeries, Dictionary<ParsedSeries, List<ParserInfo>> parsedSeries)

--- a/API/Startup.cs
+++ b/API/Startup.cs
@@ -132,7 +132,7 @@ namespace API
                     new Microsoft.Net.Http.Headers.CacheControlHeaderValue()
                     {
                         Public = false,
-                        MaxAge = TimeSpan.FromSeconds(10)
+                        MaxAge = TimeSpan.FromSeconds(10),
                     };
                 context.Response.Headers[Microsoft.Net.Http.Headers.HeaderNames.Vary] =
                     new[] { "Accept-Encoding" };

--- a/UI/Web/src/app/cards/card-item/card-item.component.html
+++ b/UI/Web/src/app/cards/card-item/card-item.component.html
@@ -15,7 +15,7 @@
         </span>
       </div>
       <div class="error-banner" *ngIf="total === 0 && !supressArchiveWarning">
-        Cannot Read Archive
+        Cannot Read
       </div>
 
       


### PR DESCRIPTION
# Changed
- Changed: Cover Images are now stored on disk in the covers/ directory. On first run, existing covers will be migrated from the DB to disk, which can take up to 20 mins depending on side of library (20k files took 20 mins). This change significantly decreases memory usage during scanning and during serving cover images without any degradation in experience. 
- Changed: Updating wording on card items when total pages is 0 to be 'Cannot Read' since it could be a non-archive file. 
- Changed: After a library scan, only cleanup cache directory and leave a full cleanup for scheduled tasks
- Changed: After we scan library, do one last filter to delete any series that have 0 pages total.

Closes #583 
Closes #554