### PR TITLE
Shakeout Bugs

### DIFF
--- a/API/API.csproj
+++ b/API/API.csproj
@@ -16,6 +16,10 @@
     <DocumentationFile>bin\Debug\API.xml</DocumentationFile>
   </PropertyGroup>
 
+    <PropertyGroup>
+        <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
+    </PropertyGroup>
+
   <!-- Set the Product and Version info for our own projects -->
   <PropertyGroup>
     <Product>Kavita</Product>

--- a/API/Extensions/ApplicationServiceExtensions.cs
+++ b/API/Extensions/ApplicationServiceExtensions.cs
@@ -42,7 +42,7 @@ namespace API.Extensions
 
             services.AddSqLite(config, env);
             services.AddLogging(config);
-            services.AddSignalR();
+            services.AddSignalR(opt => opt.EnableDetailedErrors = true);
         }
 
         private static void AddSqLite(this IServiceCollection services, IConfiguration config,

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -52,7 +52,7 @@ namespace API.Services.Tasks
        {
            var sw = new Stopwatch();
            var files = await _unitOfWork.SeriesRepository.GetFilesForSeries(seriesId);
-           var series = await _unitOfWork.SeriesRepository.GetSeriesByIdAsync(seriesId);
+           var series = await _unitOfWork.SeriesRepository.GetFullSeriesForSeriesIdAsync(seriesId);
            var chapterIds = await _unitOfWork.SeriesRepository.GetChapterIdsForSeriesAsync(new[] {seriesId});
            var library = await _unitOfWork.LibraryRepository.GetLibraryForIdAsync(libraryId, LibraryIncludes.Folders);
            var folderPaths = library.Folders.Select(f => f.Path).ToList();

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -186,7 +186,7 @@ namespace API.Services.Tasks
 
            _logger.LogInformation("[ScannerService] Beginning file scan on {LibraryName}", library.Name);
            await _messageHub.Clients.All.SendAsync(SignalREvents.ScanLibraryProgress,
-               MessageFactory.ScanLibraryProgressEvent(libraryId, 0, string.Empty));
+               MessageFactory.ScanLibraryProgressEvent(libraryId, 0));
 
            var scanner = new ParseScannedFiles(_bookService, _logger);
            var series = scanner.ScanLibrariesForSeries(library.Type, library.Folders.Select(fp => fp.Path), out var totalFiles, out var scanElapsedTime);
@@ -217,7 +217,7 @@ namespace API.Services.Tasks
 
            BackgroundJob.Enqueue(() => _metadataService.RefreshMetadata(libraryId, false));
            await _messageHub.Clients.All.SendAsync(SignalREvents.ScanLibraryProgress,
-               MessageFactory.ScanLibraryProgressEvent(libraryId, 100, string.Empty));
+               MessageFactory.ScanLibraryProgressEvent(libraryId, 100));
        }
 
        /// <summary>
@@ -301,7 +301,7 @@ namespace API.Services.Tasks
 
               var progress =  Math.Max(0, Math.Min(100, ((chunk + 1F) * chunkInfo.ChunkSize) / chunkInfo.TotalSize));
               await _messageHub.Clients.All.SendAsync(SignalREvents.ScanLibraryProgress,
-                  MessageFactory.ScanLibraryProgressEvent(library.Id, progress, string.Empty));
+                  MessageFactory.ScanLibraryProgressEvent(library.Id, progress));
           }
 
 
@@ -358,7 +358,7 @@ namespace API.Services.Tasks
                       await _messageHub.Clients.All.SendAsync(SignalREvents.SeriesAdded, MessageFactory.SeriesAddedEvent(series.Id, series.Name, library.Id));
                       var progress =  Math.Max(0F, Math.Min(100F, i * 1F / newSeries.Count));
                       await _messageHub.Clients.All.SendAsync(SignalREvents.ScanLibraryProgress,
-                          MessageFactory.ScanLibraryProgressEvent(library.Id, progress, string.Empty));
+                          MessageFactory.ScanLibraryProgressEvent(library.Id, progress));
                   }
                   else
                   {

--- a/API/SignalR/MessageFactory.cs
+++ b/API/SignalR/MessageFactory.cs
@@ -59,7 +59,7 @@ namespace API.SignalR
             };
         }
 
-        public static SignalRMessage ScanLibraryProgressEvent(int libraryId, float progress, string seriesName)
+        public static SignalRMessage ScanLibraryProgressEvent(int libraryId, float progress)
         {
             return new SignalRMessage()
             {
@@ -68,7 +68,6 @@ namespace API.SignalR
                 {
                     LibraryId = libraryId,
                     Progress = progress,
-                    SeriesName = seriesName
                 }
             };
         }

--- a/UI/Web/src/app/_services/message-hub.service.ts
+++ b/UI/Web/src/app/_services/message-hub.service.ts
@@ -83,7 +83,6 @@ export class MessageHubService {
         event: EVENTS.ScanLibraryProgress,
         payload: resp.body
       });
-      console.log('ScanLibraryProgress: ', resp.body);
       this.scanLibrary.emit(resp.body);
     });
 

--- a/UI/Web/src/app/_services/message-hub.service.ts
+++ b/UI/Web/src/app/_services/message-hub.service.ts
@@ -83,6 +83,7 @@ export class MessageHubService {
         event: EVENTS.ScanLibraryProgress,
         payload: resp.body
       });
+      console.log('ScanLibraryProgress: ', resp.body);
       this.scanLibrary.emit(resp.body);
     });
 

--- a/UI/Web/src/app/admin/manage-library/manage-library.component.ts
+++ b/UI/Web/src/app/admin/manage-library/manage-library.component.ts
@@ -36,9 +36,12 @@ export class ManageLibraryComponent implements OnInit, OnDestroy {
     this.getLibraries();
 
     // when a progress event comes in, show it on the UI next to library
-    this.hubService.messages$.pipe(takeWhile(event => event.event === EVENTS.ScanLibraryProgress)).subscribe((event) => {
+    this.hubService.messages$.pipe(takeUntil(this.onDestroy)).subscribe((event) => {
+      if (event.event != EVENTS.ScanLibraryProgress) return;
+      
       const scanEvent = event.payload as ScanLibraryProgressEvent;
       this.scanInProgress[scanEvent.libraryId] = scanEvent.progress !== 100;
+      
       if (this.scanInProgress[scanEvent.libraryId] === false && scanEvent.progress === 100) {
         this.libraryService.getLibraries().pipe(take(1)).subscribe(libraries => {
           const newLibrary = libraries.find(lib => lib.id === scanEvent.libraryId);

--- a/UI/Web/src/app/cards/card-item/card-item.component.ts
+++ b/UI/Web/src/app/cards/card-item/card-item.component.ts
@@ -123,6 +123,7 @@ export class CardItemComponent implements OnInit, OnDestroy {
   prevOffset: number = 0;
   @HostListener('touchstart', ['$event'])
   onTouchStart(event: TouchEvent) {
+    if (!this.allowSelection) return;
     const verticalOffset = (window.pageYOffset 
       || document.documentElement.scrollTop 
       || document.body.scrollTop || 0);
@@ -133,6 +134,7 @@ export class CardItemComponent implements OnInit, OnDestroy {
 
   @HostListener('touchend', ['$event'])
   onTouchEnd(event: TouchEvent) {
+    if (!this.allowSelection) return;
     const delta = event.timeStamp - this.prevTouchTime;
     const verticalOffset = (window.pageYOffset 
       || document.documentElement.scrollTop 

--- a/UI/Web/src/app/cards/series-card/series-card.component.ts
+++ b/UI/Web/src/app/cards/series-card/series-card.component.ts
@@ -1,8 +1,8 @@
-import { Component, EventEmitter, Input, OnChanges, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output } from '@angular/core';
 import { Router } from '@angular/router';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { ToastrService } from 'ngx-toastr';
-import { take, takeWhile } from 'rxjs/operators';
+import { take, takeUntil, takeWhile } from 'rxjs/operators';
 import { Series } from 'src/app/_models/series';
 import { AccountService } from 'src/app/_services/account.service';
 import { ImageService } from 'src/app/_services/image.service';
@@ -13,13 +13,14 @@ import { ActionService } from 'src/app/_services/action.service';
 import { EditSeriesModalComponent } from '../_modals/edit-series-modal/edit-series-modal.component';
 import { RefreshMetadataEvent } from 'src/app/_models/events/refresh-metadata-event';
 import { MessageHubService } from 'src/app/_services/message-hub.service';
+import { Subject } from 'rxjs';
 
 @Component({
   selector: 'app-series-card',
   templateUrl: './series-card.component.html',
   styleUrls: ['./series-card.component.scss']
 })
-export class SeriesCardComponent implements OnInit, OnChanges {
+export class SeriesCardComponent implements OnInit, OnChanges, OnDestroy {
   @Input() data!: Series;
   @Input() libraryId = 0;
   @Input() suppressLibraryLink = false;
@@ -43,6 +44,7 @@ export class SeriesCardComponent implements OnInit, OnChanges {
   isAdmin = false;
   actions: ActionItem<Series>[] = [];
   imageUrl: string = '';
+  onDestroy: Subject<void> = new Subject<void>();
 
   constructor(private accountService: AccountService, private router: Router,
               private seriesService: SeriesService, private toastr: ToastrService,
@@ -61,12 +63,10 @@ export class SeriesCardComponent implements OnInit, OnChanges {
     if (this.data) {
       this.imageUrl = this.imageService.randomize(this.imageService.getSeriesCoverImage(this.data.id));
 
-      this.hubService.refreshMetadata.pipe(takeWhile(event => event.libraryId === this.libraryId)).subscribe((event: RefreshMetadataEvent) => {
+      this.hubService.refreshMetadata.pipe(takeWhile(event => event.libraryId === this.libraryId), takeUntil(this.onDestroy)).subscribe((event: RefreshMetadataEvent) => {
         if (this.data.id === event.seriesId) {
           this.imageUrl = this.imageService.randomize(this.imageService.getSeriesCoverImage(this.data.id));
-          console.log('Refresh event came through, updating cover image');
-        }
-        
+        }    
       });
     }
   }
@@ -76,6 +76,11 @@ export class SeriesCardComponent implements OnInit, OnChanges {
       this.actions = this.actionFactoryService.getSeriesActions((action: Action, series: Series) => this.handleSeriesActionCallback(action, series)).filter(action => this.actionFactoryService.filterBookmarksForFormat(action, this.data));
       this.imageUrl = this.imageService.randomize(this.imageService.getSeriesCoverImage(this.data.id));
     }
+  }
+
+  ngOnDestroy() {
+    this.onDestroy.next();
+    this.onDestroy.complete();
   }
 
   handleSeriesActionCallback(action: Action, series: Series) {

--- a/UI/Web/src/app/user-login/user-login.component.html
+++ b/UI/Web/src/app/user-login/user-login.component.html
@@ -1,44 +1,46 @@
 <div class="mx-auto login">
     
-    <div class="display: inline-block" *ngIf="firstTimeFlow">
-        <h3 class="card-title text-center">Create an Admin Account</h3>
-        <div class="card p-3">
-            <p>Please create an admin account for yourself to start your reading journey.</p>
-            <app-register-member (created)="onAdminCreated($event)" [firstTimeFlow]="firstTimeFlow"></app-register-member>
+    <ng-container *ngIf="isLoaded">
+        <div class="display: inline-block" *ngIf="firstTimeFlow">
+            <h3 class="card-title text-center">Create an Admin Account</h3>
+            <div class="card p-3">
+                <p>Please create an admin account for yourself to start your reading journey.</p>
+                <app-register-member (created)="onAdminCreated($event)" [firstTimeFlow]="firstTimeFlow"></app-register-member>
+            </div>
         </div>
-    </div>
-
-    <form [formGroup]="loginForm" (ngSubmit)="login()" novalidate class="needs-validation" *ngIf="!firstTimeFlow">
-        <div class="row row-cols-4 row-cols-md-4 row-cols-sm-2 row-cols-xs-2">
-        <ng-container *ngFor="let member of memberNames">
-            <div class="col align-self-center card p-3 m-3" style="width: 12rem;">
-                <span tabindex="0" (click)="select(member)" a11y-click="13,32">
-                    <div class="logo-container">
-                        <h3 class="card-title text-center">{{member | titlecase}}</h3>
-                    </div>
-                </span>
-
-                <div class="card-text" #collapse="ngbCollapse" [(ngbCollapse)]="isCollapsed[member]" (keyup.enter)="$event.stopPropagation()">
-                    <div class="form-group" [ngStyle]="authDisabled ? {display: 'none'} : {}">
-                        <label for="username--{{member}}">Username</label>
-                        <input class="form-control" formControlName="username" id="username--{{member}}" type="text" [readonly]="authDisabled">
-                    </div>
-                    
-                    <div class="form-group">
-                        <label for="password--{{member}}">Password</label>
-                        <input class="form-control" formControlName="password" id="password--{{member}}" type="password" autofocus>
-                        <div *ngIf="authDisabled" class="invalid-feedback">
-                            Authentication is disabled. Only type password if this is an admin account.
+    
+        <form [formGroup]="loginForm" (ngSubmit)="login()" novalidate class="needs-validation" *ngIf="!firstTimeFlow">
+            <div class="row row-cols-4 row-cols-md-4 row-cols-sm-2 row-cols-xs-2">
+            <ng-container *ngFor="let member of memberNames">
+                <div class="col align-self-center card p-3 m-3" style="width: 12rem;">
+                    <span tabindex="0" (click)="select(member)" a11y-click="13,32">
+                        <div class="logo-container">
+                            <h3 class="card-title text-center">{{member | titlecase}}</h3>
+                        </div>
+                    </span>
+    
+                    <div class="card-text" #collapse="ngbCollapse" [(ngbCollapse)]="isCollapsed[member]" (keyup.enter)="$event.stopPropagation()">
+                        <div class="form-group" [ngStyle]="authDisabled ? {display: 'none'} : {}">
+                            <label for="username--{{member}}">Username</label>
+                            <input class="form-control" formControlName="username" id="username--{{member}}" type="text" [readonly]="authDisabled">
+                        </div>
+                        
+                        <div class="form-group">
+                            <label for="password--{{member}}">Password</label>
+                            <input class="form-control" formControlName="password" id="password--{{member}}" type="password" autofocus>
+                            <div *ngIf="authDisabled" class="invalid-feedback">
+                                Authentication is disabled. Only type password if this is an admin account.
+                            </div>
+                        </div>
+                        
+                        <div class="float-right">
+                            <button class="btn btn-primary alt" type="submit--{{member}}">Login</button>
                         </div>
                     </div>
-                    
-                    <div class="float-right">
-                        <button class="btn btn-primary alt" type="submit--{{member}}">Login</button>
-                    </div>
                 </div>
+            </ng-container>
             </div>
-        </ng-container>
-        </div>
-    </form>
+        </form>
+    </ng-container>
 
 </div>

--- a/UI/Web/src/app/user-login/user-login.component.ts
+++ b/UI/Web/src/app/user-login/user-login.component.ts
@@ -29,6 +29,10 @@ export class UserLoginComponent implements OnInit {
    * If there are no admins on the server, this will enable the registration to kick in.
    */
   firstTimeFlow: boolean = true;
+  /**
+   * Used for first time the page loads to ensure no flashing
+   */
+  isLoaded: boolean = false;
 
   constructor(private accountService: AccountService, private router: Router, private memberService: MemberService, 
     private toastr: ToastrService, private navService: NavService, private settingsService: SettingsService) { }
@@ -53,11 +57,13 @@ export class UserLoginComponent implements OnInit {
           const isOnlyOne = this.memberNames.length === 1;
           this.memberNames.forEach(name => this.isCollapsed[name] = !isOnlyOne);
           this.firstTimeFlow = members.length === 0;
+          this.isLoaded = true;
         });
       } else {
         this.memberService.adminExists().pipe(take(1)).subscribe(adminExists => {
           this.firstTimeFlow = !adminExists;
           this.setupAuthenticatedLoginFlow();
+          this.isLoaded = true;
         });
       }
     });


### PR DESCRIPTION
# Fixed
- Fixed: Fixed an issue where Scan Series would not fetch all entities and thus files would get duplicated on Chapter parsing (Fixes #616 ) (develop)
- Fixed: Fixed an issue where the websocket wouldn't receive the ending event and the spinner would never end on first scan (Fixes #618 ) (develop)
- Fixed: Fixed an issue where websocket would close on first scan due to a division by 0 (develop)
- Fixed: Don't flash first flow elements until we determine the state on login page (develop)
- Fixed: Carousels should be back to normal now on mobile devices. Don't process touch events when selection is disabled. (Fixes #617)

# Changed
- Changed: Removed extra language binaries on build. This removes ca, fr, zh, etc folders