### PR TITLE
More Filtering and Support for ComicInfo v2.1 (draft) Tags

### DIFF
--- a/API.Tests/Helpers/TagHelperTests.cs
+++ b/API.Tests/Helpers/TagHelperTests.cs
@@ -1,0 +1,119 @@
+﻿using System.Collections.Generic;
+using API.Data;
+using API.Entities;
+using API.Helpers;
+using Xunit;
+
+namespace API.Tests.Helpers;
+
+public class TagHelperTests
+{
+    [Fact]
+    public void UpdateTag_ShouldAddNewTag()
+    {
+        var allTags = new List<Tag>
+        {
+            DbFactory.Tag("Action", false),
+            DbFactory.Tag("action", false),
+            DbFactory.Tag("Sci-fi", false),
+        };
+        var tagAdded = new List<Tag>();
+
+        TagHelper.UpdateTag(allTags, new[] {"Action", "Adventure"}, false, (tag, added) =>
+        {
+            if (added)
+            {
+                tagAdded.Add(tag);
+            }
+
+        });
+
+        Assert.Equal(1, tagAdded.Count);
+        Assert.Equal(4, allTags.Count);
+    }
+
+    [Fact]
+    public void UpdateTag_ShouldNotAddDuplicateTag()
+    {
+        var allTags = new List<Tag>
+        {
+            DbFactory.Tag("Action", false),
+            DbFactory.Tag("action", false),
+            DbFactory.Tag("Sci-fi", false),
+
+        };
+        var tagAdded = new List<Tag>();
+
+        TagHelper.UpdateTag(allTags, new[] {"Action", "Scifi"}, false, (tag, added) =>
+        {
+            if (added)
+            {
+                tagAdded.Add(tag);
+            }
+            TagHelper.AddTagIfNotExists(allTags, tag);
+        });
+
+        Assert.Equal(3, allTags.Count);
+        Assert.Empty(tagAdded);
+    }
+
+    [Fact]
+    public void AddTag_ShouldAddOnlyNonExistingTag()
+    {
+        var existingTags = new List<Tag>
+        {
+            DbFactory.Tag("Action", false),
+            DbFactory.Tag("action", false),
+            DbFactory.Tag("Sci-fi", false),
+        };
+
+
+        TagHelper.AddTagIfNotExists(existingTags, DbFactory.Tag("Action", false));
+        Assert.Equal(3, existingTags.Count);
+
+        TagHelper.AddTagIfNotExists(existingTags, DbFactory.Tag("action", false));
+        Assert.Equal(3, existingTags.Count);
+
+        TagHelper.AddTagIfNotExists(existingTags, DbFactory.Tag("Shonen", false));
+        Assert.Equal(4, existingTags.Count);
+    }
+
+    [Fact]
+    public void AddTag_ShouldNotAddSameNameAndExternal()
+    {
+        var existingTags = new List<Tag>
+        {
+            DbFactory.Tag("Action", false),
+            DbFactory.Tag("action", false),
+            DbFactory.Tag("Sci-fi", false),
+        };
+
+
+        TagHelper.AddTagIfNotExists(existingTags, DbFactory.Tag("Action", true));
+        Assert.Equal(3, existingTags.Count);
+    }
+
+    [Fact]
+    public void KeepOnlySamePeopleBetweenLists()
+    {
+        var existingTags = new List<Tag>
+        {
+            DbFactory.Tag("Action", false),
+            DbFactory.Tag("Sci-fi", false),
+        };
+
+        var peopleFromChapters = new List<Tag>
+        {
+            DbFactory.Tag("Action", false),
+        };
+
+        var tagRemoved = new List<Tag>();
+        TagHelper.KeepOnlySameTagBetweenLists(existingTags,
+            peopleFromChapters, tag =>
+            {
+                tagRemoved.Add(tag);
+            });
+
+        Assert.Equal(1, tagRemoved.Count);
+    }
+}

--- a/API/Controllers/MetadataController.cs
+++ b/API/Controllers/MetadataController.cs
@@ -1,9 +1,12 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using API.Data;
 using API.DTOs;
 using API.DTOs.Metadata;
+using API.Entities.Enums;
+using Kavita.Common.Extensions;
 using Microsoft.AspNetCore.Mvc;
 
 namespace API.Controllers;
@@ -65,5 +68,26 @@ public class MetadataController : BaseApiController
             return Ok(await _unitOfWork.TagRepository.GetAllTagDtosForLibrariesAsync(ids));
         }
         return Ok(await _unitOfWork.TagRepository.GetAllTagDtosAsync());
+    }
+
+    /// <summary>
+    /// Fetches all age ratings from the instance
+    /// </summary>
+    /// <param name="libraryIds">String separated libraryIds or null for all ratings</param>
+    /// <returns></returns>
+    [HttpGet("age-ratings")]
+    public async Task<ActionResult<IList<AgeRatingDto>>> GetAllAgeRatings(string? libraryIds)
+    {
+        var ids = libraryIds?.Split(",").Select(int.Parse).ToList();
+        if (ids != null && ids.Count > 0)
+        {
+            return Ok(await _unitOfWork.SeriesRepository.GetAllAgeRatingsDtosForLibrariesAsync(ids));
+        }
+
+        return Ok(Enum.GetValues<AgeRating>().Select(t => new AgeRatingDto()
+        {
+            Title = t.ToDescription(),
+            Value = t
+        }));
     }
 }

--- a/API/Controllers/MetadataController.cs
+++ b/API/Controllers/MetadataController.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using API.Data;
 using API.DTOs;
+using API.DTOs.Filtering;
 using API.DTOs.Metadata;
 using API.Entities.Enums;
 using Kavita.Common.Extensions;
@@ -89,5 +91,29 @@ public class MetadataController : BaseApiController
             Title = t.ToDescription(),
             Value = t
         }));
+    }
+
+    /// <summary>
+    /// Fetches all age ratings from the instance
+    /// </summary>
+    /// <param name="libraryIds">String separated libraryIds or null for all ratings</param>
+    /// <returns></returns>
+    [HttpGet("languages")]
+    public async Task<ActionResult<IList<LanguageDto>>> GetAllLanguages(string? libraryIds)
+    {
+        var ids = libraryIds?.Split(",").Select(int.Parse).ToList();
+        if (ids != null && ids.Count > 0)
+        {
+            return Ok(await _unitOfWork.SeriesRepository.GetAllLanguagesForLibrariesAsync(ids));
+        }
+
+        return Ok(new List<LanguageDto>()
+        {
+            new ()
+            {
+                Title = CultureInfo.GetCultureInfo("en").DisplayName,
+                IsoCode = "en"
+            }
+        });
     }
 }

--- a/API/Controllers/MetadataController.cs
+++ b/API/Controllers/MetadataController.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using API.Data;
 using API.DTOs;
@@ -17,15 +18,36 @@ public class MetadataController : BaseApiController
         _unitOfWork = unitOfWork;
     }
 
+    /// <summary>
+    /// Fetches genres from the instance
+    /// </summary>
+    /// <param name="libraryIds">String separated libraryIds or null for all genres</param>
+    /// <returns></returns>
     [HttpGet("genres")]
-    public async Task<ActionResult<IList<GenreTagDto>>> GetAllGenres()
+    public async Task<ActionResult<IList<GenreTagDto>>> GetAllGenres(string? libraryIds)
     {
+        var ids = libraryIds?.Split(",").Select(int.Parse).ToList();
+        if (ids != null && ids.Count > 0)
+        {
+            return Ok(await _unitOfWork.GenreRepository.GetAllGenreDtosForLibrariesAsync(ids));
+        }
+
         return Ok(await _unitOfWork.GenreRepository.GetAllGenreDtosAsync());
     }
 
+    /// <summary>
+    /// Fetches people from the instance
+    /// </summary>
+    /// <param name="libraryIds">String separated libraryIds or null for all people</param>
+    /// <returns></returns>
     [HttpGet("people")]
-    public async Task<ActionResult<IList<PersonDto>>> GetAllPeople()
+    public async Task<ActionResult<IList<PersonDto>>> GetAllPeople(string? libraryIds)
     {
+        var ids = libraryIds?.Split(",").Select(int.Parse).ToList();
+        if (ids != null && ids.Count > 0)
+        {
+            return Ok(await _unitOfWork.PersonRepository.GetAllPeopleDtosForLibrariesAsync(ids));
+        }
         return Ok(await _unitOfWork.PersonRepository.GetAllPeople());
     }
 }

--- a/API/Controllers/MetadataController.cs
+++ b/API/Controllers/MetadataController.cs
@@ -50,4 +50,20 @@ public class MetadataController : BaseApiController
         }
         return Ok(await _unitOfWork.PersonRepository.GetAllPeople());
     }
+
+    /// <summary>
+    /// Fetches all tags from the instance
+    /// </summary>
+    /// <param name="libraryIds">String separated libraryIds or null for all tags</param>
+    /// <returns></returns>
+    [HttpGet("tags")]
+    public async Task<ActionResult<IList<PersonDto>>> GetAllTags(string? libraryIds)
+    {
+        var ids = libraryIds?.Split(",").Select(int.Parse).ToList();
+        if (ids != null && ids.Count > 0)
+        {
+            return Ok(await _unitOfWork.TagRepository.GetAllTagDtosForLibrariesAsync(ids));
+        }
+        return Ok(await _unitOfWork.TagRepository.GetAllTagDtosAsync());
+    }
 }

--- a/API/DTOs/ChapterDto.cs
+++ b/API/DTOs/ChapterDto.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using API.DTOs.Metadata;
+using API.Entities;
 
 namespace API.DTOs
 {
@@ -69,5 +71,6 @@ namespace API.DTOs
         public ICollection<PersonDto> Editor { get; set; } = new List<PersonDto>();
         public ICollection<PersonDto> Publisher { get; set; } = new List<PersonDto>();
         public ICollection<PersonDto> Translators { get; set; } = new List<PersonDto>();
+        public ICollection<TagDto> Tags { get; set; } = new List<TagDto>();
     }
 }

--- a/API/DTOs/ChapterDto.cs
+++ b/API/DTOs/ChapterDto.cs
@@ -68,5 +68,6 @@ namespace API.DTOs
         public ICollection<PersonDto> CoverArtist { get; set; } = new List<PersonDto>();
         public ICollection<PersonDto> Editor { get; set; } = new List<PersonDto>();
         public ICollection<PersonDto> Publisher { get; set; } = new List<PersonDto>();
+        public ICollection<PersonDto> Translators { get; set; } = new List<PersonDto>();
     }
 }

--- a/API/DTOs/Filtering/FilterDto.cs
+++ b/API/DTOs/Filtering/FilterDto.cs
@@ -69,6 +69,10 @@ namespace API.DTOs.Filtering
         /// </summary>
         public IList<int> CollectionTags { get; init; } = new List<int>();
         /// <summary>
+        /// A list of Tag ids to restrict search to. Defaults to all genres by passing an empty list
+        /// </summary>
+        public IList<int> Tags { get; init; } = new List<int>();
+        /// <summary>
         /// Will return back everything with the rating and above
         /// <see cref="AppUserRating.Rating"/>
         /// </summary>

--- a/API/DTOs/Filtering/FilterDto.cs
+++ b/API/DTOs/Filtering/FilterDto.cs
@@ -61,6 +61,10 @@ namespace API.DTOs.Filtering
         /// </summary>
         public IList<int> Character { get; init; } = new List<int>();
         /// <summary>
+        /// A list of Translator ids to restrict search to. Defaults to all genres by passing an empty list
+        /// </summary>
+        public IList<int> Translators { get; init; } = new List<int>();
+        /// <summary>
         /// A list of Collection Tag ids to restrict search to. Defaults to all genres by passing an empty list
         /// </summary>
         public IList<int> CollectionTags { get; init; } = new List<int>();
@@ -73,6 +77,10 @@ namespace API.DTOs.Filtering
         /// Sorting Options for a query. Defaults to null, which uses the queries natural sorting order
         /// </summary>
         public SortOptions SortOptions { get; init; } = null;
+        /// <summary>
+        /// Age Ratings. Empty list will return everything back
+        /// </summary>
+        public IList<AgeRating> AgeRating { get; init; } = new List<AgeRating>();
 
     }
 }

--- a/API/DTOs/Filtering/FilterDto.cs
+++ b/API/DTOs/Filtering/FilterDto.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using API.Data.Migrations;
+﻿using System.Collections.Generic;
 using API.Entities;
 using API.Entities.Enums;
 

--- a/API/DTOs/Filtering/FilterDto.cs
+++ b/API/DTOs/Filtering/FilterDto.cs
@@ -71,6 +71,10 @@ namespace API.DTOs.Filtering
         /// <see cref="AppUserRating.Rating"/>
         /// </summary>
         public int Rating { get; init; }
+        /// <summary>
+        /// Sorting Options for a query. Defaults to null, which uses the queries natural sorting order
+        /// </summary>
+        public SortOptions SortOptions { get; init; } = null;
 
     }
 }

--- a/API/DTOs/Filtering/FilterDto.cs
+++ b/API/DTOs/Filtering/FilterDto.cs
@@ -85,6 +85,10 @@ namespace API.DTOs.Filtering
         /// Age Ratings. Empty list will return everything back
         /// </summary>
         public IList<AgeRating> AgeRating { get; init; } = new List<AgeRating>();
+        /// <summary>
+        /// Languages (ISO 639-1 code) to filter by. Empty list will return everything back
+        /// </summary>
+        public IList<string> Languages { get; init; } = new List<string>();
 
     }
 }

--- a/API/DTOs/Filtering/LanguageDto.cs
+++ b/API/DTOs/Filtering/LanguageDto.cs
@@ -1,0 +1,7 @@
+﻿namespace API.DTOs.Filtering;
+
+public class LanguageDto
+{
+    public string IsoCode { get; set; }
+    public string Title { get; set; }
+}

--- a/API/DTOs/Filtering/SortField.cs
+++ b/API/DTOs/Filtering/SortField.cs
@@ -1,0 +1,8 @@
+﻿namespace API.DTOs.Filtering;
+
+public enum SortField
+{
+    SortName = 1,
+    CreatedDate = 2,
+    LastModifiedDate = 3,
+}

--- a/API/DTOs/Filtering/SortOptions.cs
+++ b/API/DTOs/Filtering/SortOptions.cs
@@ -1,0 +1,10 @@
+﻿namespace API.DTOs.Filtering;
+
+/// <summary>
+/// Sorting Options for a query
+/// </summary>
+public abstract class SortOptions
+{
+    public SortField SortField { get; set; }
+    public bool IsAscending { get; set; } = true;
+}

--- a/API/DTOs/Filtering/SortOptions.cs
+++ b/API/DTOs/Filtering/SortOptions.cs
@@ -3,7 +3,7 @@
 /// <summary>
 /// Sorting Options for a query
 /// </summary>
-public abstract class SortOptions
+public class SortOptions
 {
     public SortField SortField { get; set; }
     public bool IsAscending { get; set; } = true;

--- a/API/DTOs/Metadata/AgeRatingDto.cs
+++ b/API/DTOs/Metadata/AgeRatingDto.cs
@@ -1,0 +1,9 @@
+﻿using API.Entities.Enums;
+
+namespace API.DTOs.Metadata;
+
+public class AgeRatingDto
+{
+    public AgeRating Value { get; set; }
+    public string Title { get; set; }
+}

--- a/API/DTOs/Metadata/GenreTagDto.cs
+++ b/API/DTOs/Metadata/GenreTagDto.cs
@@ -4,6 +4,5 @@
     {
         public int Id { get; set; }
         public string Title { get; set; }
-
     }
 }

--- a/API/DTOs/Metadata/TagDto.cs
+++ b/API/DTOs/Metadata/TagDto.cs
@@ -1,0 +1,7 @@
+﻿namespace API.DTOs.Metadata;
+
+public class TagDto
+{
+    public int Id { get; set; }
+    public string Title { get; set; }
+}

--- a/API/DTOs/SeriesMetadataDto.cs
+++ b/API/DTOs/SeriesMetadataDto.cs
@@ -9,8 +9,18 @@ namespace API.DTOs
     {
         public int Id { get; set; }
         public string Summary { get; set; }
-        public ICollection<CollectionTagDto> Tags { get; set; }
+        /// <summary>
+        /// Collections the Series belongs to
+        /// </summary>
+        public ICollection<CollectionTagDto> CollectionTags { get; set; }
+        /// <summary>
+        /// Genres for the Series
+        /// </summary>
         public ICollection<GenreTagDto> Genres { get; set; }
+        /// <summary>
+        /// Collection of all Tags from underlying chapters for a Series
+        /// </summary>
+        public ICollection<TagDto> Tags { get; set; }
         public ICollection<PersonDto> Writers { get; set; } = new List<PersonDto>();
         public ICollection<PersonDto> Artists { get; set; } = new List<PersonDto>();
         public ICollection<PersonDto> Publishers { get; set; } = new List<PersonDto>();

--- a/API/DTOs/SeriesMetadataDto.cs
+++ b/API/DTOs/SeriesMetadataDto.cs
@@ -39,6 +39,10 @@ namespace API.DTOs
         /// Earliest Year from all chapters
         /// </summary>
         public int ReleaseYear { get; set; }
+        /// <summary>
+        /// Language of the content (ISO 639-1 code)
+        /// </summary>
+        public string Language { get; set; } = string.Empty;
 
         public int SeriesId { get; set; }
     }

--- a/API/DTOs/SeriesMetadataDto.cs
+++ b/API/DTOs/SeriesMetadataDto.cs
@@ -20,6 +20,7 @@ namespace API.DTOs
         public ICollection<PersonDto> Colorists { get; set; } = new List<PersonDto>();
         public ICollection<PersonDto> Letterers { get; set; } = new List<PersonDto>();
         public ICollection<PersonDto> Editors { get; set; } = new List<PersonDto>();
+        public ICollection<PersonDto> Translators { get; set; } = new List<PersonDto>();
         /// <summary>
         /// Highest Age Rating from all Chapters
         /// </summary>

--- a/API/Data/DataContext.cs
+++ b/API/Data/DataContext.cs
@@ -39,6 +39,7 @@ namespace API.Data
         public DbSet<ReadingListItem> ReadingListItem { get; set; }
         public DbSet<Person> Person { get; set; }
         public DbSet<Genre> Genre { get; set; }
+        public DbSet<Tag> Tag { get; set; }
 
 
         protected override void OnModelCreating(ModelBuilder builder)

--- a/API/Data/DbFactory.cs
+++ b/API/Data/DbFactory.cs
@@ -91,6 +91,16 @@ namespace API.Data
             };
         }
 
+        public static Tag Tag(string name, bool external)
+        {
+            return new Tag()
+            {
+                Title = name.Trim().SentenceCase(),
+                NormalizedTitle = Parser.Parser.Normalize(name),
+                ExternalTag = external
+            };
+        }
+
         public static Person Person(string name, PersonRole role)
         {
             return new Person()

--- a/API/Data/Metadata/ComicInfo.cs
+++ b/API/Data/Metadata/ComicInfo.cs
@@ -51,8 +51,16 @@ namespace API.Data.Metadata
         /// </summary>
         public string TitleSort { get; set; } = string.Empty;
 
-
-
+        /// <summary>
+        /// The translator, can be comma separated. This is part of ComicInfo.xml draft v2.1
+        /// </summary>
+        /// See https://github.com/anansi-project/comicinfo/issues/2 for information about this tag
+        public string Translator { get; set; } = string.Empty;
+        /// <summary>
+        /// Misc tags. This is part of ComicInfo.xml draft v2.1
+        /// </summary>
+        /// See https://github.com/anansi-project/comicinfo/issues/1 for information about this tag
+        public string Tags { get; set; } = string.Empty;
 
         /// <summary>
         /// This is the Author. For Books, we map creator tag in OPF to this field. Comma separated if multiple.

--- a/API/Data/Metadata/ComicInfo.cs
+++ b/API/Data/Metadata/ComicInfo.cs
@@ -20,6 +20,9 @@ namespace API.Data.Metadata
         public string Genre { get; set; } = string.Empty;
         public int PageCount { get; set; }
         // ReSharper disable once InconsistentNaming
+        /// <summary>
+        /// ISO 639-1 Code to represent the language of the content
+        /// </summary>
         public string LanguageISO { get; set; } = string.Empty;
         /// <summary>
         /// This is the link to where the data was scraped from

--- a/API/Data/Migrations/20211216150752_seriesAndChapterTags.Designer.cs
+++ b/API/Data/Migrations/20211216150752_seriesAndChapterTags.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using API.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace API.Data.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20211216150752_seriesAndChapterTags")]
+    partial class seriesAndChapterTags
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "6.0.1");

--- a/API/Data/Migrations/20211216150752_seriesAndChapterTags.cs
+++ b/API/Data/Migrations/20211216150752_seriesAndChapterTags.cs
@@ -1,0 +1,103 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace API.Data.Migrations
+{
+    public partial class seriesAndChapterTags : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Tag",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    Title = table.Column<string>(type: "TEXT", nullable: true),
+                    NormalizedTitle = table.Column<string>(type: "TEXT", nullable: true),
+                    ExternalTag = table.Column<bool>(type: "INTEGER", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Tag", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ChapterTag",
+                columns: table => new
+                {
+                    ChaptersId = table.Column<int>(type: "INTEGER", nullable: false),
+                    TagsId = table.Column<int>(type: "INTEGER", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ChapterTag", x => new { x.ChaptersId, x.TagsId });
+                    table.ForeignKey(
+                        name: "FK_ChapterTag_Chapter_ChaptersId",
+                        column: x => x.ChaptersId,
+                        principalTable: "Chapter",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_ChapterTag_Tag_TagsId",
+                        column: x => x.TagsId,
+                        principalTable: "Tag",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "SeriesMetadataTag",
+                columns: table => new
+                {
+                    SeriesMetadatasId = table.Column<int>(type: "INTEGER", nullable: false),
+                    TagsId = table.Column<int>(type: "INTEGER", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_SeriesMetadataTag", x => new { x.SeriesMetadatasId, x.TagsId });
+                    table.ForeignKey(
+                        name: "FK_SeriesMetadataTag_SeriesMetadata_SeriesMetadatasId",
+                        column: x => x.SeriesMetadatasId,
+                        principalTable: "SeriesMetadata",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_SeriesMetadataTag_Tag_TagsId",
+                        column: x => x.TagsId,
+                        principalTable: "Tag",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ChapterTag_TagsId",
+                table: "ChapterTag",
+                column: "TagsId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SeriesMetadataTag_TagsId",
+                table: "SeriesMetadataTag",
+                column: "TagsId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Tag_NormalizedTitle_ExternalTag",
+                table: "Tag",
+                columns: new[] { "NormalizedTitle", "ExternalTag" },
+                unique: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ChapterTag");
+
+            migrationBuilder.DropTable(
+                name: "SeriesMetadataTag");
+
+            migrationBuilder.DropTable(
+                name: "Tag");
+        }
+    }
+}

--- a/API/Data/Migrations/20211216191436_seriesLanguage.Designer.cs
+++ b/API/Data/Migrations/20211216191436_seriesLanguage.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using API.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace API.Data.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20211216191436_seriesLanguage")]
+    partial class seriesLanguage
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "6.0.1");

--- a/API/Data/Migrations/20211216191436_seriesLanguage.cs
+++ b/API/Data/Migrations/20211216191436_seriesLanguage.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace API.Data.Migrations
+{
+    public partial class seriesLanguage : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Language",
+                table: "SeriesMetadata",
+                type: "TEXT",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Language",
+                table: "SeriesMetadata");
+        }
+    }
+}

--- a/API/Data/Repositories/GenreRepository.cs
+++ b/API/Data/Repositories/GenreRepository.cs
@@ -17,6 +17,7 @@ public interface IGenreRepository
     Task<IList<Genre>> GetAllGenresAsync();
     Task<IList<GenreTagDto>> GetAllGenreDtosAsync();
     Task RemoveAllGenreNoLongerAssociated(bool removeExternal = false);
+    Task<IList<GenreTagDto>> GetAllGenreDtosForLibrariesAsync(IList<int> libraryIds);
 }
 
 public class GenreRepository : IGenreRepository
@@ -60,6 +61,16 @@ public class GenreRepository : IGenreRepository
         await _context.SaveChangesAsync();
     }
 
+    public async Task<IList<GenreTagDto>> GetAllGenreDtosForLibrariesAsync(IList<int> libraryIds)
+    {
+        return await _context.Series
+            .Where(s => libraryIds.Contains(s.LibraryId))
+            .SelectMany(s => s.Metadata.Genres)
+            .Distinct()
+            .ProjectTo<GenreTagDto>(_mapper.ConfigurationProvider)
+            .ToListAsync();
+    }
+
     public async Task<IList<Genre>> GetAllGenresAsync()
     {
         return await _context.Genre.ToListAsync();
@@ -68,6 +79,7 @@ public class GenreRepository : IGenreRepository
     public async Task<IList<GenreTagDto>> GetAllGenreDtosAsync()
     {
         return await _context.Genre
+            .AsNoTracking()
             .ProjectTo<GenreTagDto>(_mapper.ConfigurationProvider)
             .ToListAsync();
     }

--- a/API/Data/Repositories/SeriesRepository.cs
+++ b/API/Data/Repositories/SeriesRepository.cs
@@ -177,6 +177,10 @@ public class SeriesRepository : ISeriesRepository
 
     public async Task<PagedList<SeriesDto>> GetSeriesDtoForLibraryIdAsync(int libraryId, int userId, UserParams userParams, FilterDto filter)
     {
+        if (filter.Libraries.Count > 0)
+        {
+            libraryId = 0;
+        }
         var query = await CreateFilteredSearchQueryable(userId, libraryId, filter);
 
         if (filter.SortOptions == null)

--- a/API/Data/Repositories/SeriesRepository.cs
+++ b/API/Data/Repositories/SeriesRepository.cs
@@ -412,7 +412,7 @@ public class SeriesRepository : ISeriesRepository
 
     private IList<MangaFormat> ExtractFilters(int libraryId, int userId, FilterDto filter, ref List<int> userLibraries,
         out List<int> allPeopleIds, out bool hasPeopleFilter, out bool hasGenresFilter, out bool hasCollectionTagFilter,
-        out bool hasRatingFilter, out bool hasProgressFilter, out IList<int> seriesIds)
+        out bool hasRatingFilter, out bool hasProgressFilter, out IList<int> seriesIds, out bool hasAgeRating, out bool hasTagsFilter)
     {
         var formats = filter.GetSqlFilter();
 
@@ -438,6 +438,8 @@ public class SeriesRepository : ISeriesRepository
         hasCollectionTagFilter = filter.CollectionTags.Count > 0;
         hasRatingFilter = filter.Rating > 0;
         hasProgressFilter = !filter.ReadStatus.Read || !filter.ReadStatus.InProgress || !filter.ReadStatus.NotRead;
+        hasAgeRating = filter.AgeRating.Count > 0;
+        hasTagsFilter = filter.Tags.Count > 0;
 
 
         bool ProgressComparison(int pagesRead, int totalPages)
@@ -525,7 +527,7 @@ public class SeriesRepository : ISeriesRepository
         var formats = ExtractFilters(libraryId, userId, filter, ref userLibraries,
             out var allPeopleIds, out var hasPeopleFilter, out var hasGenresFilter,
             out var hasCollectionTagFilter, out var hasRatingFilter, out var hasProgressFilter,
-            out var seriesIds);
+            out var seriesIds, out var hasAgeRating, out var hasTagsFilter);
 
         var query = _context.Series
             .Where(s => userLibraries.Contains(s.LibraryId)
@@ -536,6 +538,8 @@ public class SeriesRepository : ISeriesRepository
                             s.Metadata.CollectionTags.Any(t => filter.CollectionTags.Contains(t.Id)))
                         && (!hasRatingFilter || s.Ratings.Any(r => r.Rating >= filter.Rating))
                         && (!hasProgressFilter || seriesIds.Contains(s.Id))
+                        && (!hasAgeRating || filter.AgeRating.Contains(s.Metadata.AgeRating))
+                        && (!hasTagsFilter || s.Metadata.Tags.Any(t => filter.Tags.Contains(t.Id)))
             )
             .AsNoTracking();
 

--- a/API/Data/Repositories/SeriesRepository.cs
+++ b/API/Data/Repositories/SeriesRepository.cs
@@ -177,10 +177,6 @@ public class SeriesRepository : ISeriesRepository
 
     public async Task<PagedList<SeriesDto>> GetSeriesDtoForLibraryIdAsync(int libraryId, int userId, UserParams userParams, FilterDto filter)
     {
-        if (filter.Libraries.Count > 0)
-        {
-            libraryId = 0;
-        }
         var query = await CreateFilteredSearchQueryable(userId, libraryId, filter);
 
         if (filter.SortOptions == null)

--- a/API/Data/Repositories/SeriesRepository.cs
+++ b/API/Data/Repositories/SeriesRepository.cs
@@ -180,7 +180,7 @@ public class SeriesRepository : ISeriesRepository
         var query = await CreateFilteredSearchQueryable(userId, libraryId, filter);
 
         var retSeries = query
-            .OrderByDescending(s => s.SortName)
+            .OrderBy(s => s.SortName)
             .ProjectTo<SeriesDto>(_mapper.ConfigurationProvider)
             .AsSplitQuery()
             .AsNoTracking();
@@ -512,40 +512,6 @@ public class SeriesRepository : ISeriesRepository
                         && (!hasProgressFilter || seriesIds.Contains(s.Id))
             )
             .AsNoTracking();
-        // IQueryable<FilterableQuery> newFilter = null;
-        // if (hasProgressFilter)
-        // {
-        //     newFilter = query
-        //         .Join(_context.AppUserProgresses, s => s.Id, progress => progress.SeriesId, (s, progress) =>
-        //         new
-        //         {
-        //             Series = s,
-        //             PagesRead = _context.AppUserProgresses.Where(s1 => s1.SeriesId == s.Id && s1.AppUserId == userId)
-        //                 .Sum(s1 => s1.PagesRead),
-        //             progress.AppUserId,
-        //             LastModified = _context.AppUserProgresses.Where(p => p.Id == progress.Id && p.AppUserId == userId)
-        //                 .Max(p => p.LastModified)
-        //         })
-        //         .Select(d => new FilterableQuery()
-        //         {
-        //             Series = d.Series,
-        //             AppUserId = d.AppUserId,
-        //             LastModified = d.LastModified,
-        //             PagesRead = d.PagesRead
-        //         })
-        //         .Where(d => seriesIds.Contains(d.Series.Id));
-        // }
-        // else
-        // {
-        //     newFilter = query.Select(s => new FilterableQuery()
-        //     {
-        //         Series = s,
-        //         LastModified = DateTime.Now, // TODO: Figure this out
-        //         AppUserId = userId,
-        //         PagesRead = 0
-        //     });
-        // }
-
 
         return query;
     }

--- a/API/Data/Repositories/SeriesRepository.cs
+++ b/API/Data/Repositories/SeriesRepository.cs
@@ -135,13 +135,23 @@ public class SeriesRepository : ISeriesRepository
     {
         var query = _context.Series
             .Where(s => s.LibraryId == libraryId)
+
             .Include(s => s.Metadata)
             .ThenInclude(m => m.People)
+
             .Include(s => s.Metadata)
             .ThenInclude(m => m.Genres)
+
+            .Include(s => s.Metadata)
+            .ThenInclude(m => m.Tags)
+
             .Include(s => s.Volumes)
             .ThenInclude(v => v.Chapters)
             .ThenInclude(cm => cm.People)
+
+            .Include(s => s.Volumes)
+            .ThenInclude(v => v.Chapters)
+
             .Include(s => s.Volumes)
             .ThenInclude(v => v.Chapters)
             .ThenInclude(c => c.Files)
@@ -168,6 +178,14 @@ public class SeriesRepository : ISeriesRepository
             .Include(s => s.Volumes)
             .ThenInclude(v => v.Chapters)
             .ThenInclude(cm => cm.People)
+
+            .Include(s => s.Volumes)
+            .ThenInclude(v => v.Chapters)
+            .ThenInclude(cm => cm.Tags)
+
+            .Include(s => s.Metadata)
+            .ThenInclude(m => m.Tags)
+
             .Include(s => s.Volumes)
             .ThenInclude(v => v.Chapters)
             .ThenInclude(c => c.Files)
@@ -555,13 +573,15 @@ public class SeriesRepository : ISeriesRepository
         var metadataDto = await _context.SeriesMetadata
             .Where(metadata => metadata.SeriesId == seriesId)
             .Include(m => m.Genres)
+            .Include(m => m.Tags)
+            .Include(m => m.People)
             .AsNoTracking()
             .ProjectTo<SeriesMetadataDto>(_mapper.ConfigurationProvider)
             .SingleOrDefaultAsync();
 
         if (metadataDto != null)
         {
-            metadataDto.Tags = await _context.CollectionTag
+            metadataDto.CollectionTags = await _context.CollectionTag
                 .Include(t => t.SeriesMetadatas)
                 .Where(t => t.SeriesMetadatas.Select(s => s.SeriesId).Contains(seriesId))
                 .ProjectTo<CollectionTagDto>(_mapper.ConfigurationProvider)

--- a/API/Data/Repositories/SeriesRepository.cs
+++ b/API/Data/Repositories/SeriesRepository.cs
@@ -179,8 +179,12 @@ public class SeriesRepository : ISeriesRepository
     {
         var query = await CreateFilteredSearchQueryable(userId, libraryId, filter);
 
+        if (filter.SortOptions == null)
+        {
+            query = query.OrderBy(s => s.SortName);
+        }
+
         var retSeries = query
-            .OrderBy(s => s.SortName)
             .ProjectTo<SeriesDto>(_mapper.ConfigurationProvider)
             .AsSplitQuery()
             .AsNoTracking();
@@ -512,6 +516,36 @@ public class SeriesRepository : ISeriesRepository
                         && (!hasProgressFilter || seriesIds.Contains(s.Id))
             )
             .AsNoTracking();
+
+        if (filter.SortOptions != null)
+        {
+            if (filter.SortOptions.IsAscending)
+            {
+                if (filter.SortOptions.SortField == SortField.SortName)
+                {
+                    query = query.OrderBy(s => s.SortName);
+                } else if (filter.SortOptions.SortField == SortField.CreatedDate)
+                {
+                    query = query.OrderBy(s => s.Created);
+                } else if (filter.SortOptions.SortField == SortField.LastModifiedDate)
+                {
+                    query = query.OrderBy(s => s.LastModified);
+                }
+            }
+            else
+            {
+                if (filter.SortOptions.SortField == SortField.SortName)
+                {
+                    query = query.OrderByDescending(s => s.SortName);
+                } else if (filter.SortOptions.SortField == SortField.CreatedDate)
+                {
+                    query = query.OrderByDescending(s => s.Created);
+                } else if (filter.SortOptions.SortField == SortField.LastModifiedDate)
+                {
+                    query = query.OrderByDescending(s => s.LastModified);
+                }
+            }
+        }
 
         return query;
     }

--- a/API/Data/Repositories/TagRepository.cs
+++ b/API/Data/Repositories/TagRepository.cs
@@ -1,0 +1,86 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using API.DTOs.Metadata;
+using API.Entities;
+using AutoMapper;
+using AutoMapper.QueryableExtensions;
+using Microsoft.EntityFrameworkCore;
+
+namespace API.Data.Repositories;
+
+public interface ITagRepository
+{
+    void Attach(Tag tag);
+    void Remove(Tag tag);
+    Task<Tag> FindByNameAsync(string tagName);
+    Task<IList<Tag>> GetAllTagsAsync();
+    Task<IList<TagDto>> GetAllTagDtosAsync();
+    Task RemoveAllTagNoLongerAssociated(bool removeExternal = false);
+    Task<IList<TagDto>> GetAllTagDtosForLibrariesAsync(IList<int> libraryIds);
+}
+
+public class TagRepository : ITagRepository
+{
+    private readonly DataContext _context;
+    private readonly IMapper _mapper;
+
+    public TagRepository(DataContext context, IMapper mapper)
+    {
+        _context = context;
+        _mapper = mapper;
+    }
+
+    public void Attach(Tag tag)
+    {
+        _context.Tag.Attach(tag);
+    }
+
+    public void Remove(Tag tag)
+    {
+        _context.Tag.Remove(tag);
+    }
+
+    public async Task<Tag> FindByNameAsync(string tagName)
+    {
+        var normalizedName = Parser.Parser.Normalize(tagName);
+        return await _context.Tag
+            .FirstOrDefaultAsync(g => g.NormalizedTitle.Equals(normalizedName));
+    }
+
+    public async Task RemoveAllTagNoLongerAssociated(bool removeExternal = false)
+    {
+        var TagsWithNoConnections = await _context.Tag
+            .Include(p => p.SeriesMetadatas)
+            .Include(p => p.Chapters)
+            .Where(p => p.SeriesMetadatas.Count == 0 && p.Chapters.Count == 0 && p.ExternalTag == removeExternal)
+            .ToListAsync();
+
+        _context.Tag.RemoveRange(TagsWithNoConnections);
+
+        await _context.SaveChangesAsync();
+    }
+
+    public async Task<IList<TagDto>> GetAllTagDtosForLibrariesAsync(IList<int> libraryIds)
+    {
+        return await _context.Series
+            .Where(s => libraryIds.Contains(s.LibraryId))
+            .SelectMany(s => s.Metadata.Tags)
+            .Distinct()
+            .ProjectTo<TagDto>(_mapper.ConfigurationProvider)
+            .ToListAsync();
+    }
+
+    public async Task<IList<Tag>> GetAllTagsAsync()
+    {
+        return await _context.Tag.ToListAsync();
+    }
+
+    public async Task<IList<TagDto>> GetAllTagDtosAsync()
+    {
+        return await _context.Tag
+            .AsNoTracking()
+            .ProjectTo<TagDto>(_mapper.ConfigurationProvider)
+            .ToListAsync();
+    }
+}

--- a/API/Data/Repositories/VolumeRepository.cs
+++ b/API/Data/Repositories/VolumeRepository.cs
@@ -173,6 +173,8 @@ public class VolumeRepository : IVolumeRepository
             .Where(vol => vol.SeriesId == seriesId)
             .Include(vol => vol.Chapters)
             .ThenInclude(c => c.People)
+            .Include(vol => vol.Chapters)
+            .ThenInclude(c => c.Tags)
             .OrderBy(volume => volume.Number)
             .ProjectTo<VolumeDto>(_mapper.ConfigurationProvider)
             .AsNoTracking()

--- a/API/Data/UnitOfWork.cs
+++ b/API/Data/UnitOfWork.cs
@@ -20,6 +20,7 @@ public interface IUnitOfWork
     ISeriesMetadataRepository SeriesMetadataRepository { get; }
     IPersonRepository PersonRepository { get; }
     IGenreRepository GenreRepository { get; }
+    ITagRepository TagRepository { get; }
     bool Commit();
     Task<bool> CommitAsync();
     bool HasChanges();
@@ -54,6 +55,7 @@ public class UnitOfWork : IUnitOfWork
     public ISeriesMetadataRepository SeriesMetadataRepository => new SeriesMetadataRepository(_context);
     public IPersonRepository PersonRepository => new PersonRepository(_context, _mapper);
     public IGenreRepository GenreRepository => new GenreRepository(_context, _mapper);
+    public ITagRepository TagRepository => new TagRepository(_context, _mapper);
 
     /// <summary>
     /// Commits changes to the DB. Completes the open transaction.

--- a/API/Entities/Chapter.cs
+++ b/API/Entities/Chapter.cs
@@ -62,6 +62,7 @@ namespace API.Entities
         /// All people attached at a Chapter level. Usually Comics will have different people per issue.
         /// </summary>
         public ICollection<Person> People { get; set; } = new List<Person>();
+        public ICollection<Tag> Tags { get; set; } = new List<Tag>();
 
 
 

--- a/API/Entities/Enums/PersonRole.cs
+++ b/API/Entities/Enums/PersonRole.cs
@@ -24,7 +24,11 @@
         /// <summary>
         /// Represents a character/person within the story
         /// </summary>
-        Character = 11
+        Character = 11,
+        /// <summary>
+        /// The Translator
+        /// </summary>
+        Translator = 12
 
 
     }

--- a/API/Entities/Metadata/SeriesMetadata.cs
+++ b/API/Entities/Metadata/SeriesMetadata.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using API.Entities.Enums;
 using API.Entities.Interfaces;

--- a/API/Entities/Metadata/SeriesMetadata.cs
+++ b/API/Entities/Metadata/SeriesMetadata.cs
@@ -17,6 +17,7 @@ namespace API.Entities.Metadata
         public ICollection<CollectionTag> CollectionTags { get; set; }
 
         public ICollection<Genre> Genres { get; set; } = new List<Genre>();
+        public ICollection<Tag> Tags { get; set; } = new List<Tag>();
         /// <summary>
         /// All people attached at a Series level.
         /// </summary>

--- a/API/Entities/Metadata/SeriesMetadata.cs
+++ b/API/Entities/Metadata/SeriesMetadata.cs
@@ -32,6 +32,10 @@ namespace API.Entities.Metadata
         /// Earliest Year from all chapters
         /// </summary>
         public int ReleaseYear { get; set; }
+        /// <summary>
+        /// Language of the content (ISO 639-1 code)
+        /// </summary>
+        public string Language { get; set; } = string.Empty;
 
         // Relationship
         public Series Series { get; set; }

--- a/API/Entities/Tag.cs
+++ b/API/Entities/Tag.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+using API.Entities.Metadata;
+using Microsoft.EntityFrameworkCore;
+
+namespace API.Entities;
+
+[Index(nameof(NormalizedTitle), nameof(ExternalTag), IsUnique = true)]
+public class Tag
+{
+    public int Id { get; set; }
+    public string Title { get; set; }
+    public string NormalizedTitle { get; set; }
+    public bool ExternalTag { get; set; }
+
+    public ICollection<SeriesMetadata> SeriesMetadatas { get; set; }
+    public ICollection<Chapter> Chapters { get; set; }
+}

--- a/API/Helpers/AutoMapperProfiles.cs
+++ b/API/Helpers/AutoMapperProfiles.cs
@@ -54,12 +54,10 @@ namespace API.Helpers
                         opt.MapFrom(src => src.People.Where(p => p.Role == PersonRole.Translator)));
 
             CreateMap<Series, SeriesDto>();
-
             CreateMap<CollectionTag, CollectionTagDto>();
-
             CreateMap<Person, PersonDto>();
-
             CreateMap<Genre, GenreTagDto>();
+            CreateMap<Tag, TagDto>();
 
             CreateMap<SeriesMetadata, SeriesMetadataDto>()
                 .ForMember(dest => dest.Writers,

--- a/API/Helpers/AutoMapperProfiles.cs
+++ b/API/Helpers/AutoMapperProfiles.cs
@@ -48,7 +48,10 @@ namespace API.Helpers
                         opt.MapFrom(src => src.People.Where(p => p.Role == PersonRole.Publisher)))
                 .ForMember(dest => dest.Editor,
                     opt =>
-                        opt.MapFrom(src => src.People.Where(p => p.Role == PersonRole.Editor)));
+                        opt.MapFrom(src => src.People.Where(p => p.Role == PersonRole.Editor)))
+                .ForMember(dest => dest.Translators,
+                    opt =>
+                        opt.MapFrom(src => src.People.Where(p => p.Role == PersonRole.Translator)));
 
             CreateMap<Series, SeriesDto>();
 
@@ -83,6 +86,9 @@ namespace API.Helpers
                 .ForMember(dest => dest.Pencillers,
                     opt =>
                         opt.MapFrom(src => src.People.Where(p => p.Role == PersonRole.Penciller)))
+                .ForMember(dest => dest.Translators,
+                    opt =>
+                        opt.MapFrom(src => src.People.Where(p => p.Role == PersonRole.Translator)))
                 .ForMember(dest => dest.Editors,
                     opt =>
                         opt.MapFrom(src => src.People.Where(p => p.Role == PersonRole.Editor)));

--- a/API/Helpers/GenreHelper.cs
+++ b/API/Helpers/GenreHelper.cs
@@ -11,23 +11,23 @@ public static class GenreHelper
     /// <summary>
     ///
     /// </summary>
-    /// <param name="allPeople"></param>
+    /// <param name="allGenres"></param>
     /// <param name="names"></param>
     /// <param name="isExternal"></param>
     /// <param name="action"></param>
-    public static void UpdateGenre(ICollection<Genre> allPeople, IEnumerable<string> names, bool isExternal, Action<Genre> action)
+    public static void UpdateGenre(ICollection<Genre> allGenres, IEnumerable<string> names, bool isExternal, Action<Genre> action)
     {
         foreach (var name in names)
         {
             if (string.IsNullOrEmpty(name.Trim())) continue;
 
             var normalizedName = Parser.Parser.Normalize(name);
-            var genre = allPeople.FirstOrDefault(p =>
+            var genre = allGenres.FirstOrDefault(p =>
                 p.NormalizedTitle.Equals(normalizedName) && p.ExternalTag == isExternal);
             if (genre == null)
             {
                 genre = DbFactory.Genre(name, false);
-                allPeople.Add(genre);
+                allGenres.Add(genre);
             }
 
             action(genre);

--- a/API/Helpers/TagHelper.cs
+++ b/API/Helpers/TagHelper.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using API.Data;
+using API.Entities;
+
+namespace API.Helpers;
+
+public static class TagHelper
+{
+    /// <summary>
+    ///
+    /// </summary>
+    /// <param name="allTags"></param>
+    /// <param name="names"></param>
+    /// <param name="isExternal"></param>
+    /// <param name="action">Callback for every item. Will give said item back and a bool if item was added</param>
+    public static void UpdateTag(ICollection<Tag> allTags, IEnumerable<string> names, bool isExternal, Action<Tag, bool> action)
+    {
+        foreach (var name in names)
+        {
+            if (string.IsNullOrEmpty(name.Trim())) continue;
+
+            var added = false;
+            var normalizedName = Parser.Parser.Normalize(name);
+
+            // var tag = DbFactory.Tag(name, isExternal);
+            // TagHelper.AddTagIfNotExists(allTags, tag);
+
+            var genre = allTags.FirstOrDefault(p =>
+                p.NormalizedTitle.Equals(normalizedName) && p.ExternalTag == isExternal);
+            if (genre == null)
+            {
+                added = true;
+                genre = DbFactory.Tag(name, false);
+                allTags.Add(genre);
+            }
+
+            action(genre, added);
+        }
+    }
+
+    public static void KeepOnlySameTagBetweenLists(ICollection<Tag> existingTags, ICollection<Tag> removeAllExcept, Action<Tag> action = null)
+    {
+        var existing = existingTags.ToList();
+        foreach (var genre in existing)
+        {
+            var existingPerson = removeAllExcept.FirstOrDefault(g => g.ExternalTag == genre.ExternalTag && genre.NormalizedTitle.Equals(g.NormalizedTitle));
+            if (existingPerson != null) continue;
+            existingTags.Remove(genre);
+            action?.Invoke(genre);
+        }
+
+    }
+
+    /// <summary>
+    /// Adds the tag to the list if it's not already in there. This will ignore the ExternalTag.
+    /// </summary>
+    /// <param name="metadataTags"></param>
+    /// <param name="tag"></param>
+    public static void AddTagIfNotExists(ICollection<Tag> metadataTags, Tag tag)
+    {
+        var existingGenre = metadataTags.FirstOrDefault(p =>
+            p.NormalizedTitle == Parser.Parser.Normalize(tag.Title));
+        if (existingGenre == null)
+        {
+            metadataTags.Add(tag);
+        }
+    }
+
+    /// <summary>
+    /// Remove tags on a list
+    /// </summary>
+    /// <remarks>Used to remove before we update/add new tags</remarks>
+    /// <param name="existingTags">Existing tags on Entity</param>
+    /// <param name="tags">Tags from metadata</param>
+    /// <param name="isExternal">Remove external tags?</param>
+    /// <param name="action">Callback which will be executed for each tag removed</param>
+    public static void RemoveTags(ICollection<Tag> existingTags, IEnumerable<string> tags, bool isExternal, Action<Tag> action = null)
+    {
+        var normalizedTags = tags.Select(Parser.Parser.Normalize).ToList();
+        foreach (var person in normalizedTags)
+        {
+            var existingTag = existingTags.FirstOrDefault(p => p.ExternalTag == isExternal && person.Equals(p.NormalizedTitle));
+            if (existingTag == null) continue;
+
+            existingTags.Remove(existingTag);
+            action?.Invoke(existingTag);
+        }
+
+    }
+}
+

--- a/API/Services/MetadataService.cs
+++ b/API/Services/MetadataService.cs
@@ -124,7 +124,6 @@ public class MetadataService : IMetadataService
         if (!string.IsNullOrEmpty(comicInfo.Tags))
         {
             var tags = comicInfo.Tags.Split(",").Select(s => s.Trim()).ToList();
-            //TagHelper.RemoveTags(chapter.Tags, tags, false, tag => chapter.Tags.Remove(tag));
             // Remove all tags that aren't matching between chapter tags and metadata
             TagHelper.KeepOnlySameTagBetweenLists(chapter.Tags, tags.Select(t => DbFactory.Tag(t, false)).ToList());
             TagHelper.UpdateTag(allTags, tags, false,

--- a/API/Services/MetadataService.cs
+++ b/API/Services/MetadataService.cs
@@ -113,6 +113,22 @@ public class MetadataService : IMetadataService
                 person => PersonHelper.AddPersonIfNotExists(chapter.People, person));
         }
 
+        if (!string.IsNullOrEmpty(comicInfo.Translator))
+        {
+            var people = comicInfo.Translator.Split(",");
+            PersonHelper.RemovePeople(chapter.People, people, PersonRole.Translator);
+            PersonHelper.UpdatePeople(allPeople, people, PersonRole.Translator,
+                person => PersonHelper.AddPersonIfNotExists(chapter.People, person));
+        }
+
+        if (!string.IsNullOrEmpty(comicInfo.Translator))
+        {
+            var people = comicInfo.Translator.Split(",");
+            PersonHelper.RemovePeople(chapter.People, people, PersonRole.Translator);
+            PersonHelper.UpdatePeople(allPeople, people, PersonRole.Translator,
+                person => PersonHelper.AddPersonIfNotExists(chapter.People, person));
+        }
+
         if (!string.IsNullOrEmpty(comicInfo.Writer))
         {
             var people = comicInfo.Writer.Split(",");

--- a/API/Services/TaskScheduler.cs
+++ b/API/Services/TaskScheduler.cs
@@ -87,7 +87,7 @@ public class TaskScheduler : ITaskScheduler
         }
 
         RecurringJob.AddOrUpdate("cleanup", () => _cleanupService.Cleanup(), Cron.Daily, TimeZoneInfo.Local);
-
+        RecurringJob.AddOrUpdate("cleanup-db", () => _cleanupService.CleanupDbEntries(), Cron.Daily, TimeZoneInfo.Local);
     }
 
     #region StatsTasks

--- a/API/Services/Tasks/CleanupService.cs
+++ b/API/Services/Tasks/CleanupService.cs
@@ -13,6 +13,7 @@ namespace API.Services.Tasks
     public interface ICleanupService
     {
         Task Cleanup();
+        Task CleanupDbEntries();
         void CleanupCacheDirectory();
         Task DeleteSeriesCoverImages();
         Task DeleteChapterCoverImages();
@@ -64,6 +65,17 @@ namespace API.Services.Tasks
             await DeleteTagCoverImages();
             await SendProgress(1F);
             _logger.LogInformation("Cleanup finished");
+        }
+
+        /// <summary>
+        /// Cleans up abandon rows in the DB
+        /// </summary>
+        public async Task CleanupDbEntries()
+        {
+            await _unitOfWork.AppUserProgressRepository.CleanupAbandonedChapters();
+            await _unitOfWork.PersonRepository.RemoveAllPeopleNoLongerAssociated();
+            await _unitOfWork.GenreRepository.RemoveAllGenreNoLongerAssociated();
+            await _unitOfWork.CollectionTagRepository.RemoveTagsWithoutSeries();
         }
 
         private async Task SendProgress(float progress)

--- a/UI/Web/src/app/_models/chapter.ts
+++ b/UI/Web/src/app/_models/chapter.ts
@@ -1,5 +1,6 @@
 import { MangaFile } from './manga-file';
 import { Person } from './person';
+import { Tag } from './tag';
 
 export interface Chapter {
     id: number;
@@ -31,4 +32,5 @@ export interface Chapter {
     coverArtist: Array<Person>;
     editor: Array<Person>;
     publisher: Array<Person>;
+    tags: Array<Tag>;
 }

--- a/UI/Web/src/app/_models/metadata/age-rating-dto.ts
+++ b/UI/Web/src/app/_models/metadata/age-rating-dto.ts
@@ -1,0 +1,6 @@
+import { AgeRating } from "./age-rating";
+
+export interface AgeRatingDto {
+    value: AgeRating;
+    title: string;
+}

--- a/UI/Web/src/app/_models/person.ts
+++ b/UI/Web/src/app/_models/person.ts
@@ -9,7 +9,8 @@ export enum PersonRole {
     CoverArtist = 8,
     Editor = 9,
     Publisher = 10,
-    Character = 11
+    Character = 11,
+    Translator = 12
 }
 
 export interface Person {

--- a/UI/Web/src/app/_models/series-filter.ts
+++ b/UI/Web/src/app/_models/series-filter.ts
@@ -20,8 +20,10 @@ export interface SeriesFilter {
     editor: Array<number>;
     publisher: Array<number>;
     character: Array<number>;
+    translators: Array<number>;
     collectionTags: Array<number>;
     rating: number;
+    ageRating: Array<number>;
     sortOptions: SortOptions | null;
 }
 

--- a/UI/Web/src/app/_models/series-filter.ts
+++ b/UI/Web/src/app/_models/series-filter.ts
@@ -25,6 +25,7 @@ export interface SeriesFilter {
     rating: number;
     ageRating: Array<number>;
     sortOptions: SortOptions | null;
+    tags: Array<number>;
 }
 
 export interface SortOptions {

--- a/UI/Web/src/app/_models/series-filter.ts
+++ b/UI/Web/src/app/_models/series-filter.ts
@@ -26,6 +26,7 @@ export interface SeriesFilter {
     ageRating: Array<number>;
     sortOptions: SortOptions | null;
     tags: Array<number>;
+    languages: Array<string>;
 }
 
 export interface SortOptions {

--- a/UI/Web/src/app/_models/series-filter.ts
+++ b/UI/Web/src/app/_models/series-filter.ts
@@ -22,6 +22,18 @@ export interface SeriesFilter {
     character: Array<number>;
     collectionTags: Array<number>;
     rating: number;
+    sortOptions: SortOptions | null;
+}
+
+export interface SortOptions {
+  sortField: SortField;
+  isAscending: boolean;
+}
+
+export enum SortField {
+  SortName = 1,
+  Created = 2,
+  LastModified = 3
 }
 
 export interface ReadStatus {

--- a/UI/Web/src/app/_models/series-metadata.ts
+++ b/UI/Web/src/app/_models/series-metadata.ts
@@ -22,5 +22,6 @@ export interface SeriesMetadata {
     translators: Array<Person>;
     ageRating: AgeRating;
     releaseYear: number;
+    language: string;
     seriesId: number;
 }

--- a/UI/Web/src/app/_models/series-metadata.ts
+++ b/UI/Web/src/app/_models/series-metadata.ts
@@ -17,6 +17,7 @@ export interface SeriesMetadata {
     colorists: Array<Person>;
     letterers: Array<Person>;
     editors: Array<Person>;
+    translators: Array<Person>;
     ageRating: AgeRating;
     releaseYear: number;
     seriesId: number;

--- a/UI/Web/src/app/_models/series-metadata.ts
+++ b/UI/Web/src/app/_models/series-metadata.ts
@@ -2,12 +2,14 @@ import { CollectionTag } from "./collection-tag";
 import { Genre } from "./genre";
 import { AgeRating } from "./metadata/age-rating";
 import { Person } from "./person";
+import { Tag } from "./tag";
 
 export interface SeriesMetadata {
     publisher: string;
     summary: string;
     genres: Array<Genre>;
-    tags: Array<CollectionTag>;
+    tags: Array<Tag>;
+    collectionTags: Array<CollectionTag>;
     writers: Array<Person>;
     artists: Array<Person>;
     publishers: Array<Person>;

--- a/UI/Web/src/app/_models/series.ts
+++ b/UI/Web/src/app/_models/series.ts
@@ -7,7 +7,6 @@ export interface Series {
     originalName: string; // This is not shown to user
     localizedName: string;
     sortName: string;
-    //summary: string;
     coverImageLocked: boolean;
     volumes: Volume[];
     pages: number; // Total pages in series

--- a/UI/Web/src/app/_models/tag.ts
+++ b/UI/Web/src/app/_models/tag.ts
@@ -1,0 +1,4 @@
+export interface Tag {
+    id: number,
+    title: string;
+}

--- a/UI/Web/src/app/_services/metadata.service.ts
+++ b/UI/Web/src/app/_services/metadata.service.ts
@@ -41,7 +41,15 @@ export class MetadataService {
     return this.httpClient.get<Genre[]>(this.baseUrl + 'metadata/genres');
   }
 
+  getGenresForLibraries(libraries: Array<number>) {
+    return this.httpClient.get<Genre[]>(this.baseUrl + 'metadata/genres?libraryIds=' + libraries.join(','));
+  }
+
   getAllPeople() {
     return this.httpClient.get<Person[]>(this.baseUrl + 'metadata/people');
+  }
+
+  getPeopleForLibraries(libraries: Array<number>) {
+    return this.httpClient.get<Person[]>(this.baseUrl + 'metadata/people?libraryIds=' + libraries.join(','));
   }
 }

--- a/UI/Web/src/app/_services/metadata.service.ts
+++ b/UI/Web/src/app/_services/metadata.service.ts
@@ -7,6 +7,7 @@ import { ChapterMetadata } from '../_models/chapter-metadata';
 import { Genre } from '../_models/genre';
 import { AgeRating } from '../_models/metadata/age-rating';
 import { AgeRatingDto } from '../_models/metadata/age-rating-dto';
+import { Language } from '../_models/metadata/language';
 import { Person } from '../_models/person';
 import { Tag } from '../_models/tag';
 
@@ -21,20 +22,16 @@ export class MetadataService {
 
   constructor(private httpClient: HttpClient) { }
 
-  // getChapterMetadata(chapterId: number) {
-  //   return this.httpClient.get<ChapterMetadata>(this.baseUrl + 'series/chapter-metadata?chapterId=' + chapterId);
-  // }
-
   getAgeRating(ageRating: AgeRating) {
     if (this.ageRatingTypes != undefined && this.ageRatingTypes.hasOwnProperty(ageRating)) {
       return of(this.ageRatingTypes[ageRating]);
     }
-    return this.httpClient.get<string>(this.baseUrl + 'series/age-rating?ageRating=' + ageRating, {responseType: 'text' as 'json'}).pipe(map(l => {
+    return this.httpClient.get<string>(this.baseUrl + 'series/age-rating?ageRating=' + ageRating, {responseType: 'text' as 'json'}).pipe(map(ratingString => {
       if (this.ageRatingTypes === undefined) {
         this.ageRatingTypes = {};
       }
 
-      this.ageRatingTypes[ageRating] = l;
+      this.ageRatingTypes[ageRating] = ratingString;
       return this.ageRatingTypes[ageRating];
     }));
   }
@@ -60,7 +57,15 @@ export class MetadataService {
     if (libraries != undefined && libraries.length > 0) {
       method += '?libraryIds=' + libraries.join(',');
     }
-    return this.httpClient.get<Genre[]>(this.baseUrl + 'metadata/genres');
+    return this.httpClient.get<Genre[]>(this.baseUrl + method);
+  }
+
+  getAllLanguages(libraries?: Array<number>) {
+    let method = 'metadata/languages'
+    if (libraries != undefined && libraries.length > 0) {
+      method += '?libraryIds=' + libraries.join(',');
+    }
+    return this.httpClient.get<Language[]>(this.baseUrl + method);
   }
 
   getAllPeople(libraries?: Array<number>) {
@@ -68,6 +73,6 @@ export class MetadataService {
     if (libraries != undefined && libraries.length > 0) {
       method += '?libraryIds=' + libraries.join(',');
     }
-    return this.httpClient.get<Person[]>(this.baseUrl + 'metadata/people');
+    return this.httpClient.get<Person[]>(this.baseUrl + method);
   }
 }

--- a/UI/Web/src/app/_services/metadata.service.ts
+++ b/UI/Web/src/app/_services/metadata.service.ts
@@ -6,7 +6,9 @@ import { environment } from 'src/environments/environment';
 import { ChapterMetadata } from '../_models/chapter-metadata';
 import { Genre } from '../_models/genre';
 import { AgeRating } from '../_models/metadata/age-rating';
+import { AgeRatingDto } from '../_models/metadata/age-rating-dto';
 import { Person } from '../_models/person';
+import { Tag } from '../_models/tag';
 
 @Injectable({
   providedIn: 'root'
@@ -37,19 +39,35 @@ export class MetadataService {
     }));
   }
 
-  getAllGenres() {
+  getAllAgeRatings(libraries?: Array<number>) {
+    let method = 'metadata/age-ratings'
+    if (libraries != undefined && libraries.length > 0) {
+      method += '?libraryIds=' + libraries.join(',');
+    }
+    return this.httpClient.get<Array<AgeRatingDto>>(this.baseUrl + method);;
+  }
+
+  getAllTags(libraries?: Array<number>) {
+    let method = 'metadata/tags'
+    if (libraries != undefined && libraries.length > 0) {
+      method += '?libraryIds=' + libraries.join(',');
+    }
+    return this.httpClient.get<Array<Tag>>(this.baseUrl + method);;
+  }
+
+  getAllGenres(libraries?: Array<number>) {
+    let method = 'metadata/genres'
+    if (libraries != undefined && libraries.length > 0) {
+      method += '?libraryIds=' + libraries.join(',');
+    }
     return this.httpClient.get<Genre[]>(this.baseUrl + 'metadata/genres');
   }
 
-  getGenresForLibraries(libraries: Array<number>) {
-    return this.httpClient.get<Genre[]>(this.baseUrl + 'metadata/genres?libraryIds=' + libraries.join(','));
-  }
-
-  getAllPeople() {
+  getAllPeople(libraries?: Array<number>) {
+    let method = 'metadata/people'
+    if (libraries != undefined && libraries.length > 0) {
+      method += '?libraryIds=' + libraries.join(',');
+    }
     return this.httpClient.get<Person[]>(this.baseUrl + 'metadata/people');
-  }
-
-  getPeopleForLibraries(libraries: Array<number>) {
-    return this.httpClient.get<Person[]>(this.baseUrl + 'metadata/people?libraryIds=' + libraries.join(','));
   }
 }

--- a/UI/Web/src/app/_services/series.service.ts
+++ b/UI/Web/src/app/_services/series.service.ts
@@ -149,7 +149,7 @@ export class SeriesService {
 
   getMetadata(seriesId: number) {
     return this.httpClient.get<SeriesMetadata>(this.baseUrl + 'series/metadata?seriesId=' + seriesId).pipe(map(items => {
-      items?.tags.forEach(tag => tag.coverImage = this.imageService.getCollectionCoverImage(tag.id));
+      items?.collectionTags.forEach(tag => tag.coverImage = this.imageService.getCollectionCoverImage(tag.id));
       return items;
     }));
   }

--- a/UI/Web/src/app/_services/series.service.ts
+++ b/UI/Web/src/app/_services/series.service.ts
@@ -201,6 +201,7 @@ export class SeriesService {
       editor: [],
       publisher: [],
       character: [],
+      translators: [],
       collectionTags: [],
       rating: 0,
       readStatus: {
@@ -208,7 +209,8 @@ export class SeriesService {
         inProgress: true,
         notRead: true
       },
-      sortOptions: null
+      sortOptions: null,
+      ageRating: []
     };
 
     if (filter === undefined) return data;

--- a/UI/Web/src/app/_services/series.service.ts
+++ b/UI/Web/src/app/_services/series.service.ts
@@ -210,7 +210,8 @@ export class SeriesService {
         notRead: true
       },
       sortOptions: null,
-      ageRating: []
+      ageRating: [],
+      tags: []
     };
 
     if (filter === undefined) return data;

--- a/UI/Web/src/app/_services/series.service.ts
+++ b/UI/Web/src/app/_services/series.service.ts
@@ -39,6 +39,18 @@ export class SeriesService {
     return paginatedVariable;
   }
 
+  getAllSeries(pageNum?: number, itemsPerPage?: number, filter?: SeriesFilter) {
+    let params = new HttpParams();
+    params = this._addPaginationIfExists(params, pageNum, itemsPerPage);
+    const data = this.createSeriesFilter(filter);
+
+    return this.httpClient.post<PaginatedResult<Series[]>>(this.baseUrl + 'series/all', data, {observe: 'response', params}).pipe(
+      map((response: any) => {
+        return this._cachePaginatedResults(response, this.paginatedResults);
+      })
+    );
+  }
+
   getSeriesForLibrary(libraryId: number, pageNum?: number, itemsPerPage?: number, filter?: SeriesFilter) {
     let params = new HttpParams();
     params = this._addPaginationIfExists(params, pageNum, itemsPerPage);
@@ -195,7 +207,8 @@ export class SeriesService {
         read: true,
         inProgress: true,
         notRead: true
-      }
+      },
+      sortOptions: null
     };
 
     if (filter === undefined) return data;

--- a/UI/Web/src/app/_services/series.service.ts
+++ b/UI/Web/src/app/_services/series.service.ts
@@ -211,7 +211,8 @@ export class SeriesService {
       },
       sortOptions: null,
       ageRating: [],
-      tags: []
+      tags: [],
+      languages: []
     };
 
     if (filter === undefined) return data;

--- a/UI/Web/src/app/admin/manage-settings/manage-settings.component.html
+++ b/UI/Web/src/app/admin/manage-settings/manage-settings.component.html
@@ -1,6 +1,6 @@
 <div class="container-fluid">
     <form [formGroup]="settingsForm" *ngIf="serverSettings !== undefined">
-        <p class="text-warning pt-2">Port, Base Url, and Logging Level require a manual restart of Kavita to take effect.</p>
+        <p class="text-warning pt-2">Port and Logging Level require a manual restart of Kavita to take effect.</p>
         <div class="form-group">
             <label for="settings-cachedir">Cache Directory</label>&nbsp;<i class="fa fa-info-circle" placement="right" [ngbTooltip]="cacheDirectoryTooltip" role="button" tabindex="0"></i>
             <ng-template #cacheDirectoryTooltip>Where the server place temporary files when reading. This will be cleaned up on a regular basis.</ng-template>

--- a/UI/Web/src/app/all-series/all-series.component.html
+++ b/UI/Web/src/app/all-series/all-series.component.html
@@ -9,6 +9,6 @@
     (pageChange)="onPageChange($event)"
     >
     <ng-template #cardItem let-item let-position="idx">
-        <app-series-card [data]="item" (reload)="loadPage()" (selection)="bulkSelectionService.handleCardSelection('series', position, series.length, $event)" [selected]="bulkSelectionService.isCardSelected('series', position)" [allowSelection]="true"></app-series-card>
+        <app-series-card [data]="item" [libraryId]="item.libraryId" (reload)="loadPage()" (selection)="bulkSelectionService.handleCardSelection('series', position, series.length, $event)" [selected]="bulkSelectionService.isCardSelected('series', position)" [allowSelection]="true"></app-series-card>
     </ng-template>
 </app-card-detail-layout>

--- a/UI/Web/src/app/all-series/all-series.component.html
+++ b/UI/Web/src/app/all-series/all-series.component.html
@@ -1,0 +1,14 @@
+<app-bulk-operations [actionCallback]="bulkActionCallback"></app-bulk-operations>
+<app-card-detail-layout header="All Series" 
+    [isLoading]="loadingSeries"
+    [items]="series"
+    [actions]="actions"
+    [pagination]="pagination"
+    [filterSettings]="filterSettings"
+    (applyFilter)="updateFilter($event)"
+    (pageChange)="onPageChange($event)"
+    >
+    <ng-template #cardItem let-item let-position="idx">
+        <app-series-card [data]="item" (reload)="loadPage()" (selection)="bulkSelectionService.handleCardSelection('series', position, series.length, $event)" [selected]="bulkSelectionService.isCardSelected('series', position)" [allowSelection]="true"></app-series-card>
+    </ng-template>
+</app-card-detail-layout>

--- a/UI/Web/src/app/app-routing.module.ts
+++ b/UI/Web/src/app/app-routing.module.ts
@@ -9,6 +9,7 @@ import { AuthGuard } from './_guards/auth.guard';
 import { LibraryAccessGuard } from './_guards/library-access.guard';
 import { OnDeckComponent } from './on-deck/on-deck.component';
 import { DashboardComponent } from './dashboard/dashboard.component';
+import { AllSeriesComponent } from './all-series/all-series.component';
 
 // TODO: Once we modularize the components, use this and measure performance impact: https://angular.io/guide/lazy-loading-ngmodules#preloading-modules
 
@@ -55,6 +56,8 @@ const routes: Routes = [
       {path: 'library', component: DashboardComponent},
       {path: 'recently-added', component: RecentlyAddedComponent},
       {path: 'on-deck', component: OnDeckComponent},
+      {path: 'all-series', component: AllSeriesComponent},
+
     ]
   },
   {path: 'login', component: UserLoginComponent},

--- a/UI/Web/src/app/app.module.ts
+++ b/UI/Web/src/app/app.module.ts
@@ -34,6 +34,7 @@ import { ConfigData } from './_models/config-data';
 import { NavEventsToggleComponent } from './nav-events-toggle/nav-events-toggle.component';
 import { PersonRolePipe } from './person-role.pipe';
 import { SeriesMetadataDetailComponent } from './series-metadata-detail/series-metadata-detail.component';
+import { AllSeriesComponent } from './all-series/all-series.component';
 
 
 @NgModule({
@@ -52,6 +53,7 @@ import { SeriesMetadataDetailComponent } from './series-metadata-detail/series-m
     NavEventsToggleComponent,
     PersonRolePipe,
     SeriesMetadataDetailComponent,
+    AllSeriesComponent,
   ],
   imports: [
     HttpClientModule,

--- a/UI/Web/src/app/cards/_modals/edit-series-modal/edit-series-modal.component.ts
+++ b/UI/Web/src/app/cards/_modals/edit-series-modal/edit-series-modal.component.ts
@@ -86,8 +86,8 @@ export class EditSeriesModalComponent implements OnInit, OnDestroy {
     this.seriesService.getMetadata(this.series.id).subscribe(metadata => {
       if (metadata) {
         this.metadata = metadata;
-        this.settings.savedData = metadata.tags;
-        this.tags = metadata.tags;
+        this.settings.savedData = metadata.collectionTags;
+        this.tags = metadata.collectionTags;
         this.editSeriesForm.get('summary')?.setValue(this.metadata.summary);
       }
     });

--- a/UI/Web/src/app/cards/card-detail-layout/card-detail-layout.component.html
+++ b/UI/Web/src/app/cards/card-detail-layout/card-detail-layout.component.html
@@ -257,14 +257,16 @@
                 </div>
 
                 <div class="col">
-                    <form>
+                    <form [formGroup]="sortGroup">
                         <div class="form-group">
                             <label for="sort-options">Sort By</label>
-                            <button class="btn btn-secondary-outline">
-                                <i class="fa fa-arrow-down" title="Ascending"></i>
-                                <!-- <i class="fa fa-arrow-up" title="Descending"></i> -->
+                            <button class="btn btn-secondary-outline" (click)="updateSortOrder()">
+                                <i class="fa fa-arrow-down" title="Ascending" *ngIf="isAscendingSort; else descSort"></i>
+                                <ng-template #descSort>
+                                    <i class="fa fa-arrow-up" title="Descending"></i>
+                                </ng-template>
                             </button>
-                            <select id="sort-options" class="form-control" formControlName="loggingLevel">
+                            <select id="sort-options" class="form-control" formControlName="sortField">
                                 <option value="sortName">Sort Name</option>
                                 <option>Created</option>
                                 <option>Last Modified</option> 
@@ -274,6 +276,7 @@
                 </div>
     
                 <div class="col">
+                    <!-- TODO: Make this float right -->
                     <button class="btn btn-secondary mr-2" (click)="clear()">Clear</button>
                     <button class="btn btn-primary" (click)="apply()">Apply</button>
                 </div>

--- a/UI/Web/src/app/cards/card-detail-layout/card-detail-layout.component.html
+++ b/UI/Web/src/app/cards/card-detail-layout/card-detail-layout.component.html
@@ -294,6 +294,18 @@
                     </app-typeahead>
                 </div>
 
+                <div class="col-md-2 mr-3" *ngIf="!filterSettings.languageDisabled">
+                    <label for="languages">Language</label>
+                    <app-typeahead (selectedData)="updateLanguageRating($event)" [settings]="languageSettings" [reset]="resetTypeaheads">
+                        <ng-template #badgeItem let-item let-position="idx">
+                            {{item.title}}
+                        </ng-template>
+                        <ng-template #optionItem let-item let-position="idx">
+                            {{item.title}}
+                        </ng-template>
+                    </app-typeahead>
+                </div>
+
                 <div class="col-md-2 mr-3" *ngIf="!filterSettings.sortDisabled">
                     <form [formGroup]="sortGroup">
                         <div class="form-group">
@@ -313,12 +325,15 @@
                     </form>
                 </div>
     
+                
+                
+            </div>
+            <div class="row no-gutters">
                 <div class="col">
                     <!-- TODO: Make this float right -->
                     <button class="btn btn-secondary mr-2" (click)="clear()">Clear</button>
                     <button class="btn btn-primary" (click)="apply()">Apply</button>
                 </div>
-                
             </div>
         </div>
     </ng-template>

--- a/UI/Web/src/app/cards/card-detail-layout/card-detail-layout.component.html
+++ b/UI/Web/src/app/cards/card-detail-layout/card-detail-layout.component.html
@@ -40,7 +40,7 @@
     <ng-template #filterSection>
         <div class="filter-section">
             <div class="row no-gutters">
-                <div class="col-md-3" *ngIf="!filterSettings.formatDisabled">
+                <div class="col-md-2 mr-3" *ngIf="!filterSettings.formatDisabled">
                     <div class="form-group">
                         <label for="format">Format</label>
                         <app-typeahead (selectedData)="updateFormatFilters($event)" [settings]="formatSettings" [reset]="resetTypeaheads">
@@ -54,7 +54,7 @@
                     </div>
                 </div>
     
-                <div class="col-md-3"*ngIf="!filterSettings.libraryDisabled">
+                <div class="col-md-2 mr-3"*ngIf="!filterSettings.libraryDisabled">
                     <div class="form-group">
                         <label for="libraries">Libraries</label>
                         <app-typeahead (selectedData)="updateLibraryFilters($event)" [settings]="librarySettings" [reset]="resetTypeaheads">
@@ -68,7 +68,7 @@
                     </div>
                 </div>
     
-                <div class="col-md-3" *ngIf="!filterSettings.collectionDisabled">
+                <div class="col-md-2 mr-3" *ngIf="!filterSettings.collectionDisabled">
                     <div class="form-group">
                         <label for="collections">Collections</label>
                         <app-typeahead (selectedData)="updateCollectionFilters($event)" [settings]="collectionSettings" [reset]="resetTypeaheads">
@@ -82,7 +82,7 @@
                     </div>
                 </div>
     
-                <div class="col-md-3" *ngIf="!filterSettings.genresDisabled">
+                <div class="col-md-2 mr-3" *ngIf="!filterSettings.genresDisabled">
                     <div class="form-group">
                         <label for="genres">Genres</label>
                         <app-typeahead (selectedData)="updateGenreFilters($event)" [settings]="genreSettings" [reset]="resetTypeaheads">
@@ -98,7 +98,7 @@
             </div>
             <div class="row no-gutters">
                 <!-- The People row -->
-                <div class="col-md-3" *ngIf="peopleSettings.hasOwnProperty(PersonRole.CoverArtist)">
+                <div class="col-md-2 mr-3" *ngIf="peopleSettings.hasOwnProperty(PersonRole.CoverArtist)">
                     <div class="form-group">
                         <label for="cover-artist">(Cover) Artists</label>
                         <app-typeahead (selectedData)="updatePersonFilters($event, PersonRole.CoverArtist)" [settings]="getPersonsSettings(PersonRole.CoverArtist)" [reset]="resetTypeaheads">
@@ -112,7 +112,7 @@
                     </div>
                 </div>
     
-                <div class="col-md-3" *ngIf="peopleSettings.hasOwnProperty(PersonRole.Writer)">
+                <div class="col-md-2 mr-3" *ngIf="peopleSettings.hasOwnProperty(PersonRole.Writer)">
                     <div class="form-group">
                         <label for="writers">Writers</label>
                         <app-typeahead (selectedData)="updatePersonFilters($event, PersonRole.Writer)" [settings]="getPersonsSettings(PersonRole.Writer)" [reset]="resetTypeaheads">
@@ -126,7 +126,7 @@
                     </div>
                 </div>
     
-                <div class="col-md-3" *ngIf="peopleSettings.hasOwnProperty(PersonRole.Publisher)">
+                <div class="col-md-2 mr-3" *ngIf="peopleSettings.hasOwnProperty(PersonRole.Publisher)">
                     <div class="form-group">
                         <label for="publisher">Publisher</label>
                         <app-typeahead (selectedData)="updatePersonFilters($event, PersonRole.Publisher)" [settings]="getPersonsSettings(PersonRole.Publisher)" [reset]="resetTypeaheads">
@@ -140,7 +140,7 @@
                     </div>
                 </div>
     
-                <div class="col-md-3" *ngIf="peopleSettings.hasOwnProperty(PersonRole.Penciller)">
+                <div class="col-md-2 mr-3" *ngIf="peopleSettings.hasOwnProperty(PersonRole.Penciller)">
                     <div class="form-group">
                         <label for="Penciller">Penciller</label>
                         <app-typeahead (selectedData)="updatePersonFilters($event, PersonRole.Penciller)" [settings]="getPersonsSettings(PersonRole.Penciller)" [reset]="resetTypeaheads">
@@ -154,7 +154,7 @@
                     </div>
                 </div>
     
-                <div class="col-md-3" *ngIf="peopleSettings.hasOwnProperty(PersonRole.Letterer)">
+                <div class="col-md-2 mr-3" *ngIf="peopleSettings.hasOwnProperty(PersonRole.Letterer)">
                     <div class="form-group">
                         <label for="letterer">Letterer</label>
                         <app-typeahead (selectedData)="updatePersonFilters($event, PersonRole.Letterer)" [settings]="getPersonsSettings(PersonRole.Letterer)" [reset]="resetTypeaheads">
@@ -168,7 +168,7 @@
                     </div>
                 </div>
     
-                <div class="col-md-3" *ngIf="peopleSettings.hasOwnProperty(PersonRole.Inker)">
+                <div class="col-md-2 mr-3" *ngIf="peopleSettings.hasOwnProperty(PersonRole.Inker)">
                     <div class="form-group">
                         <label for="inker">Inker</label>
                         <app-typeahead (selectedData)="updatePersonFilters($event, PersonRole.Inker)" [settings]="getPersonsSettings(PersonRole.Inker)" [reset]="resetTypeaheads">
@@ -182,7 +182,7 @@
                     </div>
                 </div>
     
-                <div class="col-md-3" *ngIf="peopleSettings.hasOwnProperty(PersonRole.Editor)">
+                <div class="col-md-2 mr-3" *ngIf="peopleSettings.hasOwnProperty(PersonRole.Editor)">
                     <div class="form-group">
                         <label for="editor">Editor</label>
                         <app-typeahead (selectedData)="updatePersonFilters($event, PersonRole.Editor)" [settings]="getPersonsSettings(PersonRole.Editor)" [reset]="resetTypeaheads">
@@ -196,7 +196,7 @@
                     </div>
                 </div>
     
-                <div class="col-md-3" *ngIf="peopleSettings.hasOwnProperty(PersonRole.Colorist)">
+                <div class="col-md-2 mr-3" *ngIf="peopleSettings.hasOwnProperty(PersonRole.Colorist)">
                     <div class="form-group">
                         <label for="colorist">Colorist</label>
                         <app-typeahead (selectedData)="updatePersonFilters($event, PersonRole.Colorist)" [settings]="getPersonsSettings(PersonRole.Colorist)" [reset]="resetTypeaheads">
@@ -210,7 +210,7 @@
                     </div>
                 </div>
     
-                <div class="col-md-3" *ngIf="peopleSettings.hasOwnProperty(PersonRole.Character)">
+                <div class="col-md-2 mr-3" *ngIf="peopleSettings.hasOwnProperty(PersonRole.Character)">
                     <div class="form-group">
                         <label for="character">Character</label>
                         <app-typeahead (selectedData)="updatePersonFilters($event, PersonRole.Character)" [settings]="getPersonsSettings(PersonRole.Character)" [reset]="resetTypeaheads">
@@ -225,9 +225,7 @@
                 </div>
             </div>
             <div class="row no-gutters">
-                <!-- Rating/Review/Progress -->
                 <div class="col" *ngIf="!filterSettings.readProgressDisabled">
-                    <!-- Not sure how to do this on the backend, might have to be a UI control -->
                     <label>Read Progress</label>
                     <form [formGroup]="readProgressGroup" class="ml-2">
                         <div class="form-check form-check-inline">
@@ -242,18 +240,7 @@
                             <input class="form-check-input" type="checkbox" id="read" formControlName="read">
                             <label class="form-check-label" for="read">Read</label>
                           </div>
-                          <div class="alert alert-warning" *ngIf="!readProgressGroup.get('read')?.value && !readProgressGroup.get('unread')?.value && !readProgressGroup.get('inProgress')?.value">
-                            You must select at least one to get results
-                          </div>
                     </form>
-                    <!-- <app-typeahead (selectedData)="updateReadStatusFilters($event)" [settings]="readStatusSettings" [reset]="resetTypeaheads">
-                        <ng-template #badgeItem let-item let-position="idx">
-                            {{item.title}}
-                        </ng-template>
-                        <ng-template #optionItem let-item let-position="idx">
-                            {{item.title}}
-                        </ng-template>
-                    </app-typeahead> -->
                 </div>
     
                 <div class="col" *ngIf="!filterSettings.ratingDisabled">

--- a/UI/Web/src/app/cards/card-detail-layout/card-detail-layout.component.html
+++ b/UI/Web/src/app/cards/card-detail-layout/card-detail-layout.component.html
@@ -267,9 +267,9 @@
                                 </ng-template>
                             </button>
                             <select id="sort-options" class="form-control" formControlName="sortField">
-                                <option value="sortName">Sort Name</option>
-                                <option>Created</option>
-                                <option>Last Modified</option> 
+                                <option [value]="SortField.SortName">Sort Name</option>
+                                <option [value]="SortField.Created">Created</option>
+                                <option [value]="SortField.LastModified">Last Modified</option> 
                             </select>
                         </div>
                     </form>

--- a/UI/Web/src/app/cards/card-detail-layout/card-detail-layout.component.html
+++ b/UI/Web/src/app/cards/card-detail-layout/card-detail-layout.component.html
@@ -95,6 +95,20 @@
                         </app-typeahead>
                     </div>
                 </div>
+
+                <div class="col-md-2 mr-3" *ngIf="!filterSettings.tagsDisabled">
+                    <div class="form-group">
+                        <label for="tags">Tags</label>
+                        <app-typeahead (selectedData)="updateTagFilters($event)" [settings]="tagsSettings" [reset]="resetTypeaheads">
+                            <ng-template #badgeItem let-item let-position="idx">
+                                {{item.title}}
+                            </ng-template>
+                            <ng-template #optionItem let-item let-position="idx">
+                                {{item.title}}
+                            </ng-template>
+                        </app-typeahead>
+                    </div>
+                </div>
             </div>
             <div class="row no-gutters">
                 <!-- The People row -->
@@ -223,9 +237,23 @@
                         </app-typeahead>
                     </div>
                 </div>
+
+                <div class="col-md-2 mr-3" *ngIf="peopleSettings.hasOwnProperty(PersonRole.Translator)">
+                    <div class="form-group">
+                        <label for="translators">Translators</label>
+                        <app-typeahead (selectedData)="updatePersonFilters($event, PersonRole.Translator)" [settings]="getPersonsSettings(PersonRole.Translator)" [reset]="resetTypeaheads">
+                            <ng-template #badgeItem let-item let-position="idx">
+                                {{item.title}}
+                            </ng-template>
+                            <ng-template #optionItem let-item let-position="idx">
+                                {{item.title}}
+                            </ng-template>
+                        </app-typeahead>
+                    </div>
+                </div>
             </div>
             <div class="row no-gutters">
-                <div class="col" *ngIf="!filterSettings.readProgressDisabled">
+                <div class="col-md-2 mr-3" *ngIf="!filterSettings.readProgressDisabled">
                     <label>Read Progress</label>
                     <form [formGroup]="readProgressGroup" class="ml-2">
                         <div class="form-check form-check-inline">
@@ -243,7 +271,7 @@
                     </form>
                 </div>
     
-                <div class="col" *ngIf="!filterSettings.ratingDisabled">
+                <div class="col-md-2 mr-3" *ngIf="!filterSettings.ratingDisabled">
                     <label for="ratings">Rating</label>
                     <form class="form-inline ml-2">
                         <ngb-rating class="rating-star" [(rate)]="filter.rating" (rateChange)="updateRating($event)" [resettable]="true">
@@ -254,7 +282,19 @@
                     </form>
                 </div>
 
-                <div class="col" *ngIf="!filterSettings.sortDisabled">
+                <div class="col-md-2 mr-3" *ngIf="!filterSettings.ageRatingDisabled">
+                    <label for="age-rating">Age Rating</label>
+                    <app-typeahead (selectedData)="updateAgeRating($event)" [settings]="ageRatingSettings" [reset]="resetTypeaheads">
+                        <ng-template #badgeItem let-item let-position="idx">
+                            {{item.title}}
+                        </ng-template>
+                        <ng-template #optionItem let-item let-position="idx">
+                            {{item.title}}
+                        </ng-template>
+                    </app-typeahead>
+                </div>
+
+                <div class="col-md-2 mr-3" *ngIf="!filterSettings.sortDisabled">
                     <form [formGroup]="sortGroup">
                         <div class="form-group">
                             <label for="sort-options">Sort By</label>

--- a/UI/Web/src/app/cards/card-detail-layout/card-detail-layout.component.html
+++ b/UI/Web/src/app/cards/card-detail-layout/card-detail-layout.component.html
@@ -156,7 +156,7 @@
     
                 <div class="col-md-2 mr-3" *ngIf="peopleSettings.hasOwnProperty(PersonRole.Penciller)">
                     <div class="form-group">
-                        <label for="Penciller">Penciller</label>
+                        <label for="penciller">Penciller</label>
                         <app-typeahead (selectedData)="updatePersonFilters($event, PersonRole.Penciller)" [settings]="getPersonsSettings(PersonRole.Penciller)" [reset]="resetTypeaheads">
                             <ng-template #badgeItem let-item let-position="idx">
                                 {{item.title}}
@@ -298,13 +298,13 @@
                     <form [formGroup]="sortGroup">
                         <div class="form-group">
                             <label for="sort-options">Sort By</label>
-                            <button class="btn btn-secondary-outline" (click)="updateSortOrder()">
+                            <button class="btn btn-sm btn-secondary-outline" (click)="updateSortOrder()" style="height: 25px; padding-bottom: 0px;">
                                 <i class="fa fa-arrow-down" title="Ascending" *ngIf="isAscendingSort; else descSort"></i>
                                 <ng-template #descSort>
                                     <i class="fa fa-arrow-up" title="Descending"></i>
                                 </ng-template>
                             </button>
-                            <select id="sort-options" class="form-control" formControlName="sortField">
+                            <select id="sort-options" class="form-control" formControlName="sortField" style="height: 38px;">
                                 <option [value]="SortField.SortName">Sort Name</option>
                                 <option [value]="SortField.Created">Created</option>
                                 <option [value]="SortField.LastModified">Last Modified</option> 

--- a/UI/Web/src/app/cards/card-detail-layout/card-detail-layout.component.html
+++ b/UI/Web/src/app/cards/card-detail-layout/card-detail-layout.component.html
@@ -256,7 +256,7 @@
                     </form>
                 </div>
 
-                <div class="col">
+                <div class="col" *ngIf="!filterSettings.sortDisabled">
                     <form [formGroup]="sortGroup">
                         <div class="form-group">
                             <label for="sort-options">Sort By</label>

--- a/UI/Web/src/app/cards/card-detail-layout/card-detail-layout.component.html
+++ b/UI/Web/src/app/cards/card-detail-layout/card-detail-layout.component.html
@@ -242,7 +242,18 @@
                             <input class="form-check-input" type="checkbox" id="read" formControlName="read">
                             <label class="form-check-label" for="read">Read</label>
                           </div>
+                          <div class="alert alert-warning" *ngIf="!readProgressGroup.get('read')?.value && !readProgressGroup.get('unread')?.value && !readProgressGroup.get('inProgress')?.value">
+                            You must select at least one to get results
+                          </div>
                     </form>
+                    <!-- <app-typeahead (selectedData)="updateReadStatusFilters($event)" [settings]="readStatusSettings" [reset]="resetTypeaheads">
+                        <ng-template #badgeItem let-item let-position="idx">
+                            {{item.title}}
+                        </ng-template>
+                        <ng-template #optionItem let-item let-position="idx">
+                            {{item.title}}
+                        </ng-template>
+                    </app-typeahead> -->
                 </div>
     
                 <div class="col" *ngIf="!filterSettings.ratingDisabled">

--- a/UI/Web/src/app/cards/card-detail-layout/card-detail-layout.component.html
+++ b/UI/Web/src/app/cards/card-detail-layout/card-detail-layout.component.html
@@ -255,15 +255,29 @@
                         </ngb-rating>
                     </form>
                 </div>
+
+                <div class="col">
+                    <form>
+                        <div class="form-group">
+                            <label for="sort-options">Sort By</label>
+                            <button class="btn btn-secondary-outline">
+                                <i class="fa fa-arrow-down" title="Ascending"></i>
+                                <!-- <i class="fa fa-arrow-up" title="Descending"></i> -->
+                            </button>
+                            <select id="sort-options" class="form-control" formControlName="loggingLevel">
+                                <option value="sortName">Sort Name</option>
+                                <option>Created</option>
+                                <option>Last Modified</option> 
+                            </select>
+                        </div>
+                    </form>
+                </div>
     
                 <div class="col">
                     <button class="btn btn-secondary mr-2" (click)="clear()">Clear</button>
                     <button class="btn btn-primary" (click)="apply()">Apply</button>
                 </div>
                 
-            </div>
-            <div class="row no-gutters">
-                <!-- Sort by functionalities -->
             </div>
         </div>
     </ng-template>

--- a/UI/Web/src/app/cards/card-detail-layout/card-detail-layout.component.ts
+++ b/UI/Web/src/app/cards/card-detail-layout/card-detail-layout.component.ts
@@ -109,6 +109,21 @@ export class CardDetailLayoutComponent implements OnInit, OnDestroy {
       this.filter.readStatus.read = this.readProgressGroup.get('read')?.value;
       this.filter.readStatus.inProgress = this.readProgressGroup.get('inProgress')?.value;
       this.filter.readStatus.notRead = this.readProgressGroup.get('notRead')?.value;
+
+      let sum = 0;
+      sum += (this.filter.readStatus.read ? 1 : 0);
+      sum += (this.filter.readStatus.inProgress ? 1 : 0);
+      sum += (this.filter.readStatus.notRead ? 1 : 0);
+
+      if (sum === 1) {
+        if (this.filter.readStatus.read) this.readProgressGroup.get('read')?.disable({ emitEvent: false });
+        if (this.filter.readStatus.notRead) this.readProgressGroup.get('notRead')?.disable({ emitEvent: false });
+        if (this.filter.readStatus.inProgress) this.readProgressGroup.get('inProgress')?.disable({ emitEvent: false });
+      } else {
+        this.readProgressGroup.get('read')?.enable({ emitEvent: false });
+        this.readProgressGroup.get('notRead')?.enable({ emitEvent: false });
+        this.readProgressGroup.get('inProgress')?.enable({ emitEvent: false });
+      }
     });
 
     this.sortGroup.valueChanges.pipe(takeUntil(this.onDestory)).subscribe(changes => {
@@ -470,7 +485,7 @@ export class CardDetailLayoutComponent implements OnInit, OnDestroy {
     this.sortGroup.get('sortField')?.setValue(SortField.SortName);
     this.isAscendingSort = true;
     this.resetTypeaheads.next(true);
-    
+
     this.applyFilter.emit(this.filter);
     this.updateApplied++;
   }

--- a/UI/Web/src/app/cards/card-detail-layout/card-detail-layout.component.ts
+++ b/UI/Web/src/app/cards/card-detail-layout/card-detail-layout.component.ts
@@ -464,7 +464,13 @@ export class CardDetailLayoutComponent implements OnInit, OnDestroy {
 
   clear() {
     this.filter = this.seriesService.createSeriesFilter();
+    this.readProgressGroup.get('read')?.setValue(true);
+    this.readProgressGroup.get('notRead')?.setValue(true);
+    this.readProgressGroup.get('inProgress')?.setValue(true);
+    this.sortGroup.get('sortField')?.setValue(SortField.SortName);
+    this.isAscendingSort = true;
     this.resetTypeaheads.next(true);
+    
     this.applyFilter.emit(this.filter);
     this.updateApplied++;
   }

--- a/UI/Web/src/app/cards/card-detail-layout/card-detail-layout.component.ts
+++ b/UI/Web/src/app/cards/card-detail-layout/card-detail-layout.component.ts
@@ -152,24 +152,7 @@ export class CardDetailLayoutComponent implements OnInit, OnDestroy {
       this.filterSettings = new FilterSettings();
     }
     
-    let apiCall;
-    if (this.filter.libraries.length > 0) {
-      apiCall = this.metadataService.getGenresForLibraries(this.filter.libraries);
-    } else {
-      apiCall = this.metadataService.getAllGenres();
-    }
-
-    apiCall.subscribe(genres => {
-      this.genres = genres.map(genre => {
-        return {
-          title: genre.title,
-          value: genre,
-          selected: false,
-        }
-      });
-      this.setupGenreTypeahead();
-
-    });
+    this.setupGenreTypeahead();
 
     this.libraryService.getLibrariesForMember().subscribe(libs => {
       this.libraries = libs.map(lib => {
@@ -182,29 +165,8 @@ export class CardDetailLayoutComponent implements OnInit, OnDestroy {
       this.setupLibraryTypeahead();
     });
 
-    this.metadataService.getAllPeople().subscribe(res => {
-      this.persons = res.map(lib => {
-        return {
-          title: lib.name,
-          value: lib,
-          selected: true,
-        }
-      });
-      this.setupPersonTypeahead();
-    });
-
-    this.collectionTagService.allTags().subscribe(tags => {
-      this.collectionTags = tags.map(lib => {
-        return {
-          title: lib.title,
-          value: lib,
-          selected: false,
-        }
-      });
-      this.setupCollectionTagTypeahead();
-    });
-
-
+    this.setupCollectionTagTypeahead();
+    this.setupPersonTypeahead();
     this.setupAgeRatingSettings();
     this.setupTagSettings();
     
@@ -326,7 +288,15 @@ export class CardDetailLayoutComponent implements OnInit, OnDestroy {
     this.collectionSettings.unique = true;
     this.collectionSettings.addIfNonExisting = false;
     this.collectionSettings.fetchFn = (filter: string) => {
-      return of (this.collectionTags)
+      return this.collectionTagService.allTags().pipe(map(tags => {
+        return tags.map(lib => {
+          return {
+            title: lib.title,
+            value: lib,
+            selected: false,
+          }
+        });
+      }));
     };
     this.collectionSettings.compareFn = (options: FilterItem<CollectionTag>[], filter: string) => {
       const f = filter.toLowerCase();
@@ -460,6 +430,10 @@ export class CardDetailLayoutComponent implements OnInit, OnDestroy {
 
   updateGenreFilters(genres: FilterItem<Genre>[]) {
     this.filter.genres = genres.map(item => item.value.id) || [];
+  }
+
+  updateTagFilters(tags: FilterItem<Tag>[]) {
+    this.filter.tags = tags.map(item => item.value.id) || [];
   }
 
   updatePersonFilters(persons: FilterItem<Person>[], role: PersonRole) {

--- a/UI/Web/src/app/cards/card-detail-layout/card-detail-layout.component.ts
+++ b/UI/Web/src/app/cards/card-detail-layout/card-detail-layout.component.ts
@@ -10,7 +10,7 @@ import { Library } from 'src/app/_models/library';
 import { MangaFormat } from 'src/app/_models/manga-format';
 import { Pagination } from 'src/app/_models/pagination';
 import { Person, PersonRole } from 'src/app/_models/person';
-import { FilterItem, mangaFormatFilters, SeriesFilter } from 'src/app/_models/series-filter';
+import { FilterItem, mangaFormatFilters, SeriesFilter, SortField } from 'src/app/_models/series-filter';
 import { ActionItem } from 'src/app/_services/action-factory.service';
 import { CollectionTagService } from 'src/app/_services/collection-tag.service';
 import { LibraryService } from 'src/app/_services/library.service';
@@ -88,6 +88,10 @@ export class CardDetailLayoutComponent implements OnInit, OnDestroy {
     return PersonRole;
   }
 
+  get SortField(): typeof SortField {
+    return SortField;
+  }
+
   constructor(private libraryService: LibraryService, private metadataService: MetadataService, private seriesService: SeriesService,
     private utilityService: UtilityService, private collectionTagService: CollectionTagService) {
     this.filter = this.seriesService.createSeriesFilter();
@@ -98,7 +102,7 @@ export class CardDetailLayoutComponent implements OnInit, OnDestroy {
     });
 
     this.sortGroup = new FormGroup({
-      sortField: new FormControl(this.filter.sortOptions?.sortField, []),
+      sortField: new FormControl(this.filter.sortOptions?.sortField || SortField.SortName, []),
     });
 
     this.readProgressGroup.valueChanges.pipe(takeUntil(this.onDestory)).subscribe(changes => {
@@ -111,10 +115,10 @@ export class CardDetailLayoutComponent implements OnInit, OnDestroy {
       if (this.filter.sortOptions == null) {
         this.filter.sortOptions = {
           isAscending: this.isAscendingSort,
-          sortField: this.readProgressGroup.get('sortField')?.value
+          sortField: parseInt(this.sortGroup.get('sortField')?.value, 10)
         };
       }
-      this.filter.sortOptions.sortField = this.readProgressGroup.get('sortField')?.value;
+      this.filter.sortOptions.sortField = parseInt(this.sortGroup.get('sortField')?.value, 10);
     });
   }
 
@@ -275,63 +279,54 @@ export class CardDetailLayoutComponent implements OnInit, OnDestroy {
     var personSettings = this.createBlankPersonSettings('writers');
     personSettings.fetchFn = (filter: string) => {
       return this.fetchPeople(PersonRole.Writer, filter);
-      //return of (this.persons.filter(p => p.value.role == PersonRole.Writer && this.utilityService.filter(p.value.name, filter)));
     };
     this.peopleSettings[PersonRole.Writer] = personSettings;
 
     personSettings = this.createBlankPersonSettings('character');
     personSettings.fetchFn = (filter: string) => {
       return this.fetchPeople(PersonRole.Character, filter);
-      //return of (this.persons.filter(p => p.value.role == PersonRole.Character && this.utilityService.filter(p.title, filter)))
     };
     this.peopleSettings[PersonRole.Character] = personSettings;
 
     personSettings = this.createBlankPersonSettings('colorist');
     personSettings.fetchFn = (filter: string) => {
       return this.fetchPeople(PersonRole.Colorist, filter);
-      //return of (this.persons.filter(p => p.value.role == PersonRole.Colorist && this.utilityService.filter(p.title, filter)))
     };
     this.peopleSettings[PersonRole.Colorist] = personSettings;
 
     personSettings = this.createBlankPersonSettings('cover-artist');
     personSettings.fetchFn = (filter: string) => {
       return this.fetchPeople(PersonRole.CoverArtist, filter);
-      //return of (this.persons.filter(p => p.value.role == PersonRole.CoverArtist && this.utilityService.filter(p.title, filter)))
     };
     this.peopleSettings[PersonRole.CoverArtist] = personSettings;
 
     personSettings = this.createBlankPersonSettings('editor');
     personSettings.fetchFn = (filter: string) => {
       return this.fetchPeople(PersonRole.Editor, filter);
-      //return of (this.persons.filter(p => p.value.role == PersonRole.Editor && this.utilityService.filter(p.title, filter)))
     };
     this.peopleSettings[PersonRole.Editor] = personSettings;
 
     personSettings = this.createBlankPersonSettings('inker');
     personSettings.fetchFn = (filter: string) => {
       return this.fetchPeople(PersonRole.Inker, filter);
-      //return of (this.persons.filter(p => p.value.role == PersonRole.Inker && this.utilityService.filter(p.title, filter)))
     };
     this.peopleSettings[PersonRole.Inker] = personSettings;
 
     personSettings = this.createBlankPersonSettings('letterer');
     personSettings.fetchFn = (filter: string) => {
       return this.fetchPeople(PersonRole.Letterer, filter);
-      //return of (this.persons.filter(p => p.value.role == PersonRole.Letterer && this.utilityService.filter(p.title, filter)))
     };
     this.peopleSettings[PersonRole.Letterer] = personSettings;
 
     personSettings = this.createBlankPersonSettings('penciller');
     personSettings.fetchFn = (filter: string) => {
       return this.fetchPeople(PersonRole.Penciller, filter);
-      //return of (this.persons.filter(p => p.value.role == PersonRole.Penciller && this.utilityService.filter(p.title, filter)))
     };
     this.peopleSettings[PersonRole.Penciller] = personSettings;
 
     personSettings = this.createBlankPersonSettings('publisher');
     personSettings.fetchFn = (filter: string) => {
       return this.fetchPeople(PersonRole.Publisher, filter);
-      //return of (this.persons.filter(p => p.value.role == PersonRole.Publisher && this.utilityService.filter(p.title, filter)))
     };
     this.peopleSettings[PersonRole.Publisher] = personSettings;
   }

--- a/UI/Web/src/app/cards/card-item/card-item.component.scss
+++ b/UI/Web/src/app/cards/card-item/card-item.component.scss
@@ -1,6 +1,6 @@
 @use '../../../theme/colors';
 
-$triangle-size: 40px;
+$triangle-size: 30px;
 $image-height: 230px;
 $image-width: 160px;
 

--- a/UI/Web/src/app/collections/collection-detail/collection-detail.component.html
+++ b/UI/Web/src/app/collections/collection-detail/collection-detail.component.html
@@ -32,6 +32,7 @@
     [isLoading]="isLoading"
     [items]="series"
     [pagination]="seriesPagination"
+    [filterSettings]="filterSettings"
     (pageChange)="onPageChange($event)"
     (applyFilter)="updateFilter($event)"
     >

--- a/UI/Web/src/app/collections/collection-detail/collection-detail.component.ts
+++ b/UI/Web/src/app/collections/collection-detail/collection-detail.component.ts
@@ -6,6 +6,7 @@ import { ToastrService } from 'ngx-toastr';
 import { Subject } from 'rxjs';
 import { debounceTime, take, takeUntil, takeWhile } from 'rxjs/operators';
 import { BulkSelectionService } from 'src/app/cards/bulk-selection.service';
+import { FilterSettings } from 'src/app/cards/card-detail-layout/card-detail-layout.component';
 import { EditCollectionTagsComponent } from 'src/app/cards/_modals/edit-collection-tags/edit-collection-tags.component';
 import { KEY_CODES } from 'src/app/shared/_services/utility.service';
 import { CollectionTag } from 'src/app/_models/collection-tag';
@@ -38,6 +39,7 @@ export class CollectionDetailComponent implements OnInit, OnDestroy {
   collectionTagActions: ActionItem<CollectionTag>[] = [];
   isAdmin: boolean = false;
   filter: SeriesFilter | undefined = undefined;
+  filterSettings: FilterSettings = new FilterSettings();
 
   private onDestory: Subject<void> = new Subject<void>();
 
@@ -95,6 +97,9 @@ export class CollectionDetailComponent implements OnInit, OnDestroy {
         return;
       }
       const tagId = parseInt(routeId, 10);
+
+      this.filterSettings.presetCollectionId = tagId;
+      
       this.updateTag(tagId);
   }
 

--- a/UI/Web/src/app/library-detail/library-detail.component.html
+++ b/UI/Web/src/app/library-detail/library-detail.component.html
@@ -4,6 +4,7 @@
     [items]="series"
     [actions]="actions"
     [pagination]="pagination"
+    [filterSettings]="filterSettings"
     (applyFilter)="updateFilter($event)"
     (pageChange)="onPageChange($event)"
     >

--- a/UI/Web/src/app/library-detail/library-detail.component.ts
+++ b/UI/Web/src/app/library-detail/library-detail.component.ts
@@ -4,6 +4,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { Subject } from 'rxjs';
 import { debounceTime, take, takeUntil, takeWhile } from 'rxjs/operators';
 import { BulkSelectionService } from '../cards/bulk-selection.service';
+import { FilterSettings } from '../cards/card-detail-layout/card-detail-layout.component';
 import { KEY_CODES } from '../shared/_services/utility.service';
 import { SeriesAddedEvent } from '../_models/events/series-added-event';
 import { Library } from '../_models/library';
@@ -31,6 +32,7 @@ export class LibraryDetailComponent implements OnInit, OnDestroy {
   actions: ActionItem<Library>[] = [];
   filter: SeriesFilter | undefined = undefined;
   onDestroy: Subject<void> = new Subject<void>();
+  filterSettings: FilterSettings = new FilterSettings();
 
   bulkActionCallback = (action: Action, data: any) => {
     const selectedSeriesIndexies = this.bulkSelectionService.getSelectedCardsForSource('series');
@@ -85,6 +87,8 @@ export class LibraryDetailComponent implements OnInit, OnDestroy {
     });
     this.actions = this.actionFactoryService.getLibraryActions(this.handleAction.bind(this));
     this.pagination = {currentPage: 0, itemsPerPage: 30, totalItems: 0, totalPages: 1};
+    this.filterSettings.presetLibraryId = this.libraryId;
+    
     this.loadPage();
   }
 

--- a/UI/Web/src/app/library/library.component.html
+++ b/UI/Web/src/app/library/library.component.html
@@ -17,7 +17,7 @@
     </ng-template>
 </app-carousel-reel>
 
-<app-carousel-reel [items]="libraries" title="Libraries">
+<app-carousel-reel [items]="libraries" title="Libraries" (sectionClick)="handleSectionClick($event)">
     <ng-template #carouselItem let-item let-position="idx">
         <app-library-card [data]="item"></app-library-card>
     </ng-template>

--- a/UI/Web/src/app/library/library.component.ts
+++ b/UI/Web/src/app/library/library.component.ts
@@ -110,6 +110,8 @@ export class LibraryComponent implements OnInit, OnDestroy {
       this.router.navigate(['recently-added']);
     } else if (sectionTitle.toLowerCase() === 'on deck') {
       this.router.navigate(['on-deck']);
+    } else if (sectionTitle.toLowerCase() === 'libraries') {
+      this.router.navigate(['all-series']);
     } 
   }
 

--- a/UI/Web/src/app/on-deck/on-deck.component.ts
+++ b/UI/Web/src/app/on-deck/on-deck.component.ts
@@ -34,6 +34,7 @@ export class OnDeckComponent implements OnInit {
       this.pagination = {currentPage: 0, itemsPerPage: 30, totalItems: 0, totalPages: 1};
     }
     this.filterSettings.readProgressDisabled = true;
+    this.filterSettings.sortDisabled = true;
     this.loadPage();
   }
 

--- a/UI/Web/src/app/recently-added/recently-added.component.html
+++ b/UI/Web/src/app/recently-added/recently-added.component.html
@@ -3,6 +3,7 @@
 [isLoading]="isLoading"
 [items]="series"
 [pagination]="pagination"
+[filterSettings]="filterSettings"
 (applyFilter)="applyFilter($event)"
 (pageChange)="onPageChange($event)"
 >

--- a/UI/Web/src/app/recently-added/recently-added.component.ts
+++ b/UI/Web/src/app/recently-added/recently-added.component.ts
@@ -4,6 +4,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { Subject } from 'rxjs';
 import { debounceTime, take, takeUntil, takeWhile } from 'rxjs/operators';
 import { BulkSelectionService } from '../cards/bulk-selection.service';
+import { FilterSettings } from '../cards/card-detail-layout/card-detail-layout.component';
 import { KEY_CODES } from '../shared/_services/utility.service';
 import { SeriesAddedEvent } from '../_models/events/series-added-event';
 import { Pagination } from '../_models/pagination';
@@ -30,6 +31,7 @@ export class RecentlyAddedComponent implements OnInit, OnDestroy {
   libraryId!: number;
 
   filter: SeriesFilter | undefined = undefined;
+  filterSettings: FilterSettings = new FilterSettings();
 
   onDestroy: Subject<void> = new Subject();
 
@@ -40,6 +42,8 @@ export class RecentlyAddedComponent implements OnInit, OnDestroy {
     if (this.pagination === undefined || this.pagination === null) {
       this.pagination = {currentPage: 0, itemsPerPage: 30, totalItems: 0, totalPages: 1};
     }
+    this.filterSettings.sortDisabled = true;
+
     this.loadPage();
   }
 

--- a/UI/Web/src/app/series-metadata-detail/series-metadata-detail.component.html
+++ b/UI/Web/src/app/series-metadata-detail/series-metadata-detail.component.html
@@ -101,6 +101,15 @@
             <app-person-badge *ngFor="let person of seriesMetadata.letterers" [person]="person"></app-person-badge>
         </div>
     </div>
+
+    <div class="row no-gutters mt-1"  *ngIf="seriesMetadata.translators && seriesMetadata.translators.length > 0">
+        <div class="col-md-4">
+            <h5>Translators</h5>
+        </div>
+        <div class="col-md-8">
+            <app-person-badge *ngFor="let person of seriesMetadata.translators" [person]="person"></app-person-badge>
+        </div>
+    </div>
     
     <div class="row no-gutters mt-1"  *ngIf="seriesMetadata.pencillers && seriesMetadata.pencillers.length > 0">
         <div class="col-md-4">

--- a/UI/Web/src/app/series-metadata-detail/series-metadata-detail.component.html
+++ b/UI/Web/src/app/series-metadata-detail/series-metadata-detail.component.html
@@ -3,12 +3,13 @@
 </div>
 
 <!-- This first row will have random information about the series-->
-<div class="row no-gutters mb-2" *ngIf="seriesMetadata.ageRating">
-    <app-tag-badge title="Age Rating">{{ageRatingName}}</app-tag-badge>
+<div class="row no-gutters mb-2">
+    <app-tag-badge title="Age Rating" *ngIf="seriesMetadata.ageRating">{{metadataService.getAgeRating(this.seriesMetadata.ageRating) | async}}</app-tag-badge>
     <ng-container *ngIf="series">
         <!-- Maybe we can put the library this resides in to make it easier to get back -->
         <!-- tooltip here explaining how this is year of first issue -->
         <app-tag-badge *ngIf="seriesMetadata.releaseYear > 0" title="Release date">{{seriesMetadata.releaseYear}}</app-tag-badge>
+        <app-tag-badge *ngIf="seriesMetadata.language !== ''" title="Language">{{seriesMetadata.language}}</app-tag-badge>
         <app-tag-badge [selectionMode]="TagBadgeCursor.NotAllowed">
             <app-series-format [format]="series.format">{{utilityService.mangaFormat(series.format)}}</app-series-format>
         </app-tag-badge>

--- a/UI/Web/src/app/series-metadata-detail/series-metadata-detail.component.html
+++ b/UI/Web/src/app/series-metadata-detail/series-metadata-detail.component.html
@@ -1,9 +1,9 @@
-<div class="row no-gutters {{series?.userReview ? '' : 'mt-2'}}">
+<div class="row no-gutters mt-2 mb-2">
     <app-read-more [text]="seriesSummary" [maxLength]="250"></app-read-more>
 </div>
 
 <!-- This first row will have random information about the series-->
-<div class="row no-gutters" *ngIf="seriesMetadata.ageRating">
+<div class="row no-gutters mb-2" *ngIf="seriesMetadata.ageRating">
     <app-tag-badge title="Age Rating">{{ageRatingName}}</app-tag-badge>
     <ng-container *ngIf="series">
         <!-- Maybe we can put the library this resides in to make it easier to get back -->
@@ -32,9 +32,13 @@
         <h5>Collections</h5>
     </div>
     <div class="col-md-8">
-        <app-tag-badge *ngFor="let tag of seriesMetadata.collectionTags" a11y-click="13,32" class="clickable" routerLink="/collections/{{tag.id}}"  [selectionMode]="TagBadgeCursor.Clickable">
-            {{tag.title}}
-        </app-tag-badge>
+        <app-badge-expander [items]="seriesMetadata.collectionTags">
+            <ng-template #badgeExpanderItem let-item let-position="idx">
+                <app-tag-badge a11y-click="13,32" class="clickable" routerLink="/collections/{{item.id}}"  [selectionMode]="TagBadgeCursor.Clickable">
+                    {{item.title}}
+                </app-tag-badge>
+            </ng-template>  
+        </app-badge-expander>
     </div>
 </div>
 <div class="row no-gutters mt-1"  *ngIf="seriesMetadata.writers && seriesMetadata.writers.length > 0">
@@ -42,7 +46,11 @@
         <h5>Authors</h5>
     </div>
     <div class="col-md-8">
-        <app-person-badge *ngFor="let person of seriesMetadata.writers" [person]="person"></app-person-badge>
+        <app-badge-expander [items]="seriesMetadata.writers">
+            <ng-template #badgeExpanderItem let-item let-position="idx">
+                <app-person-badge [person]="item"></app-person-badge>
+            </ng-template>  
+        </app-badge-expander>
     </div>
 </div>
 
@@ -57,7 +65,11 @@
             <h5>Artists</h5>
         </div>
         <div class="col-md-8">
-            <app-person-badge *ngFor="let person of seriesMetadata.artists" [person]="person"></app-person-badge>
+            <app-badge-expander [items]="seriesMetadata.artists">
+                <ng-template #badgeExpanderItem let-item let-position="idx">
+                    <app-person-badge [person]="item"></app-person-badge>
+                </ng-template>  
+            </app-badge-expander>
         </div>
     </div>
     
@@ -66,7 +78,11 @@
             <h5>Characters</h5>
         </div>
         <div class="col-md-8">
-            <app-person-badge *ngFor="let person of seriesMetadata.characters" [person]="person"></app-person-badge>
+            <app-badge-expander [items]="seriesMetadata.characters">
+                <ng-template #badgeExpanderItem let-item let-position="idx">
+                    <app-person-badge [person]="item"></app-person-badge>
+                </ng-template>  
+            </app-badge-expander>
         </div>
     </div>
 
@@ -75,7 +91,11 @@
             <h5>Colorists</h5>
         </div>
         <div class="col-md-8">
-            <app-person-badge *ngFor="let person of seriesMetadata.colorists" [person]="person"></app-person-badge>
+            <app-badge-expander [items]="seriesMetadata.colorists">
+                <ng-template #badgeExpanderItem let-item let-position="idx">
+                    <app-person-badge [person]="item"></app-person-badge>
+                </ng-template>  
+            </app-badge-expander>
         </div>
     </div>
 
@@ -84,7 +104,11 @@
             <h5>Editors</h5>
         </div>
         <div class="col-md-8">
-            <app-person-badge *ngFor="let person of seriesMetadata.editors" [person]="person"></app-person-badge>
+            <app-badge-expander [items]="seriesMetadata.editors">
+                <ng-template #badgeExpanderItem let-item let-position="idx">
+                    <app-person-badge [person]="item"></app-person-badge>
+                </ng-template>  
+            </app-badge-expander>
         </div>
     </div>
 
@@ -93,7 +117,11 @@
             <h5>Inkers</h5>
         </div>
         <div class="col-md-8">
-            <app-person-badge *ngFor="let person of seriesMetadata.inkers" [person]="person"></app-person-badge>
+            <app-badge-expander [items]="seriesMetadata.inkers">
+                <ng-template #badgeExpanderItem let-item let-position="idx">
+                    <app-person-badge [person]="item"></app-person-badge>
+                </ng-template>  
+            </app-badge-expander>
         </div>
     </div>
 
@@ -102,7 +130,11 @@
             <h5>Letterers</h5>
         </div>
         <div class="col-md-8">
-            <app-person-badge *ngFor="let person of seriesMetadata.letterers" [person]="person"></app-person-badge>
+            <app-badge-expander [items]="seriesMetadata.letterers">
+                <ng-template #badgeExpanderItem let-item let-position="idx">
+                    <app-person-badge [person]="item"></app-person-badge>
+                </ng-template>  
+            </app-badge-expander>
         </div>
     </div>
     <div class="row no-gutters" *ngIf="seriesMetadata.tags && seriesMetadata.tags.length > 0">
@@ -122,7 +154,11 @@
             <h5>Translators</h5>
         </div>
         <div class="col-md-8">
-            <app-person-badge *ngFor="let person of seriesMetadata.translators" [person]="person"></app-person-badge>
+            <app-badge-expander [items]="seriesMetadata.translators">
+                <ng-template #badgeExpanderItem let-item let-position="idx">
+                    <app-person-badge [person]="item"></app-person-badge>
+                </ng-template>  
+            </app-badge-expander>
         </div>
     </div>
     
@@ -131,7 +167,11 @@
             <h5>Pencillers</h5>
         </div>
         <div class="col-md-8">
-            <app-person-badge *ngFor="let person of seriesMetadata.pencillers" [person]="person"></app-person-badge>
+            <app-badge-expander [items]="seriesMetadata.pencillers">
+                <ng-template #badgeExpanderItem let-item let-position="idx">
+                    <app-person-badge [person]="item"></app-person-badge>
+                </ng-template>  
+            </app-badge-expander>
         </div>
     </div>
 
@@ -140,7 +180,11 @@
             <h5>Publishers</h5>
         </div>
         <div class="col-md-8">
-            <app-person-badge *ngFor="let person of seriesMetadata.publishers" [person]="person"></app-person-badge>
+            <app-badge-expander [items]="seriesMetadata.publishers">
+                <ng-template #badgeExpanderItem let-item let-position="idx">
+                    <app-person-badge [person]="item"></app-person-badge>
+                </ng-template>  
+            </app-badge-expander>
         </div>
     </div>
 </div>

--- a/UI/Web/src/app/series-metadata-detail/series-metadata-detail.component.html
+++ b/UI/Web/src/app/series-metadata-detail/series-metadata-detail.component.html
@@ -20,15 +20,19 @@
         <h5>Genres</h5>
     </div>
     <div class="col-md-8">
-        <app-tag-badge *ngFor="let genre of seriesMetadata.genres" [selectionMode]="TagBadgeCursor.Clickable">{{genre.title}}</app-tag-badge>
+        <app-badge-expander [items]="seriesMetadata.genres">
+            <ng-template #badgeExpanderItem let-item let-position="idx">
+                <app-tag-badge [selectionMode]="TagBadgeCursor.Clickable">{{item.title}}</app-tag-badge>
+            </ng-template>  
+        </app-badge-expander>
     </div>
 </div>
-<div class="row no-gutters mt-1" *ngIf="seriesMetadata.tags && seriesMetadata.tags.length > 0">
+<div class="row no-gutters mt-1" *ngIf="seriesMetadata.collectionTags && seriesMetadata.collectionTags.length > 0">
     <div class="col-md-4">
         <h5>Collections</h5>
     </div>
     <div class="col-md-8">
-        <app-tag-badge *ngFor="let tag of seriesMetadata.tags" a11y-click="13,32" class="clickable" routerLink="/collections/{{tag.id}}"  [selectionMode]="TagBadgeCursor.Clickable">
+        <app-tag-badge *ngFor="let tag of seriesMetadata.collectionTags" a11y-click="13,32" class="clickable" routerLink="/collections/{{tag.id}}"  [selectionMode]="TagBadgeCursor.Clickable">
             {{tag.title}}
         </app-tag-badge>
     </div>
@@ -43,7 +47,7 @@
 </div>
 
 <div class="row no-gutters">
-    <hr class="col-md-11">
+    <hr class="col-md-11" *ngIf="hasExtendedProperites" >
     <a [class.hidden]="hasExtendedProperites" *ngIf="hasExtendedProperites" class="col-md-1 read-more-link" (click)="toggleView()">&nbsp;<i aria-hidden="true" class="fa fa-caret-{{isCollapsed ? 'down' : 'up'}}" aria-controls="extended-series-metadata"></i>&nbsp;See {{isCollapsed ? 'More' : 'Less'}}</a>
 </div>
 
@@ -101,7 +105,18 @@
             <app-person-badge *ngFor="let person of seriesMetadata.letterers" [person]="person"></app-person-badge>
         </div>
     </div>
-
+    <div class="row no-gutters" *ngIf="seriesMetadata.tags && seriesMetadata.tags.length > 0">
+        <div class="col-md-4">
+            <h5>Tags</h5>
+        </div>
+        <div class="col-md-8">
+            <app-badge-expander [items]="seriesMetadata.tags">
+                <ng-template #badgeExpanderItem let-item let-position="idx">
+                    <app-tag-badge [selectionMode]="TagBadgeCursor.Clickable">{{item.title}}</app-tag-badge>
+                </ng-template>  
+            </app-badge-expander>
+        </div>
+    </div>
     <div class="row no-gutters mt-1"  *ngIf="seriesMetadata.translators && seriesMetadata.translators.length > 0">
         <div class="col-md-4">
             <h5>Translators</h5>

--- a/UI/Web/src/app/series-metadata-detail/series-metadata-detail.component.ts
+++ b/UI/Web/src/app/series-metadata-detail/series-metadata-detail.component.ts
@@ -45,7 +45,9 @@ export class SeriesMetadataDetailComponent implements OnInit, OnChanges {
                                   this.seriesMetadata.inkers.length > 0 ||
                                   this.seriesMetadata.letterers.length > 0 ||
                                   this.seriesMetadata.pencillers.length > 0 ||
-                                  this.seriesMetadata.publishers.length > 0;
+                                  this.seriesMetadata.publishers.length > 0 || 
+                                  this.seriesMetadata.translators.length > 0 ||
+                                  this.seriesMetadata.tags.length > 0;
 
     this.metadataService.getAgeRating(this.seriesMetadata.ageRating).subscribe(rating => {
       this.ageRatingName = rating;

--- a/UI/Web/src/app/series-metadata-detail/series-metadata-detail.component.ts
+++ b/UI/Web/src/app/series-metadata-detail/series-metadata-detail.component.ts
@@ -20,10 +20,6 @@ export class SeriesMetadataDetailComponent implements OnInit, OnChanges {
   hasExtendedProperites: boolean = false;
 
   /**
-   * String representation of AgeRating enum
-   */
-  ageRatingName: string = '';
-  /**
    * Html representation of Series Summary
    */
   seriesSummary: string = '';
@@ -36,7 +32,7 @@ export class SeriesMetadataDetailComponent implements OnInit, OnChanges {
     return TagBadgeCursor;
   }
 
-  constructor(public utilityService: UtilityService, private metadataService: MetadataService) { }
+  constructor(public utilityService: UtilityService, public metadataService: MetadataService) { }
   
   ngOnChanges(changes: SimpleChanges): void {
     this.hasExtendedProperites = this.seriesMetadata.colorists.length > 0 || 
@@ -48,10 +44,6 @@ export class SeriesMetadataDetailComponent implements OnInit, OnChanges {
                                   this.seriesMetadata.publishers.length > 0 || 
                                   this.seriesMetadata.translators.length > 0 ||
                                   this.seriesMetadata.tags.length > 0;
-
-    this.metadataService.getAgeRating(this.seriesMetadata.ageRating).subscribe(rating => {
-      this.ageRatingName = rating;
-    });
 
     if (this.seriesMetadata !== null) {
       this.seriesSummary = (this.seriesMetadata.summary === null ? '' : this.seriesMetadata.summary).replace(/\n/g, '<br>');

--- a/UI/Web/src/app/shared/badge-expander/badge-expander.component.html
+++ b/UI/Web/src/app/shared/badge-expander/badge-expander.component.html
@@ -1,9 +1,8 @@
 <div class="badge-expander">
-    <div class="content {{isCollapsed ? 'collapsed' : ''}}">
+    <div class="content">
         <ng-container *ngFor="let item of visibleItems; index as i;" [ngTemplateOutlet]="itemTemplate" [ngTemplateOutletContext]="{ $implicit: item, idx: i }"></ng-container>
+        <button type="button" *ngIf="!isCollapsed && itemsLeft !== 0" class="btn btn-outline-primary" (click)="toggleVisible()" [attr.aria-expanded]="!isCollapsed">
+            and {{itemsLeft}} more
+        </button>
     </div>
-
-    <button type="button" class="btn btn-outline-primary" (click)="isCollapsed = !isCollapsed" [attr.aria-expanded]="!isCollapsed">
-        and {{items.length - 4}} more
-    </button>
 </div>

--- a/UI/Web/src/app/shared/badge-expander/badge-expander.component.html
+++ b/UI/Web/src/app/shared/badge-expander/badge-expander.component.html
@@ -1,17 +1,9 @@
-<!-- 
-<div #collapse="ngbCollapse" [(ngbCollapse)]="isCollapsed">
-    
-</div>
-<button type="button" class="btn btn-outline-primary" (click)="collapse.toggle()" [attr.aria-expanded]="!isCollapsed">
-    <i class="fa fa-arrow-{{isCollapsed ? 'up' : 'down'}}"></i>
-</button> -->
-
-
 <div class="badge-expander">
     <div class="content {{isCollapsed ? 'collapsed' : ''}}">
-        <ng-container *ngFor="let item of items; index as i;" [ngTemplateOutlet]="itemTemplate" [ngTemplateOutletContext]="{ $implicit: item, idx: i }"></ng-container>
+        <ng-container *ngFor="let item of visibleItems; index as i;" [ngTemplateOutlet]="itemTemplate" [ngTemplateOutletContext]="{ $implicit: item, idx: i }"></ng-container>
     </div>
+
     <button type="button" class="btn btn-outline-primary" (click)="isCollapsed = !isCollapsed" [attr.aria-expanded]="!isCollapsed">
-        <!-- <i class="fa fa-arrow-{{isCollapsed ? 'up' : 'down'}}"></i> -->...
+        and {{items.length - 4}} more
     </button>
 </div>

--- a/UI/Web/src/app/shared/badge-expander/badge-expander.component.html
+++ b/UI/Web/src/app/shared/badge-expander/badge-expander.component.html
@@ -1,0 +1,17 @@
+<!-- 
+<div #collapse="ngbCollapse" [(ngbCollapse)]="isCollapsed">
+    
+</div>
+<button type="button" class="btn btn-outline-primary" (click)="collapse.toggle()" [attr.aria-expanded]="!isCollapsed">
+    <i class="fa fa-arrow-{{isCollapsed ? 'up' : 'down'}}"></i>
+</button> -->
+
+
+<div class="badge-expander">
+    <div class="content {{isCollapsed ? 'collapsed' : ''}}">
+        <ng-container *ngFor="let item of items; index as i;" [ngTemplateOutlet]="itemTemplate" [ngTemplateOutletContext]="{ $implicit: item, idx: i }"></ng-container>
+    </div>
+    <button type="button" class="btn btn-outline-primary" (click)="isCollapsed = !isCollapsed" [attr.aria-expanded]="!isCollapsed">
+        <!-- <i class="fa fa-arrow-{{isCollapsed ? 'up' : 'down'}}"></i> -->...
+    </button>
+</div>

--- a/UI/Web/src/app/shared/badge-expander/badge-expander.component.scss
+++ b/UI/Web/src/app/shared/badge-expander/badge-expander.component.scss
@@ -1,0 +1,12 @@
+.content {
+    width: 100%;
+}
+
+.collapsed {
+    height: 35px;
+    overflow: hidden;
+}
+
+.badge-expander {
+    //display: inline-block;
+}

--- a/UI/Web/src/app/shared/badge-expander/badge-expander.component.ts
+++ b/UI/Web/src/app/shared/badge-expander/badge-expander.component.ts
@@ -10,9 +10,13 @@ export class BadgeExpanderComponent implements OnInit {
   @Input() items: Array<any> = [];
   @ContentChild('badgeExpanderItem') itemTemplate!: TemplateRef<any>;
 
-  visibleItems: Array<any> = [];
 
+  visibleItems: Array<any> = [];
   isCollapsed: boolean = false;
+
+  get itemsLeft() {
+    return Math.max(this.items.length - 4, 0);
+  }
   constructor() { }
 
   ngOnInit(): void {

--- a/UI/Web/src/app/shared/badge-expander/badge-expander.component.ts
+++ b/UI/Web/src/app/shared/badge-expander/badge-expander.component.ts
@@ -1,0 +1,20 @@
+import { Component, ContentChild, Input, OnInit, TemplateRef } from '@angular/core';
+
+@Component({
+  selector: 'app-badge-expander',
+  templateUrl: './badge-expander.component.html',
+  styleUrls: ['./badge-expander.component.scss']
+})
+export class BadgeExpanderComponent implements OnInit {
+
+  @Input() items: Array<any> = [];
+  @ContentChild('badgeExpanderItem') itemTemplate!: TemplateRef<any>;
+
+  isCollapsed: boolean = false;
+  constructor() { }
+
+  ngOnInit(): void {
+    console.log(this.items);
+  }
+
+}

--- a/UI/Web/src/app/shared/badge-expander/badge-expander.component.ts
+++ b/UI/Web/src/app/shared/badge-expander/badge-expander.component.ts
@@ -10,11 +10,19 @@ export class BadgeExpanderComponent implements OnInit {
   @Input() items: Array<any> = [];
   @ContentChild('badgeExpanderItem') itemTemplate!: TemplateRef<any>;
 
+  visibleItems: Array<any> = [];
+
   isCollapsed: boolean = false;
   constructor() { }
 
   ngOnInit(): void {
-    console.log(this.items);
+    this.visibleItems = this.items.slice(0, 4);
+  }
+
+  toggleVisible() {
+    this.isCollapsed = !this.isCollapsed;
+
+    this.visibleItems = this.items;
   }
 
 }

--- a/UI/Web/src/app/shared/shared.module.ts
+++ b/UI/Web/src/app/shared/shared.module.ts
@@ -17,6 +17,7 @@ import { CircularLoaderComponent } from './circular-loader/circular-loader.compo
 import { NgCircleProgressModule } from 'ng-circle-progress';
 import { SentenceCasePipe } from './sentence-case.pipe';
 import { PersonBadgeComponent } from './person-badge/person-badge.component';
+import { BadgeExpanderComponent } from './badge-expander/badge-expander.component';
 
 @NgModule({
   declarations: [
@@ -32,7 +33,8 @@ import { PersonBadgeComponent } from './person-badge/person-badge.component';
     UpdateNotificationModalComponent,
     CircularLoaderComponent,
     SentenceCasePipe,
-    PersonBadgeComponent
+    PersonBadgeComponent,
+    BadgeExpanderComponent
   ],
   imports: [
     CommonModule,
@@ -55,7 +57,8 @@ import { PersonBadgeComponent } from './person-badge/person-badge.component';
     SeriesFormatComponent,
     TagBadgeComponent,
     CircularLoaderComponent,
-    PersonBadgeComponent
+    PersonBadgeComponent,
+    BadgeExpanderComponent
   ],
 })
 export class SharedModule { }

--- a/UI/Web/src/app/typeahead/typeahead.component.scss
+++ b/UI/Web/src/app/typeahead/typeahead.component.scss
@@ -35,6 +35,9 @@ input {
         line-height: inherit !important;
         box-shadow: none !important;
     }
+    input:empty {
+        padding-top: 6px !important;
+    }
 }
 
 ::ng-deep .bg-dark .typeahead-input {
@@ -62,7 +65,7 @@ input {
     overflow-x: hidden;
 
     .list-group-item {
-        padding: 5px 5px;
+        padding: 5px 10px;
     }
 
 

--- a/UI/Web/src/app/typeahead/typeahead.component.ts
+++ b/UI/Web/src/app/typeahead/typeahead.component.ts
@@ -254,7 +254,7 @@ export class TypeaheadComponent implements OnInit, OnDestroy {
 
 
   @HostListener('window:click', ['$event'])
-  handleDocumentClick() {
+  handleDocumentClick(event: any) {
     this.hasFocus = false;
   }
 
@@ -370,6 +370,8 @@ export class TypeaheadComponent implements OnInit, OnDestroy {
     }
 
     if (this.inputElem) {
+      // hack: To prevent multiple typeaheads from being open at once, click document then trigger the focus
+      document.querySelector('body')?.click();
       this.inputElem.nativeElement.focus();
       this.hasFocus = true;
     }


### PR DESCRIPTION
# Added
- Added: Added support for ComicInfo v2.1 draft's Translator tag
- Added: Added support for ComicInfo v2.1 draft's Tags tag
- Added: You can now Sort by Sort Name, Created, Last Modified on screens that don't have existing sorting (ie You can't apply custom sort on Recently Added as that already uses a custom sort)
- Added: New All Series page. This page will combine all series from all libraries in one page and let you apply custom filters on it. You can reach this page by clicking 'Libraries' on the home page
- Added: Series can now be tagged with Language via ComicInfo and filtered in the UI. 
- Added: Added a re-occuring task to cleanup the Database of abandoned entities rather than doing the check exclusively after a scan. 

# Changed
- Changed: Reduced the size of the unread badge on cards
- Changed: When opening genre, tags, people, age rating typeaheads, they will now only show options for the library you have selected in the filter.
- Changed: Some filter fields are disabled on pages where they don't make sense
- Changed: Some filter fields are pre-populated on some pages (ie filtering on collection page will pre-popluate the collection tag)
- Changed: We only show 4 metadata tags on the Series Detail before we provide an expansion button to see more
- Changed: (Performance) Removed one full I/O operation per series for ComicInfo parsing

# Fixed
- Fixed: Fixed a bug with Filtering against Genres and People (develop)
- Fixed: Fixed a bug with typeahead where clicking two typeaheads would keep both their dropdown lists open

Closes #846 

