### PR TITLE
Misc Fixes

### DIFF
--- a/API.Tests/Comparers/NaturalSortComparerTest.cs
+++ b/API.Tests/Comparers/NaturalSortComparerTest.cs
@@ -46,6 +46,14 @@ namespace API.Tests.Comparers
             new[] {"Solo Leveling - c000 (v01) - p000 [Cover] [dig] [Yen Press] [LuCaZ].jpg", "Solo Leveling - c000 (v01) - p001 [dig] [Yen Press] [LuCaZ].jpg", "Solo Leveling - c000 (v01) - p002 [dig] [Yen Press] [LuCaZ].jpg", "Solo Leveling - c000 (v01) - p003 [dig] [Yen Press] [LuCaZ].jpg"},
             new[] {"Solo Leveling - c000 (v01) - p000 [Cover] [dig] [Yen Press] [LuCaZ].jpg", "Solo Leveling - c000 (v01) - p001 [dig] [Yen Press] [LuCaZ].jpg", "Solo Leveling - c000 (v01) - p002 [dig] [Yen Press] [LuCaZ].jpg", "Solo Leveling - c000 (v01) - p003 [dig] [Yen Press] [LuCaZ].jpg"}
         )]
+        [InlineData(
+            new[] {"Marvel2In1-7", "Marvel2In1-7-01", "Marvel2In1-7-02"},
+            new[] {"Marvel2In1-7", "Marvel2In1-7-01", "Marvel2In1-7-02"}
+        )]
+        [InlineData(
+            new[] {"!001", "001", "002"},
+            new[] {"!001", "001", "002"}
+        )]
         public void TestNaturalSortComparer(string[] input, string[] expected)
         {
             Array.Sort(input, _nc);

--- a/API.Tests/Comparers/NaturalSortComparerTest.cs
+++ b/API.Tests/Comparers/NaturalSortComparerTest.cs
@@ -40,7 +40,7 @@ namespace API.Tests.Comparers
         )]
         [InlineData(
             new[] {"3and4.cbz", "The World God Only Knows - Oneshot.cbz", "5.cbz", "1and2.cbz"},
-            new[] {"1and2.cbz", "3and4.cbz", "5.cbz", "The World God Only Knows - Oneshot.cbz"}
+            new[] {"The World God Only Knows - Oneshot.cbz", "1and2.cbz", "3and4.cbz", "5.cbz"}
         )]
         [InlineData(
             new[] {"Solo Leveling - c000 (v01) - p000 [Cover] [dig] [Yen Press] [LuCaZ].jpg", "Solo Leveling - c000 (v01) - p001 [dig] [Yen Press] [LuCaZ].jpg", "Solo Leveling - c000 (v01) - p002 [dig] [Yen Press] [LuCaZ].jpg", "Solo Leveling - c000 (v01) - p003 [dig] [Yen Press] [LuCaZ].jpg"},
@@ -57,13 +57,7 @@ namespace API.Tests.Comparers
         public void TestNaturalSortComparer(string[] input, string[] expected)
         {
             Array.Sort(input, _nc);
-
-            var i = 0;
-            foreach (var s in input)
-            {
-                Assert.Equal(s, expected[i]);
-                i++;
-            }
+            Assert.Equal(expected, input);
         }
 
 

--- a/API.Tests/Extensions/PathExtensionsTests.cs
+++ b/API.Tests/Extensions/PathExtensionsTests.cs
@@ -1,0 +1,20 @@
+﻿using System.IO;
+using Xunit;
+using API.Extensions;
+
+namespace API.Tests.Extensions;
+
+public class PathExtensionsTests
+{
+    #region GetFullPathWithoutExtension
+
+    [Theory]
+    [InlineData("joe.png", "joe")]
+    [InlineData("c:/directory/joe.png", "c:/directory/joe")]
+    public void GetFullPathWithoutExtension_Test(string input, string expected)
+    {
+        Assert.Equal(Path.GetFullPath(expected), input.GetFullPathWithoutExtension());
+    }
+
+    #endregion
+}

--- a/API.Tests/Parser/ComicParserTests.cs
+++ b/API.Tests/Parser/ComicParserTests.cs
@@ -76,6 +76,7 @@ namespace API.Tests.Parser
         [InlineData("Conquistador_-Tome_2", "Conquistador")]
         [InlineData("Max_l_explorateur-_Tome_0", "Max l explorateur")]
         [InlineData("Chevaliers d'Héliopolis T3 - Rubedo, l'oeuvre au rouge (Jodorowsky & Jérémy)", "Chevaliers d'Héliopolis")]
+        [InlineData("Bd Fr-Aldebaran-Antares-t6", "Aldebaran-Antares")]
         public void ParseComicSeriesTest(string filename, string expected)
         {
             Assert.Equal(expected, API.Parser.Parser.ParseComicSeries(filename));
@@ -175,6 +176,10 @@ namespace API.Tests.Parser
         [InlineData("Zombie Tramp vs. Vampblade TPB (2016) (Digital) (TheArchivist-Empire)", true)]
         [InlineData("Baldwin the Brave & Other Tales Special SP1.cbr", true)]
         [InlineData("Mouse Guard Specials - Spring 1153 - Fraggle Rock FCBD 2010", true)]
+        [InlineData("Boule et Bill - THS -Bill à disparu", true)]
+        [InlineData("Asterix - HS - Les 12 travaux d'Astérix", true)]
+        [InlineData("Sillage Hors Série - Le Collectionneur - Concordance-DKFR", true)]
+        [InlineData("laughs", false)]
         public void ParseComicSpecialTest(string input, bool expected)
         {
             Assert.Equal(expected, !string.IsNullOrEmpty(API.Parser.Parser.ParseComicSpecial(input)));

--- a/API.Tests/Parser/ComicParserTests.cs
+++ b/API.Tests/Parser/ComicParserTests.cs
@@ -70,6 +70,12 @@ namespace API.Tests.Parser
         [InlineData("Green Lantern v2 017 - The Spy-Eye that doomed Green Lantern v2", "Green Lantern")]
         [InlineData("Green Lantern - Circle of Fire Special - Adam Strange (2000)", "Green Lantern - Circle of Fire  - Adam Strange")]
         [InlineData("Identity Crisis Extra - Rags Morales Sketches (2005)", "Identity Crisis  - Rags Morales Sketches")]
+        [InlineData("Daredevil - t6 - 10 - (2019)", "Daredevil")]
+        [InlineData("Batgirl T2000 #57", "Batgirl")]
+        [InlineData("Teen Titans t1 001 (1966-02) (digital) (OkC.O.M.P.U.T.O.-Novus)", "Teen Titans")]
+        [InlineData("Conquistador_-Tome_2", "Conquistador")]
+        [InlineData("Max_l_explorateur-_Tome_0", "Max l explorateur")]
+        [InlineData("Chevaliers d'Héliopolis T3 - Rubedo, l'oeuvre au rouge (Jodorowsky & Jérémy)", "Chevaliers d'Héliopolis")]
         public void ParseComicSeriesTest(string filename, string expected)
         {
             Assert.Equal(expected, API.Parser.Parser.ParseComicSeries(filename));
@@ -108,6 +114,13 @@ namespace API.Tests.Parser
         [InlineData("Cyberpunk 2077 - Trauma Team 04.cbz", "0")]
         [InlineData("2000 AD 0366 [1984-04-28] (flopbie)", "0")]
         [InlineData("Daredevil - v6 - 10 - (2019)", "6")]
+        // Tome Tests
+        [InlineData("Daredevil - t6 - 10 - (2019)", "6")]
+        [InlineData("Batgirl T2000 #57", "2000")]
+        [InlineData("Teen Titans t1 001 (1966-02) (digital) (OkC.O.M.P.U.T.O.-Novus)", "1")]
+        [InlineData("Conquistador_Tome_2", "2")]
+        [InlineData("Max_l_explorateur-_Tome_0", "0")]
+        [InlineData("Chevaliers d'Héliopolis T3 - Rubedo, l'oeuvre au rouge (Jodorowsky & Jérémy)", "3")]
         public void ParseComicVolumeTest(string filename, string expected)
         {
             Assert.Equal(expected, API.Parser.Parser.ParseComicVolume(filename));

--- a/API.Tests/Parser/DefaultParserTests.cs
+++ b/API.Tests/Parser/DefaultParserTests.cs
@@ -28,6 +28,7 @@ public class DefaultParserTests
     [InlineData("C:/", "C:/Love Hina/Love Hina - Special.cbz", "Love Hina")]
     [InlineData("C:/", "C:/Love Hina/Specials/Ani-Hina Art Collection.cbz", "Love Hina")]
     [InlineData("C:/", "C:/Mujaki no Rakuen Something/Mujaki no Rakuen Vol12 ch76.cbz", "Mujaki no Rakuen")]
+    [InlineData("C:/", "C:/Something Random/Mujaki no Rakuen SP01.cbz", "Something Random")]
     public void ParseFromFallbackFolders_FallbackShouldParseSeries(string rootDir, string inputPath, string expectedSeries)
     {
         var actual = _defaultParser.Parse(inputPath, rootDir);

--- a/API.Tests/Parser/MangaParserTests.cs
+++ b/API.Tests/Parser/MangaParserTests.cs
@@ -168,6 +168,7 @@ namespace API.Tests.Parser
         [InlineData("[Renzokusei]_Kimi_wa_Midara_na_Boku_no_Joou_Ch5_Final_Chapter", "Kimi wa Midara na Boku no Joou")]
         [InlineData("Battle Royale, v01 (2000) [TokyoPop] [Manga-Sketchbook]", "Battle Royale")]
         [InlineData("Kaiju No. 8 036 (2021) (Digital)", "Kaiju No. 8")]
+        [InlineData("Seraph of the End - Vampire Reign 093  (2020) (Digital) (LuCaZ).cbz", "Seraph of the End - Vampire Reign")]
         public void ParseSeriesTest(string filename, string expected)
         {
             Assert.Equal(expected, API.Parser.Parser.ParseSeries(filename));

--- a/API.Tests/Parser/MangaParserTests.cs
+++ b/API.Tests/Parser/MangaParserTests.cs
@@ -167,6 +167,7 @@ namespace API.Tests.Parser
         [InlineData("Great_Teacher_Onizuka_v16[TheSpectrum]", "Great Teacher Onizuka")]
         [InlineData("[Renzokusei]_Kimi_wa_Midara_na_Boku_no_Joou_Ch5_Final_Chapter", "Kimi wa Midara na Boku no Joou")]
         [InlineData("Battle Royale, v01 (2000) [TokyoPop] [Manga-Sketchbook]", "Battle Royale")]
+        [InlineData("Kaiju No. 8 036 (2021) (Digital)", "Kaiju No. 8")]
         public void ParseSeriesTest(string filename, string expected)
         {
             Assert.Equal(expected, API.Parser.Parser.ParseSeries(filename));
@@ -240,6 +241,7 @@ namespace API.Tests.Parser
         [InlineData("Deku_&_Bakugo_-_Rising_v1_c1.1.cbz", "1.1")]
         [InlineData("Chapter 63 - The Promise Made for 520 Cenz.cbr", "63")]
         [InlineData("Harrison, Kim - The Good, The Bad, and the Undead - Hollows Vol 2.5.epub", "0")]
+        [InlineData("Kaiju No. 8 036 (2021) (Digital)", "36")]
         public void ParseChaptersTest(string filename, string expected)
         {
             Assert.Equal(expected, API.Parser.Parser.ParseChapter(filename));

--- a/API.Tests/Parser/ParserTest.cs
+++ b/API.Tests/Parser/ParserTest.cs
@@ -49,6 +49,8 @@ namespace API.Tests.Parser
         [InlineData("Hello_I_am_here   ",  false, "Hello I am here")]
         [InlineData("[ReleaseGroup] The Title", false, "The Title")]
         [InlineData("[ReleaseGroup]_The_Title", false, "The Title")]
+        [InlineData("-The Title", false, "The Title")]
+        [InlineData("- The Title", false, "The Title")]
         [InlineData("[Suihei Kiki]_Kasumi_Otoko_no_Ko_[Taruby]_v1.1", false, "Kasumi Otoko no Ko v1.1")]
         [InlineData("Batman - Detective Comics - Rebirth Deluxe Edition Book 04 (2019) (digital) (Son of Ultron-Empire)", true, "Batman - Detective Comics - Rebirth Deluxe Edition")]
         public void CleanTitleTest(string input, bool isComic, string expected)

--- a/API/Comparators/NaturalSortComparer.cs
+++ b/API/Comparators/NaturalSortComparer.cs
@@ -44,17 +44,18 @@ namespace API.Comparators
             for (var i = 0; i < x1.Length && i < y1.Length; i++)
             {
                 if (x1[i] == y1[i]) continue;
+                if (x1[i] == Empty || y1[i] == Empty) continue;
                 returnVal = PartCompare(x1[i], y1[i]);
                 return _isAscending ? returnVal : -returnVal;
             }
 
             if (y1.Length > x1.Length)
             {
-                returnVal = 1;
+                returnVal = -1;
             }
             else if (x1.Length > y1.Length)
             {
-                returnVal = -1;
+                returnVal = 1;
             }
             else
             {

--- a/API/Data/Metadata/ComicInfo.cs
+++ b/API/Data/Metadata/ComicInfo.cs
@@ -74,6 +74,7 @@ namespace API.Data.Metadata
 
         public static AgeRating ConvertAgeRatingToEnum(string value)
         {
+            if (string.IsNullOrEmpty(value)) return Entities.Enums.AgeRating.Unknown;
             return Enum.GetValues<AgeRating>()
                 .SingleOrDefault(t => t.ToDescription().ToUpperInvariant().Equals(value.ToUpperInvariant()), Entities.Enums.AgeRating.Unknown);
         }

--- a/API/Extensions/PathExtensions.cs
+++ b/API/Extensions/PathExtensions.cs
@@ -1,0 +1,13 @@
+﻿using System.IO;
+
+namespace API.Extensions;
+
+public static class PathExtensions
+{
+    public static string GetFullPathWithoutExtension(this string filepath)
+    {
+        if (string.IsNullOrEmpty(filepath)) return filepath;
+        var extension = Path.GetExtension(filepath);
+        return Path.GetFullPath(filepath.Replace(extension, string.Empty));
+    }
+}

--- a/API/Parser/Parser.cs
+++ b/API/Parser/Parser.cs
@@ -409,7 +409,7 @@ namespace API.Parser
                 MatchOptions, RegexTimeout),
             // Hinowa ga CRUSH! 018 (2019) (Digital) (LuCaZ).cbz, Hinowa ga CRUSH! 018.5 (2019) (Digital) (LuCaZ).cbz
             new Regex(
-                @"^(?!Vol)(?<Series>.+?)(?<!Vol)\.?\s(?<Chapter>\d+(?:.\d+|-\d+)?)(?:\s\(\d{4}\))?(\b|_|-)",
+                @"^(?!Vol)(?<Series>.+?)(?<!Vol)\.?\s(\d\s)?(?<Chapter>\d+(?:\.\d+|-\d+)?)(?:\s\(\d{4}\))?(\b|_|-)",
                 MatchOptions, RegexTimeout),
             // Tower Of God S01 014 (CBT) (digital).cbz
             new Regex(

--- a/API/Parser/Parser.cs
+++ b/API/Parser/Parser.cs
@@ -240,7 +240,7 @@ namespace API.Parser
         {
             // Invincible Vol 01 Family matters (2005) (Digital)
             new Regex(
-                @"(?<Series>.*)(\b|_)(vol\.?)( |_)(?<Volume>\d+(-\d+)?)",
+                @"(?<Series>.*)(\b|_)((vol|tome|t)\.?)( |_)(?<Volume>\d+(-\d+)?)",
                 MatchOptions, RegexTimeout),
             // Batman Beyond 2.0 001 (2013)
             new Regex(
@@ -260,7 +260,7 @@ namespace API.Parser
                 MatchOptions, RegexTimeout),
             // Teen Titans v1 001 (1966-02) (digital) (OkC.O.M.P.U.T.O.-Novus)
             new Regex(
-                @"^(?<Series>.+?)(?: |_)v\d+",
+                @"^(?<Series>.+?)(?: |_)(v|t)\d+",
                 MatchOptions, RegexTimeout),
             // Amazing Man Comics chapter 25
             new Regex(
@@ -308,11 +308,11 @@ namespace API.Parser
         {
             // Teen Titans v1 001 (1966-02) (digital) (OkC.O.M.P.U.T.O.-Novus)
             new Regex(
-                @"^(?<Series>.*)(?: |_)v(?<Volume>\d+)",
+                @"^(?<Series>.*)(?: |_)(t|v)(?<Volume>\d+)",
                 MatchOptions, RegexTimeout),
             // Batgirl Vol.2000 #57 (December, 2004)
             new Regex(
-                @"^(?<Series>.+?)(?:\s|_)vol\.?\s?(?<Volume>\d+)",
+                @"^(?<Series>.+?)(?:\s|_)(v|vol|tome|t)\.?(\s|_)?(?<Volume>\d+)",
                 MatchOptions, RegexTimeout),
         };
 

--- a/API/Parser/Parser.cs
+++ b/API/Parser/Parser.cs
@@ -166,7 +166,7 @@ namespace API.Parser
                 MatchOptions, RegexTimeout),
             // Hinowa ga CRUSH! 018 (2019) (Digital) (LuCaZ).cbz
             new Regex(
-                @"(?<Series>.*) (?<Chapter>\d+) (?:\(\d{4}\)) ",
+                @"(?<Series>.*)\s+(?<Chapter>\d+)\s+(?:\(\d{4}\))\s",
                 MatchOptions, RegexTimeout),
             // Goblin Slayer - Brand New Day 006.5 (2019) (Digital) (danke-Empire)
             new Regex(
@@ -209,7 +209,6 @@ namespace API.Parser
             new Regex(
                 @"^(?!Vol\.?)(?<Series>.*)( |_|-)(?<!-)(episode|chapter|(ch\.?) ?)\d+-?\d*",
                 MatchOptions, RegexTimeout),
-
             // Baketeriya ch01-05.zip
             new Regex(
                 @"^(?!Vol)(?<Series>.*)ch\d+-?\d?",

--- a/API/Parser/ParserInfo.cs
+++ b/API/Parser/ParserInfo.cs
@@ -48,6 +48,7 @@ namespace API.Parser
         /// <summary>
         /// This can potentially story things like "Omnibus, Color, Full Contact Edition, Extra, Final, etc"
         /// </summary>
+        /// <remarks>Not Used in Database</remarks>
         public string Edition { get; set; } = "";
 
         /// <summary>
@@ -70,10 +71,6 @@ namespace API.Parser
             return (IsSpecial || (Volumes == "0" && Chapters == "0"));
         }
 
-        // (TODO: Make this a ValueType). Has at least 1 year, maybe 2 representing a range
-        // public string YearRange { get; set; }
-        // public IList<string> Genres { get; set; } = new List<string>();
-
         /// <summary>
         /// This will contain any EXTRA comicInfo information parsed from the epub or archive. If there is an archive with comicInfo.xml AND it contains
         /// series, volume information, that will override what we parsed.
@@ -93,6 +90,7 @@ namespace API.Parser
             Title = string.IsNullOrEmpty(Title) ? info2.Title : Title;
             Series = string.IsNullOrEmpty(Series) ? info2.Series : Series;
             IsSpecial = IsSpecial || info2.IsSpecial;
+            // TODO: Merge ComicInfos?
         }
     }
 }

--- a/API/Services/ArchiveService.cs
+++ b/API/Services/ArchiveService.cs
@@ -497,10 +497,10 @@ namespace API.Services
                         break;
                     }
                     case ArchiveLibrary.NotSupported:
-                        _logger.LogWarning("[ExtractArchive] This archive cannot be read: {ArchivePath}. Defaulting to 0 pages", archivePath);
+                        _logger.LogWarning("[ExtractArchive] This archive cannot be read: {ArchivePath}", archivePath);
                         return;
                     default:
-                        _logger.LogWarning("[ExtractArchive] There was an exception when reading archive stream: {ArchivePath}. Defaulting to 0 pages", archivePath);
+                        _logger.LogWarning("[ExtractArchive] There was an exception when reading archive stream: {ArchivePath}", archivePath);
                         return;
                 }
 

--- a/API/Services/CacheService.cs
+++ b/API/Services/CacheService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -169,7 +170,9 @@ namespace API.Services
             // Calculate what chapter the page belongs to
             var path = GetCachePath(chapter.Id);
             var files = _directoryService.GetFilesWithExtension(path, Parser.Parser.ImageFileExtensions);
-            Array.Sort(files, _numericComparer);
+            using var nc = new NaturalSortComparer();
+            files = files.ToList().OrderBy(Path.GetFileNameWithoutExtension, nc).ToArray();
+
 
             if (files.Length == 0)
             {

--- a/API/Services/DirectoryService.cs
+++ b/API/Services/DirectoryService.cs
@@ -677,7 +677,8 @@ namespace API.Services
             {
                 var fileIndex = 1;
 
-                foreach (var file in directory.EnumerateFiles().OrderBy(file => file.FullName, new NaturalSortComparer()))
+                using var nc = new NaturalSortComparer();
+                foreach (var file in directory.EnumerateFiles().OrderBy(file => file.FullName, nc))
                 {
                     if (file.Directory == null) continue;
                     var paddedIndex = Parser.Parser.PadZeros(directoryIndex + "");

--- a/API/Services/ImageService.cs
+++ b/API/Services/ImageService.cs
@@ -78,8 +78,9 @@ public class ImageService : IImageService
             return null;
         }
 
+        using var nc = new NaturalSortComparer();
         var firstImage = _directoryService.GetFilesWithExtension(directory, Parser.Parser.ImageFileExtensions)
-            .OrderBy(f => f, new NaturalSortComparer()).FirstOrDefault();
+            .OrderBy(Path.GetFileNameWithoutExtension, nc).FirstOrDefault();
 
         return firstImage;
     }

--- a/API/Services/MetadataService.cs
+++ b/API/Services/MetadataService.cs
@@ -237,13 +237,6 @@ public class MetadataService : IMetadataService
         if (comicInfo == null) return;
 
 
-        // Summary Info
-        if (!string.IsNullOrEmpty(comicInfo.Summary))
-        {
-            // PERF: I can move this to the bottom as I have a comicInfo selection, save me an extra read
-            series.Metadata.Summary = comicInfo.Summary;
-        }
-
         foreach (var chapter in series.Volumes.SelectMany(volume => volume.Chapters))
         {
             PersonHelper.UpdatePeople(allPeople, chapter.People.Where(p => p.Role == PersonRole.Writer).Select(p => p.Name), PersonRole.Writer,
@@ -282,6 +275,12 @@ public class MetadataService : IMetadataService
             .ToList();
 
         //var firstComicInfo = comicInfos.First(i => i.)
+        // Summary Info
+        if (!string.IsNullOrEmpty(comicInfo.Summary))
+        {
+            // PERF: I can move this to the bottom as I have a comicInfo selection, save me an extra read
+            series.Metadata.Summary = comicInfo.Summary;
+        }
 
         // Set the AgeRating as highest in all the comicInfos
         series.Metadata.AgeRating = comicInfos.Max(i => ComicInfo.ConvertAgeRatingToEnum(comicInfo.AgeRating));

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -430,12 +430,6 @@ public class ScannerService : IScannerService
             newSeries.Count, stopwatch.ElapsedMilliseconds, library.Name);
     }
 
-    // private static bool FindSeries(Series series, ParsedSeries parsedInfoKey)
-    // {
-    //     return (series.NormalizedName.Equals(parsedInfoKey.NormalizedName) || Parser.Parser.Normalize(series.OriginalName).Equals(parsedInfoKey.NormalizedName))
-    //            && (series.Format == parsedInfoKey.Format || series.Format == MangaFormat.Unknown);
-    // }
-
     private void UpdateSeries(Series series, Dictionary<ParsedSeries, List<ParserInfo>> parsedSeries)
     {
         try

--- a/UI/Web/src/app/cards/series-card/series-card.component.ts
+++ b/UI/Web/src/app/cards/series-card/series-card.component.ts
@@ -109,6 +109,9 @@ export class SeriesCardComponent implements OnInit, OnChanges, OnDestroy {
       case(Action.AddToReadingList):
         this.actionService.addSeriesToReadingList(series, (series) => {/* No Operation */ });
         break;
+      case(Action.AddToCollection):
+        this.actionService.addMultipleSeriesToCollectionTag([series], () => {/* No Operation */ });
+        break;
       default:
         break;
     }

--- a/global.json
+++ b/global.json
@@ -2,6 +2,6 @@
   "sdk": {
     "version": "6.0",
     "rollForward": "latestMajor",
-    "allowPrerelease": true
+    "allowPrerelease": false
   }
 }


### PR DESCRIPTION
# Added
- Added: Kavita now includes parsing support for European comics with Tome notation and HS identification. In addition, Br Fr will be cleaned out of titles. (Closes #835)

# Changed
- Changed: From filename parsing, if a series starts with - or , Kavita will clean it out
- Changed: Refactored natural sort order to behave closer to how Windows works (Fixes #783 )

# Fixed
- Fixed: Fixed a case where chapter was being parsed incorrectly when the series title ends in a number. (Fixes #787 )
- Fixed: Fixed an issue where add to collection for a single series wasn't calling the handler (Fixes #808)
- Fixed: Fixed a crash when a comicinfo.xml did not include an AgeRating field
- Fixed: Fixed an issue where when looking for cover image, the file extension would throw off sorting code (Fixes #837 )
- Fixed: Fixed a rare issue where when reading manga, the code that picks the files in order would choose the wrong one due to OS sorting discrepancies. Now Kavita uses natural sort order as well.
- Fixed: Updated parser to handle a case where there was more than one space as a separator (Fixes #813)
