### PR TITLE
I can't believe it's more fixes!

### DIFF
--- a/API.Tests/Parser/ParserTest.cs
+++ b/API.Tests/Parser/ParserTest.cs
@@ -171,6 +171,8 @@ namespace API.Tests.Parser
         [InlineData("TEST/Love Hina - Special.jpg", false)]
         [InlineData("__macosx/Love Hina/", false)]
         [InlineData("MACOSX/Love Hina/", false)]
+        [InlineData("._Love Hina/Love Hina/", true)]
+        [InlineData("@Recently-Snapshot/Love Hina/", true)]
         public void HasBlacklistedFolderInPathTest(string inputPath, bool expected)
         {
             Assert.Equal(expected, HasBlacklistedFolderInPath(inputPath));

--- a/API/API.csproj
+++ b/API/API.csproj
@@ -62,6 +62,7 @@
     <PackageReference Include="NetVips.Native" Version="8.12.1" />
     <PackageReference Include="NReco.Logging.File" Version="1.1.2" />
     <PackageReference Include="SharpCompress" Version="0.30.1" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="8.33.0.40503">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/API/Data/Metadata/ComicInfo.cs
+++ b/API/Data/Metadata/ComicInfo.cs
@@ -76,6 +76,7 @@ namespace API.Data.Metadata
         public string CoverArtist { get; set; } = string.Empty;
         public string Editor { get; set; } = string.Empty;
         public string Publisher { get; set; } = string.Empty;
+        public string Characters { get; set; } = string.Empty;
 
         public static AgeRating ConvertAgeRatingToEnum(string value)
         {

--- a/API/Middleware/ExceptionMiddleware.cs
+++ b/API/Middleware/ExceptionMiddleware.cs
@@ -14,7 +14,7 @@ namespace API.Middleware
         private readonly RequestDelegate _next;
         private readonly ILogger<ExceptionMiddleware> _logger;
         private readonly IHostEnvironment _env;
-        
+
 
         public ExceptionMiddleware(RequestDelegate next, ILogger<ExceptionMiddleware> logger, IHostEnvironment env)
         {
@@ -34,14 +34,14 @@ namespace API.Middleware
                 _logger.LogError(ex, "There was an exception");
                 context.Response.ContentType = "application/json";
                 context.Response.StatusCode = (int) HttpStatusCode.InternalServerError;
-                
-                var response = _env.IsDevelopment() 
+
+                var response = _env.IsDevelopment()
                     ? new ApiException(context.Response.StatusCode, ex.Message, ex.StackTrace)
-                    : new ApiException(context.Response.StatusCode, "Internal Server Error");
-                
+                    : new ApiException(context.Response.StatusCode, "Internal Server Error", ex.StackTrace);
+
                 var options = new JsonSerializerOptions
                 {
-                    PropertyNamingPolicy = 
+                    PropertyNamingPolicy =
                         JsonNamingPolicy.CamelCase
                 };
 

--- a/API/Parser/Parser.cs
+++ b/API/Parser/Parser.cs
@@ -1097,7 +1097,7 @@ namespace API.Parser
 
         public static bool HasBlacklistedFolderInPath(string path)
         {
-            return path.Contains("__MACOSX");
+            return path.Contains("__MACOSX") || path.StartsWith("@Recently-Snapshot");
         }
 
 

--- a/API/Services/ArchiveService.cs
+++ b/API/Services/ArchiveService.cs
@@ -346,6 +346,7 @@ namespace API.Services
                 info.Letterer = Parser.Parser.CleanAuthor(info.Letterer);
                 info.Penciller = Parser.Parser.CleanAuthor(info.Penciller);
                 info.Publisher = Parser.Parser.CleanAuthor(info.Publisher);
+                info.Characters = Parser.Parser.CleanAuthor(info.Characters);
 
                 if (!string.IsNullOrEmpty(info.Web))
                 {

--- a/API/Services/BookService.cs
+++ b/API/Services/BookService.cs
@@ -20,7 +20,12 @@ using ExCSS;
 using HtmlAgilityPack;
 using Microsoft.Extensions.Logging;
 using Microsoft.IO;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats.Bmp;
+using SixLabors.ImageSharp.PixelFormats;
 using VersOne.Epub;
+using Image = SixLabors.ImageSharp.Image;
+using Rectangle = System.Drawing.Rectangle;
 
 namespace API.Services
 {
@@ -541,15 +546,21 @@ namespace API.Services
             var rawBytes = pageReader.GetImage(new NaiveTransparencyRemover());
             var width = pageReader.GetPageWidth();
             var height = pageReader.GetPageHeight();
-            using var bmp = new Bitmap(width, height, PixelFormat.Format32bppArgb);
-            AddBytesToBitmap(bmp, rawBytes);
-            // Removes 1px margin on left/right side after bitmap is copied out
-            for (var y = 0; y < bmp.Height; y++)
-            {
-                bmp.SetPixel(bmp.Width - 1, y, bmp.GetPixel(bmp.Width - 2, y));
-            }
+            //var decoder = new BmpDecoder().Decode(Configuration.Default, stream);
+            var image = Image.LoadPixelData<Bgra32>(rawBytes, width, height);
+
+            //var stream = new MemoryStream();
             stream.Seek(0, SeekOrigin.Begin);
-            bmp.Save(stream, ImageFormat.Jpeg);
+            image.SaveAsPng(stream);
+            // using var bmp = new Bitmap(width, height, PixelFormat.Format32bppArgb);
+            // AddBytesToBitmap(bmp, rawBytes);
+            // // Removes 1px margin on left/right side after bitmap is copied out
+            // for (var y = 0; y < bmp.Height; y++)
+            // {
+            //     bmp.SetPixel(bmp.Width - 1, y, bmp.GetPixel(bmp.Width - 2, y));
+            // }
+            // stream.Seek(0, SeekOrigin.Begin);
+            // bmp.Save(stream, ImageFormat.Jpeg);
             stream.Seek(0, SeekOrigin.Begin);
         }
 

--- a/API/Services/BookService.cs
+++ b/API/Services/BookService.cs
@@ -1,10 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Drawing;
-using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -21,11 +18,9 @@ using HtmlAgilityPack;
 using Microsoft.Extensions.Logging;
 using Microsoft.IO;
 using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.Formats.Bmp;
 using SixLabors.ImageSharp.PixelFormats;
 using VersOne.Epub;
 using Image = SixLabors.ImageSharp.Image;
-using Rectangle = System.Drawing.Rectangle;
 
 namespace API.Services
 {
@@ -450,31 +445,25 @@ namespace API.Services
            return null;
         }
 
-        private static void AddBytesToBitmap(Bitmap bmp, byte[] rawBytes)
-        {
-            var rect = new Rectangle(0, 0, bmp.Width, bmp.Height);
-
-            var bmpData = bmp.LockBits(rect, ImageLockMode.WriteOnly, bmp.PixelFormat);
-            var pNative = bmpData.Scan0;
-
-            Marshal.Copy(rawBytes, 0, pNative, rawBytes.Length);
-            bmp.UnlockBits(bmpData);
-        }
-
+        /// <summary>
+        /// Extracts a pdf into images to a target directory. Uses multi-threaded implementation since docnet is slow normally.
+        /// </summary>
+        /// <param name="fileFilePath"></param>
+        /// <param name="targetDirectory"></param>
         public void ExtractPdfImages(string fileFilePath, string targetDirectory)
         {
             _directoryService.ExistOrCreate(targetDirectory);
 
             using var docReader = DocLib.Instance.GetDocReader(fileFilePath, new PageDimensions(1080, 1920));
             var pages = docReader.GetPageCount();
-            using var stream = StreamManager.GetStream("BookService.GetPdfPage");
-            for (var pageNumber = 0; pageNumber < pages; pageNumber++)
+            Parallel.For(0, pages, pageNumber =>
             {
+                using var stream = StreamManager.GetStream("BookService.GetPdfPage");
                 GetPdfPage(docReader, pageNumber, stream);
                 using var fileStream = File.Create(Path.Combine(targetDirectory, "Page-" + pageNumber + ".png"));
                 stream.Seek(0, SeekOrigin.Begin);
                 stream.CopyTo(fileStream);
-            }
+            });
         }
 
         /// <summary>
@@ -541,26 +530,14 @@ namespace API.Services
 
         private static void GetPdfPage(IDocReader docReader, int pageNumber, Stream stream)
         {
-            // TODO: BUG: Most of this Bitmap code is only supported on Windows. Refactor.
             using var pageReader = docReader.GetPageReader(pageNumber);
             var rawBytes = pageReader.GetImage(new NaiveTransparencyRemover());
             var width = pageReader.GetPageWidth();
             var height = pageReader.GetPageHeight();
-            //var decoder = new BmpDecoder().Decode(Configuration.Default, stream);
             var image = Image.LoadPixelData<Bgra32>(rawBytes, width, height);
 
-            //var stream = new MemoryStream();
             stream.Seek(0, SeekOrigin.Begin);
             image.SaveAsPng(stream);
-            // using var bmp = new Bitmap(width, height, PixelFormat.Format32bppArgb);
-            // AddBytesToBitmap(bmp, rawBytes);
-            // // Removes 1px margin on left/right side after bitmap is copied out
-            // for (var y = 0; y < bmp.Height; y++)
-            // {
-            //     bmp.SetPixel(bmp.Width - 1, y, bmp.GetPixel(bmp.Width - 2, y));
-            // }
-            // stream.Seek(0, SeekOrigin.Begin);
-            // bmp.Save(stream, ImageFormat.Jpeg);
             stream.Seek(0, SeekOrigin.Begin);
         }
 

--- a/API/Services/MetadataService.cs
+++ b/API/Services/MetadataService.cs
@@ -113,6 +113,14 @@ public class MetadataService : IMetadataService
                 person => PersonHelper.AddPersonIfNotExists(chapter.People, person));
         }
 
+        if (!string.IsNullOrEmpty(comicInfo.Characters))
+        {
+            var people = comicInfo.Characters.Split(",");
+            PersonHelper.RemovePeople(chapter.People, people, PersonRole.Character);
+            PersonHelper.UpdatePeople(allPeople, people, PersonRole.Character,
+                person => PersonHelper.AddPersonIfNotExists(chapter.People, person));
+        }
+
         if (!string.IsNullOrEmpty(comicInfo.Translator))
         {
             var people = comicInfo.Translator.Split(",");
@@ -220,7 +228,6 @@ public class MetadataService : IMetadataService
     {
         if (series == null) return;
 
-        //var firstFile = series.Volumes.FirstWithChapters().Chapters.Fir
         if (!_cacheHelper.ShouldUpdateCoverImage(_directoryService.FileSystem.Path.Join(_directoryService.CoverImageDirectory, series.CoverImage),
                 null, series.Created, forceUpdate, series.CoverImageLocked))
             return;

--- a/API/Services/ReadingItemService.cs
+++ b/API/Services/ReadingItemService.cs
@@ -86,6 +86,7 @@ public class ReadingItemService : IReadingItemService
             MangaFormat.Epub => _bookService.GetCoverImage(filePath, fileName),
             MangaFormat.Archive => _archiveService.GetCoverImage(filePath, fileName),
             MangaFormat.Image => _imageService.GetCoverImage(filePath, fileName),
+            MangaFormat.Pdf => _bookService.GetCoverImage(filePath, fileName),
             _ => string.Empty
         };
     }


### PR DESCRIPTION
# Added
- Added: Ignore @Recently-Snapshot folders during scanning for QNAP devices (Closes #860)
- Added: PDF Rendering is now multithreaded with a drastic speed up

# Changed
- Changed: Removed all Bitmap operations, which removes the need for libgdiplus to be installed on systems (Closes #785)

# Fixed
- Fixed: Fixed an issue with PDFs not rendering to disk due to .NET 6 upgrade (Fixes #862 )
- Fixed: Added Characters field from ComicInfo, which got skipped in initial pass
