### PR TITLE
Vacation Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -501,3 +501,6 @@ API/stats/
 UI/Web/dist/
 /API.Tests/Extensions/Test Data/modified on run.txt
 /API/covers/
+API/config/covers/
+API/config/*.db
+UI/Web/.vscode/settings.json

--- a/API.Tests/Parser/ComicParserTests.cs
+++ b/API.Tests/Parser/ComicParserTests.cs
@@ -57,6 +57,7 @@ namespace API.Tests.Parser
         [InlineData("Fables 021 (2004) (Digital) (Nahga-Empire)", "Fables")]
         [InlineData("2000 AD 0366 [1984-04-28] (flopbie)", "2000 AD")]
         [InlineData("Daredevil - v6 - 10 - (2019)", "Daredevil")]
+        [InlineData("Batman - The Man Who Laughs #1 (2005)", "Batman - The Man Who Laughs")]
         public void ParseComicSeriesTest(string filename, string expected)
         {
             Assert.Equal(expected, API.Parser.Parser.ParseComicSeries(filename));
@@ -183,10 +184,18 @@ namespace API.Tests.Parser
                  FullFilePath = filepath, IsSpecial = false
              });
 
+             filepath = @"E:\Comics\Comics\Batman - The Man Who Laughs #1 (2005)\Batman - The Man Who Laughs #1 (2005).cbr";
+             expected.Add(filepath, new ParserInfo
+             {
+                 Series = "Batman - The Man Who Laughs", Volumes = "0", Edition = "",
+                 Chapters = "1", Filename = "Batman - The Man Who Laughs #1 (2005).cbr", Format = MangaFormat.Archive,
+                 FullFilePath = filepath, IsSpecial = false
+             });
+
             foreach (var file in expected.Keys)
             {
                 var expectedInfo = expected[file];
-                var actual = API.Parser.Parser.Parse(file, rootPath);
+                var actual = API.Parser.Parser.Parse(file, rootPath, LibraryType.Comic);
                 if (expectedInfo == null)
                 {
                     Assert.Null(actual);

--- a/API.Tests/Parser/ComicParserTests.cs
+++ b/API.Tests/Parser/ComicParserTests.cs
@@ -56,6 +56,7 @@ namespace API.Tests.Parser
         [InlineData("Batgirl V2000 #57", "Batgirl")]
         [InlineData("Fables 021 (2004) (Digital) (Nahga-Empire)", "Fables")]
         [InlineData("2000 AD 0366 [1984-04-28] (flopbie)", "2000 AD")]
+        [InlineData("Daredevil - v6 - 10 - (2019)", "Daredevil")]
         public void ParseComicSeriesTest(string filename, string expected)
         {
             Assert.Equal(expected, API.Parser.Parser.ParseComicSeries(filename));
@@ -93,6 +94,7 @@ namespace API.Tests.Parser
         [InlineData("Fables 021 (2004) (Digital) (Nahga-Empire).cbr", "0")]
         [InlineData("Cyberpunk 2077 - Trauma Team 04.cbz", "0")]
         [InlineData("2000 AD 0366 [1984-04-28] (flopbie)", "0")]
+        [InlineData("Daredevil - v6 - 10 - (2019)", "6")]
         public void ParseComicVolumeTest(string filename, string expected)
         {
             Assert.Equal(expected, API.Parser.Parser.ParseComicVolume(filename));
@@ -134,6 +136,7 @@ namespace API.Tests.Parser
         [InlineData("Fables 021 (2004) (Digital) (Nahga-Empire).cbr", "21")]
         [InlineData("Cyberpunk 2077 - Trauma Team #04.cbz", "4")]
         [InlineData("2000 AD 0366 [1984-04-28] (flopbie)", "366")]
+        [InlineData("Daredevil - v6 - 10 - (2019)", "10")]
         public void ParseComicChapterTest(string filename, string expected)
         {
             Assert.Equal(expected, API.Parser.Parser.ParseComicChapter(filename));
@@ -169,6 +172,14 @@ namespace API.Tests.Parser
              {
                  Series = "Babe", Volumes = "0", Edition = "",
                  Chapters = "1", Filename = "Babe 01.cbr", Format = MangaFormat.Archive,
+                 FullFilePath = filepath, IsSpecial = false
+             });
+
+             filepath = @"E:\Comics\Comics\Publisher\Batman the Detective (2021)\Batman the Detective - v6 - 11 - (2021).cbr";
+             expected.Add(filepath, new ParserInfo
+             {
+                 Series = "Batman the Detective", Volumes = "6", Edition = "",
+                 Chapters = "11", Filename = "Batman the Detective - v6 - 11 - (2021).cbr", Format = MangaFormat.Archive,
                  FullFilePath = filepath, IsSpecial = false
              });
 

--- a/API/Services/DirectoryService.cs
+++ b/API/Services/DirectoryService.cs
@@ -375,8 +375,11 @@ namespace API.Services
                IEnumerable<string> subDirs;
                string[] files;
 
-               try {
-                  subDirs = Directory.GetDirectories(currentDir).Where(path => ExcludeDirectories.Matches(path).Count == 0);
+               try
+               {
+                   // Default EnumerationOptions will ignore system and hidden folders
+                   subDirs = Directory.GetDirectories(currentDir, "*", new EnumerationOptions())
+                       .Where(path => ExcludeDirectories.Matches(path).Count == 0);
                }
                // Thrown if we do not have discovery permission on the directory.
                catch (UnauthorizedAccessException e) {

--- a/API/Startup.cs
+++ b/API/Startup.cs
@@ -106,6 +106,11 @@ namespace API
 
             services.AddResponseCaching();
 
+            services.Configure<ForwardedHeadersOptions>(options =>
+            {
+                options.ForwardedHeaders =
+                    ForwardedHeaders.All;
+            });
 
             services.AddHangfire(configuration => configuration
                 .UseSimpleAssemblyNameTypeSerializer()
@@ -140,7 +145,7 @@ namespace API
 
             app.UseForwardedHeaders(new ForwardedHeadersOptions
             {
-                ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto
+                ForwardedHeaders = ForwardedHeaders.All
             });
 
             app.UseRouting();


### PR DESCRIPTION
# Fixed
- Fixed: Ignore Hidden and System folders when doing a library scan (Fixes #707)
- Fixed: Accept all forwarded headers (to fix an issue where epubs could request something on HTTP, when user is using HTTPS reverse proxy)