### PR TITLE
Hashing

### DIFF
--- a/API.Tests/Parser/ParserTest.cs
+++ b/API.Tests/Parser/ParserTest.cs
@@ -142,6 +142,8 @@ namespace API.Tests.Parser
         [InlineData("Darker Than Black", "darkerthanblack")]
         [InlineData("Darker Than Black - Something", "darkerthanblacksomething")]
         [InlineData("Darker Than_Black", "darkerthanblack")]
+        [InlineData("Citrus", "citrus")]
+        [InlineData("Citrus+", "citrus+")]
         [InlineData("", "")]
         public void NormalizeTest(string input, string expected)
         {

--- a/API/Extensions/HttpExtensions.cs
+++ b/API/Extensions/HttpExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.IO;
+using System.Linq;
 using System.Text;
 using System.Text.Json;
 using API.Helpers;
@@ -41,8 +42,9 @@ namespace API.Extensions
         public static void AddCacheHeader(this HttpResponse response, string filename)
         {
             if (filename == null || filename.Length <= 0) return;
+            var hashContent = filename + File.GetLastWriteTimeUtc(filename);
             using var sha1 = new System.Security.Cryptography.SHA256CryptoServiceProvider();
-            response.Headers.Add("ETag", string.Concat(sha1.ComputeHash(Encoding.UTF8.GetBytes(filename)).Select(x => x.ToString("X2"))));
+            response.Headers.Add("ETag", string.Concat(sha1.ComputeHash(Encoding.UTF8.GetBytes(hashContent)).Select(x => x.ToString("X2"))));
         }
 
     }

--- a/API/Parser/Parser.cs
+++ b/API/Parser/Parser.cs
@@ -48,7 +48,7 @@ namespace API.Parser
             MatchOptions,
             RegexTimeout);
 
-        private static readonly Regex NormalizeRegex = new Regex(@"[^a-zA-Z0-9]",
+        private static readonly Regex NormalizeRegex = new Regex(@"[^a-zA-Z0-9\+]",
             MatchOptions,
             RegexTimeout);
 

--- a/API/Services/MetadataService.cs
+++ b/API/Services/MetadataService.cs
@@ -139,6 +139,8 @@ namespace API.Services
         {
             var madeUpdate = false;
             if (series == null) return false;
+
+            // NOTE: This will fail if we replace the cover of the first volume on a first scan. Because the series will already have a cover image
             if (ShouldUpdateCoverImage(series.CoverImage, null, forceUpdate, series.CoverImageLocked))
             {
                 series.Volumes ??= new List<Volume>();

--- a/API/SignalR/MessageFactory.cs
+++ b/API/SignalR/MessageFactory.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading;
+﻿using System;
 using API.DTOs.Update;
 
 namespace API.SignalR
@@ -46,19 +46,6 @@ namespace API.SignalR
             };
         }
 
-        public static SignalRMessage ScanLibraryEvent(int libraryId, string stage)
-        {
-            return new SignalRMessage()
-            {
-                Name = SignalREvents.ScanLibrary,
-                Body = new
-                {
-                    LibraryId = libraryId,
-                    Stage = stage
-                }
-            };
-        }
-
         public static SignalRMessage ScanLibraryProgressEvent(int libraryId, float progress)
         {
             return new SignalRMessage()
@@ -68,6 +55,7 @@ namespace API.SignalR
                 {
                     LibraryId = libraryId,
                     Progress = progress,
+                    EventTime = DateTime.Now
                 }
             };
         }

--- a/UI/Web/src/app/_models/events/scan-library-progress-event.ts
+++ b/UI/Web/src/app/_models/events/scan-library-progress-event.ts
@@ -1,4 +1,5 @@
 export interface ScanLibraryProgressEvent {
     libraryId: number;
     progress: number;
+    eventTime: string;
 }

--- a/UI/Web/src/app/admin/manage-library/manage-library.component.html
+++ b/UI/Web/src/app/admin/manage-library/manage-library.component.html
@@ -8,7 +8,7 @@
             <div>
                 <h4>
                     <span id="library-name--{{idx}}">{{library.name}}</span>&nbsp;
-                    <div class="spinner-border text-primary" style="width: 1.5rem; height: 1.5rem;" role="status" *ngIf="scanInProgress.hasOwnProperty(library.id) && scanInProgress[library.id]" title="Scan in progress">
+                    <div class="spinner-border text-primary" style="width: 1.5rem; height: 1.5rem;" role="status" *ngIf="scanInProgress.hasOwnProperty(library.id) && scanInProgress[library.id].progress" title="Scan in progress. Started at {{scanInProgress[library.id].timestamp | date: 'short'}}">
                         <span class="sr-only">Scan for {{library.name}} in progress</span>
                     </div>
                     <div class="float-right">

--- a/UI/Web/src/app/book-reader/book-reader/book-reader.component.ts
+++ b/UI/Web/src/app/book-reader/book-reader/book-reader.component.ts
@@ -558,9 +558,12 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
         margin = this.user.preferences.bookReaderMargin + '%';
       }
       this.pageStyles = {'font-family': this.user.preferences.bookReaderFontFamily, 'font-size': this.user.preferences.bookReaderFontSize + '%', 'margin-left': margin, 'margin-right': margin, 'line-height': this.user.preferences.bookReaderLineSpacing + '%'};
-      if (this.user.preferences.siteDarkMode && !this.user.preferences.bookReaderDarkMode) {
-        this.user.preferences.bookReaderDarkMode = true;
+      if (!afterSave) {
+        if (this.user.preferences.siteDarkMode && !this.user.preferences.bookReaderDarkMode) {
+          this.user.preferences.bookReaderDarkMode = true;
+        }
       }
+      
       this.toggleDarkMode(this.user.preferences.bookReaderDarkMode);
     } else {
       this.pageStyles = {'font-family': 'default', 'font-size': '100%', 'margin-left': margin, 'margin-right': margin, 'line-height': '100%'};


### PR DESCRIPTION
# Added
- Added: Added the ability to see when a scan library started by hovering over the spinner
- Added: When an OPDS collection is empty, we now send an Entry saying "Nothing here"

# Changed
- Changed: Hashing for images now takes into account the last time it was modified, so browser doesn't cache old entries. This usually affects when files inside an archive are modified and re-read. (Fixes #631)
- Changed: + is now allowed in normalization scheme. This allows series that use + as a way to denote sequels to not merge with their prequel series. (Fixes #632)

# Fixed
- Fixed: Fixed a bug where we would reset dark mode on the book reader to dark mode if our site was on dark mode, despite user setting light mode. (Fixes #633)