### PR TITLE
Scan Chunking

### DIFF
--- a/API.Benchmark/API.Benchmark.csproj
+++ b/API.Benchmark/API.Benchmark.csproj
@@ -15,4 +15,10 @@
       <PackageReference Include="NSubstitute" Version="4.2.2" />
     </ItemGroup>
 
+    <ItemGroup>
+      <None Update="Data\SeriesNamesForNormalization.txt">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </None>
+    </ItemGroup>
+
 </Project>

--- a/API.Benchmark/Data/SeriesNamesForNormalization.txt
+++ b/API.Benchmark/Data/SeriesNamesForNormalization.txt
@@ -1,0 +1,573 @@
+﻿Liar-Game
+Your Lie in April
+Love Hina
+Love Hina
+A Chronicle of the Last Pagans
+Otherworldly Munchkin - Let's Speedrun the Dungeon with Only 1 HP!
+Love Hina
+Rokka - Braves of the Six Flowers
+Real Account
+Bakekano
+Yancha Gal no Anjou-san
+Moshi Fanren
+The Devil Is a Part-Timer!
+My Home Hero
+Itoshi no Karin
+Claymore
+Dolls Fall
+Dragons Rioting
+Tokyo Ghoul - re
+Hajime no Ippo
+Mahoromatic
+DEATHTOPIA
+Negima! Neo - Magister Negi Magi
+Ichinensei ni Nacchattara
+How NOT to Summon a Demon Lord
+U12
+"Don't Toy With Me, Miss Nagatoro"
+Karakai Jouzu no  Takagi-san
+UQ Holder!
+"Ore no Nounai Sentakushi ga, Gakuen Rabukome o Zenryoku de Jama Shite Iru"
+Do Chokkyuu Kareshi x Kanojo
+Ana Satsujin
+Deus Ex Machina
+Hidan no Aria
+Bokura wa Minna Kawaisou
+Epigraph of the Closed Curve
+Ibitsu
+Rave Master
+Lunar Legend Tsukihime
+Starving Anonymous
+High-Rise Invasion
+Fuuka
+Dai Dark
+Zero no Tsukaima Chevalier
+Cells at Work! CODE BLACK
+004 Cut Hero
+Renjoh Desperado
+Himegoto - Juukyuusai No Seifuku
+Shark Skin Man and Peach Hip Girl
+Tokyo Revengers
+Fire Punch
+Boarding School Juliet
+Mushihime
+Sankarea - Undying Love
+Hanako and the Terror of Allegory
+Mad Chimera World
+Kono Subarashii Sekai ni Bakuen wo!
+21st Century Boys
+Kono Subarashii Sekai ni Shukufuku wo! Megumin Anthology
+Konosuba
+Iinari
+Shimoneta - Manmaru Hen
+Ichiban Ushiro No Daimaou
+Yamada-kun and the Seven Witches
+Busou Shoujo Machiavellism
+Negative Happy Chainsaw Edge
+Stravaganza - Isai No Hime
+Seraph of the End - Vampire Reign 095
+Seraph of the End - Vampire Reign 098
+Kokkoku - Moment by Moment
+Magico
+Samurai Harem - Asu no Yoichi
+Change123
+Shomin Sample
+Eureka SeveN
+Kekkaishi
+Goblin Slayer Side Story - Year One
+Yomeiro Choice
+Okusama wa Shougakusei
+Monster No Goshujin-Sama
+Ase To Sekken
+How Do We Relationship
+Hantsu x Torasshu
+Magical Girl Apocalypse
+I Am a Hero
+Air Gear
+Dolly Kill Kill
+Blue Exorcist
+Kingdom of Z
+The Fable
+Mairimashita! Iruma-kun
+Spy x Family
+Goblin Slayer - Brand New Day
+Yesterday wo Utatte
+Mujaki No Rakuen
+Summer Time Rendering
+Eureka Seven Gravity Boys and Lifting Girl
+06
+Domestic Girlfriend
+Imperfect Girl
+Chrno Crusade
+Higurashi no Naku Koro ni Kai - Tsumihoroboshihen
+Nande koko ni sensei ga!
+Fukukaichou Ganbaru.
+Fraction
+Kono Subarashii Sekai ni Shukufuku wo! Megumin Anthology Aka
+Mouryou no Yurikago
+Ral Ω Grad
+Shomin Sample I Was Abducted by an Elite All-Girls School as a Sample Commoner
+City of Love Prison
+Tsugumomo
+Highschool of the Dead -  Edition
+Cynthia The Mission
+Amano Megumi wa Suki Darake!
+Aria The Scarlet Ammo
+Noblesse
+Outlanders
+Bleach
+Kimi ni Todoke
+Corpse Party - Another Child
+The Heroic Legend of Arslan
+Fujiyama-San Wa Shishunki
+Let's Go Play
+Astra Lost in Space
+Mirai Nikki
+Doubt
+Again!!
+Gesellschaft Blume
+Momo The Blood Taker
+World's End Harem - Fantasia
+Tengoku Daimakyou
+Amaenaideyo MS
+Cage of Eden
+Arifureta - From Commonplace to World's Strongest
+"The 100 Girlfriends Who Really, Really, Really, Really, Really Love You"
+Frogman
+Chaika - The Coffin Princess
+Pandora Hearts
+I'm Not a Lolicon!
+Criminale!
+Drifting Net Cafe
+Kono Subarashii Sekai ni Nichijou wo!
+Tomodachi Game
+Accel World
+Sun-Ken Rock
+Parallel Paradise
+Otherworldly Munchkin - Let's Speedrun the Dungeon with Only 1 HP!
+Hentai Ouji to Warawanai Neko. Nya!
+Gokukoku no Brynhildr
+Rosario+Vampire Season 2
+Higurashi no Naku Koro ni - Tatarigoroshihen
+BEASTARS
+Grenadier
+The Duke of Death and His Black Maid
+Helck
+Ijousha no Ai
+Beelzebub
+Infection
+"Ota Tomo ga Kareshi ni Nattara, Saikou, Kamo Shirenai"
+Battle Vixens
+Kimi ha midara na Boku no Joou
+Immortal Hounds
+Battle Angel Alita
+My Monster Secret
+Blood Rain
+Kakegurui - Compulsive Gambler
+Combatants Will Be Dispatched!
+Tenjo Tenge - Digital Colored Comics
+Dorohedoro
+Tower Of God
+Toradora!
+Spice and Wolf
+Loose Relation Between Wizard and Apprentice
+Kaguya-sama - Love Is War - Digital Colored Comics
+RaW Hero
+Aiki
+Jagaaaaaan
+Gleipnir
+Darwin's Game
+I'm Standing on a Million Lives
+Battle Club
+School Rumble Z
+Wotakoi - Love Is Hard for Otaku
+Majimoji Rurumo
+Suisei no Gargantia
+Madan No Ou To Vanadis
+Full Metal Panic - Sigma
+Konosuba - An Explosion on This Wonderful World!
+Seraph of the End - Vampire Reign 096
+Higurashi no Naku Koro ni - Onikakushihen
+Corpse Party Cemetery 0 - Kaibyaku No Ars Moriendi
+World's End Harem
+Jack Frost
+The Men Who Created The Prison School Anime
+My Hero Academia
+Elfen Lied
+Berserk
+Witchcraft Works
+Chobits 20th Anniversary Edition
+Mx0
+Youkai Kyoushitsu
+Horimiya
+Mieruko-chan
+Drifters
+Suzuka
+The Iceblade Magician Rules Over the World
+Kaiju No. 8
+Yu-Gi-Oh!
+"A Story About Treating a Female Knight, Who Has Never Been Treated as a Woman, as a Woman"
+Mahoutsukai to Deshi no Futekisetsu na Kankei
+Battle Royale
+Mato Seihei no Slave
+One-Punch Man
+Boku No Kokoro No Yabai Yatsu
+Doku Mushi
+Kuzu no Honkai
+Hoshihimemura No Naishobanashi
+Knights of Sidonia
+Amaenaideyo
+Kono Subarashii Sekai ni Shukufuku wo! Spin-off Kono Kamen no Akuma ni Soudan wo!
+Killing Bites
+Fly Me to the Moon
+Tenjo Tenge
+D-Princess
+7thGARDEN
+Sumomomo Momomo
+Accel World  Dural - Magisa Garden
+History's Strongest Disciple Kenichi
+Future Diary - Mosaic
+DEAD Tube
+Kaworu Watashiya - Kodomo no Jikan
+Undead Unluck
+Black Bullet
+Fureru To Kikoeru
+Konchuki
+Akuma no Riddle - Riddle Story of Devil
+Great Teacher Onizuka
+Scumbag Loser
+Jisatsutou
+Boku wa Mari no Naka
+Cherry x Cherry
+Seraph of the End - Vampire Reign 093
+Yumekui Merry - 4-Koma Anthology
+Love and Lies
+Nisekoi - False Love
+Another
+My Balls
+Akame ga KILL!
+Corpse Princess
+Needless 0
+My Charms Are Wasted On Kuroiwa Medaka
+Made in Abyss
+Hanako to Guuwa no Tera
+Yumekui Merry
+Miman Renai
+Sundome
+Gantz
+Accomplishments of the Duke's Daughter
+Grimgar of Fantasy and Ash
+Dansei Kyoufushou Datta Watashi Ga Av Jouyu Ni Naru Made No Hanashi
+Hour of the Zombie
+NOiSE
+Onani Master Kurosawa
+Sekirei
+Full Metal Panic
+Zero no Tsukaima
+Solo Leveling
+B Gata H Kei
+Shurabara!
+DEATH NOTE
+Terra Formars
+Goblin Slayer
+March Story
+Nozoki Ana
+Youkai Shoujo - Monsuga
+Maji de Watashi ni Koi Shinasai!!
+"Ore no Nounai Sentakushi ga, Gakuen Rabukome o Zenryoku de Jama Shite Iru H"
+Destruction Princess
+Mob Psycho 100
+Negima!
+Zero - The Illust collection of The Familiar of Zero
+20th Century Boys
+Girls of the Wild's
+Bleach - Digital Colored Comics
+Taboo Tattoo
+Let's Buy The Land And Cultivate In Different World
+Oroka na Tenshi wa Akuma to Odoru
+Future Diary
+Negima! Party Book!
+Buso Renkin
+Offal Island
+Mysterious Girlfriend X
+Getsurin ni Kiri Saku
+Magi
+Uzaki-chan Wants to Hang Out!
+A Town Where You Live
+WITCH WATCH
+Lord Marksman and Vanadis
+Kimi no Koto ga Daidaidaidaidaisuki na 100-nin no Kanojo
+Tonari No Furi-San Ga Tonikaku Kowai
+Hinowa ga CRUSH!
+Tsuredure Children
+Dance in the Vampire Bund
+Sperman
+The Rising Of The Shield Hero
+Triage X
+Kiruru Kill Me
+Hidan no Aria AA
+Origin
+Senran Kagura - Skirting Shadows
+Higurashi no Naku Koro ni - Himatsubushihen
+APOSIMZ
+Franken Fran
+Is This a Zombie
+School Rumble
+Darker than Black - Shikkoku no Hana
+Sweet X Trouble
+Close As Neighbors
+7SEEDS
+Dungeon Seeker
+Necromance
+Code Breaker
+Rokka Braves of the Six Flowers
+Prison School
+COPPELION
+Grand Blue Dreaming
+Libidors
+Skill of Lure
+Pluto - Urasawa x Tezuka
+Chibi Vampire
+Omamori Himari
+"Zoku, Kono Subarashii Sekai ni Bakuen wo!"
+"Please Go Home, Akutsu-San!"
+Mahoutsukai to Teishi no Futekisetsu na Kankei
+Chobits
+The Seven Deadly Sins
+Black Clover
+We Never Learn
+Tomogui Kyoushitsu
+Tokyo Ghoul
+Sweat and Soap
+Seraph of the End - Vampire Reign 097
+Higurashi no Naku Koro ni Kai - Meakashihen
+Children
+"Can You Just Die, My Darling"
+"Haganai, I Don't Have Many Friends"
+Heion Sedai no Idaten-tachi
+Baketeriya
+Magical Sempai
+Ajin - Demi-Human
+Kimi wa Midara na Boku no Joou
+DearS
+Pluto
+Lotte no Omocha!
+Love Hina
+Shoujo Kaitai
+El Cazador de la Bruja
+Akame ga KILL! ZERO
+"Beauty, Sage And The Devil's Sword"
+Higurashi no Naku Koro ni - Watanagashihen
+Corpse Party - Musume
+Getsuyoubi no Tawawa
+Trinity Seven
+"No Game, No Life"
+KanoKari Mythology
+Seraph of the End - Vampire Reign 094
+Uzumaki
+Darling in the FranXX
+The Blade Of Evolution-Walking Alone In The Dungeon
+BLAME! Master Edition
+Fire Force
+Toukyou Akazukin
+Darker than Black
+Karin
+Higurashi no Naku Koro ni Kai - Matsuribayashihen
+Akazukin
+Velvet Kiss
+"Kanojo, Okarishimasu"
+Teasing Master Takagi-san
+The Hentai Prince and the Stony Cat
+Corpse Party - Book of Shadows
+.hackxxxx
+Hachigatsu Kokonoka Boku wa Kimi ni Kuwareru.
+Corpse Party - Blood Covered
+King Of Thorn
+BTOOOM!
+Chimamire Sukeban Chainsaw
+Seraph of the End - Vampire Reign
+Juni Taisen Zodiac War
+Masamune-kun's Revenge
+How Many Light-Years to Babylon
+Midori no Hibi
+A Girl on the Shore
+Plunderer
+School Rumble - Pleasure File
+Green WorldZ
+Golden Boy
+Yuusha ga Shinda!
+Kodomo no Jikan
+unOrdinary
+My Wife is Wagatsuma-san
+VanDread
+Rosario+Vampire
+Kyochuu Rettou
+Deadman Wonderland
+KILL la KILL
+Mushoku Tensei - Jobless Reincarnation
+404 Case Manual 30 Seconds Till Apocalypse
+Iris Zero
+All You Need is Kill
+Shimoneta to Iu Gainen ga Sonzai Shinai Taikutsu na Sekai Man-hen
+High School DxD
+Needless
+Ichiban no Daimaou
+My Girlfriend Is A Zombie
+Hare-Kon
+Minamoto-kun Monogatari
+Batman Beyond 02
+Spawn
+iZombie
+Invincible 070.5 - Invincible Returns
+Invincible Presents - Atom Eve
+Invincible 033.5 - Marvel Team-Up
+Invincible 031.5 - Image - Future Shock
+Batman Wayne Family Adventures
+Batman Beyond 04
+Batman Beyond 2.0
+Batman Beyond 03
+Batman Beyond 05
+Chew
+Zombie Tramp vs. Vampblade TPB
+Free Scott Pilgrim
+Invincible Presents - Atom Eve & Rex Splode
+Scott Pilgrim 03 - Scott Pilgrim & The Infinite Sadness
+I Hate Fairyland
+Scott Pilgrim 06 - Scott Pilgrim's Finest Hour
+Scott Pilgrim 04 - Scott Pilgrim Gets It Together
+Scott Pilgrim 01 - Scott Pilgrim's Precious Little Life
+Spawn - 25th Anniversary Director's Cut
+Zombie Tramp
+Invincible Universe
+The Official Handbook of the Invincible Universe
+Batman Beyond
+Saga
+Scott Pilgrim 05 - Scott Pilgrim vs. the Universe
+Batman Beyond 06
+Batman - Detective Comics - Rebirth Deluxe Edition Book
+Batman Beyond 01
+Batman - Catwoman
+Invincible 022.5 - Invincible
+Teen Titans - Raven
+Invincible 052
+Invincible 014.5 - Image Comics Summer
+Zombie Tramp v3 TPB
+Scott Pilgrim 02 - Scott Pilgrim vs. The World
+Invincible
+Spawn 220
+Y - The Last Man
+Kick-Ass - The Dave Lizewski Years
+Teen Titans
+Fables
+Book of Enoch
+To Love-Ru Darkness - Digital Colored Comics
+Medaka Box - Digital Colored Comics
+Magical P tissi re Kosaki-chan!!
+Pandora in the Crimson Shell - Ghost Urn
+Yuragi-sou no Yuuna-san - Digital Colored Comics
+Ziggurat
+Tsugumomo - Digital Colored Comics
+The War Poems Of Siegfried Sassoon
+Rokka - Braves of the Six Flowers
+Demon King Daimaou
+Blockade Billy
+Cujo
+The Magicians
+The Gunslinger
+Danse Macabre
+Christine
+Fool moon
+On Writing
+Roadwork
+Deep Learning with Python - A Hands-on Introduction
+If It Bleeds
+Night Shift
+Bag of Bones
+Dreamcatcher
+Desperation
+Duma Key
+Four Past Midnight
+Elevation
+The Colorado Kid
+The Eyes of the Dragon
+Consulting With This Masked Devil!
+Gifting the Wonderful World with Blessings!
+The Golden Harpoon / Lost Among the Floes
+Invaders of the Rokujouma
+Cell
+Uncollected Stories 2003
+Faithful
+"Full Dark, No Stars"
+Dolores Claiborne
+It
+Antonio's Tale
+Joyland
+konosuba
+CSHP19
+By the Grace of the Gods - LN
+EPUB 3 Collection
+Talisman
+Sword Art Online
+The Mist
+Insomnia
+Hearts In Atlantis
+11/22/63
+Kono Subarashii Sekai ni Bakuen wo!
+In the Tall Grass
+Nightmares and Dreamscapes
+Eloquent JavaScript
+The Bell Jar
+Six Stories
+Rose Madder
+The Stand
+The Devil Is a Part-Timer!
+Grimgar of Fantasy and Ash
+A Chronicle of the Last Pagans
+Cycle of the Werewolf
+Gifting this Wonderful World With Blessings!
+Unit 1. Operations on Numbers.
+Firestarter
+The Dark Half
+Accel World
+Love Hina - Volume
+Skeleton Crew
+Needful Things
+Kono Subarashii Sekai ni Syukufuku wo!
+Carrie
+Thinner
+Hentai Ouji to Warawanai Neko
+Blaze
+Saturn Run
+Throttle
+Just After Sunset
+Gerald's Game
+The Regulators
+Different Seasons
+The Dark Tower
+Pet Sematary
+The Girl Who Loved Tom Gordon
+Ano Orokamono ni mo Kyakkou wo!
+From A Buick 8
+The Green Mile
+"Celebration of Discipline, Special Anniversary Edition"
+Combatants Will Be Dispatched!
+Kore Wa Zombie Desu Ka
+The Shining
+The Tatami Galaxy
+Salem's Lot
+The Tommyknockers
+A Face in the Crowd
+UR
+この素晴らしい世界に祝福を！　９　紅の宿命　【電子特別版】
+Outsider
+Lisey's Story
+Everything's Eventual
+Dune
+The Dead Zone
+Mile 81
+Under the Dome
+The Long Walk
+The Running Man
+EPUB3 UNLEASHED 2012
+Gifting The Wonderful World With Explosions!
+Rage

--- a/API.Benchmark/ParserBenchmarks.cs
+++ b/API.Benchmark/ParserBenchmarks.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.RegularExpressions;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Order;
+
+namespace API.Benchmark
+{
+    [MemoryDiagnoser]
+    [Orderer(SummaryOrderPolicy.FastestToSlowest)]
+    [RankColumn]
+    public class ParserBenchmarks
+    {
+        private readonly IList<string> _names;
+
+        private static readonly Regex NormalizeRegex = new Regex(@"[^a-zA-Z0-9]",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            TimeSpan.FromMilliseconds(300));
+
+        private static readonly Regex IsEpub = new Regex(@"\.epub",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            TimeSpan.FromMilliseconds(300));
+
+        public ParserBenchmarks()
+        {
+            // Read all series from SeriesNamesForNormalization.txt
+            _names = File.ReadAllLines("Data/SeriesNamesForNormalization.txt");
+            Console.WriteLine($"Performing benchmark on {_names.Count} series");
+        }
+
+        private static string NormalizeOriginal(string name)
+        {
+            return Regex.Replace(name.ToLower(), "[^a-zA-Z0-9]", string.Empty);
+        }
+
+        private static string NormalizeNew(string name)
+        {
+            return NormalizeRegex.Replace(name, string.Empty).ToLower();
+            //return Regex.Replace(name.ToLower(), "[^a-zA-Z0-9]", string.Empty);
+        }
+
+
+        [Benchmark]
+        public void TestNormalizeName()
+        {
+            foreach (var name in _names)
+            {
+                NormalizeOriginal(name);
+            }
+        }
+
+
+        [Benchmark]
+        public void TestNormalizeName_New()
+        {
+            foreach (var name in _names)
+            {
+                NormalizeNew(name);
+            }
+        }
+
+        [Benchmark]
+        public void TestIsEpub()
+        {
+            foreach (var name in _names)
+            {
+                if ((name + ".epub").ToLower() == ".epub")
+                {
+                }
+            }
+        }
+
+        [Benchmark]
+        public void TestIsEpub_New()
+        {
+            foreach (var name in _names)
+            {
+
+                if (IsEpub.IsMatch((name + ".epub")))
+                {
+                }
+            }
+        }
+
+
+    }
+}

--- a/API.Benchmark/ParserBenchmarks.cs
+++ b/API.Benchmark/ParserBenchmarks.cs
@@ -29,15 +29,14 @@ namespace API.Benchmark
             Console.WriteLine($"Performing benchmark on {_names.Count} series");
         }
 
-        private static string NormalizeOriginal(string name)
+        private static void NormalizeOriginal(string name)
         {
-            return Regex.Replace(name.ToLower(), "[^a-zA-Z0-9]", string.Empty);
+            Regex.Replace(name.ToLower(), "[^a-zA-Z0-9]", string.Empty);
         }
 
-        private static string NormalizeNew(string name)
+        private static void NormalizeNew(string name)
         {
-            return NormalizeRegex.Replace(name, string.Empty).ToLower();
-            //return Regex.Replace(name.ToLower(), "[^a-zA-Z0-9]", string.Empty);
+            NormalizeRegex.Replace(name, string.Empty).ToLower();
         }
 
 
@@ -67,6 +66,7 @@ namespace API.Benchmark
             {
                 if ((name + ".epub").ToLower() == ".epub")
                 {
+                    /* No Operation */
                 }
             }
         }
@@ -79,6 +79,7 @@ namespace API.Benchmark
 
                 if (IsEpub.IsMatch((name + ".epub")))
                 {
+                    /* No Operation */
                 }
             }
         }

--- a/API.Benchmark/Program.cs
+++ b/API.Benchmark/Program.cs
@@ -12,8 +12,10 @@ namespace API.Benchmark
     {
         static void Main(string[] args)
         {
-            BenchmarkRunner.Run<ParseScannedFilesBenchmarks>();
+            //BenchmarkRunner.Run<ParseScannedFilesBenchmarks>();
             //BenchmarkRunner.Run<TestBenchmark>();
+            BenchmarkRunner.Run<ParserBenchmarks>();
+
         }
     }
 }

--- a/API.Tests/Parser/ParserTest.cs
+++ b/API.Tests/Parser/ParserTest.cs
@@ -54,7 +54,7 @@ namespace API.Tests.Parser
         // public void ReplaceStyleUrlTest(string input, string expected)
         // {
         //     var replacementStr = "PaytoneOne.ttf";
-        //     // TODO: Use Match to validate since replace is weird
+        //     // Use Match to validate since replace is weird
         //     //Assert.Equal(expected, FontSrcUrlRegex.Replace(input, "$1" + replacementStr + "$2" + "$3"));
         //     var match = FontSrcUrlRegex.Match(input);
         //     Assert.Equal(!string.IsNullOrEmpty(expected), FontSrcUrlRegex.Match(input).Success);

--- a/API.Tests/Services/ScannerServiceTests.cs
+++ b/API.Tests/Services/ScannerServiceTests.cs
@@ -111,7 +111,7 @@ namespace API.Tests.Services
 
 
 
-            Assert.Empty(_scannerService.FindSeriesNotOnDisk(existingSeries, infos));
+            Assert.Empty(ScannerService.FindSeriesNotOnDisk(existingSeries, infos));
         }
 
 

--- a/API/Controllers/DownloadController.cs
+++ b/API/Controllers/DownloadController.cs
@@ -63,7 +63,7 @@ namespace API.Controllers
         public async Task<ActionResult> DownloadVolume(int volumeId)
         {
             var files = await _unitOfWork.VolumeRepository.GetFilesForVolume(volumeId);
-            var volume = await _unitOfWork.SeriesRepository.GetVolumeByIdAsync(volumeId);
+            var volume = await _unitOfWork.VolumeRepository.GetVolumeByIdAsync(volumeId);
             var series = await _unitOfWork.SeriesRepository.GetSeriesByIdAsync(volume.SeriesId);
             try
             {
@@ -92,7 +92,7 @@ namespace API.Controllers
         {
             var files = await _unitOfWork.ChapterRepository.GetFilesForChapterAsync(chapterId);
             var chapter = await _unitOfWork.ChapterRepository.GetChapterAsync(chapterId);
-            var volume = await _unitOfWork.SeriesRepository.GetVolumeByIdAsync(chapter.VolumeId);
+            var volume = await _unitOfWork.VolumeRepository.GetVolumeByIdAsync(chapter.VolumeId);
             var series = await _unitOfWork.SeriesRepository.GetSeriesByIdAsync(volume.SeriesId);
             try
             {

--- a/API/Controllers/LibraryController.cs
+++ b/API/Controllers/LibraryController.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using API.Data.Repositories;
 using API.DTOs;
 using API.Entities;
 using API.Entities.Enums;
@@ -179,7 +180,7 @@ namespace API.Controllers
 
             try
             {
-                var library = await _unitOfWork.LibraryRepository.GetLibraryForIdAsync(libraryId);
+                var library = await _unitOfWork.LibraryRepository.GetLibraryForIdAsync(libraryId, LibraryIncludes.None);
                 _unitOfWork.LibraryRepository.Delete(library);
                 await _unitOfWork.CommitAsync();
 
@@ -203,7 +204,7 @@ namespace API.Controllers
         [HttpPost("update")]
         public async Task<ActionResult> UpdateLibrary(UpdateLibraryDto libraryForUserDto)
         {
-            var library = await _unitOfWork.LibraryRepository.GetLibraryForIdAsync(libraryForUserDto.Id);
+            var library = await _unitOfWork.LibraryRepository.GetLibraryForIdAsync(libraryForUserDto.Id, LibraryIncludes.Folders);
 
             var originalFolders = library.Folders.Select(x => x.Path).ToList();
 

--- a/API/Controllers/OPDSController.cs
+++ b/API/Controllers/OPDSController.cs
@@ -467,7 +467,7 @@ namespace API.Controllers
                 return BadRequest("OPDS is not enabled on this server");
             var userId = await GetUser(apiKey);
             var series = await _unitOfWork.SeriesRepository.GetSeriesDtoByIdAsync(seriesId, userId);
-            var volumes = await _unitOfWork.SeriesRepository.GetVolumesDtoAsync(seriesId, userId);
+            var volumes = await _unitOfWork.VolumeRepository.GetVolumesDtoAsync(seriesId, userId);
             var feed = CreateFeed(series.Name + " - Volumes", $"{apiKey}/series/{series.Id}", apiKey);
             feed.Links.Add(CreateLink(FeedLinkRelation.Image, FeedLinkType.Image, $"/api/image/series-cover?seriesId={seriesId}"));
             foreach (var volumeDto in volumes)
@@ -486,7 +486,7 @@ namespace API.Controllers
                 return BadRequest("OPDS is not enabled on this server");
             var userId = await GetUser(apiKey);
             var series = await _unitOfWork.SeriesRepository.GetSeriesDtoByIdAsync(seriesId, userId);
-            var volume = await _unitOfWork.SeriesRepository.GetVolumeAsync(volumeId);
+            var volume = await _unitOfWork.VolumeRepository.GetVolumeAsync(volumeId);
             var chapters =
                 (await _unitOfWork.ChapterRepository.GetChaptersAsync(volumeId)).OrderBy(x => double.Parse(x.Number),
                     _chapterSortComparer);
@@ -517,7 +517,7 @@ namespace API.Controllers
                 return BadRequest("OPDS is not enabled on this server");
             var userId = await GetUser(apiKey);
             var series = await _unitOfWork.SeriesRepository.GetSeriesDtoByIdAsync(seriesId, userId);
-            var volume = await _unitOfWork.SeriesRepository.GetVolumeAsync(volumeId);
+            var volume = await _unitOfWork.VolumeRepository.GetVolumeAsync(volumeId);
             var chapter = await _unitOfWork.ChapterRepository.GetChapterDtoAsync(chapterId);
             var files = await _unitOfWork.ChapterRepository.GetFilesForChapterAsync(chapterId);
 

--- a/API/Controllers/ReaderController.cs
+++ b/API/Controllers/ReaderController.cs
@@ -97,7 +97,7 @@ namespace API.Controllers
         public async Task<ActionResult> MarkRead(MarkReadDto markReadDto)
         {
             var user = await _unitOfWork.UserRepository.GetUserByUsernameAsync(User.GetUsername(), AppUserIncludes.Progress);
-            var volumes = await _unitOfWork.SeriesRepository.GetVolumes(markReadDto.SeriesId);
+            var volumes = await _unitOfWork.VolumeRepository.GetVolumes(markReadDto.SeriesId);
             user.Progresses ??= new List<AppUserProgress>();
             foreach (var volume in volumes)
             {
@@ -125,7 +125,7 @@ namespace API.Controllers
         public async Task<ActionResult> MarkUnread(MarkReadDto markReadDto)
         {
             var user = await _unitOfWork.UserRepository.GetUserByUsernameAsync(User.GetUsername(), AppUserIncludes.Progress);
-            var volumes = await _unitOfWork.SeriesRepository.GetVolumes(markReadDto.SeriesId);
+            var volumes = await _unitOfWork.VolumeRepository.GetVolumes(markReadDto.SeriesId);
             user.Progresses ??= new List<AppUserProgress>();
             foreach (var volume in volumes)
             {
@@ -267,7 +267,7 @@ namespace API.Controllers
             var user = await _unitOfWork.UserRepository.GetUserByUsernameAsync(User.GetUsername(), AppUserIncludes.Progress);
             user.Progresses ??= new List<AppUserProgress>();
 
-            var volumes = await _unitOfWork.SeriesRepository.GetVolumesForSeriesAsync(dto.SeriesIds.ToArray(), true);
+            var volumes = await _unitOfWork.VolumeRepository.GetVolumesForSeriesAsync(dto.SeriesIds.ToArray(), true);
             foreach (var volume in volumes)
             {
                 _readerService.MarkChaptersAsRead(user, volume.SeriesId, volume.Chapters);
@@ -294,7 +294,7 @@ namespace API.Controllers
             var user = await _unitOfWork.UserRepository.GetUserByUsernameAsync(User.GetUsername(), AppUserIncludes.Progress);
             user.Progresses ??= new List<AppUserProgress>();
 
-            var volumes = await _unitOfWork.SeriesRepository.GetVolumesForSeriesAsync(dto.SeriesIds.ToArray(), true);
+            var volumes = await _unitOfWork.VolumeRepository.GetVolumesForSeriesAsync(dto.SeriesIds.ToArray(), true);
             foreach (var volume in volumes)
             {
                 _readerService.MarkChaptersAsUnread(user, volume.SeriesId, volume.Chapters);

--- a/API/Controllers/SeriesController.cs
+++ b/API/Controllers/SeriesController.cs
@@ -217,7 +217,7 @@ namespace API.Controllers
         [HttpPost("refresh-metadata")]
         public ActionResult RefreshSeriesMetadata(RefreshSeriesDto refreshSeriesDto)
         {
-            _taskScheduler.RefreshSeriesMetadata(refreshSeriesDto.LibraryId, refreshSeriesDto.SeriesId);
+            _taskScheduler.RefreshSeriesMetadata(refreshSeriesDto.LibraryId, refreshSeriesDto.SeriesId, true);
             return Ok();
         }
 

--- a/API/Controllers/SeriesController.cs
+++ b/API/Controllers/SeriesController.cs
@@ -97,14 +97,14 @@ namespace API.Controllers
         public async Task<ActionResult<IEnumerable<VolumeDto>>> GetVolumes(int seriesId)
         {
             var userId = await _unitOfWork.UserRepository.GetUserIdByUsernameAsync(User.GetUsername());
-            return Ok(await _unitOfWork.SeriesRepository.GetVolumesDtoAsync(seriesId, userId));
+            return Ok(await _unitOfWork.VolumeRepository.GetVolumesDtoAsync(seriesId, userId));
         }
 
         [HttpGet("volume")]
         public async Task<ActionResult<VolumeDto>> GetVolume(int volumeId)
         {
             var userId = await _unitOfWork.UserRepository.GetUserIdByUsernameAsync(User.GetUsername());
-            return Ok(await _unitOfWork.SeriesRepository.GetVolumeDtoAsync(volumeId, userId));
+            return Ok(await _unitOfWork.VolumeRepository.GetVolumeDtoAsync(volumeId, userId));
         }
 
         [HttpGet("chapter")]

--- a/API/Controllers/UploadController.cs
+++ b/API/Controllers/UploadController.cs
@@ -148,7 +148,7 @@ namespace API.Controllers
                     chapter.CoverImage = filePath;
                     chapter.CoverImageLocked = true;
                     _unitOfWork.ChapterRepository.Update(chapter);
-                    var volume = await _unitOfWork.SeriesRepository.GetVolumeAsync(chapter.VolumeId);
+                    var volume = await _unitOfWork.VolumeRepository.GetVolumeAsync(chapter.VolumeId);
                     volume.CoverImage = chapter.CoverImage;
                     _unitOfWork.VolumeRepository.Update(volume);
                 }
@@ -185,7 +185,7 @@ namespace API.Controllers
                 chapter.CoverImage = string.Empty;
                 chapter.CoverImageLocked = false;
                 _unitOfWork.ChapterRepository.Update(chapter);
-                var volume = await _unitOfWork.SeriesRepository.GetVolumeAsync(chapter.VolumeId);
+                var volume = await _unitOfWork.VolumeRepository.GetVolumeAsync(chapter.VolumeId);
                 volume.CoverImage = chapter.CoverImage;
                 _unitOfWork.VolumeRepository.Update(volume);
                 var series = await _unitOfWork.SeriesRepository.GetSeriesByIdAsync(volume.SeriesId);

--- a/API/Controllers/UsersController.cs
+++ b/API/Controllers/UsersController.cs
@@ -42,9 +42,8 @@ namespace API.Controllers
         [HttpGet("has-reading-progress")]
         public async Task<ActionResult<bool>> HasReadingProgress(int libraryId)
         {
-            // TODO: Test this flow to ensure that no joins is fine for this API
-            var library = await _unitOfWork.LibraryRepository.GetLibraryForIdAsync(libraryId, LibraryIncludes.None);
             var userId = await _unitOfWork.UserRepository.GetUserIdByUsernameAsync(User.GetUsername());
+            var library = await _unitOfWork.LibraryRepository.GetLibraryForIdAsync(libraryId, LibraryIncludes.None);
             return Ok(await _unitOfWork.AppUserProgressRepository.UserHasProgress(library.Type, userId));
         }
 

--- a/API/Controllers/UsersController.cs
+++ b/API/Controllers/UsersController.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using API.Data.Repositories;
 using API.DTOs;
 using API.Extensions;
 using API.Interfaces;
@@ -41,7 +42,8 @@ namespace API.Controllers
         [HttpGet("has-reading-progress")]
         public async Task<ActionResult<bool>> HasReadingProgress(int libraryId)
         {
-            var library = await _unitOfWork.LibraryRepository.GetLibraryForIdAsync(libraryId);
+            // TODO: Test this flow to ensure that no joins is fine for this API
+            var library = await _unitOfWork.LibraryRepository.GetLibraryForIdAsync(libraryId, LibraryIncludes.None);
             var userId = await _unitOfWork.UserRepository.GetUserIdByUsernameAsync(User.GetUsername());
             return Ok(await _unitOfWork.AppUserProgressRepository.UserHasProgress(library.Type, userId));
         }

--- a/API/Data/Repositories/LibraryRepository.cs
+++ b/API/Data/Repositories/LibraryRepository.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using API.DTOs;
@@ -11,6 +12,17 @@ using Microsoft.EntityFrameworkCore;
 
 namespace API.Data.Repositories
 {
+
+    [Flags]
+    public enum LibraryIncludes
+    {
+        None = 1,
+        Series = 2,
+        AppUser = 4,
+        Folders = 8,
+        // Ratings = 16
+    }
+
     public class LibraryRepository : ILibraryRepository
     {
         private readonly DataContext _context;
@@ -58,7 +70,7 @@ namespace API.Data.Repositories
 
         public async Task<bool> DeleteLibrary(int libraryId)
         {
-            var library = await GetLibraryForIdAsync(libraryId);
+            var library = await GetLibraryForIdAsync(libraryId, LibraryIncludes.Folders | LibraryIncludes.Series);
             _context.Library.Remove(library);
             return await _context.SaveChangesAsync() > 0;
         }
@@ -91,14 +103,37 @@ namespace API.Data.Repositories
                 .ToListAsync();
         }
 
-        public async Task<Library> GetLibraryForIdAsync(int libraryId)
+        public async Task<Library> GetLibraryForIdAsync(int libraryId, LibraryIncludes includes)
         {
-            return await _context.Library
-                .Where(x => x.Id == libraryId)
-                .Include(f => f.Folders)
-                .Include(l => l.Series)
-                .SingleAsync();
+
+            var query = _context.Library
+                .Where(x => x.Id == libraryId);
+
+            AddIncludesToQuery(query, includes);
+            return await query.SingleAsync();
         }
+
+        private static IQueryable<Library> AddIncludesToQuery(IQueryable<Library> query, LibraryIncludes includeFlags)
+        {
+            if (includeFlags.HasFlag(LibraryIncludes.Folders))
+            {
+                query = query.Include(l => l.Folders);
+            }
+
+            if (includeFlags.HasFlag(LibraryIncludes.Series))
+            {
+                query = query.Include(l => l.Series);
+            }
+
+            if (includeFlags.HasFlag(LibraryIncludes.AppUser))
+            {
+                query = query.Include(l => l.AppUsers);
+            }
+
+            return query;
+        }
+
+
         /// <summary>
         /// This returns a Library with all it's Series -> Volumes -> Chapters. This is expensive. Should only be called when needed.
         /// </summary>
@@ -106,7 +141,6 @@ namespace API.Data.Repositories
         /// <returns></returns>
         public async Task<Library> GetFullLibraryForIdAsync(int libraryId)
         {
-
             return await _context.Library
                 .Where(x => x.Id == libraryId)
                 .Include(f => f.Folders)

--- a/API/Data/Repositories/LibraryRepository.cs
+++ b/API/Data/Repositories/LibraryRepository.cs
@@ -109,7 +109,7 @@ namespace API.Data.Repositories
             var query = _context.Library
                 .Where(x => x.Id == libraryId);
 
-            AddIncludesToQuery(query, includes);
+            query = AddIncludesToQuery(query, includes);
             return await query.SingleAsync();
         }
 

--- a/API/Data/Repositories/SeriesRepository.cs
+++ b/API/Data/Repositories/SeriesRepository.cs
@@ -468,7 +468,6 @@ namespace API.Data.Repositories
 
         public async Task<Chunk> GetChunkInfo(int libraryId = 0)
         {
-            //var totalSeries = await GetSeriesCount(libraryId);
             var (totalSeries, chunkSize) = await GetChunkSize(libraryId);
 
             if (totalSeries == 0) return new Chunk()

--- a/API/Data/Repositories/SeriesRepository.cs
+++ b/API/Data/Repositories/SeriesRepository.cs
@@ -497,5 +497,21 @@ namespace API.Data.Repositories
                 .AsNoTracking()
                 .ToListAsync();
         }
+
+        /// <summary>
+        /// Returns the number of series for a given library (or all libraries if libraryId is 0)
+        /// </summary>
+        /// <param name="libraryId">Defaults to 0, library to restrict count to</param>
+        /// <returns></returns>
+        public async Task<int> GetSeriesCount(int libraryId = 0)
+        {
+            if (libraryId > 0)
+            {
+                return await _context.Series
+                    .Where(s => s.LibraryId == libraryId)
+                    .CountAsync();
+            }
+            return await _context.Series.CountAsync();
+        }
     }
 }

--- a/API/Data/Repositories/SeriesRepository.cs
+++ b/API/Data/Repositories/SeriesRepository.cs
@@ -452,6 +452,8 @@ namespace API.Data.Repositories
         /// <returns></returns>
         private async Task<Tuple<int, int>> GetChunkSize(int libraryId = 0)
         {
+            // TODO: Think about making this bigger depending on number of files a user has in said library
+            // and number of cores and amount of memory. We can then make an optimal choice
             var totalSeries = await GetSeriesCount(libraryId);
             var procCount = Math.Max(Environment.ProcessorCount - 1, 1);
 

--- a/API/Data/Repositories/SeriesRepository.cs
+++ b/API/Data/Repositories/SeriesRepository.cs
@@ -96,6 +96,7 @@ namespace API.Data.Repositories
                 .Include(s => s.Volumes)
                 .ThenInclude(v => v.Chapters)
                 .ThenInclude(c => c.Files)
+                .AsSplitQuery()
                 .SingleOrDefaultAsync();
         }
 

--- a/API/Data/Repositories/VolumeRepository.cs
+++ b/API/Data/Repositories/VolumeRepository.cs
@@ -1,8 +1,12 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using API.Comparators;
+using API.DTOs;
 using API.Entities;
 using API.Interfaces.Repositories;
+using AutoMapper;
+using AutoMapper.QueryableExtensions;
 using Microsoft.EntityFrameworkCore;
 
 namespace API.Data.Repositories
@@ -10,10 +14,12 @@ namespace API.Data.Repositories
     public class VolumeRepository : IVolumeRepository
     {
         private readonly DataContext _context;
+        private readonly IMapper _mapper;
 
-        public VolumeRepository(DataContext context)
+        public VolumeRepository(DataContext context, IMapper mapper)
         {
             _context = context;
+            _mapper = mapper;
         }
 
         public void Add(Volume volume)
@@ -31,6 +37,11 @@ namespace API.Data.Repositories
             _context.Volume.Remove(volume);
         }
 
+        /// <summary>
+        /// Returns a list of non-tracked files for a given volume.
+        /// </summary>
+        /// <param name="volumeId"></param>
+        /// <returns></returns>
         public async Task<IList<MangaFile>> GetFilesForVolume(int volumeId)
         {
             return await _context.Chapter
@@ -41,6 +52,11 @@ namespace API.Data.Repositories
                 .ToListAsync();
         }
 
+        /// <summary>
+        /// Returns the cover image file for the given volume
+        /// </summary>
+        /// <param name="volumeId"></param>
+        /// <returns></returns>
         public async Task<string> GetVolumeCoverImageAsync(int volumeId)
         {
            return await _context.Volume
@@ -50,6 +66,11 @@ namespace API.Data.Repositories
                 .SingleOrDefaultAsync();
         }
 
+        /// <summary>
+        /// Returns all chapter Ids belonging to a list of Volume Ids
+        /// </summary>
+        /// <param name="volumeIds"></param>
+        /// <returns></returns>
         public async Task<IList<int>> GetChapterIdsByVolumeIds(IReadOnlyList<int> volumeIds)
         {
             return await _context.Chapter
@@ -57,5 +78,131 @@ namespace API.Data.Repositories
                 .Select(c => c.Id)
                 .ToListAsync();
         }
+
+        /// <summary>
+        /// Returns all volumes that contain a seriesId in passed array.
+        /// </summary>
+        /// <param name="seriesIds"></param>
+        /// <returns></returns>
+        public async Task<IEnumerable<Volume>> GetVolumesForSeriesAsync(IList<int> seriesIds, bool includeChapters = false)
+        {
+            var query = _context.Volume
+                .Where(v => seriesIds.Contains(v.SeriesId));
+
+            if (includeChapters)
+            {
+                query = query.Include(v => v.Chapters);
+            }
+            return await query.ToListAsync();
+        }
+
+        /// <summary>
+        /// Returns an individual Volume including Chapters and Files and Reading Progress for a given volumeId
+        /// </summary>
+        /// <param name="volumeId"></param>
+        /// <param name="userId"></param>
+        /// <returns></returns>
+        public async Task<VolumeDto> GetVolumeDtoAsync(int volumeId, int userId)
+        {
+            var volume = await _context.Volume
+                .Where(vol => vol.Id == volumeId)
+                .Include(vol => vol.Chapters)
+                .ThenInclude(c => c.Files)
+                .ProjectTo<VolumeDto>(_mapper.ConfigurationProvider)
+                .SingleAsync(vol => vol.Id == volumeId);
+
+            var volumeList = new List<VolumeDto>() {volume};
+            await AddVolumeModifiers(userId, volumeList);
+
+            return volumeList[0];
+        }
+
+        /// <summary>
+        /// Returns the full Volumes including Chapters and Files for a given series
+        /// </summary>
+        /// <param name="seriesId"></param>
+        /// <returns></returns>
+        public async Task<IEnumerable<Volume>> GetVolumes(int seriesId)
+        {
+            return await _context.Volume
+                .Where(vol => vol.SeriesId == seriesId)
+                .Include(vol => vol.Chapters)
+                .ThenInclude(c => c.Files)
+                .OrderBy(vol => vol.Number)
+                .ToListAsync();
+        }
+
+        /// <summary>
+        /// Returns a single volume with Chapter and Files
+        /// </summary>
+        /// <param name="volumeId"></param>
+        /// <returns></returns>
+        public async Task<Volume> GetVolumeAsync(int volumeId)
+        {
+            return await _context.Volume
+                .Include(vol => vol.Chapters)
+                .ThenInclude(c => c.Files)
+                .SingleOrDefaultAsync(vol => vol.Id == volumeId);
+        }
+
+
+        /// <summary>
+        /// Returns all volumes for a given series with progress information attached. Includes all Chapters as well.
+        /// </summary>
+        /// <param name="seriesId"></param>
+        /// <param name="userId"></param>
+        /// <returns></returns>
+        public async Task<IEnumerable<VolumeDto>> GetVolumesDtoAsync(int seriesId, int userId)
+        {
+            var volumes =  await _context.Volume
+                .Where(vol => vol.SeriesId == seriesId)
+                .Include(vol => vol.Chapters)
+                .OrderBy(volume => volume.Number)
+                .ProjectTo<VolumeDto>(_mapper.ConfigurationProvider)
+                .AsNoTracking()
+                .ToListAsync();
+
+            await AddVolumeModifiers(userId, volumes);
+            SortSpecialChapters(volumes);
+
+            return volumes;
+        }
+
+        public async Task<Volume> GetVolumeByIdAsync(int volumeId)
+        {
+            return await _context.Volume.SingleOrDefaultAsync(x => x.Id == volumeId);
+        }
+
+
+        private static void SortSpecialChapters(IEnumerable<VolumeDto> volumes)
+        {
+            var sorter = new NaturalSortComparer();
+            foreach (var v in volumes.Where(vDto => vDto.Number == 0))
+            {
+                v.Chapters = v.Chapters.OrderBy(x => x.Range, sorter).ToList();
+            }
+        }
+
+
+        private async Task AddVolumeModifiers(int userId, IReadOnlyCollection<VolumeDto> volumes)
+        {
+            var volIds = volumes.Select(s => s.Id);
+            var userProgress = await _context.AppUserProgresses
+                .Where(p => p.AppUserId == userId && volIds.Contains(p.VolumeId))
+                .AsNoTracking()
+                .ToListAsync();
+
+            foreach (var v in volumes)
+            {
+                foreach (var c in v.Chapters)
+                {
+                    c.PagesRead = userProgress.Where(p => p.ChapterId == c.Id).Sum(p => p.PagesRead);
+                }
+
+                v.PagesRead = userProgress.Where(p => p.VolumeId == v.Id).Sum(p => p.PagesRead);
+            }
+        }
+
+
     }
 }

--- a/API/Data/Repositories/VolumeRepository.cs
+++ b/API/Data/Repositories/VolumeRepository.cs
@@ -1,13 +1,8 @@
 ﻿using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using API.DTOs;
-using API.DTOs.Reader;
 using API.Entities;
 using API.Interfaces.Repositories;
-using AutoMapper;
-using AutoMapper.QueryableExtensions;
 using Microsoft.EntityFrameworkCore;
 
 namespace API.Data.Repositories
@@ -21,9 +16,19 @@ namespace API.Data.Repositories
             _context = context;
         }
 
+        public void Add(Volume volume)
+        {
+            _context.Volume.Add(volume);
+        }
+
         public void Update(Volume volume)
         {
             _context.Entry(volume).State = EntityState.Modified;
+        }
+
+        public void Remove(Volume volume)
+        {
+            _context.Volume.Remove(volume);
         }
 
         public async Task<IList<MangaFile>> GetFilesForVolume(int volumeId)

--- a/API/Data/Scanner/Chunk.cs
+++ b/API/Data/Scanner/Chunk.cs
@@ -1,0 +1,21 @@
+﻿namespace API.Data.Scanner
+{
+    /// <summary>
+    /// Represents a set of Entities which is broken up and iterated on
+    /// </summary>
+    public class Chunk
+    {
+        /// <summary>
+        /// Total number of entities
+        /// </summary>
+        public int TotalSize { get; set; }
+        /// <summary>
+        /// Size of each chunk to iterate over
+        /// </summary>
+        public int ChunkSize { get; set; }
+        /// <summary>
+        /// Total chunks to iterate over
+        /// </summary>
+        public int TotalChunks { get; set; }
+    }
+}

--- a/API/Data/UnitOfWork.cs
+++ b/API/Data/UnitOfWork.cs
@@ -25,7 +25,7 @@ namespace API.Data
         public IUserRepository UserRepository => new UserRepository(_context, _userManager, _mapper);
         public ILibraryRepository LibraryRepository => new LibraryRepository(_context, _mapper);
 
-        public IVolumeRepository VolumeRepository => new VolumeRepository(_context);
+        public IVolumeRepository VolumeRepository => new VolumeRepository(_context, _mapper);
 
         public ISettingsRepository SettingsRepository => new SettingsRepository(_context, _mapper);
 

--- a/API/Entities/FolderPath.cs
+++ b/API/Entities/FolderPath.cs
@@ -8,10 +8,10 @@ namespace API.Entities
         public int Id { get; set; }
         public string Path { get; set; }
         /// <summary>
-        /// Used when scanning to see if we can skip if nothing has changed.
+        /// Used when scanning to see if we can skip if nothing has changed. (not implemented)
         /// </summary>
         public DateTime LastScanned { get; set; }
-        
+
         // Relationship
         public Library Library { get; set; }
         public int LibraryId { get; set; }

--- a/API/Entities/MangaFile.cs
+++ b/API/Entities/MangaFile.cs
@@ -38,5 +38,13 @@ namespace API.Entities
         {
             return File.GetLastWriteTime(FilePath) > LastModified;
         }
+
+        /// <summary>
+        /// Updates the Last Modified time of the underlying file
+        /// </summary>
+        public void UpdateLastModified()
+        {
+            LastModified = File.GetLastWriteTime(FilePath);
+        }
     }
 }

--- a/API/Entities/Series.cs
+++ b/API/Entities/Series.cs
@@ -33,7 +33,7 @@ namespace API.Entities
         /// <summary>
         /// Summary information related to the Series
         /// </summary>
-        public string Summary { get; set; } // TODO: Migrate into SeriesMetdata (with Metadata update)
+        public string Summary { get; set; } // NOTE: Migrate into SeriesMetdata (with Metadata update)
         public DateTime Created { get; set; }
         public DateTime LastModified { get; set; }
         /// <summary>

--- a/API/Interfaces/Repositories/ILibraryRepository.cs
+++ b/API/Interfaces/Repositories/ILibraryRepository.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
+using API.Data.Repositories;
 using API.DTOs;
 using API.Entities;
 using API.Entities.Enums;
@@ -13,7 +14,7 @@ namespace API.Interfaces.Repositories
         void Delete(Library library);
         Task<IEnumerable<LibraryDto>> GetLibraryDtosAsync();
         Task<bool> LibraryExists(string libraryName);
-        Task<Library> GetLibraryForIdAsync(int libraryId);
+        Task<Library> GetLibraryForIdAsync(int libraryId, LibraryIncludes includes);
         Task<Library> GetFullLibraryForIdAsync(int libraryId);
         Task<Library> GetFullLibraryForIdAsync(int libraryId, int seriesId);
         Task<IEnumerable<LibraryDto>> GetLibraryDtosForUsernameAsync(string userName);

--- a/API/Interfaces/Repositories/ISeriesRepository.cs
+++ b/API/Interfaces/Repositories/ISeriesRepository.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using API.Data.Scanner;
 using API.DTOs;
 using API.DTOs.Filtering;
 using API.Entities;
@@ -73,5 +74,7 @@ namespace API.Interfaces.Repositories
         Task<IEnumerable<string>> GetLockedCoverImagesAsync();
         Task<int> GetSeriesCount(int libraryId = 0);
         Task<PagedList<Series>> GetFullSeriesForLibraryIdAsync(int libraryId, UserParams userParams);
+        Task<Series> GetFullSeriesForSeriesIdAsync(int seriesId);
+        Task<Chunk> GetChunkInfo(int libraryId = 0);
     }
 }

--- a/API/Interfaces/Repositories/ISeriesRepository.cs
+++ b/API/Interfaces/Repositories/ISeriesRepository.cs
@@ -12,14 +12,10 @@ namespace API.Interfaces.Repositories
 {
     public interface ISeriesRepository
     {
-        //void Add(Series series);
         void Attach(Series series);
         void Update(Series series);
         void Remove(Series series);
-        Task<Series> GetSeriesByNameAsync(string name);
         Task<bool> DoesSeriesNameExistInLibrary(string name);
-        Series GetSeriesByName(string name);
-
         /// <summary>
         /// Adds user information like progress, ratings, etc
         /// </summary>
@@ -28,7 +24,6 @@ namespace API.Interfaces.Repositories
         /// <param name="userParams"></param>
         /// <returns></returns>
         Task<PagedList<SeriesDto>> GetSeriesDtoForLibraryIdAsync(int libraryId, int userId, UserParams userParams, FilterDto filter);
-
         /// <summary>
         /// Does not add user information like progress, ratings, etc.
         /// </summary>
@@ -37,20 +32,8 @@ namespace API.Interfaces.Repositories
         /// <returns></returns>
         Task<IEnumerable<SearchResultDto>> SearchSeries(int[] libraryIds, string searchQuery);
         Task<IEnumerable<Series>> GetSeriesForLibraryIdAsync(int libraryId);
-        Task<IEnumerable<VolumeDto>> GetVolumesDtoAsync(int seriesId, int userId);
-        Task<IEnumerable<Volume>> GetVolumes(int seriesId);
         Task<SeriesDto> GetSeriesDtoByIdAsync(int seriesId, int userId);
-        Task<Volume> GetVolumeAsync(int volumeId);
-        Task<VolumeDto> GetVolumeDtoAsync(int volumeId, int userId);
-        /// <summary>
-        /// A fast lookup of just the volume information with no tracking.
-        /// </summary>
-        /// <param name="volumeId"></param>
-        /// <returns></returns>
-        Task<VolumeDto> GetVolumeDtoAsync(int volumeId);
-        Task<IEnumerable<Volume>> GetVolumesForSeriesAsync(IList<int> seriesIds, bool includeChapters = false);
         Task<bool> DeleteSeriesAsync(int seriesId);
-        Task<Volume> GetVolumeByIdAsync(int volumeId);
         Task<Series> GetSeriesByIdAsync(int seriesId);
         Task<int[]> GetChapterIdsForSeriesAsync(int[] seriesIds);
         Task<IDictionary<int, IList<int>>> GetChapterIdWithSeriesIdForSeriesAsync(int[] seriesIds);
@@ -65,14 +48,13 @@ namespace API.Interfaces.Repositories
 
         Task<string> GetSeriesCoverImageAsync(int seriesId);
         Task<IEnumerable<SeriesDto>> GetInProgress(int userId, int libraryId, UserParams userParams, FilterDto filter);
-        Task<PagedList<SeriesDto>> GetRecentlyAdded(int libraryId, int userId, UserParams userParams, FilterDto filter);
+        Task<PagedList<SeriesDto>> GetRecentlyAdded(int libraryId, int userId, UserParams userParams, FilterDto filter); // NOTE: Probably put this in LibraryRepo
         Task<SeriesMetadataDto> GetSeriesMetadata(int seriesId);
         Task<PagedList<SeriesDto>> GetSeriesDtoForCollectionAsync(int collectionId, int userId, UserParams userParams);
         Task<IList<MangaFile>> GetFilesForSeries(int seriesId);
         Task<IEnumerable<SeriesDto>> GetSeriesDtoForIdsAsync(IEnumerable<int> seriesIds, int userId);
         Task<IList<string>> GetAllCoverImagesAsync();
         Task<IEnumerable<string>> GetLockedCoverImagesAsync();
-        Task<int> GetSeriesCount(int libraryId = 0);
         Task<PagedList<Series>> GetFullSeriesForLibraryIdAsync(int libraryId, UserParams userParams);
         Task<Series> GetFullSeriesForSeriesIdAsync(int seriesId);
         Task<Chunk> GetChunkInfo(int libraryId = 0);

--- a/API/Interfaces/Repositories/ISeriesRepository.cs
+++ b/API/Interfaces/Repositories/ISeriesRepository.cs
@@ -11,8 +11,10 @@ namespace API.Interfaces.Repositories
 {
     public interface ISeriesRepository
     {
-        void Add(Series series);
+        //void Add(Series series);
+        void Attach(Series series);
         void Update(Series series);
+        void Remove(Series series);
         Task<Series> GetSeriesByNameAsync(string name);
         Task<bool> DoesSeriesNameExistInLibrary(string name);
         Series GetSeriesByName(string name);
@@ -70,5 +72,6 @@ namespace API.Interfaces.Repositories
         Task<IList<string>> GetAllCoverImagesAsync();
         Task<IEnumerable<string>> GetLockedCoverImagesAsync();
         Task<int> GetSeriesCount(int libraryId = 0);
+        Task<PagedList<Series>> GetFullSeriesForLibraryIdAsync(int libraryId, UserParams userParams);
     }
 }

--- a/API/Interfaces/Repositories/ISeriesRepository.cs
+++ b/API/Interfaces/Repositories/ISeriesRepository.cs
@@ -69,5 +69,6 @@ namespace API.Interfaces.Repositories
         Task<IEnumerable<SeriesDto>> GetSeriesDtoForIdsAsync(IEnumerable<int> seriesIds, int userId);
         Task<IList<string>> GetAllCoverImagesAsync();
         Task<IEnumerable<string>> GetLockedCoverImagesAsync();
+        Task<int> GetSeriesCount(int libraryId = 0);
     }
 }

--- a/API/Interfaces/Repositories/IVolumeRepository.cs
+++ b/API/Interfaces/Repositories/IVolumeRepository.cs
@@ -7,7 +7,9 @@ namespace API.Interfaces.Repositories
 {
     public interface IVolumeRepository
     {
+        void Add(Volume volume);
         void Update(Volume volume);
+        void Remove(Volume volume);
         Task<IList<MangaFile>> GetFilesForVolume(int volumeId);
         Task<string> GetVolumeCoverImageAsync(int volumeId);
         Task<IList<int>> GetChapterIdsByVolumeIds(IReadOnlyList<int> volumeIds);

--- a/API/Interfaces/Repositories/IVolumeRepository.cs
+++ b/API/Interfaces/Repositories/IVolumeRepository.cs
@@ -13,5 +13,13 @@ namespace API.Interfaces.Repositories
         Task<IList<MangaFile>> GetFilesForVolume(int volumeId);
         Task<string> GetVolumeCoverImageAsync(int volumeId);
         Task<IList<int>> GetChapterIdsByVolumeIds(IReadOnlyList<int> volumeIds);
+
+        // From Series Repo
+        Task<IEnumerable<VolumeDto>> GetVolumesDtoAsync(int seriesId, int userId);
+        Task<Volume> GetVolumeAsync(int volumeId);
+        Task<VolumeDto> GetVolumeDtoAsync(int volumeId, int userId);
+        Task<IEnumerable<Volume>> GetVolumesForSeriesAsync(IList<int> seriesIds, bool includeChapters = false);
+        Task<IEnumerable<Volume>> GetVolumes(int seriesId);
+        Task<Volume> GetVolumeByIdAsync(int volumeId);
     }
 }

--- a/API/Interfaces/Services/IScannerService.cs
+++ b/API/Interfaces/Services/IScannerService.cs
@@ -11,9 +11,8 @@ namespace API.Interfaces.Services
         /// cover images if forceUpdate is true.
         /// </summary>
         /// <param name="libraryId">Library to scan against</param>
-        /// <param name="forceUpdate">Force overwriting for cover images</param>
-        Task ScanLibrary(int libraryId, bool forceUpdate);
+        Task ScanLibrary(int libraryId);
         Task ScanLibraries();
-        Task ScanSeries(int libraryId, int seriesId, bool forceUpdate, CancellationToken token);
+        Task ScanSeries(int libraryId, int seriesId, CancellationToken token);
     }
 }

--- a/API/Interfaces/Services/ReaderService.cs
+++ b/API/Interfaces/Services/ReaderService.cs
@@ -210,7 +210,7 @@ namespace API.Interfaces.Services
         /// <returns>-1 if nothing can be found</returns>
         public async Task<int> GetNextChapterIdAsync(int seriesId, int volumeId, int currentChapterId, int userId)
         {
-            var volumes = (await _unitOfWork.SeriesRepository.GetVolumesDtoAsync(seriesId, userId)).ToList();
+            var volumes = (await _unitOfWork.VolumeRepository.GetVolumesDtoAsync(seriesId, userId)).ToList();
             var currentVolume = volumes.Single(v => v.Id == volumeId);
             var currentChapter = currentVolume.Chapters.Single(c => c.Id == currentChapterId);
 
@@ -262,7 +262,7 @@ namespace API.Interfaces.Services
         /// <returns>-1 if nothing can be found</returns>
         public async Task<int> GetPrevChapterIdAsync(int seriesId, int volumeId, int currentChapterId, int userId)
         {
-            var volumes = (await _unitOfWork.SeriesRepository.GetVolumesDtoAsync(seriesId, userId)).Reverse().ToList();
+            var volumes = (await _unitOfWork.VolumeRepository.GetVolumesDtoAsync(seriesId, userId)).Reverse().ToList();
             var currentVolume = volumes.Single(v => v.Id == volumeId);
             var currentChapter = currentVolume.Chapters.Single(c => c.Id == currentChapterId);
 

--- a/API/Parser/Parser.cs
+++ b/API/Parser/Parser.cs
@@ -45,6 +45,10 @@ namespace API.Parser
             RegexOptions.IgnoreCase | RegexOptions.Compiled,
             RegexTimeout);
 
+        private static readonly Regex NormalizeRegex = new Regex(@"[^a-zA-Z0-9]",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            RegexTimeout);
+
 
         private static readonly Regex[] MangaVolumeRegex = new[]
         {
@@ -1064,7 +1068,7 @@ namespace API.Parser
 
         public static string Normalize(string name)
         {
-            return Regex.Replace(name.ToLower(), "[^a-zA-Z0-9]", string.Empty);
+            return NormalizeRegex.Replace(name, string.Empty).ToLower();
         }
 
 

--- a/API/Services/ArchiveService.cs
+++ b/API/Services/ArchiveService.cs
@@ -160,7 +160,6 @@ namespace API.Services
                 {
                     case ArchiveLibrary.Default:
                     {
-                        _logger.LogDebug("Using default compression handling");
                         using var archive = ZipFile.OpenRead(archivePath);
                         var entryNames = archive.Entries.Select(e => e.FullName).ToArray();
 
@@ -172,7 +171,6 @@ namespace API.Services
                     }
                     case ArchiveLibrary.SharpCompress:
                     {
-                        _logger.LogDebug("Using SharpCompress compression handling");
                         using var archive = ArchiveFactory.Open(archivePath);
                         var entryNames = archive.Entries.Where(archiveEntry => !archiveEntry.IsDirectory).Select(e => e.Key).ToList();
 

--- a/API/Services/ArchiveService.cs
+++ b/API/Services/ArchiveService.cs
@@ -13,10 +13,8 @@ using API.Interfaces.Services;
 using API.Services.Tasks;
 using Kavita.Common;
 using Microsoft.Extensions.Logging;
-using Microsoft.IO;
 using SharpCompress.Archives;
 using SharpCompress.Common;
-using Image = NetVips.Image;
 
 namespace API.Services
 {
@@ -28,14 +26,12 @@ namespace API.Services
     {
         private readonly ILogger<ArchiveService> _logger;
         private readonly IDirectoryService _directoryService;
-        private readonly NaturalSortComparer _comparer;
         private const string ComicInfoFilename = "comicinfo";
 
         public ArchiveService(ILogger<ArchiveService> logger, IDirectoryService directoryService)
         {
             _logger = logger;
             _directoryService = directoryService;
-            _comparer = new NaturalSortComparer();
         }
 
         /// <summary>
@@ -81,13 +77,11 @@ namespace API.Services
                 {
                     case ArchiveLibrary.Default:
                     {
-                        _logger.LogDebug("Using default compression handling");
-                        using ZipArchive archive = ZipFile.OpenRead(archivePath);
+                        using var archive = ZipFile.OpenRead(archivePath);
                         return archive.Entries.Count(e => !Parser.Parser.HasBlacklistedFolderInPath(e.FullName) && Parser.Parser.IsImage(e.FullName));
                     }
                     case ArchiveLibrary.SharpCompress:
                     {
-                        _logger.LogDebug("Using SharpCompress compression handling");
                         using var archive = ArchiveFactory.Open(archivePath);
                         return archive.Entries.Count(entry => !entry.IsDirectory &&
                                                               !Parser.Parser.HasBlacklistedFolderInPath(Path.GetDirectoryName(entry.Key) ?? string.Empty)
@@ -130,7 +124,7 @@ namespace API.Services
         /// <returns>Entry name of match, null if no match</returns>
         public string FirstFileEntry(IEnumerable<string> entryFullNames)
         {
-            var result = entryFullNames.OrderBy(Path.GetFileName, _comparer)
+            var result = entryFullNames.OrderBy(Path.GetFileName, new NaturalSortComparer())
                 .FirstOrDefault(x => !Parser.Parser.HasBlacklistedFolderInPath(x)
                                      && Parser.Parser.IsImage(x)
                                      && !x.StartsWith(Parser.Parser.MacOsMetadataFileStartsWith));
@@ -314,7 +308,6 @@ namespace API.Services
                 {
                     case ArchiveLibrary.Default:
                     {
-                        _logger.LogTrace("Using default compression handling");
                         using var archive = ZipFile.OpenRead(archivePath);
                         var entry = archive.Entries.SingleOrDefault(x => !Parser.Parser.HasBlacklistedFolderInPath(x.FullName)
                                                                          && Path.GetFileNameWithoutExtension(x.Name)?.ToLower() == ComicInfoFilename
@@ -330,7 +323,6 @@ namespace API.Services
                     }
                     case ArchiveLibrary.SharpCompress:
                     {
-                        _logger.LogTrace("Using SharpCompress compression handling");
                         using var archive = ArchiveFactory.Open(archivePath);
                         info = FindComicInfoXml(archive.Entries.Where(entry => !entry.IsDirectory
                                                                                && !Parser.Parser.HasBlacklistedFolderInPath(Path.GetDirectoryName(entry.Key) ?? string.Empty)
@@ -408,14 +400,12 @@ namespace API.Services
                 {
                     case ArchiveLibrary.Default:
                     {
-                        _logger.LogDebug("Using default compression handling");
                         using var archive = ZipFile.OpenRead(archivePath);
                         ExtractArchiveEntries(archive, extractPath);
                         break;
                     }
                     case ArchiveLibrary.SharpCompress:
                     {
-                        _logger.LogDebug("Using SharpCompress compression handling");
                         using var archive = ArchiveFactory.Open(archivePath);
                         ExtractArchiveEntities(archive.Entries.Where(entry => !entry.IsDirectory
                                                                               && !Parser.Parser.HasBlacklistedFolderInPath(Path.GetDirectoryName(entry.Key) ?? string.Empty)

--- a/API/Services/BookService.cs
+++ b/API/Services/BookService.cs
@@ -412,7 +412,7 @@ namespace API.Services
 
                 if (coverImageContent == null) return string.Empty;
                 using var stream = coverImageContent.GetContentStream();
-                //using var stream = StreamManager.GetStream("BookService.GetCoverImage", coverImageContent.ReadContent());
+
                 return ImageService.WriteCoverThumbnail(stream, fileName);
             }
             catch (Exception ex)

--- a/API/Services/BookService.cs
+++ b/API/Services/BookService.cs
@@ -393,7 +393,7 @@ namespace API.Services
         /// <returns></returns>
         public string GetCoverImage(string fileFilePath, string fileName)
         {
-            if (!IsValidFile(fileFilePath)) return String.Empty;
+            if (!IsValidFile(fileFilePath)) return string.Empty;
 
             if (Parser.Parser.IsPdf(fileFilePath))
             {
@@ -411,8 +411,8 @@ namespace API.Services
                                         ?? epubBook.Content.Images.Values.FirstOrDefault();
 
                 if (coverImageContent == null) return string.Empty;
-
-                using var stream = StreamManager.GetStream("BookService.GetCoverImage", coverImageContent.ReadContent());
+                using var stream = coverImageContent.GetContentStream();
+                //using var stream = StreamManager.GetStream("BookService.GetCoverImage", coverImageContent.ReadContent());
                 return ImageService.WriteCoverThumbnail(stream, fileName);
             }
             catch (Exception ex)

--- a/API/Services/ImageService.cs
+++ b/API/Services/ImageService.cs
@@ -47,6 +47,8 @@ namespace API.Services
       var firstImage = _directoryService.GetFilesWithExtension(directory, Parser.Parser.ImageFileExtensions)
         .OrderBy(f => f, new NaturalSortComparer()).FirstOrDefault();
 
+
+
       return firstImage;
     }
 
@@ -73,7 +75,7 @@ namespace API.Services
         {
             using var thumbnail = Image.Thumbnail(path, ThumbnailWidth);
             var filename = fileName + ".png";
-            thumbnail.WriteToFile(Path.Join(DirectoryService.CoverImageDirectory, fileName + ".png"));
+            thumbnail.WriteToFile(Path.Join(DirectoryService.CoverImageDirectory, filename));
             return filename;
         }
         catch (Exception e)

--- a/API/Services/MetadataService.cs
+++ b/API/Services/MetadataService.cs
@@ -104,6 +104,7 @@ namespace API.Services
 
             if (ShouldUpdateCoverImage(chapter.CoverImage, firstFile, forceUpdate, chapter.CoverImageLocked))
             {
+                _logger.LogDebug("[RefreshMetadata] Generating cover image for {File}", firstFile?.FilePath);
                 chapter.CoverImage = GetCoverImage(firstFile, chapter.VolumeId, chapter.Id);
                 return true;
             }
@@ -280,9 +281,10 @@ namespace API.Services
 
             if (_unitOfWork.HasChanges() && await _unitOfWork.CommitAsync())
             {
-                _logger.LogInformation("[MetadataService] Updated metadata for {SeriesName} in {ElapsedMilliseconds} milliseconds", series.Name, sw.ElapsedMilliseconds);
                 await _messageHub.Clients.All.SendAsync(SignalREvents.RefreshMetadata, MessageFactory.RefreshMetadataEvent(series.LibraryId, series.Id));
             }
+
+            _logger.LogInformation("[MetadataService] Updated metadata for {SeriesName} in {ElapsedMilliseconds} milliseconds", series.Name, sw.ElapsedMilliseconds);
         }
     }
 }

--- a/API/Services/MetadataService.cs
+++ b/API/Services/MetadataService.cs
@@ -76,7 +76,7 @@ namespace API.Services
 
         private string GetCoverImage(MangaFile file, int volumeId, int chapterId)
         {
-            file.LastModified = DateTime.Now;
+            file.UpdateLastModified();
             switch (file.Format)
             {
                 case MangaFormat.Pdf:

--- a/API/Services/TaskScheduler.cs
+++ b/API/Services/TaskScheduler.cs
@@ -119,7 +119,7 @@ namespace API.Services
         public void ScanLibrary(int libraryId, bool forceUpdate = false)
         {
             _logger.LogInformation("Enqueuing library scan for: {LibraryId}", libraryId);
-            BackgroundJob.Enqueue(() => _scannerService.ScanLibrary(libraryId, forceUpdate));
+            BackgroundJob.Enqueue(() => _scannerService.ScanLibrary(libraryId));
             // When we do a scan, force cache to re-unpack in case page numbers change
             BackgroundJob.Enqueue(() => _cleanupService.CleanupCacheDirectory());
         }
@@ -141,7 +141,7 @@ namespace API.Services
             BackgroundJob.Enqueue(() => DirectoryService.ClearDirectory(tempDirectory));
         }
 
-        public void RefreshSeriesMetadata(int libraryId, int seriesId, bool forceUpdate = false)
+        public void RefreshSeriesMetadata(int libraryId, int seriesId, bool forceUpdate = true)
         {
             _logger.LogInformation("Enqueuing series metadata refresh for: {SeriesId}", seriesId);
             BackgroundJob.Enqueue(() => _metadataService.RefreshMetadataForSeries(libraryId, seriesId, forceUpdate));
@@ -150,7 +150,7 @@ namespace API.Services
         public void ScanSeries(int libraryId, int seriesId, bool forceUpdate = false)
         {
             _logger.LogInformation("Enqueuing series scan for: {SeriesId}", seriesId);
-            BackgroundJob.Enqueue(() => _scannerService.ScanSeries(libraryId, seriesId, forceUpdate, CancellationToken.None));
+            BackgroundJob.Enqueue(() => _scannerService.ScanSeries(libraryId, seriesId, CancellationToken.None));
         }
 
         public void BackupDatabase()

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -320,21 +320,21 @@ namespace API.Services.Tasks
               }
               catch (Exception e)
               {
-                  _logger.LogCritical(e, "There are multiple series that map to normalized key {Key}. You can manually delete the entity via UI and rescan to fix it", key.NormalizedName);
+                  _logger.LogCritical(e, "There are multiple series that map to normalized key {Key}. You can manually delete the entity via UI and rescan to fix it. This will be skipped", key.NormalizedName);
                   var duplicateSeries = allSeries.Where(s => s.NormalizedName == key.NormalizedName || Parser.Parser.Normalize(s.OriginalName) == key.NormalizedName).ToList();
                   foreach (var series in duplicateSeries)
                   {
-                      _logger.LogCritical("{Key} maps with {Series}", key.Name, series.OriginalName);
+                      _logger.LogCritical("Duplicate Series Found: {Key} maps with {Series}", key.Name, series.OriginalName);
                   }
 
                   continue;
               }
-              if (existingSeries == null)
-              {
-                  existingSeries = DbFactory.Series(infos[0].Series);
-                  existingSeries.Format = key.Format;
-                  newSeries.Add(existingSeries);
-              }
+
+              if (existingSeries != null) continue;
+
+              existingSeries = DbFactory.Series(infos[0].Series);
+              existingSeries.Format = key.Format;
+              newSeries.Add(existingSeries);
           }
 
           Parallel.ForEach(newSeries, (series) =>

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -87,7 +87,7 @@ namespace API.Services.Tasks
                    {
                        dirs = new Dictionary<string, string>();
                        var path = Directory.GetParent(existingFolder)?.FullName;
-                       if (!folderPaths.Contains(path))
+                       if (!folderPaths.Contains(path) || !folderPaths.Any(p => p.Contains(path ?? string.Empty)))
                        {
                            _logger.LogInformation("[ScanService] Aborted: {SeriesName} has bad naming convention and sits at root of library. Cannot scan series without deletion occuring. Correct file names to have Series Name within it or perform Scan Library", series.OriginalName);
                            return;

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -531,5 +531,18 @@ namespace API.Services.Tasks
              }
           }
        }
+
+       /// <summary>
+       /// Returns the number of series that should be processed in parallel to optimize speed and memory.
+       /// </summary>
+       /// <param name="libraryId">Defaults to 0 meaning no library</param>
+       /// <returns></returns>
+       public async Task<int> GetChunkSize(int libraryId = 0)
+       {
+           var totalSeries = await _unitOfWork.SeriesRepository.GetSeriesCount(libraryId);
+           var procCount = Math.Max(Environment.ProcessorCount - 1, 1);
+
+           return totalSeries / procCount;
+       }
     }
 }

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -325,13 +325,11 @@ namespace API.Services.Tasks
               newSeries.Add(existingSeries);
           }
 
-          // TODO: BUG: This is throwing UNIQUE constraint failed: Series.Name, Series.NormalizedName, Series.LocalizedName, Series.LibraryId, Series.Format
-          // Either the series already exists or there is a deadlock on DB
           foreach(var series in newSeries)
           {
               try
               {
-                  _logger.LogInformation("[ScannerService] Processing series {SeriesName}", series.OriginalName);
+                  _logger.LogDebug("[ScannerService] Processing series {SeriesName}", series.OriginalName);
                   UpdateVolumes(series, ParseScannedFiles.GetInfosByName(parsedSeries, series).ToArray());
                   series.Pages = series.Volumes.Sum(v => v.Pages);
                   series.LibraryId = library.Id; // We have to manually set this since we aren't adding the series to the Library's series.

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -588,7 +588,8 @@ namespace API.Services.Tasks
                 {
                    FilePath = info.FullFilePath,
                    Format = info.Format,
-                   Pages = _archiveService.GetNumberOfPagesFromArchive(info.FullFilePath)
+                   Pages = _archiveService.GetNumberOfPagesFromArchive(info.FullFilePath),
+                   LastModified = File.GetLastWriteTime(info.FullFilePath)
                 };
              }
              case MangaFormat.Pdf:
@@ -598,7 +599,8 @@ namespace API.Services.Tasks
                 {
                    FilePath = info.FullFilePath,
                    Format = info.Format,
-                   Pages = _bookService.GetNumberOfPages(info.FullFilePath)
+                   Pages = _bookService.GetNumberOfPages(info.FullFilePath),
+                   LastModified = File.GetLastWriteTime(info.FullFilePath)
                 };
              }
              case MangaFormat.Image:
@@ -607,7 +609,8 @@ namespace API.Services.Tasks
                {
                  FilePath = info.FullFilePath,
                  Format = info.Format,
-                 Pages = 1
+                 Pages = 1,
+                 LastModified = File.GetLastWriteTime(info.FullFilePath)
                };
              }
              default:
@@ -625,33 +628,30 @@ namespace API.Services.Tasks
           if (existingFile != null)
           {
              existingFile.Format = info.Format;
-             if (existingFile.HasFileBeenModified() || existingFile.Pages == 0)
+             if (!existingFile.HasFileBeenModified() && existingFile.Pages != 0) return;
+             switch (existingFile.Format)
              {
-                 switch (existingFile.Format)
-                 {
-                     case MangaFormat.Epub:
-                     case MangaFormat.Pdf:
-                         existingFile.Pages = _bookService.GetNumberOfPages(info.FullFilePath);
-                         break;
-                     case MangaFormat.Image:
-                         existingFile.Pages = 1;
-                         break;
-                     case MangaFormat.Unknown:
-                         existingFile.Pages = 0;
-                         break;
-                     case MangaFormat.Archive:
-                         existingFile.Pages = _archiveService.GetNumberOfPagesFromArchive(info.FullFilePath);
-                         break;
-                 }
-                 existingFile.LastModified = DateTime.Now;
+                 case MangaFormat.Epub:
+                 case MangaFormat.Pdf:
+                     existingFile.Pages = _bookService.GetNumberOfPages(info.FullFilePath);
+                     break;
+                 case MangaFormat.Image:
+                     existingFile.Pages = 1;
+                     break;
+                 case MangaFormat.Unknown:
+                     existingFile.Pages = 0;
+                     break;
+                 case MangaFormat.Archive:
+                     existingFile.Pages = _archiveService.GetNumberOfPagesFromArchive(info.FullFilePath);
+                     break;
              }
+             existingFile.LastModified = File.GetLastWriteTime(info.FullFilePath);
           }
           else
           {
              var file = CreateMangaFile(info);
              if (file == null) return;
 
-             file.LastModified = DateTime.Now;
              chapter.Files.Add(file);
           }
        }

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -643,15 +643,16 @@ namespace API.Services.Tasks
                          existingFile.Pages = _archiveService.GetNumberOfPagesFromArchive(info.FullFilePath);
                          break;
                  }
+                 existingFile.LastModified = DateTime.Now;
              }
           }
           else
           {
              var file = CreateMangaFile(info);
-             if (file != null)
-             {
-                chapter.Files.Add(file);
-             }
+             if (file == null) return;
+
+             file.LastModified = DateTime.Now;
+             chapter.Files.Add(file);
           }
        }
     }

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -600,45 +600,47 @@ namespace API.Services.Tasks
 
        private MangaFile CreateMangaFile(ParserInfo info)
        {
-          switch (info.Format)
+           MangaFile mangaFile = null;
+           switch (info.Format)
           {
              case MangaFormat.Archive:
              {
-                return new MangaFile()
+                 mangaFile = new MangaFile()
                 {
                    FilePath = info.FullFilePath,
                    Format = info.Format,
-                   Pages = _archiveService.GetNumberOfPagesFromArchive(info.FullFilePath),
-                   LastModified = File.GetLastWriteTime(info.FullFilePath)
+                   Pages = _archiveService.GetNumberOfPagesFromArchive(info.FullFilePath)
                 };
+                 break;
              }
              case MangaFormat.Pdf:
              case MangaFormat.Epub:
              {
-                return new MangaFile()
+                 mangaFile = new MangaFile()
                 {
                    FilePath = info.FullFilePath,
                    Format = info.Format,
-                   Pages = _bookService.GetNumberOfPages(info.FullFilePath),
-                   LastModified = File.GetLastWriteTime(info.FullFilePath)
+                   Pages = _bookService.GetNumberOfPages(info.FullFilePath)
                 };
+                 break;
              }
              case MangaFormat.Image:
              {
-               return new MangaFile()
-               {
-                 FilePath = info.FullFilePath,
-                 Format = info.Format,
-                 Pages = 1,
-                 LastModified = File.GetLastWriteTime(info.FullFilePath)
-               };
+                 mangaFile = new MangaFile()
+                 {
+                     FilePath = info.FullFilePath,
+                     Format = info.Format,
+                     Pages = 1
+                 };
+                 break;
              }
              default:
                 _logger.LogWarning("[Scanner] Ignoring {Filename}. File type is not supported", info.Filename);
                 break;
           }
 
-          return null;
+           mangaFile?.UpdateLastModified();
+           return mangaFile;
        }
 
        private void AddOrUpdateFileForChapter(Chapter chapter, ParserInfo info)

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -182,11 +182,11 @@ namespace API.Services.Tasks
            catch (Exception ex)
            {
                // This usually only fails if user is not authenticated.
-               _logger.LogError(ex, "There was an issue fetching Library {LibraryId}", libraryId);
+               _logger.LogError(ex, "[ScannerService] There was an issue fetching Library {LibraryId}", libraryId);
                return;
            }
 
-           _logger.LogInformation("Beginning file scan on {LibraryName}", library.Name);
+           _logger.LogInformation("[ScannerService] Beginning file scan on {LibraryName}", library.Name);
            var scanner = new ParseScannedFiles(_bookService, _logger);
            var series = scanner.ScanLibrariesForSeries(library.Type, library.Folders.Select(fp => fp.Path), out var totalFiles, out var scanElapsedTime);
 
@@ -202,13 +202,13 @@ namespace API.Services.Tasks
            if (await _unitOfWork.CommitAsync())
            {
                _logger.LogInformation(
-                   "Processed {TotalFiles} files and {ParsedSeriesCount} series in {ElapsedScanTime} milliseconds for {LibraryName}",
+                   "[ScannerService] Processed {TotalFiles} files and {ParsedSeriesCount} series in {ElapsedScanTime} milliseconds for {LibraryName}",
                    totalFiles, series.Keys.Count, sw.ElapsedMilliseconds + scanElapsedTime, library.Name);
            }
            else
            {
                _logger.LogCritical(
-                   "There was a critical error that resulted in a failed scan. Please check logs and rescan");
+                   "[ScannerService] There was a critical error that resulted in a failed scan. Please check logs and rescan");
            }
 
            await CleanupAbandonedChapters();
@@ -248,7 +248,7 @@ namespace API.Services.Tasks
           for (var chunk = 0; chunk <= chunkInfo.TotalChunks; chunk++)
           {
               stopwatch.Restart();
-              _logger.LogDebug($"Processing chunk {chunk} / {chunkInfo.TotalChunks} with size {chunkInfo.ChunkSize}");
+              _logger.LogDebug($"[ScannerService] Processing chunk {chunk} / {chunkInfo.TotalChunks} with size {chunkInfo.ChunkSize} Series ({chunk * chunkInfo.ChunkSize} - {(chunk + 1) * chunkInfo.ChunkSize}");
               var nonLibrarySeries = await _unitOfWork.SeriesRepository.GetFullSeriesForLibraryIdAsync(library.Id, new UserParams()
               {
                   PageNumber = chunk,

--- a/API/SignalR/MessageFactory.cs
+++ b/API/SignalR/MessageFactory.cs
@@ -5,7 +5,7 @@ namespace API.SignalR
 {
     public static class MessageFactory
     {
-        public static SignalRMessage ScanSeriesEvent(int seriesId)
+        public static SignalRMessage ScanSeriesEvent(int seriesId, string seriesName)
         {
             return new SignalRMessage()
             {
@@ -13,7 +13,7 @@ namespace API.SignalR
                 Body = new
                 {
                     SeriesId = seriesId,
-                    SeriesName = string.Empty // TODO: Add this
+                    SeriesName = seriesName
                 }
             };
         }

--- a/API/SignalR/MessageFactory.cs
+++ b/API/SignalR/MessageFactory.cs
@@ -12,7 +12,36 @@ namespace API.SignalR
                 Name = SignalREvents.ScanSeries,
                 Body = new
                 {
-                    SeriesId = seriesId
+                    SeriesId = seriesId,
+                    SeriesName = string.Empty // TODO: Add this
+                }
+            };
+        }
+
+        public static SignalRMessage SeriesAddedEvent(int seriesId, string seriesName, int libraryId)
+        {
+            return new SignalRMessage()
+            {
+                Name = SignalREvents.SeriesAdded,
+                Body = new
+                {
+                    SeriesId = seriesId,
+                    SeriesName = seriesName,
+                    LibraryId = libraryId
+                }
+            };
+        }
+
+        public static SignalRMessage SeriesRemovedEvent(int seriesId, string seriesName, int libraryId)
+        {
+            return new SignalRMessage()
+            {
+                Name = SignalREvents.SeriesRemoved,
+                Body = new
+                {
+                    SeriesId = seriesId,
+                    SeriesName = seriesName,
+                    LibraryId = libraryId
                 }
             };
         }

--- a/API/SignalR/SignalREvents.cs
+++ b/API/SignalR/SignalREvents.cs
@@ -6,6 +6,8 @@
         public const string ScanSeries = "ScanSeries";
         public const string RefreshMetadata = "RefreshMetadata";
         public const string ScanLibrary = "ScanLibrary";
+        public const string SeriesAdded = "SeriesAdded";
+        public const string SeriesRemoved = "SeriesRemoved";
 
     }
 }

--- a/UI/Web/src/app/_models/events/refresh-metadata-event.ts
+++ b/UI/Web/src/app/_models/events/refresh-metadata-event.ts
@@ -1,0 +1,4 @@
+export interface RefreshMetadataEvent {
+    libraryId: number;
+    seriesId: number;
+}

--- a/UI/Web/src/app/_models/events/scan-series-event.ts
+++ b/UI/Web/src/app/_models/events/scan-series-event.ts
@@ -1,3 +1,4 @@
 export interface ScanSeriesEvent {
     seriesId: number;
+    seriesName: string;
 }

--- a/UI/Web/src/app/_models/events/series-added-event.ts
+++ b/UI/Web/src/app/_models/events/series-added-event.ts
@@ -1,0 +1,5 @@
+export interface SeriesAddedEvent {
+    libraryId: number;
+    seriesId: number;
+    seriesName: string;
+}

--- a/UI/Web/src/app/_services/message-hub.service.ts
+++ b/UI/Web/src/app/_services/message-hub.service.ts
@@ -6,6 +6,7 @@ import { ToastrService } from 'ngx-toastr';
 import { ReplaySubject } from 'rxjs';
 import { environment } from 'src/environments/environment';
 import { UpdateNotificationModalComponent } from '../shared/update-notification/update-notification-modal.component';
+import { RefreshMetadataEvent } from '../_models/events/refresh-metadata-event';
 import { ScanLibraryEvent } from '../_models/events/scan-library-event';
 import { ScanSeriesEvent } from '../_models/events/scan-series-event';
 import { SeriesAddedEvent } from '../_models/events/series-added-event';
@@ -37,6 +38,7 @@ export class MessageHubService {
   public scanSeries: EventEmitter<ScanSeriesEvent> = new EventEmitter<ScanSeriesEvent>();
   public scanLibrary: EventEmitter<ScanLibraryEvent> = new EventEmitter<ScanLibraryEvent>();
   public seriesAdded: EventEmitter<SeriesAddedEvent> = new EventEmitter<SeriesAddedEvent>();
+  public refreshMetadata: EventEmitter<RefreshMetadataEvent> = new EventEmitter<RefreshMetadataEvent>();
 
   constructor(private modalService: NgbModal, private toastr: ToastrService) { }
 
@@ -82,6 +84,14 @@ export class MessageHubService {
       });
       this.seriesAdded.emit(resp.body);
       this.toastr.info('Series ' + (resp.body as SeriesAddedEvent).seriesName + ' added');
+    });
+
+    this.hubConnection.on(EVENTS.RefreshMetadata, resp => {
+      this.messagesSource.next({
+        event: EVENTS.RefreshMetadata,
+        payload: resp.body
+      });
+      this.refreshMetadata.emit(resp.body);
     });
 
     this.hubConnection.on(EVENTS.UpdateAvailable, resp => {

--- a/UI/Web/src/app/person-badge/person-badge.component.html
+++ b/UI/Web/src/app/person-badge/person-badge.component.html
@@ -1,5 +1,5 @@
 <div class="badge">
-    <!-- TODO: Put a person image container here -->
+    <!-- Put a person image container here -->
     <div class="img">
 
     </div>


### PR DESCRIPTION
This is an overhaul of how the scan loop and metadata refresh loop performs. The goal of this was to reduce memory consumption in these loops by not loading all entities but only load chunks of entities from the DB at a time. This reduces the amount of memory pressure that occurs and also gives us the ability to perform additions in chunks, in case the machine is slow or uses network storage (which can take 10x as long due to overhead of rclone). 

In addition, this lays the foundational work to send updates as entities are added and removed or metadata is refreshed to the UI via SignalR and have the UI react to the changes occuring in the backend. This PR includes a first pass, but not a comprehensive implementation. A more comprehensive implementation will follow after testing on more devices and feedback from users.

# Added
- Added: Scan Series, Scan Library, and Refresh Metadata now all use chunking to perform the main work. Each series is still parallelized, but only X entities are loaded into memory at once, significantly reducing memory consumption (1GB (old) vs 200MB (new) on 12k files) (Closes #167)
- Added: UI will now show toastrs when new series are added to Kavita
- Added: UI will now update on library detail view with new cards when they are added to library

# Changed
- Changed: (Performance) Changed some code to avoid a byte[] copy for getting cover image of epubs
- Changed: Scan Library and Refresh Metadata now saves to DB in Chunks
- Changed: Added more checks in the Scan Series loop to ensure that we never go above the library root for handling an edge case where files are super poorly named
- Changed: Log messages in Scanner Service or Refresh Service will now have the service name in [] and are more verbose to give indication of what's happening. 

# Fixed
- Fixed: Fixed a bug where we didn't save a file's last write time in the DB so we ended up opening files for page calculation each time. 
- Fixed: Fixed a regression from last release where Scan Series could fall into scanning higher level folder (root folder) due to files being deleted rather than original case of files being really poorly named.
- Fixed: Fixed a concurrency issue with natural sorted when used in ArchiveService. 