### PR TITLE
Feature/image rework cleanup

### DIFF
--- a/API.Tests/Parser/MangaParserTests.cs
+++ b/API.Tests/Parser/MangaParserTests.cs
@@ -237,6 +237,7 @@ namespace API.Tests.Parser
         [InlineData("Hentai Ouji to Warawanai Neko. - Vol. 06 Ch. 034.5", "34.5")]
         [InlineData("Kimi no Koto ga Daidaidaidaidaisuki na 100-nin no Kanojo Chapter 1-10", "1-10")]
         [InlineData("Deku_&_Bakugo_-_Rising_v1_c1.1.cbz", "1.1")]
+        [InlineData("Chapter 63 - The Promise Made for 520 Cenz.cbr", "63")]
         public void ParseChaptersTest(string filename, string expected)
         {
             Assert.Equal(expected, API.Parser.Parser.ParseChapter(filename));

--- a/API/Controllers/ImageController.cs
+++ b/API/Controllers/ImageController.cs
@@ -1,4 +1,6 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
+using System.Net;
 using System.Threading.Tasks;
 using API.Extensions;
 using API.Interfaces;
@@ -34,7 +36,7 @@ namespace API.Controllers
             var format = Path.GetExtension(path).Replace(".", "");
 
             Response.AddCacheHeader(path);
-            return PhysicalFile(path, "image/" + format);
+            return PhysicalFile(path, "image/" + format, Path.GetFileName(path));
         }
 
         /// <summary>
@@ -50,7 +52,7 @@ namespace API.Controllers
             var format = Path.GetExtension(path).Replace(".", "");
 
             Response.AddCacheHeader(path);
-            return PhysicalFile(path, "image/" + format);
+            return PhysicalFile(path, "image/" + format, Path.GetFileName(path));
         }
 
         /// <summary>
@@ -66,7 +68,7 @@ namespace API.Controllers
             var format = Path.GetExtension(path).Replace(".", "");
 
             Response.AddCacheHeader(path);
-            return PhysicalFile(path, "image/" + format);
+            return PhysicalFile(path, "image/" + format, Path.GetFileName(path));
         }
 
         /// <summary>
@@ -82,7 +84,7 @@ namespace API.Controllers
             var format = Path.GetExtension(path).Replace(".", "");
 
             Response.AddCacheHeader(path);
-            return PhysicalFile(path, "image/" + format);
+            return PhysicalFile(path, "image/" + format, Path.GetFileName(path));
         }
     }
 }

--- a/API/Controllers/ReaderController.cs
+++ b/API/Controllers/ReaderController.cs
@@ -54,7 +54,7 @@ namespace API.Controllers
                 if (string.IsNullOrEmpty(path) || !System.IO.File.Exists(path)) return BadRequest($"No such image for page {page}");
                 var format = Path.GetExtension(path).Replace(".", "");
 
-                return PhysicalFile(path, "image/" + format);
+                return PhysicalFile(path, "image/" + format, Path.GetFileName(path));
             }
             catch (Exception)
             {

--- a/API/Parser/Parser.cs
+++ b/API/Parser/Parser.cs
@@ -448,7 +448,7 @@ namespace API.Parser
             RegexTimeout),
             // Hinowa ga CRUSH! 018 (2019) (Digital) (LuCaZ).cbz, Hinowa ga CRUSH! 018.5 (2019) (Digital) (LuCaZ).cbz
             new Regex(
-                @"^(?!Vol)(?<Series>.*)\s(?<!vol\. )(?<Chapter>\d+(?:.\d+|-\d+)?)(?:\s\(\d{4}\))?(\b|_|-)",
+                @"^(?!Vol)(?<Series>.+?)\s(?<!vol\. )(?<Chapter>\d+(?:.\d+|-\d+)?)(?:\s\(\d{4}\))?(\b|_|-)",
                 RegexOptions.IgnoreCase | RegexOptions.Compiled,
             RegexTimeout),
             // Tower Of God S01 014 (CBT) (digital).cbz

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -128,12 +128,13 @@ namespace API.Services.Tasks
        [AutomaticRetry(Attempts = 0, OnAttemptsExceeded = AttemptsExceededAction.Delete)]
        public async Task ScanLibraries()
        {
+           _logger.LogInformation("Starting Scan of All Libraries");
           var libraries = await _unitOfWork.LibraryRepository.GetLibrariesAsync();
           foreach (var lib in libraries)
           {
              await ScanLibrary(lib.Id, false);
           }
-
+          _logger.LogInformation("Scan of All Libraries Finished");
        }
 
 

--- a/UI/Web/src/app/admin/_modals/library-access-modal/library-access-modal.component.html
+++ b/UI/Web/src/app/admin/_modals/library-access-modal/library-access-modal.component.html
@@ -14,6 +14,9 @@
                 <label attr.for="library-{{i}}" class="form-check-label">{{library.data.name}}</label>
             </div>
         </li>
+        <li class="list-group-item" *ngIf="selectedLibraries.length === 0">
+            There are no libraries setup yet.
+        </li>
     </div>
 </div>
 <div class="modal-footer">

--- a/UI/Web/src/app/admin/manage-users/manage-users.component.html
+++ b/UI/Web/src/app/admin/manage-users/manage-users.component.html
@@ -9,7 +9,7 @@
         <li *ngFor="let member of members; let idx = index;" class="list-group-item">
             <div>
                 <h4>
-                    <i class="presence fa fa-circle" title="Active" aria-hidden="true" *ngIf="false && (presence.onlineUsers$ | async)?.includes(member.username)"></i><span id="member-name--{{idx}}">{{member.username | titlecase}} </span><span *ngIf="member.isAdmin" class="badge badge-pill badge-secondary">Admin</span>
+                    <i class="presence fa fa-circle" title="Active" aria-hidden="true" *ngIf="false && (presence.onlineUsers$ | async)?.includes(member.username)"></i><span id="member-name--{{idx}}">{{member.username | titlecase}} </span><span *ngIf="member.username === loggedInUsername">(You)</span>
                     <div class="float-right" *ngIf="canEditMember(member)">
                         <button class="btn btn-danger mr-2" (click)="deleteUser(member)" placement="top" ngbTooltip="Delete User" attr.aria-label="Delete User {{member.username | titlecase}}"><i class="fa fa-trash" aria-hidden="true"></i></button>
                         <button class="btn btn-secondary mr-2" (click)="updatePassword(member)" placement="top" ngbTooltip="Change Password" attr.aria-label="Change Password for {{member.username | titlecase}}"><i class="fa fa-key" aria-hidden="true"></i></button>

--- a/UI/Web/src/app/admin/manage-users/manage-users.component.ts
+++ b/UI/Web/src/app/admin/manage-users/manage-users.component.ts
@@ -53,7 +53,18 @@ export class ManageUsersComponent implements OnInit, OnDestroy {
   loadMembers() {
     this.loadingMembers = true;
     this.memberService.getMembers().subscribe(members => {
-      this.members = members.filter(member => member.username !== this.loggedInUsername);
+      this.members = members;
+      // Show logged in user at the top of the list
+      this.members.sort((a: Member, b: Member) => {
+        if (a.username === this.loggedInUsername) return 1;
+        if (b.username === this.loggedInUsername) return 1;
+
+        const nameA = a.username.toUpperCase();
+        const nameB = b.username.toUpperCase();
+        if (nameA < nameB) return -1;
+        if (nameA > nameB) return 1;
+        return 0;
+      })
       this.loadingMembers = false;
     });
   }


### PR DESCRIPTION
# Fixed
- Fixed: Added volume cover image migrations. (develop)

# Added
- Added: Added parser case for 'Chapter 63 - The Promise Made for 520 Cenz.cbr' where regex was consuming too many characters
- Added: Admins can now see themselves in the manage users page. No operations are still possible on your current account, create a secondary admin if you need to modify your permissions. 
- Added: Added some messaging when you are trying to add a user to a library but haven't setup any libraries yet. 