### PR TITLE
Scanner & Parser Changes

### DIFF
--- a/API/Services/BookService.cs
+++ b/API/Services/BookService.cs
@@ -371,7 +371,7 @@ namespace API.Services
                             FullFilePath = filePath,
                             IsSpecial = false,
                             Series = series.Trim(),
-                            Volumes = seriesIndex.Split(".")[0]
+                            Volumes = seriesIndex
                         };
                     }
                 }

--- a/API/Services/DirectoryService.cs
+++ b/API/Services/DirectoryService.cs
@@ -173,7 +173,15 @@ namespace API.Services
          return true;
        }
 
-
+       /// <summary>
+       /// Checks if the root path of a path exists or not.
+       /// </summary>
+       /// <param name="path"></param>
+       /// <returns></returns>
+       public static bool IsDriveMounted(string path)
+       {
+           return new DirectoryInfo(Path.GetPathRoot(path) ?? string.Empty).Exists;
+       }
 
        public static string[] GetFilesWithExtension(string path, string searchPatternExpression = "")
        {

--- a/UI/Web/src/app/_models/events/series-removed-event.ts
+++ b/UI/Web/src/app/_models/events/series-removed-event.ts
@@ -1,0 +1,5 @@
+export interface SeriesRemovedEvent {
+    libraryId: number;
+    seriesId: number;
+    seriesName: string;
+}

--- a/UI/Web/src/app/_services/message-hub.service.ts
+++ b/UI/Web/src/app/_services/message-hub.service.ts
@@ -16,6 +16,7 @@ export enum EVENTS {
   ScanSeries = 'ScanSeries',
   RefreshMetadata = 'RefreshMetadata',
   SeriesAdded = 'SeriesAdded',
+  SeriesRemoved = 'SeriesRemoved',
   ScanLibraryProgress = 'ScanLibraryProgress',
   OnlineUsers = 'OnlineUsers',
   SeriesAddedToCollection = 'SeriesAddedToCollection',
@@ -113,6 +114,13 @@ export class MessageHubService {
       if (this.isAdmin) {
         this.toastr.info('Series ' + (resp.body as SeriesAddedEvent).seriesName + ' added');
       }
+    });
+
+    this.hubConnection.on(EVENTS.SeriesRemoved, resp => {
+      this.messagesSource.next({
+        event: EVENTS.SeriesRemoved,
+        payload: resp.body
+      });
     });
 
     this.hubConnection.on(EVENTS.RefreshMetadata, resp => {

--- a/UI/Web/src/app/cards/_modals/card-details-modal/card-details-modal.component.html
+++ b/UI/Web/src/app/cards/_modals/card-details-modal/card-details-modal.component.html
@@ -17,7 +17,8 @@
                 <div class="col">
                     Id: {{data.id}}
                 </div>
-                <div class="col">
+                <div class="col" *ngIf="series !== undefined">
+                    Format: <span class="badge badge-secondary">{{utilityService.mangaFormat(series.format) | sentenceCase}}</span>
                 </div>
             </div>
             <div class="row no-gutters">
@@ -58,8 +59,8 @@
                                 <div class="col">
                                     Pages: {{file.pages}}
                                 </div>
-                                <div class="col">
-                                    Format: <span class="badge badge-secondary">{{utilityService.mangaFormatToText(file.format)}}</span>
+                                <div class="col" *ngIf="data.hasOwnProperty('created')">
+                                    Added: {{(data.created | date: 'short') || '-'}}
                                 </div>
                             </div>
                         </li>

--- a/UI/Web/src/app/cards/_modals/card-details-modal/card-details-modal.component.ts
+++ b/UI/Web/src/app/cards/_modals/card-details-modal/card-details-modal.component.ts
@@ -15,6 +15,8 @@ import { UploadService } from 'src/app/_services/upload.service';
 import { ChangeCoverImageModalComponent } from '../change-cover-image/change-cover-image-modal.component';
 import { LibraryType } from '../../../_models/library';
 import { LibraryService } from '../../../_services/library.service';
+import { SeriesService } from 'src/app/_services/series.service';
+import { Series } from 'src/app/_models/series';
 
 
 
@@ -42,6 +44,7 @@ export class CardDetailsModalComponent implements OnInit {
   actions: ActionItem<any>[] = [];
   chapterActions: ActionItem<Chapter>[] = [];
   libraryType: LibraryType = LibraryType.Manga; 
+  series: Series | undefined = undefined;
 
   get LibraryType(): typeof LibraryType {
     return LibraryType;
@@ -50,7 +53,8 @@ export class CardDetailsModalComponent implements OnInit {
   constructor(private modalService: NgbModal, public modal: NgbActiveModal, public utilityService: UtilityService, 
     public imageService: ImageService, private uploadService: UploadService, private toastr: ToastrService, 
     private accountService: AccountService, private actionFactoryService: ActionFactoryService, 
-    private actionService: ActionService, private router: Router, private libraryService: LibraryService) { }
+    private actionService: ActionService, private router: Router, private libraryService: LibraryService,
+    private seriesService: SeriesService) { }
 
   ngOnInit(): void {
     this.isChapter = this.utilityService.isChapter(this.data);
@@ -79,6 +83,10 @@ export class CardDetailsModalComponent implements OnInit {
     this.chapters.forEach((c: Chapter) => {
       c.files.sort((a: MangaFile, b: MangaFile) => collator.compare(a.filePath, b.filePath));
     });
+
+    this.seriesService.getSeries(this.seriesId).subscribe(series => {
+      this.series = series;
+    })
   }
 
   close() {

--- a/UI/Web/src/app/collections/collection-detail/collection-detail.component.ts
+++ b/UI/Web/src/app/collections/collection-detail/collection-detail.component.ts
@@ -11,6 +11,7 @@ import { EditCollectionTagsComponent } from 'src/app/cards/_modals/edit-collecti
 import { KEY_CODES } from 'src/app/shared/_services/utility.service';
 import { CollectionTag } from 'src/app/_models/collection-tag';
 import { SeriesAddedToCollectionEvent } from 'src/app/_models/events/series-added-to-collection-event';
+import { SeriesRemovedEvent } from 'src/app/_models/events/series-removed-event';
 import { Pagination } from 'src/app/_models/pagination';
 import { Series } from 'src/app/_models/series';
 import { FilterItem, mangaFormatFilters, SeriesFilter } from 'src/app/_models/series-filter';
@@ -106,8 +107,12 @@ export class CollectionDetailComponent implements OnInit, OnDestroy {
     this.collectionTagActions = this.actionFactoryService.getCollectionTagActions(this.handleCollectionActionCallback.bind(this));
 
     this.messageHub.messages$.pipe(takeWhile(event => event.event === EVENTS.SeriesAddedToCollection), takeUntil(this.onDestory), debounceTime(2000)).subscribe(event => {
-      const collectionEvent = event.payload as SeriesAddedToCollectionEvent;
-      if (collectionEvent.tagId === this.collectionTag.id) {
+      if (event.event == EVENTS.SeriesAddedToCollection) {
+        const collectionEvent = event.payload as SeriesAddedToCollectionEvent;
+        if (collectionEvent.tagId === this.collectionTag.id) {
+          this.loadPage();
+        }
+      } else if (event.event === EVENTS.SeriesRemoved) {
         this.loadPage();
       }
     });

--- a/UI/Web/src/app/library/library.component.ts
+++ b/UI/Web/src/app/library/library.component.ts
@@ -1,19 +1,15 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 import { Router } from '@angular/router';
-import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { Subject } from 'rxjs';
 import { take, takeUntil } from 'rxjs/operators';
-import { EditCollectionTagsComponent } from '../cards/_modals/edit-collection-tags/edit-collection-tags.component';
-import { CollectionTag } from '../_models/collection-tag';
 import { SeriesAddedEvent } from '../_models/events/series-added-event';
+import { SeriesRemovedEvent } from '../_models/events/series-removed-event';
 import { InProgressChapter } from '../_models/in-progress-chapter';
 import { Library } from '../_models/library';
 import { Series } from '../_models/series';
 import { User } from '../_models/user';
 import { AccountService } from '../_services/account.service';
-import { Action, ActionFactoryService, ActionItem } from '../_services/action-factory.service';
-import { CollectionTagService } from '../_services/collection-tag.service';
 import { ImageService } from '../_services/image.service';
 import { LibraryService } from '../_services/library.service';
 import { EVENTS, MessageHubService } from '../_services/message-hub.service';
@@ -44,14 +40,18 @@ export class LibraryComponent implements OnInit, OnDestroy {
     private titleService: Title, public imageService: ImageService, 
     private messageHub: MessageHubService) {
       this.messageHub.messages$.pipe(takeUntil(this.onDestroy)).subscribe(res => {
-        if (res.event == EVENTS.SeriesAdded) {
+        if (res.event === EVENTS.SeriesAdded) {
           const seriesAddedEvent = res.payload as SeriesAddedEvent;
           this.seriesService.getSeries(seriesAddedEvent.seriesId).subscribe(series => {
             this.recentlyAdded.unshift(series);
           });
+        } else if (res.event === EVENTS.SeriesRemoved) {
+          const seriesRemovedEvent = res.payload as SeriesRemovedEvent;
+          this.recentlyAdded = this.recentlyAdded.filter(item => item.id != seriesRemovedEvent.seriesId);
+          this.inProgress = this.inProgress.filter(item => item.id != seriesRemovedEvent.seriesId);
         }
       });
-    }
+  }
 
   ngOnInit(): void {
     this.titleService.setTitle('Kavita - Dashboard');
@@ -111,5 +111,12 @@ export class LibraryComponent implements OnInit, OnDestroy {
     } else if (sectionTitle.toLowerCase() === 'in progress') {
       this.router.navigate(['in-progress']);
     } 
+  }
+
+  removeFromArray(arr: Array<any>, element: any) {
+    const index = arr.indexOf(element);
+    if (index >= 0) {
+      arr.splice(index);
+    }
   }
 }

--- a/UI/Web/src/app/series-detail/series-detail.component.ts
+++ b/UI/Web/src/app/series-detail/series-detail.component.ts
@@ -16,6 +16,7 @@ import { KEY_CODES, UtilityService } from '../shared/_services/utility.service';
 import { ReviewSeriesModalComponent } from '../_modals/review-series-modal/review-series-modal.component';
 import { Chapter } from '../_models/chapter';
 import { ScanSeriesEvent } from '../_models/events/scan-series-event';
+import { SeriesRemovedEvent } from '../_models/events/series-removed-event';
 import { LibraryType } from '../_models/library';
 import { MangaFormat } from '../_models/manga-format';
 import { Series } from '../_models/series';
@@ -182,8 +183,11 @@ export class SeriesDetailComponent implements OnInit, OnDestroy {
 
     this.messageHub.messages$.pipe(takeUntil(this.onDestroy)).subscribe(event => {
       if (event.event === EVENTS.SeriesRemoved) {
-        this.toastr.info('This series no longer exists');
-        this.router.navigateByUrl('/libraries');
+        const seriesRemovedEvent = event.payload as SeriesRemovedEvent;
+        if (seriesRemovedEvent.seriesId === this.series.id) {
+          this.toastr.info('This series no longer exists');
+          this.router.navigateByUrl('/libraries');
+        }
       }
     });
 

--- a/UI/Web/src/app/series-detail/series-detail.component.ts
+++ b/UI/Web/src/app/series-detail/series-detail.component.ts
@@ -26,7 +26,7 @@ import { ActionItem, ActionFactoryService, Action } from '../_services/action-fa
 import { ActionService } from '../_services/action.service';
 import { ImageService } from '../_services/image.service';
 import { LibraryService } from '../_services/library.service';
-import { MessageHubService } from '../_services/message-hub.service';
+import { EVENTS, MessageHubService } from '../_services/message-hub.service';
 import { ReaderService } from '../_services/reader.service';
 import { SeriesService } from '../_services/series.service';
 
@@ -178,6 +178,13 @@ export class SeriesDetailComponent implements OnInit, OnDestroy {
       this.loadSeries(seriesId);
       this.seriesImage = this.imageService.randomize(this.imageService.getSeriesCoverImage(this.series.id));
       this.toastr.success('Scan series completed');
+    });
+
+    this.messageHub.messages$.pipe(takeUntil(this.onDestroy)).subscribe(event => {
+      if (event.event === EVENTS.SeriesRemoved) {
+        this.toastr.info('This series no longer exists');
+        this.router.navigateByUrl('/libraries');
+      }
     });
 
     const seriesId = parseInt(routeId, 10);

--- a/UI/Web/src/app/shared/_services/utility.service.ts
+++ b/UI/Web/src/app/shared/_services/utility.service.ts
@@ -158,5 +158,4 @@ export class UtilityService {
         rect.right <= (window.innerWidth || document.documentElement.clientWidth)
     );
   }
-
 }


### PR DESCRIPTION
# Added
- Added: Added a check during library scan to check if the drives are accessible and if any in the library root aren't, the scan will be aborted. (Closes #713)
- Added: In progress and Recently Added will now remove a card if the series is deleted during a scan
- Added: Series detail page will now send user to dashboard if a series is deleted during a scan

# Changed
- Changed: Moved format for card details to the highest level since all chapters and files have the same format for a series and added date added to each file/chapter to help users understand when chapters are added to the volume.

# Fixed
- Fixed: Fixed a missed case where partial volume support got missed on the epub parser. Now your books with Volume 1 and Volume 1.5 won't group. (Fixes #727 )
