### PR TITLE
UI Updates + New Events

### DIFF
--- a/API/Controllers/OPDSController.cs
+++ b/API/Controllers/OPDSController.cs
@@ -583,7 +583,7 @@ namespace API.Controllers
                 feed.Links.Add(CreateLink(FeedLinkRelation.Prev, FeedLinkType.AtomNavigation, url + "pageNumber=" + (pageNumber - 1)));
             }
 
-            if (pageNumber + 1 < list.TotalPages)
+            if (pageNumber + 1 <= list.TotalPages)
             {
                 feed.Links.Add(CreateLink(FeedLinkRelation.Next, FeedLinkType.AtomNavigation, url + "pageNumber=" + (pageNumber + 1)));
             }

--- a/API/Controllers/OPDSController.cs
+++ b/API/Controllers/OPDSController.cs
@@ -596,7 +596,7 @@ namespace API.Controllers
             }
 
 
-            feed.Total = list.TotalPages * list.PageSize;
+            feed.Total = list.TotalCount;
             feed.ItemsPerPage = list.PageSize;
             feed.StartIndex = (Math.Max(list.CurrentPage - 1, 0) * list.PageSize) + 1;
         }

--- a/API/Extensions/IdentityServiceExtensions.cs
+++ b/API/Extensions/IdentityServiceExtensions.cs
@@ -17,8 +17,13 @@ namespace API.Extensions
         {
             services.AddIdentityCore<AppUser>(opt =>
                 {
-                    // Change password / signin requirements here
                     opt.Password.RequireNonAlphanumeric = false;
+                    opt.Password.RequireDigit = false;
+                    opt.Password.RequireDigit = false;
+                    opt.Password.RequireLowercase = false;
+                    opt.Password.RequireUppercase = false;
+                    opt.Password.RequireNonAlphanumeric = false;
+                    opt.Password.RequiredLength = 6;
                 })
                 .AddRoles<AppRole>()
                 .AddRoleManager<RoleManager<AppRole>>()

--- a/API/Services/TaskScheduler.cs
+++ b/API/Services/TaskScheduler.cs
@@ -120,7 +120,7 @@ namespace API.Services
         {
             _logger.LogInformation("Scheduling Auto-Update tasks");
             // Schedule update check between noon and 6pm local time
-            RecurringJob.AddOrUpdate("check-updates", () => _versionUpdaterService.CheckForUpdate(), Cron.Daily(Rnd.Next(12, 18)), TimeZoneInfo.Local);
+            RecurringJob.AddOrUpdate("check-updates", () => CheckForUpdate(), Cron.Daily(Rnd.Next(12, 18)), TimeZoneInfo.Local);
         }
         #endregion
 

--- a/API/Services/Tasks/VersionUpdaterService.cs
+++ b/API/Services/Tasks/VersionUpdaterService.cs
@@ -86,10 +86,6 @@ namespace API.Services.Tasks
             return CreateDto(update);
         }
 
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns></returns>
         public async Task<IEnumerable<UpdateNotificationDto>> GetAllReleases()
         {
             var updates = await GetGithubReleases();
@@ -140,13 +136,7 @@ namespace API.Services.Tasks
 
         private async Task SendEvent(UpdateNotificationDto update, IReadOnlyList<string> admins)
         {
-            var connections = new List<string>();
-            foreach (var admin in admins)
-            {
-                connections.AddRange(await _tracker.GetConnectionsForUser(admin));
-            }
-
-            await _messageHub.Clients.Users(admins).SendAsync(SignalREvents.UpdateVersion, MessageFactory.UpdateVersionEvent(update));
+            await _messageHub.Clients.Users(admins).SendAsync(SignalREvents.UpdateAvailable, MessageFactory.UpdateVersionEvent(update));
         }
 
 

--- a/API/SignalR/MessageFactory.cs
+++ b/API/SignalR/MessageFactory.cs
@@ -147,5 +147,19 @@ namespace API.SignalR
                 }
             };
         }
+
+        public static SignalRMessage DownloadProgressEvent(string username, string downloadName, float progress)
+        {
+            return new SignalRMessage()
+            {
+                Name = SignalREvents.DownloadProgress,
+                Body = new
+                {
+                    UserName = username,
+                    DownloadName = downloadName,
+                    Progress = progress
+                }
+            };
+        }
     }
 }

--- a/API/SignalR/MessageFactory.cs
+++ b/API/SignalR/MessageFactory.cs
@@ -118,7 +118,7 @@ namespace API.SignalR
         {
             return new SignalRMessage
             {
-                Name = SignalREvents.UpdateVersion,
+                Name = SignalREvents.UpdateAvailable,
                 Body = update
             };
         }
@@ -127,7 +127,7 @@ namespace API.SignalR
         {
             return new SignalRMessage
             {
-                Name = SignalREvents.UpdateVersion,
+                Name = SignalREvents.UpdateAvailable,
                 Body = new
                 {
                     TagId = tagId,

--- a/API/SignalR/SignalREvents.cs
+++ b/API/SignalR/SignalREvents.cs
@@ -27,5 +27,10 @@
         /// Event sent out during cleaning up temp and cache folders
         /// </summary>
         public const string CleanupProgress = "CleanupProgress";
+        /// <summary>
+        /// Event sent out during downloading of files
+        /// </summary>
+        public const string DownloadProgress = "DownloadProgress";
+
     }
 }

--- a/API/SignalR/SignalREvents.cs
+++ b/API/SignalR/SignalREvents.cs
@@ -2,7 +2,7 @@
 {
     public static class SignalREvents
     {
-        public const string UpdateVersion = "UpdateVersion";
+        public const string UpdateAvailable = "UpdateAvailable";
         public const string ScanSeries = "ScanSeries";
         /// <summary>
         /// Event during Refresh Metadata for cover image change

--- a/UI/Web/src/app/_services/action.service.ts
+++ b/UI/Web/src/app/_services/action.service.ts
@@ -23,6 +23,7 @@ export type VolumeActionCallback = (volume: Volume) => void;
 export type ChapterActionCallback = (chapter: Chapter) => void;
 export type ReadingListActionCallback = (readingList: ReadingList) => void;
 export type VoidActionCallback = () => void;
+export type BooleanActionCallback = (result: boolean) => void;
 
 /**
  * Responsible for executing actions
@@ -480,6 +481,22 @@ export class ActionService implements OnDestroy {
 
       if (callback) {
         callback();
+      }
+    });
+  }
+
+  async deleteSeries(series: Series, callback?: BooleanActionCallback) {
+    if (!await this.confirmService.confirm('Are you sure you want to delete this series? It will not modify files on disk.')) {
+      if (callback) {
+        callback(false);
+      }
+      return;
+    }
+
+    this.seriesService.delete(series.id).subscribe((res: boolean) => {
+      if (callback) {
+        this.toastr.success('Series deleted');
+        callback(res);
       }
     });
   }

--- a/UI/Web/src/app/_services/action.service.ts
+++ b/UI/Web/src/app/_services/action.service.ts
@@ -139,6 +139,9 @@ export class ActionService implements OnDestroy {
    */
   async refreshMetdata(series: Series, callback?: SeriesActionCallback) {
     if (!await this.confirmService.confirm('Refresh metadata will force all cover images and metadata to be recalculated. This is a heavy operation. Are you sure you don\'t want to perform a Scan instead?')) {
+      if (callback) {
+        callback(series);
+      }
       return;
     }
 

--- a/UI/Web/src/app/_services/message-hub.service.ts
+++ b/UI/Web/src/app/_services/message-hub.service.ts
@@ -39,7 +39,6 @@ export interface Message<T> {
 export class MessageHubService {
   hubUrl = environment.hubUrl;
   private hubConnection!: HubConnection;
-  private updateNotificationModalRef: NgbModalRef | null = null;
 
   private messagesSource = new ReplaySubject<Message<any>>(1);
   public messages$ = this.messagesSource.asObservable();
@@ -54,7 +53,7 @@ export class MessageHubService {
 
   isAdmin: boolean = false;
 
-  constructor(private modalService: NgbModal, private toastr: ToastrService, private router: Router) {
+  constructor(private toastr: ToastrService, private router: Router) {
     
   }
 
@@ -169,16 +168,6 @@ export class MessageHubService {
       this.messagesSource.next({
         event: EVENTS.UpdateAvailable,
         payload: resp.body
-      });
-      // Ensure only 1 instance of UpdateNotificationModal can be open at once
-      if (this.updateNotificationModalRef != null) { return; }
-      this.updateNotificationModalRef = this.modalService.open(UpdateNotificationModalComponent, { scrollable: true, size: 'lg' });
-      this.updateNotificationModalRef.componentInstance.updateData = resp.body;
-      this.updateNotificationModalRef.closed.subscribe(() => {
-        this.updateNotificationModalRef = null;
-      });
-      this.updateNotificationModalRef.dismissed.subscribe(() => {
-        this.updateNotificationModalRef = null;
       });
     });
   }

--- a/UI/Web/src/app/_services/message-hub.service.ts
+++ b/UI/Web/src/app/_services/message-hub.service.ts
@@ -24,7 +24,8 @@ export enum EVENTS {
   SeriesAddedToCollection = 'SeriesAddedToCollection',
   ScanLibraryError = 'ScanLibraryError',
   BackupDatabaseProgress = 'BackupDatabaseProgress',
-  CleanupProgress = 'CleanupProgress'
+  CleanupProgress = 'CleanupProgress',
+  DownloadProgress = 'DownloadProgress'
 }
 
 export interface Message<T> {
@@ -102,6 +103,13 @@ export class MessageHubService {
     this.hubConnection.on(EVENTS.CleanupProgress, resp => {
       this.messagesSource.next({
         event: EVENTS.CleanupProgress,
+        payload: resp.body
+      });
+    });
+
+    this.hubConnection.on(EVENTS.DownloadProgress, resp => {
+      this.messagesSource.next({
+        event: EVENTS.DownloadProgress,
         payload: resp.body
       });
     });

--- a/UI/Web/src/app/cards/series-card/series-card.component.ts
+++ b/UI/Web/src/app/cards/series-card/series-card.component.ts
@@ -132,35 +132,26 @@ export class SeriesCardComponent implements OnInit, OnChanges, OnDestroy {
     });
   }
 
-  refreshMetdata(series: Series) {
-    this.seriesService.refreshMetadata(series).subscribe((res: any) => {
-      this.toastr.success('Refresh started for ' + series.name);
-    });
+  async refreshMetdata(series: Series) {
+    this.actionService.refreshMetdata(series);
   }
 
-  scanLibrary(series: Series) {
+  async scanLibrary(series: Series) {
     this.seriesService.scan(series.libraryId, series.id).subscribe((res: any) => {
       this.toastr.success('Scan started for ' + series.name);
     });
   }
 
   async deleteSeries(series: Series) {
-    if (!await this.confirmService.confirm('Are you sure you want to delete this series? It will not modify files on disk.')) {
-      return;
-    }
-
-    this.seriesService.delete(series.id).subscribe((res: boolean) => {
-      if (res) {
-        this.toastr.success('Series deleted');
+    this.actionService.deleteSeries(series, (result: boolean) => {
+      if (result) {
         this.reload.emit(true);
       }
     });
   }
 
   markAsUnread(series: Series) {
-    this.seriesService.markUnread(series.id).subscribe(res => {
-      this.toastr.success(series.name + ' is now unread');
-      series.pagesRead = 0;
+    this.actionService.markSeriesAsUnread(series, () => {
       if (this.data) {
         this.data.pagesRead = 0;
       }
@@ -170,9 +161,7 @@ export class SeriesCardComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   markAsRead(series: Series) {
-    this.seriesService.markRead(series.id).subscribe(res => {
-      this.toastr.success(series.name + ' is now read');
-      series.pagesRead = series.pages;
+    this.actionService.markSeriesAsRead(series, () => {
       if (this.data) {
         this.data.pagesRead = series.pages;
       }

--- a/UI/Web/src/app/nav-events-toggle/nav-events-toggle.component.html
+++ b/UI/Web/src/app/nav-events-toggle/nav-events-toggle.component.html
@@ -14,7 +14,7 @@
                     <span class="sr-only">Scan for {{event.libraryName}} in progress</span>
                 </div>
                 {{prettyPrintProgress(event.progress)}}%
-                {{prettyPrintEvent(event.eventType)}} {{event.libraryName}}
+                {{prettyPrintEvent(event.eventType, event)}} {{event.libraryName}}
             </li>
             <li class="list-group-item dark-menu-item" *ngIf="progressEventsSource.getValue().length === 0">Not much going on here</li>
         </ul>

--- a/UI/Web/src/app/nav-events-toggle/nav-events-toggle.component.html
+++ b/UI/Web/src/app/nav-events-toggle/nav-events-toggle.component.html
@@ -1,6 +1,6 @@
 <ng-container>
     
-    <button type="button" class="btn btn-icon {{progressEventsSource.getValue().length > 0 ? 'colored' : ''}}" 
+    <button type="button" class="btn btn-icon {{(progressEventsSource.getValue().length > 0 || updateAvailable) ? 'colored' : ''}}" 
         [ngbPopover]="popContent" title="Activity" placement="bottom" [popoverClass]="'nav-events'">
         <i aria-hidden="true" class="fa fa-wave-square"></i>
     </button>
@@ -16,7 +16,10 @@
                 {{prettyPrintProgress(event.progress)}}%
                 {{prettyPrintEvent(event.eventType, event)}} {{event.libraryName}}
             </li>
-            <li class="list-group-item dark-menu-item" *ngIf="progressEventsSource.getValue().length === 0">Not much going on here</li>
+            <li class="list-group-item dark-menu-item" *ngIf="progressEventsSource.getValue().length === 0 && !updateAvailable">Not much going on here</li>
+            <li class="list-group-item dark-menu-item update-available" *ngIf="updateAvailable" (click)="handleUpdateAvailableClick()">
+                <i class="fa fa-chevron-circle-up" aria-hidden="true"></i>&nbsp;Update available
+            </li>
         </ul>
     </ng-template>
 </ng-container>

--- a/UI/Web/src/app/nav-events-toggle/nav-events-toggle.component.scss
+++ b/UI/Web/src/app/nav-events-toggle/nav-events-toggle.component.scss
@@ -21,3 +21,12 @@
     background-color: colors.$primary-color;
     border-radius: 60px;
 }
+
+.update-available {
+    cursor: pointer;
+    
+    i.fa {
+        color: colors.$primary-color !important;
+    }
+    color: colors.$primary-color;
+}

--- a/UI/Web/src/app/nav-events-toggle/nav-events-toggle.component.ts
+++ b/UI/Web/src/app/nav-events-toggle/nav-events-toggle.component.ts
@@ -16,6 +16,8 @@ interface ProcessedEvent {
 
 type ProgressType = EVENTS.ScanLibraryProgress | EVENTS.RefreshMetadataProgress | EVENTS.BackupDatabaseProgress | EVENTS.CleanupProgress;
 
+const acceptedEvents = [EVENTS.ScanLibraryProgress, EVENTS.RefreshMetadataProgress, EVENTS.BackupDatabaseProgress, EVENTS.CleanupProgress, EVENTS.DownloadProgress];
+
 @Component({
   selector: 'app-nav-events-toggle',
   templateUrl: './nav-events-toggle.component.html',
@@ -43,7 +45,7 @@ export class NavEventsToggleComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.messageHub.messages$.pipe(takeUntil(this.onDestroy)).subscribe(event => {
-      if (event.event === EVENTS.ScanLibraryProgress || event.event === EVENTS.RefreshMetadataProgress || event.event === EVENTS.BackupDatabaseProgress  || event.event === EVENTS.CleanupProgress) {
+      if (acceptedEvents.includes(event.event)) {
         this.processProgressEvent(event, event.event);
       }
     });
@@ -64,7 +66,7 @@ export class NavEventsToggleComponent implements OnInit, OnDestroy {
 
       if (scanEvent.progress !== 1) {
         const libraryName = names[scanEvent.libraryId] || '';
-        const newEvent = {eventType: eventType, timestamp: scanEvent.eventTime, progress: scanEvent.progress, libraryId: scanEvent.libraryId, libraryName};
+        const newEvent = {eventType: eventType, timestamp: scanEvent.eventTime, progress: scanEvent.progress, libraryId: scanEvent.libraryId, libraryName, rawBody: event.payload};
         data.push(newEvent);
       }
 
@@ -77,12 +79,13 @@ export class NavEventsToggleComponent implements OnInit, OnDestroy {
     return Math.trunc(progress * 100);
   }
 
-  prettyPrintEvent(eventType: string) {
+  prettyPrintEvent(eventType: string, event: any) {
     switch(eventType) {
       case (EVENTS.ScanLibraryProgress): return 'Scanning ';
       case (EVENTS.RefreshMetadataProgress): return 'Refreshing ';
       case (EVENTS.CleanupProgress): return 'Clearing Cache';
       case (EVENTS.BackupDatabaseProgress): return 'Backing up Database';
+      case (EVENTS.DownloadProgress): return event.rawBody.userName.charAt(0).toUpperCase() + event.rawBody.userName.substr(1) + ' is downloading ' + event.rawBody.downloadName;
       default: return eventType;
     }
   }

--- a/UI/Web/src/app/register-member/register-member.component.html
+++ b/UI/Web/src/app/register-member/register-member.component.html
@@ -12,8 +12,12 @@
     </div>
     
     <div class="form-group" *ngIf="registerForm.get('isAdmin')?.value || !authDisabled">
-        <label for="password">Password</label>
-        <input id="password" class="form-control" formControlName="password" type="password">
+        <label for="password">Password</label>&nbsp;<i class="fa fa-info-circle" placement="right" [ngbTooltip]="passwordTooltip" role="button" tabindex="0"></i>
+        <ng-template #passwordTooltip>
+            Password must be between 6 and 32 characters in length
+        </ng-template>
+        <span class="sr-only" id="password-help"><ng-container [ngTemplateOutlet]="passwordTooltip"></ng-container></span>
+        <input id="password" class="form-control" formControlName="password" type="password" aria-describedby="password-help">
     </div>
 
     <div class="form-check" *ngIf="!firstTimeFlow">

--- a/UI/Web/src/app/series-detail/series-detail.component.ts
+++ b/UI/Web/src/app/series-detail/series-detail.component.ts
@@ -302,17 +302,11 @@ export class SeriesDetailComponent implements OnInit, OnDestroy {
 
 
   async deleteSeries(series: Series) {
-    if (!await this.confirmService.confirm('Are you sure you want to delete this series? It will not modify files on disk.')) {
+    this.actionService.deleteSeries(series, (result: boolean) => {
       this.actionInProgress = false;
-      return;
-    }
-
-    this.seriesService.delete(series.id).subscribe((res: boolean) => {
-      if (res) {
-        this.toastr.success('Series deleted');
+      if (result) {
         this.router.navigate(['library', this.libraryId]);
       }
-      this.actionInProgress = false;
     });
   }
 

--- a/UI/Web/src/app/shared/shared.module.ts
+++ b/UI/Web/src/app/shared/shared.module.ts
@@ -1,7 +1,7 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule } from '@angular/forms';
-import { NgbCollapseModule } from '@ng-bootstrap/ng-bootstrap';
+import { NgbCollapseModule, NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
 import { ConfirmDialogComponent } from './confirm-dialog/confirm-dialog.component';
 import { SafeHtmlPipe } from './safe-html.pipe';
 import { RegisterMemberComponent } from '../register-member/register-member.component';
@@ -37,6 +37,7 @@ import { SentenceCasePipe } from './sentence-case.pipe';
     RouterModule,
     ReactiveFormsModule,
     NgbCollapseModule,
+    NgbTooltipModule, // RegisterMemberComponent
     NgCircleProgressModule.forRoot(),
   ],
   exports: [


### PR DESCRIPTION
# Added
- Added: When a user is downloading files from Kavita, the events widget will now show those events (Closes #798, Closes #794 )
- Added: Version updates are now pushed to the events widget and allow the user take action from there (Closes #798)
- Added: Password requirements are now shown on register form in a tooltip (Closes #804)

# Changed
- Changed: Password requirements are now relaxed, only requiring  6-32 characters. 

# Fixed
- Fixed: Fixed a bug where weekly checks for new versions would not send the correct name to the UI, thus the modal was not opened.
- Fixed: Fixed a bug where OPDS pagination would send the incorrect number of entities on the feed, making the last page impossible to get to. (Fixes #805)
