### PR TITLE
64-bit ARM PDF Support

### DIFF
--- a/API/API.csproj
+++ b/API/API.csproj
@@ -37,7 +37,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
-    <PackageReference Include="Docnet.Core" Version="2.4.0-alpha.1" />
+    <PackageReference Include="Docnet.Core" Version="2.4.0-alpha.2" />
     <PackageReference Include="ExCSS" Version="4.1.0" />
     <PackageReference Include="Flurl" Version="3.0.2" />
     <PackageReference Include="Flurl.Http" Version="3.2.0" />


### PR DESCRIPTION
# Fixed
- Fixed: 64bit ARM installs will now be able to read PDF files (Fixes #712). Thanks @ChristofferGreen again for the help.
