### PR TITLE
Added more verbose errors when scanner fails due to constraint error

### DIFF
--- a/API/SignalR/MessageFactory.cs
+++ b/API/SignalR/MessageFactory.cs
@@ -96,5 +96,17 @@ namespace API.SignalR
                 }
             };
         }
+
+        public static SignalRMessage ScanLibraryError(int libraryId)
+        {
+            return new SignalRMessage
+            {
+                Name = SignalREvents.ScanLibraryError,
+                Body = new
+                {
+                    LibraryId = libraryId,
+                }
+            };
+        }
     }
 }

--- a/API/SignalR/SignalREvents.cs
+++ b/API/SignalR/SignalREvents.cs
@@ -11,5 +11,6 @@
         public const string ScanLibraryProgress = "ScanLibraryProgress";
         public const string OnlineUsers = "OnlineUsers";
         public const string SeriesAddedToCollection = "SeriesAddedToCollection";
+        public const string ScanLibraryError = "ScanLibraryError";
     }
 }

--- a/UI/Web/src/app/_services/message-hub.service.ts
+++ b/UI/Web/src/app/_services/message-hub.service.ts
@@ -18,7 +18,8 @@ export enum EVENTS {
   SeriesAdded = 'SeriesAdded',
   ScanLibraryProgress = 'ScanLibraryProgress',
   OnlineUsers = 'OnlineUsers',
-  SeriesAddedToCollection = 'SeriesAddedToCollection'
+  SeriesAddedToCollection = 'SeriesAddedToCollection',
+  ScanLibraryError = 'ScanLibraryError'
 }
 
 export interface Message<T> {
@@ -91,6 +92,16 @@ export class MessageHubService {
         event: EVENTS.SeriesAddedToCollection,
         payload: resp.body
       });
+    });
+
+    this.hubConnection.on(EVENTS.ScanLibraryError, resp => {
+      this.messagesSource.next({
+        event: EVENTS.ScanLibraryError,
+        payload: resp.body
+      });
+      if (this.isAdmin) {
+        this.toastr.error('Library Scan had a critical error. Some series were not saved. Check logs');
+      }
     });
 
     this.hubConnection.on(EVENTS.SeriesAdded, resp => {


### PR DESCRIPTION
# Changed
- Changed: When the DB fails to save, log out all the series the user should look into for constraint issues and push a message to the admins connected to site. This has a side effect that we will allow the rest of the chunks to process even if one fails. 
