### PR TITLE
Added check to see if mount folder is empty

### DIFF
--- a/API.Tests/Services/DirectoryServiceTests.cs
+++ b/API.Tests/Services/DirectoryServiceTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Abstractions;
@@ -370,6 +370,29 @@ namespace API.Tests.Services
             var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), fileSystem);
 
             Assert.True(ds.IsDriveMounted("c:/manga/file"));
+        }
+        #endregion
+
+        #region IsDirectoryEmpty
+        [Fact]
+        public void IsDirectoryEmpty_DirectoryIsEmpty()
+        {
+            const string testDirectory = "c:/manga/";
+            var fileSystem = new MockFileSystem();
+            var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), fileSystem);
+
+            Assert.False(ds.IsDirectoryEmpty("c:/manga/"));
+        }
+
+        [Fact]
+        public void IsDirectoryEmpty_DirectoryIsNotEmpty()
+        {
+            const string testDirectory = "c:/manga/";
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddFile($"{testDirectory}data-0.txt", new MockFileData("abc"));
+            var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), fileSystem);
+
+            Assert.False(ds.IsDirectoryEmpty("c:/manga/"));
         }
         #endregion
 

--- a/API/Services/DirectoryService.cs
+++ b/API/Services/DirectoryService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -32,6 +32,7 @@ namespace API.Services
         void CopyFileToDirectory(string fullFilePath, string targetDirectory);
         int TraverseTreeParallelForEach(string root, Action<string> action, string searchPattern, ILogger logger);
         bool IsDriveMounted(string path);
+        bool IsDirectoryEmpty(string path);
         long GetTotalSize(IEnumerable<string> paths);
         void ClearDirectory(string directoryPath);
         void ClearAndDeleteDirectory(string directoryPath);
@@ -259,7 +260,12 @@ namespace API.Services
            return FileSystem.DirectoryInfo.FromDirectoryName(FileSystem.Path.GetPathRoot(path) ?? string.Empty).Exists;
        }
 
-       public string[] GetFilesWithExtension(string path, string searchPatternExpression = "")
+        public bool IsDirectoryEmpty(string path)
+        {
+            return Directory.EnumerateFileSystemEntries(path).Any();
+        }
+
+        public string[] GetFilesWithExtension(string path, string searchPatternExpression = "")
        {
            // TODO: Use GitFiles instead
           if (searchPatternExpression != string.Empty)

--- a/API/Services/DirectoryService.cs
+++ b/API/Services/DirectoryService.cs
@@ -260,6 +260,12 @@ namespace API.Services
            return FileSystem.DirectoryInfo.FromDirectoryName(FileSystem.Path.GetPathRoot(path) ?? string.Empty).Exists;
        }
 
+
+        /// <summary>
+        /// Checks if the root path of a path is empty or not.
+        /// </summary>
+        /// <param name="path"></param>
+        /// <returns></returns>
         public bool IsDirectoryEmpty(string path)
         {
             return Directory.EnumerateFileSystemEntries(path).Any();

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -218,6 +218,13 @@ public class ScannerService : IScannerService
         if (library.Folders.Any(f => !_directoryService.IsDriveMounted(f.Path)))
         {
             _logger.LogError("Some of the root folders for library are not accessible. Please check that drives are connected and rescan. Scan will be aborted");
+            return;
+        }
+
+        // For Docker instances check if any of the folder roots are not available (ie disconnected volumes, etc) and fail if any of them are
+        if (library.Folders.Any(f => !_directoryService.IsDirectoryEmpty(f.Path)))
+        {
+            _logger.LogError("Some of the root folders for library are empty. Please check that drives are connected and rescan. Scan will be aborted");
             return;
         }
 

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -224,7 +224,7 @@ public class ScannerService : IScannerService
         // For Docker instances check if any of the folder roots are not available (ie disconnected volumes, etc) and fail if any of them are
         if (library.Folders.Any(f => !_directoryService.IsDirectoryEmpty(f.Path)))
         {
-            _logger.LogError("Some of the root folders for library are empty. Please check that drives are connected and rescan. Scan will be aborted");
+            _logger.LogError("Some of the root folders for the library are empty. Either your mount has been disconnected or you are trying to delete all series in the library. Scan will be aborted. Check that your mount is connected or change the library's root folder and rescan.");
             return;
         }
 


### PR DESCRIPTION
# Fixed
- Fixed: Fixed a bug where running a scan in a docker container with a disconnected mount would still run. (Fixes #844 )
