### PR TITLE
OPDS Spec issue with Panels

### DIFF
--- a/API/Controllers/OPDSController.cs
+++ b/API/Controllers/OPDSController.cs
@@ -202,6 +202,7 @@ namespace API.Controllers
             {
                 feed.Entries.Add(new FeedEntry()
                 {
+                    Id = "0",
                     Title = "Nothing here",
                 });
             }
@@ -324,6 +325,7 @@ namespace API.Controllers
             {
                 feed.Entries.Add(new FeedEntry()
                 {
+                    Id = "0",
                     Title = "Nothing here",
                 });
             }
@@ -390,6 +392,7 @@ namespace API.Controllers
             {
                 feed.Entries.Add(new FeedEntry()
                 {
+                    Id = "0",
                     Title = "Nothing here",
                 });
             }
@@ -429,6 +432,7 @@ namespace API.Controllers
             {
                 feed.Entries.Add(new FeedEntry()
                 {
+                    Id = "0",
                     Title = "Nothing here",
                 });
             }

--- a/API/Data/Seed.cs
+++ b/API/Data/Seed.cs
@@ -71,6 +71,8 @@ namespace API.Data
                 Configuration.LogLevel + string.Empty;
             context.ServerSetting.First(s => s.Key == ServerSettingKey.CacheDirectory).Value =
                 DirectoryService.CacheDirectory + string.Empty;
+            context.ServerSetting.First(s => s.Key == ServerSettingKey.BackupDirectory).Value =
+                DirectoryService.BackupDirectory + string.Empty;
 
             await context.SaveChangesAsync();
 


### PR DESCRIPTION
# Fixed
- Fixed: Fixed a spec issue with entries that contain no items. We send 'Nothing here', but I forgot to send an Id for that feed.
- Fixed: Fixed a missing migration for backup directory to the new config directory. Docker users will now have backups in config, all other users would have to manually move them over. 
