### PR TITLE
Book Reader Issues

### DIFF
--- a/API.Tests/Parser/ParserTest.cs
+++ b/API.Tests/Parser/ParserTest.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using API.Entities.Enums;
 using Xunit;
 using static API.Parser.Parser;
@@ -58,20 +59,28 @@ namespace API.Tests.Parser
             Assert.Equal(expected, CleanTitle(input, isComic));
         }
 
+        [Theory]
+        [InlineData("src: url(fonts/AvenirNext-UltraLight.ttf)", true)]
+        [InlineData("src: url(ideal-sans-serif.woff)", true)]
+        [InlineData("src: local(\"Helvetica Neue Bold\")", true)]
+        [InlineData("src: url(\"/fonts/OpenSans-Regular-webfont.woff2\")", true)]
+        [InlineData("src: local(\"/fonts/OpenSans-Regular-webfont.woff2\")", true)]
+        [InlineData("src: url(data:application/x-font-woff", false)]
+        public void FontCssRewriteMatches(string input, bool expectedMatch)
+        {
+            Assert.Equal(expectedMatch, FontSrcUrlRegex.Matches(input).Count > 0);
+        }
 
-        // [Theory]
-        // //[InlineData("@font-face{font-family:\"PaytoneOne\";src:url(\"..\\/Fonts\\/PaytoneOne.ttf\")}", "@font-face{font-family:\"PaytoneOne\";src:url(\"PaytoneOne.ttf\")}")]
-        // [InlineData("@font-face{font-family:\"PaytoneOne\";src:url(\"..\\/Fonts\\/PaytoneOne.ttf\")}", "..\\/Fonts\\/PaytoneOne.ttf")]
-        // //[InlineData("@font-face{font-family:'PaytoneOne';src:url('..\\/Fonts\\/PaytoneOne.ttf')}", "@font-face{font-family:'PaytoneOne';src:url('PaytoneOne.ttf')}")]
-        // //[InlineData("@font-face{\r\nfont-family:'PaytoneOne';\r\nsrc:url('..\\/Fonts\\/PaytoneOne.ttf')\r\n}", "@font-face{font-family:'PaytoneOne';src:url('PaytoneOne.ttf')}")]
-        // public void ReplaceStyleUrlTest(string input, string expected)
-        // {
-        //     var replacementStr = "PaytoneOne.ttf";
-        //     // Use Match to validate since replace is weird
-        //     //Assert.Equal(expected, FontSrcUrlRegex.Replace(input, "$1" + replacementStr + "$2" + "$3"));
-        //     var match = FontSrcUrlRegex.Match(input);
-        //     Assert.Equal(!string.IsNullOrEmpty(expected), FontSrcUrlRegex.Match(input).Success);
-        // }
+        [Theory]
+        [InlineData("src: url(fonts/AvenirNext-UltraLight.ttf)", new [] {"src: url(", "fonts/AvenirNext-UltraLight.ttf", ")"})]
+        [InlineData("src: url(ideal-sans-serif.woff)", new [] {"src: url(", "ideal-sans-serif.woff", ")"})]
+        [InlineData("src: local(\"Helvetica Neue Bold\")", new [] {"src: local(\"", "Helvetica Neue Bold", "\")"})]
+        [InlineData("src: url(\"/fonts/OpenSans-Regular-webfont.woff2\")", new [] {"src: url(\"", "/fonts/OpenSans-Regular-webfont.woff2", "\")"})]
+        [InlineData("src: local(\"/fonts/OpenSans-Regular-webfont.woff2\")", new [] {"src: local(\"", "/fonts/OpenSans-Regular-webfont.woff2", "\")"})]
+        public void FontCssCorrectlySeparates(string input, string[] expected)
+        {
+            Assert.Equal(expected, FontSrcUrlRegex.Match(input).Groups.Values.Select(g => g.Value).Where((s, i) => i > 0).ToArray());
+        }
 
 
         [Theory]

--- a/API.Tests/Parser/ParserTest.cs
+++ b/API.Tests/Parser/ParserTest.cs
@@ -170,6 +170,8 @@ namespace API.Tests.Parser
         [InlineData("cover.jpg", true)]
         [InlineData("cover.png", true)]
         [InlineData("ch1/cover.png", true)]
+        [InlineData("ch1/backcover.png", false)]
+        [InlineData("backcover.png", false)]
         public void IsCoverImageTest(string inputPath, bool expected)
         {
             Assert.Equal(expected, IsCoverImage(inputPath));

--- a/API/Controllers/AccountController.cs
+++ b/API/Controllers/AccountController.cs
@@ -12,7 +12,6 @@ using API.Extensions;
 using API.Services;
 using AutoMapper;
 using Kavita.Common;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;

--- a/API/Controllers/BookController.cs
+++ b/API/Controllers/BookController.cs
@@ -10,6 +10,7 @@ using API.Extensions;
 using API.Services;
 using HtmlAgilityPack;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using VersOne.Epub;
 
@@ -21,10 +22,11 @@ namespace API.Controllers
         private readonly IBookService _bookService;
         private readonly IUnitOfWork _unitOfWork;
         private readonly ICacheService _cacheService;
-        private static readonly string BookApiUrl = "book-resources?file=";
+        private const string BookApiUrl = "book-resources?file=";
 
 
-        public BookController(ILogger<BookController> logger, IBookService bookService, IUnitOfWork unitOfWork, ICacheService cacheService)
+        public BookController(ILogger<BookController> logger, IBookService bookService,
+            IUnitOfWork unitOfWork, ICacheService cacheService)
         {
             _logger = logger;
             _bookService = bookService;
@@ -212,7 +214,8 @@ namespace API.Controllers
 
             var counter = 0;
             var doc = new HtmlDocument {OptionFixNestedTags = true};
-            var baseUrl = Request.Scheme + "://" + Request.Host + Request.PathBase + "/api/";
+
+            var baseUrl = "//" + Request.Host + Request.PathBase + "/api/";
             var apiBase = baseUrl + "book/" + chapterId + "/" + BookApiUrl;
             var bookPages = await book.GetReadingOrderAsync();
             foreach (var contentFileRef in bookPages)

--- a/API/Data/Metadata/ComicInfo.cs
+++ b/API/Data/Metadata/ComicInfo.cs
@@ -28,9 +28,9 @@ namespace API.Data.Metadata
         /// This is the link to where the data was scraped from
         /// </summary>
         public string Web { get; set; } = string.Empty;
-        public int Day { get; set; }
-        public int Month { get; set; }
-        public int Year { get; set; }
+        public int Day { get; set; } = 0;
+        public int Month { get; set; } = 0;
+        public int Year { get; set; } = 0;
 
 
         /// <summary>

--- a/API/Parser/Parser.cs
+++ b/API/Parser/Parser.cs
@@ -55,7 +55,7 @@ namespace API.Parser
             MatchOptions, RegexTimeout);
         private static readonly Regex BookFileRegex = new Regex(BookFileExtensions,
             MatchOptions, RegexTimeout);
-        private static readonly Regex CoverImageRegex = new Regex(@"(?<![[a-z]\d])(?:!?)(cover|folder)(?![\w\d])",
+        private static readonly Regex CoverImageRegex = new Regex(@"(?<![[a-z]\d])(?:!?)((?<!back)cover|folder)(?![\w\d])",
             MatchOptions, RegexTimeout);
 
         private static readonly Regex NormalizeRegex = new Regex(@"[^a-zA-Z0-9\+]",
@@ -1089,11 +1089,12 @@ namespace API.Parser
         /// <summary>
         /// Tests whether the file is a cover image such that: contains "cover", is named "folder", and is an image
         /// </summary>
-        /// <param name="name"></param>
+        /// <remarks>If the path has "backcover" in it, it will be ignored</remarks>
+        /// <param name="filename">Filename with extension</param>
         /// <returns></returns>
-        public static bool IsCoverImage(string name)
+        public static bool IsCoverImage(string filename)
         {
-            return IsImage(name, true) && (CoverImageRegex.IsMatch(name));
+            return IsImage(filename, true) && CoverImageRegex.IsMatch(filename);
         }
 
         public static bool HasBlacklistedFolderInPath(string path)

--- a/API/Parser/Parser.cs
+++ b/API/Parser/Parser.cs
@@ -28,7 +28,8 @@ namespace API.Parser
         /// Matches against font-family css syntax. Does not match if url import has data: starting, as that is binary data
         /// </summary>
         /// <remarks>See here for some examples https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face</remarks>
-        public static readonly Regex FontSrcUrlRegex = new Regex(@"(?<Start>(src:\s?)?url\((?!data:).(?!data:))" + "(?<Filename>(?!data:)[^\"']*)" + @"(?<End>.{1}\))",
+        public static readonly Regex FontSrcUrlRegex = new Regex(@"(?<Start>(?:src:\s?)?(?:url|local)\((?!data:)" + "(?:[\"']?)" + @"(?!data:))"
+                                                                 + "(?<Filename>(?!data:)[^\"']+?)" + "(?<End>[\"']?" + @"\);?)",
             MatchOptions, RegexTimeout);
         /// <summary>
         /// https://developer.mozilla.org/en-US/docs/Web/CSS/@import

--- a/API/Services/BookService.cs
+++ b/API/Services/BookService.cs
@@ -168,8 +168,14 @@ namespace API.Services
             }
 
             stylesheetHtml = stylesheetHtml.Insert(0, importBuilder.ToString());
-            var importMatches = Parser.Parser.CssImportUrlRegex.Matches(stylesheetHtml);
-            foreach (Match match in importMatches)
+            foreach (Match match in Parser.Parser.CssImportUrlRegex.Matches(stylesheetHtml))
+            {
+                if (!match.Success) continue;
+                var importFile = match.Groups["Filename"].Value;
+                stylesheetHtml = stylesheetHtml.Replace(importFile, apiBase + prepend + importFile);
+            }
+
+            foreach (Match match in Parser.Parser.FontSrcUrlRegex.Matches(stylesheetHtml))
             {
                 if (!match.Success) continue;
                 var importFile = match.Groups["Filename"].Value;

--- a/API/Services/BookService.cs
+++ b/API/Services/BookService.cs
@@ -47,6 +47,8 @@ namespace API.Services
         /// <param name="fileFilePath"></param>
         /// <param name="targetDirectory">Where the files will be extracted to. If doesn't exist, will be created.</param>
         void ExtractPdfImages(string fileFilePath, string targetDirectory);
+
+        Task<string> ScopePage(HtmlDocument doc, EpubBookRef book, string apiBase, HtmlNode body, Dictionary<string, int> mappings, int page);
     }
 
     public class BookService : IBookService
@@ -168,12 +170,8 @@ namespace API.Services
             }
 
             stylesheetHtml = stylesheetHtml.Insert(0, importBuilder.ToString());
-            foreach (Match match in Parser.Parser.CssImportUrlRegex.Matches(stylesheetHtml))
-            {
-                if (!match.Success) continue;
-                var importFile = match.Groups["Filename"].Value;
-                stylesheetHtml = stylesheetHtml.Replace(importFile, apiBase + prepend + importFile);
-            }
+
+            EscapeCSSImportReferences(ref stylesheetHtml, apiBase, prepend);
 
             EscapeFontFamilyReferences(ref stylesheetHtml, apiBase, prepend);
 
@@ -202,6 +200,16 @@ namespace API.Services
             return RemoveWhiteSpaceFromStylesheets(stylesheet.ToCss());
         }
 
+        private static void EscapeCSSImportReferences(ref string stylesheetHtml, string apiBase, string prepend)
+        {
+            foreach (Match match in Parser.Parser.CssImportUrlRegex.Matches(stylesheetHtml))
+            {
+                if (!match.Success) continue;
+                var importFile = match.Groups["Filename"].Value;
+                stylesheetHtml = stylesheetHtml.Replace(importFile, apiBase + prepend + importFile);
+            }
+        }
+
         private static void EscapeFontFamilyReferences(ref string stylesheetHtml, string apiBase, string prepend)
         {
             foreach (Match match in Parser.Parser.FontSrcUrlRegex.Matches(stylesheetHtml))
@@ -224,6 +232,128 @@ namespace API.Services
                 if (!book.Content.AllFiles.ContainsKey(key)) continue;
 
                 stylesheetHtml = stylesheetHtml.Replace(importFile, apiBase + key);
+            }
+        }
+
+        private static void ScopeImages(HtmlDocument doc, EpubBookRef book, string apiBase)
+        {
+            var images = doc.DocumentNode.SelectNodes("//img");
+            if (images != null)
+            {
+                foreach (var image in images)
+                {
+                    if (image.Name != "img") continue;
+
+                    // Need to do for xlink:href
+                    if (image.Attributes["src"] != null)
+                    {
+                        var imageFile = image.Attributes["src"].Value;
+                        if (!book.Content.Images.ContainsKey(imageFile))
+                        {
+                            var correctedKey = book.Content.Images.Keys.SingleOrDefault(s => s.EndsWith(imageFile));
+                            if (correctedKey != null)
+                            {
+                                imageFile = correctedKey;
+                            }
+                        }
+
+                        image.Attributes.Remove("src");
+                        image.Attributes.Add("src", $"{apiBase}" + imageFile);
+                    }
+                }
+            }
+
+            images = doc.DocumentNode.SelectNodes("//image");
+            if (images != null)
+            {
+                foreach (var image in images)
+                {
+                    if (image.Name != "image") continue;
+
+                    if (image.Attributes["xlink:href"] != null)
+                    {
+                        var imageFile = image.Attributes["xlink:href"].Value;
+                        if (!book.Content.Images.ContainsKey(imageFile))
+                        {
+                            var correctedKey = book.Content.Images.Keys.SingleOrDefault(s => s.EndsWith(imageFile));
+                            if (correctedKey != null)
+                            {
+                                imageFile = correctedKey;
+                            }
+                        }
+
+                        image.Attributes.Remove("xlink:href");
+                        image.Attributes.Add("xlink:href", $"{apiBase}" + imageFile);
+                    }
+                }
+            }
+        }
+
+        private static string PrepareFinalHtml(HtmlDocument doc, HtmlNode body)
+        {
+            // Check if any classes on the html node (some r2l books do this) and move them to body tag for scoping
+            var htmlNode = doc.DocumentNode.SelectSingleNode("//html");
+            if (htmlNode == null || !htmlNode.Attributes.Contains("class")) return body.InnerHtml;
+
+            var bodyClasses = body.Attributes.Contains("class") ? body.Attributes["class"].Value : string.Empty;
+            var classes = htmlNode.Attributes["class"].Value + " " + bodyClasses;
+            body.Attributes.Add("class", $"{classes}");
+            // I actually need the body tag itself for the classes, so i will create a div and put the body stuff there.
+            //return Ok($"<div class=\"{body.Attributes["class"].Value}\">{body.InnerHtml}</div>");
+            return $"<div class=\"{body.Attributes["class"].Value}\">{body.InnerHtml}</div>";
+        }
+
+        private static void RewriteAnchors(int page, HtmlDocument doc, Dictionary<string, int> mappings)
+        {
+            var anchors = doc.DocumentNode.SelectNodes("//a");
+            if (anchors != null)
+            {
+                foreach (var anchor in anchors)
+                {
+                    BookService.UpdateLinks(anchor, mappings, page);
+                }
+            }
+        }
+
+        private async Task InlineStyles(HtmlDocument doc, EpubBookRef book, string apiBase, HtmlNode body)
+        {
+            var inlineStyles = doc.DocumentNode.SelectNodes("//style");
+            if (inlineStyles != null)
+            {
+                foreach (var inlineStyle in inlineStyles)
+                {
+                    var styleContent = await ScopeStyles(inlineStyle.InnerHtml, apiBase, "", book);
+                    body.PrependChild(HtmlNode.CreateNode($"<style>{styleContent}</style>"));
+                }
+            }
+
+            var styleNodes = doc.DocumentNode.SelectNodes("/html/head/link");
+            if (styleNodes != null)
+            {
+                foreach (var styleLinks in styleNodes)
+                {
+                    var key = BookService.CleanContentKeys(styleLinks.Attributes["href"].Value);
+                    // Some epubs are malformed the key in content.opf might be: content/resources/filelist_0_0.xml but the actual html links to resources/filelist_0_0.xml
+                    // In this case, we will do a search for the key that ends with
+                    if (!book.Content.Css.ContainsKey(key))
+                    {
+                        var correctedKey = book.Content.Css.Keys.SingleOrDefault(s => s.EndsWith(key));
+                        if (correctedKey == null)
+                        {
+                            _logger.LogError("Epub is Malformed, key: {Key} is not matching OPF file", key);
+                            continue;
+                        }
+
+                        key = correctedKey;
+                    }
+
+                    var styleContent = await ScopeStyles(await book.Content.Css[key].ReadContentAsync(), apiBase,
+                        book.Content.Css[key].FileName, book);
+                    if (styleContent != null)
+                    {
+                        body.PrependChild(HtmlNode.CreateNode($"<style>{styleContent}</style>"));
+                    }
+                }
             }
         }
 
@@ -475,6 +605,27 @@ namespace API.Services
                 stream.Seek(0, SeekOrigin.Begin);
                 stream.CopyTo(fileStream);
             });
+        }
+
+        /// <summary>
+        /// Responsible to scope all the css, links, tags, etc to prepare a self contained html file for the page
+        /// </summary>
+        /// <param name="doc">Html Doc that will be appended to</param>
+        /// <param name="book">Underlying epub</param>
+        /// <param name="apiBase">API Url for file loading to pass through</param>
+        /// <param name="body">Body element from the epub</param>
+        /// <param name="mappings">Epub mappings</param>
+        /// <param name="page">Page number we are loading</param>
+        /// <returns></returns>
+        public async Task<string> ScopePage(HtmlDocument doc, EpubBookRef book, string apiBase, HtmlNode body, Dictionary<string, int> mappings, int page)
+        {
+            await InlineStyles(doc, book, apiBase, body);
+
+            RewriteAnchors(page, doc, mappings);
+
+            ScopeImages(doc, book, apiBase);
+
+            return PrepareFinalHtml(doc, body);
         }
 
         /// <summary>

--- a/API/Services/BookService.cs
+++ b/API/Services/BookService.cs
@@ -175,12 +175,7 @@ namespace API.Services
                 stylesheetHtml = stylesheetHtml.Replace(importFile, apiBase + prepend + importFile);
             }
 
-            foreach (Match match in Parser.Parser.FontSrcUrlRegex.Matches(stylesheetHtml))
-            {
-                if (!match.Success) continue;
-                var importFile = match.Groups["Filename"].Value;
-                stylesheetHtml = stylesheetHtml.Replace(importFile, apiBase + prepend + importFile);
-            }
+            EscapeFontFamilyReferences(ref stylesheetHtml, apiBase, prepend);
 
             // Check if there are any background images and rewrite those urls
             EscapeCssImageReferences(ref stylesheetHtml, apiBase, book);
@@ -205,6 +200,16 @@ namespace API.Services
                 styleRule.Text = $"{CssScopeClass} " + styleRule.Text;
             }
             return RemoveWhiteSpaceFromStylesheets(stylesheet.ToCss());
+        }
+
+        private static void EscapeFontFamilyReferences(ref string stylesheetHtml, string apiBase, string prepend)
+        {
+            foreach (Match match in Parser.Parser.FontSrcUrlRegex.Matches(stylesheetHtml))
+            {
+                if (!match.Success) continue;
+                var importFile = match.Groups["Filename"].Value;
+                stylesheetHtml = stylesheetHtml.Replace(importFile, apiBase + prepend + importFile);
+            }
         }
 
         private static void EscapeCssImageReferences(ref string stylesheetHtml, string apiBase, EpubBookRef book)

--- a/API/Services/MetadataService.cs
+++ b/API/Services/MetadataService.cs
@@ -323,6 +323,12 @@ public class MetadataService : IMetadataService
         series.Metadata.ReleaseYear = series.Volumes
             .SelectMany(volume => volume.Chapters).Min(c => c.ReleaseDate.Year);
 
+        if (series.Metadata.ReleaseYear < 1000)
+        {
+            // Not a valid year, default to 0
+            series.Metadata.ReleaseYear = 0;
+        }
+
         var genres = comicInfos.SelectMany(i => i?.Genre.Split(",")).Distinct().ToList();
         var tags = comicInfos.SelectMany(i => i?.Tags.Split(",")).Distinct().ToList();
         var people = series.Volumes.SelectMany(volume => volume.Chapters).SelectMany(c => c.People).ToList();

--- a/API/Startup.cs
+++ b/API/Startup.cs
@@ -209,7 +209,7 @@ namespace API
 
             app.UseForwardedHeaders(new ForwardedHeadersOptions
             {
-                ForwardedHeaders = ForwardedHeaders.All
+                ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto | ForwardedHeaders.XForwardedHost
             });
 
             app.UseRouting();

--- a/UI/Web/src/app/_services/reader.service.ts
+++ b/UI/Web/src/app/_services/reader.service.ts
@@ -203,13 +203,6 @@ export class ReaderService {
           }
         });
       }
-      //  else if (el.mozRequestFullScreen) {
-      //   el.mozRequestFullScreen();
-      // } else if (el.webkitRequestFullscreen) {
-      //   el.webkitRequestFullscreen(Element.ALLOW_KEYBOARD_INPUT);
-      // } else if (el.msRequestFullscreen) {
-      //   el.msRequestFullscreen();
-      // }
     }
   }
 
@@ -221,13 +214,6 @@ export class ReaderService {
         }
       });
     }
-    //  else if (document.msExitFullscreen) {
-    //   document.msExitFullscreen();
-    // } else if (document.mozCancelFullScreen) {
-    //   document.mozCancelFullScreen();
-    // } else if (document.webkitExitFullscreen) {
-    //   document.webkitExitFullscreen();
-    // }
   }
 
   /**

--- a/UI/Web/src/app/book-reader/book-reader/book-reader.component.html
+++ b/UI/Web/src/app/book-reader/book-reader/book-reader.component.html
@@ -1,4 +1,4 @@
-<div class="container-flex {{darkMode ? 'dark-mode' : ''}}">
+<div class="container-flex {{darkMode ? 'dark-mode' : ''}}" style="overflow: auto;" #reader>
     <div class="fixed-top" #stickyTop>
         <a class="sr-only sr-only-focusable focus-visible" href="javascript:void(0);" (click)="moveFocus()">Skip to main content</a>
         <ng-container [ngTemplateOutlet]="actionBar"></ng-container>
@@ -110,7 +110,7 @@
         </app-drawer>
     </div>
 
-    <div #readingSection class="reading-section" [ngStyle]="{'padding-top': topOffset + 20 + 'px', 'overflow': 'auto'}" 
+    <div #readingSection class="reading-section" [ngStyle]="{'padding-top': topOffset + 20 + 'px'}" 
         [@isLoading]="isLoading ? true : false" (click)="handleReaderClick($event)">
 
         <div #readingHtml class="book-content" [ngStyle]="{'padding-bottom': topOffset + 20 + 'px', 'margin': '0px 0px'}" 

--- a/UI/Web/src/app/book-reader/book-reader/book-reader.component.html
+++ b/UI/Web/src/app/book-reader/book-reader/book-reader.component.html
@@ -1,4 +1,4 @@
-<div class="container-flex {{darkMode ? 'dark-mode' : ''}}" #reader>
+<div class="container-flex {{darkMode ? 'dark-mode' : ''}}">
     <div class="fixed-top" #stickyTop>
         <a class="sr-only sr-only-focusable focus-visible" href="javascript:void(0);" (click)="moveFocus()">Skip to main content</a>
         <ng-container [ngTemplateOutlet]="actionBar"></ng-container>
@@ -110,7 +110,7 @@
         </app-drawer>
     </div>
 
-    <div #readingSection class="reading-section" [ngStyle]="{'padding-top': topOffset + 20 + 'px', 'overflow': isFullscreen ? 'auto' : 'initial'}" 
+    <div #readingSection class="reading-section" [ngStyle]="{'padding-top': topOffset + 20 + 'px', 'overflow': 'auto'}" 
         [@isLoading]="isLoading ? true : false" (click)="handleReaderClick($event)">
 
         <div #readingHtml class="book-content" [ngStyle]="{'padding-bottom': topOffset + 20 + 'px', 'margin': '0px 0px'}" 

--- a/UI/Web/src/app/book-reader/book-reader/book-reader.component.html
+++ b/UI/Web/src/app/book-reader/book-reader/book-reader.component.html
@@ -94,7 +94,7 @@
                         </ul>
                     </div>
                     <ng-template #nestedChildren>
-                        <ul *ngFor="let chapterGroup of chapters" style="padding-inline-start: 0px">
+                        <ul *ngFor="let chapterGroup of chapters" class="chapter-title">
                             <li class="{{chapterGroup.page == pageNum ? 'active': ''}}" (click)="loadChapterPage(chapterGroup.page, '')">
                                 {{chapterGroup.title}}
                             </li>

--- a/UI/Web/src/app/book-reader/book-reader/book-reader.component.html
+++ b/UI/Web/src/app/book-reader/book-reader/book-reader.component.html
@@ -110,8 +110,11 @@
         </app-drawer>
     </div>
 
-    <div #readingSection class="reading-section" [ngStyle]="{'padding-top': topOffset + 20 + 'px'}" [@isLoading]="isLoading ? true : false" (click)="handleReaderClick($event)">
-        <div #readingHtml class="book-content" [ngStyle]="{'padding-bottom': topOffset + 20 + 'px', 'margin': '0px 0px'}" [innerHtml]="page" *ngIf="page !== undefined"></div>
+    <div #readingSection class="reading-section" [ngStyle]="{'padding-top': topOffset + 20 + 'px', 'overflow': isFullscreen ? 'auto' : 'initial'}" 
+        [@isLoading]="isLoading ? true : false" (click)="handleReaderClick($event)">
+
+        <div #readingHtml class="book-content" [ngStyle]="{'padding-bottom': topOffset + 20 + 'px', 'margin': '0px 0px'}" 
+            [innerHtml]="page" *ngIf="page !== undefined"></div>
 
         <div class="left {{clickOverlayClass('left')}} no-observe" (click)="prevPage()" *ngIf="clickToPaginate">
         </div>

--- a/UI/Web/src/app/book-reader/book-reader/book-reader.component.scss
+++ b/UI/Web/src/app/book-reader/book-reader/book-reader.component.scss
@@ -154,7 +154,7 @@ $primary-color: #0062cc;
 }
 
 .reading-section {
-    height: 100vh;
+    max-height: 100vh;
     width: 100%;
     //overflow: auto;  // This will break progress reporting
 }

--- a/UI/Web/src/app/book-reader/book-reader/book-reader.component.scss
+++ b/UI/Web/src/app/book-reader/book-reader/book-reader.component.scss
@@ -161,62 +161,21 @@ $primary-color: #0062cc;
 
 .book-content {
     position: relative;
+}
 
-    // A bunch of resets so books render correctly
-    html, body, div, span, applet, object, iframe,
-    h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-    a, abbr, acronym, address, big, cite, code,
-    del, dfn, em, img, ins, kbd, q, s, samp,
-    small, strike, strong, sub, sup, tt, var,
-    b, u, i, center,
-    dl, dt, dd, ol, ul, li,
-    fieldset, form, label, legend,
-    table, caption, tbody, tfoot, thead, tr, th, td,
-    article, aside, canvas, details, embed, 
-    figure, figcaption, footer, header, hgroup, 
-    menu, nav, output, ruby, section, summary,
-    time, mark, audio, video {
-        margin: 0;
-        padding: 0;
-        border: 0;
-        font-size: 100%;
-        font: inherit;
-        vertical-align: baseline;
-    }
-    /* HTML5 display-role reset for older browsers */
-    article, aside, details, figcaption, figure, 
-    footer, header, hgroup, menu, nav, section {
-        display: block;
-    }
-    body {
-        line-height: 1;
-    }
-    & ol, & ul {
-        list-style: none;
-    }
-    & blockquote, & q {
-        quotes: none;
-    }
-    & blockquote:before, & blockquote:after,
-    & q:before, & q:after {
-        content: '';
-        content: none;
-    }
-    & table {
-        border-collapse: collapse;
-        border-spacing: 0;
-    }
+// A bunch of resets so books render correctly
+::ng-deep .book-content {
     & a, & :link {
         color: blue;
     }
 }
 
-.book-content a {
-    color: blue;
-}
-
 .drawer-body {
     padding-bottom: 20px;
+}
+
+.chapter-title {
+    padding-inline-start: 0px
 }
 
 

--- a/UI/Web/src/app/book-reader/book-reader/book-reader.component.scss
+++ b/UI/Web/src/app/book-reader/book-reader/book-reader.component.scss
@@ -178,6 +178,10 @@ $primary-color: #0062cc;
     padding-inline-start: 0px
 }
 
+::ng-deep .scale-width {
+    max-width: 100%;
+}
+
 
 // Click to Paginate styles
 .icon-primary-color {

--- a/UI/Web/src/app/book-reader/book-reader/book-reader.component.scss
+++ b/UI/Web/src/app/book-reader/book-reader/book-reader.component.scss
@@ -156,17 +156,68 @@ $primary-color: #0062cc;
 .reading-section {
     height: 100vh;
     width: 100%;
-    overflow: auto;
+    //overflow: auto;  // This will break progress reporting
 }
 
 .book-content {
     position: relative;
+
+    // A bunch of resets so books render correctly
+    html, body, div, span, applet, object, iframe,
+    h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+    a, abbr, acronym, address, big, cite, code,
+    del, dfn, em, img, ins, kbd, q, s, samp,
+    small, strike, strong, sub, sup, tt, var,
+    b, u, i, center,
+    dl, dt, dd, ol, ul, li,
+    fieldset, form, label, legend,
+    table, caption, tbody, tfoot, thead, tr, th, td,
+    article, aside, canvas, details, embed, 
+    figure, figcaption, footer, header, hgroup, 
+    menu, nav, output, ruby, section, summary,
+    time, mark, audio, video {
+        margin: 0;
+        padding: 0;
+        border: 0;
+        font-size: 100%;
+        font: inherit;
+        vertical-align: baseline;
+    }
+    /* HTML5 display-role reset for older browsers */
+    article, aside, details, figcaption, figure, 
+    footer, header, hgroup, menu, nav, section {
+        display: block;
+    }
+    body {
+        line-height: 1;
+    }
+    & ol, & ul {
+        list-style: none;
+    }
+    & blockquote, & q {
+        quotes: none;
+    }
+    & blockquote:before, & blockquote:after,
+    & q:before, & q:after {
+        content: '';
+        content: none;
+    }
+    & table {
+        border-collapse: collapse;
+        border-spacing: 0;
+    }
+    & a, & :link {
+        color: blue;
+    }
+}
+
+.book-content a {
+    color: blue;
 }
 
 .drawer-body {
     padding-bottom: 20px;
 }
-
 
 
 // Click to Paginate styles

--- a/UI/Web/src/app/book-reader/book-reader/book-reader.component.ts
+++ b/UI/Web/src/app/book-reader/book-reader/book-reader.component.ts
@@ -1041,15 +1041,10 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       this.readerService.exitFullscreen(() => {
         this.isFullscreen = false;
         //this.renderer.removeStyle(this.readingHtml, 'overflow');
-        this.renderer.removeStyle(this.reader.nativeElement, 'background-color');
       });
     } else {
       this.readerService.enterFullscreen(this.reader.nativeElement, () => {
         this.isFullscreen = true;
-        if (!this.darkMode) {
-          // For some reason, in fullscreen mode the browser sets background color for us, so we need to make the background color white 
-          this.renderer.setStyle(this.reader.nativeElement, 'background-color', 'white', RendererStyleFlags2.Important);
-        }
       });
     }
   }

--- a/UI/Web/src/app/book-reader/book-reader/book-reader.component.ts
+++ b/UI/Web/src/app/book-reader/book-reader/book-reader.component.ts
@@ -300,6 +300,8 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       .pipe(debounceTime(200), takeUntil(this.onDestroy)).subscribe((event) => {
         if (this.isLoading) return;
 
+        console.log('Scroll');
+
         // Highlight the current chapter we are on
         if (Object.keys(this.pageAnchors).length !== 0) {
           // get the height of the document so we can capture markers that are halfway on the document viewport
@@ -868,14 +870,25 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
 
   updateReaderStyles() {
     if (this.readingHtml != undefined && this.readingHtml.nativeElement) {
-      for(let i = 0; i < this.readingHtml.nativeElement.children.length; i++) {
-        const elem = this.readingHtml.nativeElement.children.item(i);
-        if (elem?.tagName != 'STYLE') {
-          Object.entries(this.pageStyles).forEach(item => {
-            this.renderer.setStyle(elem, item[0], item[1], RendererStyleFlags2.Important);
-          });
+      // for(let i = 0; i < this.readingHtml.nativeElement.children.length; i++) {
+      //   const elem = this.readingHtml.nativeElement.children.item(i);
+      //   if (elem?.tagName != 'STYLE') {
+      //     Object.entries(this.pageStyles).forEach(item => {
+      //       if (item[1] == '100%' || item[1] == '0px' || item[1] == 'inherit') return;
+      //       this.renderer.setStyle(elem, item[0], item[1], RendererStyleFlags2.Important);
+      //     });
+      //   }
+      // }
+      console.log('pageStyles: ', this.pageStyles);
+      console.log('readingHtml: ', this.readingHtml.nativeElement);
+      Object.entries(this.pageStyles).forEach(item => {
+        if (item[1] == '100%' || item[1] == '0px' || item[1] == 'inherit') {
+          // Remove the style or skip
+          this.renderer.removeStyle(this.readingHtml.nativeElement, item[0]);
+          return;
         }
-      }
+        this.renderer.setStyle(this.readingHtml.nativeElement, item[0], item[1], RendererStyleFlags2.Important);
+      });
     }
   }
 
@@ -1027,10 +1040,16 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
     if (this.isFullscreen) {
       this.readerService.exitFullscreen(() => {
         this.isFullscreen = false;
+        //this.renderer.removeStyle(this.readingHtml, 'overflow');
+        this.renderer.removeStyle(this.reader.nativeElement, 'background-color');
       });
     } else {
       this.readerService.enterFullscreen(this.reader.nativeElement, () => {
         this.isFullscreen = true;
+        if (!this.darkMode) {
+          // For some reason, in fullscreen mode the browser sets background color for us, so we need to make the background color white 
+          this.renderer.setStyle(this.reader.nativeElement, 'background-color', 'white', RendererStyleFlags2.Important);
+        }
       });
     }
   }

--- a/UI/Web/src/app/book-reader/book-reader/book-reader.component.ts
+++ b/UI/Web/src/app/book-reader/book-reader/book-reader.component.ts
@@ -719,6 +719,10 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
           this.setupPage(part, scrollTop);
           return;
         }
+
+        // Apply scaling class to all images to ensure they scale down to max width to not blow out the reader
+        Array.from(imgs).forEach(img => this.renderer.addClass(img, 'scale-width'));
+
         Promise.all(Array.from(imgs)
         .filter(img => !img.complete)
         .map(img => new Promise(resolve => { img.onload = img.onerror = resolve; })))

--- a/UI/Web/src/app/book-reader/book-reader/book-reader.component.ts
+++ b/UI/Web/src/app/book-reader/book-reader/book-reader.component.ts
@@ -297,7 +297,7 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
    */
   ngAfterViewInit() {
     // check scroll offset and if offset is after any of the "id" markers, save progress
-    fromEvent(this.readingSectionElemRef.nativeElement, 'scroll')
+    fromEvent(this.reader.nativeElement, 'scroll')
       .pipe(debounceTime(200), takeUntil(this.onDestroy)).subscribe((event) => {
         if (this.isLoading) return;
 
@@ -1048,7 +1048,7 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
         this.renderer.removeStyle(this.reader.nativeElement, 'background');
       });
     } else {
-      this.readerService.enterFullscreen(this.readingSectionElemRef.nativeElement, () => {
+      this.readerService.enterFullscreen(this.reader.nativeElement, () => {
         this.isFullscreen = true;
         // HACK: This is a bug with how browsers change the background color for fullscreen mode
         if (!this.darkMode) {

--- a/UI/Web/src/app/book-reader/book-reader/book-reader.component.ts
+++ b/UI/Web/src/app/book-reader/book-reader/book-reader.component.ts
@@ -1044,11 +1044,15 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
     if (this.isFullscreen) {
       this.readerService.exitFullscreen(() => {
         this.isFullscreen = false;
-        //this.renderer.removeStyle(this.readingHtml, 'overflow');
+        this.renderer.removeStyle(this.reader.nativeElement, 'background');
       });
     } else {
       this.readerService.enterFullscreen(this.reader.nativeElement, () => {
         this.isFullscreen = true;
+        // HACK: This is a bug with how browsers change the background color for fullscreen mode
+        if (!this.darkMode) {
+          this.renderer.setStyle(this.reader.nativeElement, 'background', 'white');
+        }
       });
     }
   }

--- a/UI/Web/src/app/user-settings/user-preferences/user-preferences.component.html
+++ b/UI/Web/src/app/user-settings/user-preferences/user-preferences.component.html
@@ -49,39 +49,47 @@
                             <ng-template ngbPanelContent>
                                 <form [formGroup]="settingsForm" *ngIf="user !== undefined">
                                     <h3 id="manga-header">Image Reader</h3>
-                                    <div class="form-group">
-                                        <label for="settings-reading-direction">Reading Direction</label>&nbsp;<i class="fa fa-info-circle" aria-hidden="true" placement="right" [ngbTooltip]="readingDirectionTooltip" role="button" tabindex="0"></i>
-                                        <ng-template #readingDirectionTooltip>Direction to click to move to next page. Right to Left means you click on left side of screen to move to next page.</ng-template>
-                                        <span class="sr-only" id="settings-reading-direction-help">Direction to click to move to next page. Right to Left means you click on left side of screen to move to next page.</span>
-                                        <select class="form-control" aria-describedby="manga-header" formControlName="readingDirection" id="settings-reading-direction">
-                                            <option *ngFor="let opt of readingDirections" [value]="opt.value">{{opt.text | titlecase}}</option>
-                                        </select>
+                                    
+                                    <div class="row no-gutters">
+                                        <div class="form-group col-md-6 col-sm-12 pr-2">
+                                            <label for="settings-reading-direction">Reading Direction</label>&nbsp;<i class="fa fa-info-circle" aria-hidden="true" placement="right" [ngbTooltip]="readingDirectionTooltip" role="button" tabindex="0"></i>
+                                            <ng-template #readingDirectionTooltip>Direction to click to move to next page. Right to Left means you click on left side of screen to move to next page.</ng-template>
+                                            <span class="sr-only" id="settings-reading-direction-help">Direction to click to move to next page. Right to Left means you click on left side of screen to move to next page.</span>
+                                            <select class="form-control" aria-describedby="manga-header" formControlName="readingDirection" id="settings-reading-direction">
+                                                <option *ngFor="let opt of readingDirections" [value]="opt.value">{{opt.text | titlecase}}</option>
+                                            </select>
+                                        </div>
+                                
+                                        <div class="form-group col-md-6 col-sm-12">
+                                            <label for="settings-scaling-option">Scaling Options</label>&nbsp;<i class="fa fa-info-circle" aria-hidden="true" placement="right" [ngbTooltip]="taskBackupTooltip" role="button" tabindex="0"></i>
+                                            <ng-template #taskBackupTooltip>How to scale the image to your screen.</ng-template>
+                                            <span class="sr-only" id="settings-scaling-option-help">How to scale the image to your screen.</span>
+                                            <select class="form-control" aria-describedby="manga-header" formControlName="scalingOption" id="settings-scaling-option">
+                                                <option *ngFor="let opt of scalingOptions" [value]="opt.value">{{opt.text | titlecase}}</option>
+                                            </select>
+                                        </div>
+                                    </div>
+                                    
+                                    <div class="row no-gutters">
+                                        <div class="form-group col-md-6 col-sm-12 pr-2">
+                                            <label for="settings-pagesplit-option">Page Splitting</label>&nbsp;<i class="fa fa-info-circle" aria-hidden="true" placement="right" [ngbTooltip]="pageSplitOptionTooltip" role="button" tabindex="0"></i>
+                                            <ng-template #pageSplitOptionTooltip>How to split a full width image (ie both left and right images are combined)</ng-template>
+                                            <span class="sr-only" id="settings-pagesplit-option-help">How to split a full width image (ie both left and right images are combined)</span>
+                                            <select class="form-control" aria-describedby="manga-header" formControlName="pageSplitOption" id="settings-pagesplit-option">
+                                                <option *ngFor="let opt of pageSplitOptions" [value]="opt.value">{{opt.text | titlecase}}</option>
+                                            </select>
+                                        </div>
+                                        <div class="form-group col-md-6 col-sm-12">
+                                            <label for="settings-readingmode-option">Reading Mode</label>
+                                            <select class="form-control" aria-describedby="manga-header" formControlName="readerMode" id="settings-readingmode-option">
+                                                <option *ngFor="let opt of readingModes" [value]="opt.value">{{opt.text | titlecase}}</option>
+                                            </select>
+                                        </div>
                                     </div>
                             
+                                    
                                     <div class="form-group">
-                                        <label for="settings-scaling-option">Scaling Options</label>&nbsp;<i class="fa fa-info-circle" aria-hidden="true" placement="right" [ngbTooltip]="taskBackupTooltip" role="button" tabindex="0"></i>
-                                        <ng-template #taskBackupTooltip>How to scale the image to your screen.</ng-template>
-                                        <span class="sr-only" id="settings-scaling-option-help">How to scale the image to your screen.</span>
-                                        <select class="form-control" aria-describedby="manga-header" formControlName="scalingOption" id="settings-scaling-option">
-                                            <option *ngFor="let opt of scalingOptions" [value]="opt.value">{{opt.text | titlecase}}</option>
-                                        </select>
-                                    </div>
-                            
-                                    <div class="form-group">
-                                        <label for="settings-pagesplit-option">Page Splitting</label>&nbsp;<i class="fa fa-info-circle" aria-hidden="true" placement="right" [ngbTooltip]="pageSplitOptionTooltip" role="button" tabindex="0"></i>
-                                        <ng-template #pageSplitOptionTooltip>How to split a full width image (ie both left and right images are combined)</ng-template>
-                                        <span class="sr-only" id="settings-pagesplit-option-help">How to split a full width image (ie both left and right images are combined)</span>
-                                        <select class="form-control" aria-describedby="manga-header" formControlName="pageSplitOption" id="settings-pagesplit-option">
-                                            <option *ngFor="let opt of pageSplitOptions" [value]="opt.value">{{opt.text | titlecase}}</option>
-                                        </select>
-                                    </div>
-                                    <div class="form-group">
-                                        <label for="settings-readingmode-option">Reading Mode</label>
-                                        <select class="form-control" aria-describedby="manga-header" formControlName="readerMode" id="settings-readingmode-option">
-                                            <option *ngFor="let opt of readingModes" [value]="opt.value">{{opt.text | titlecase}}</option>
-                                        </select>
-                                    </div>
-                                    <div class="form-group">
+                                        <!-- TODO: Turn this into a checkbox -->
                                         <label id="auto-close-label">Auto Close Menu</label>
                                         <div class="form-group">
                                             <div class="custom-control custom-radio custom-control-inline">
@@ -96,67 +104,82 @@
                                     </div>
                                     <hr>
                                     <h3>Book Reader</h3>
-                                    <div class="form-group">
-                                        <label id="dark-mode-label">Dark Mode</label>
-                                        <div class="form-group">
-                                            <div class="custom-control custom-radio custom-control-inline">
-                                                <input type="radio" id="dark-mode" formControlName="bookReaderDarkMode" class="custom-control-input" [value]="true" aria-labelledby="dark-mode-label">
-                                                <label class="custom-control-label" for="dark-mode">True</label>
-                                            </div>
-                                            <div class="custom-control custom-radio custom-control-inline">
-                                                <input type="radio" id="not-dark-mode" formControlName="bookReaderDarkMode" class="custom-control-input" [value]="false" aria-labelledby="dark-mode-label">
-                                                <label class="custom-control-label" for="not-dark-mode">False</label>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <div class="form-group">
-                                        <label for="settings-book-reading-direction">Book Reading Direction</label>&nbsp;<i class="fa fa-info-circle" aria-hidden="true" placement="right" [ngbTooltip]="bookReadingDirectionTooltip" role="button" tabindex="0"></i>
-                                        <ng-template #bookReadingDirectionTooltip>Direction to click to move to next page. Right to Left means you click on left side of screen to move to next page.</ng-template>
-                                        <span class="sr-only" id="settings-reading-direction-help">Direction to click to move to next page. Right to Left means you click on left side of screen to move to next page.</span>
-                                        <select class="form-control" aria-describedby="settings-reading-direction-help" formControlName="bookReaderReadingDirection">
-                                            <option *ngFor="let opt of readingDirections" [value]="opt.value">{{opt.text | titlecase}}</option>
-                                        </select>
-                                    </div>
-                                    <div class="form-group">
-                                        <label id="taptopaginate-label">Tap to Paginate</label>&nbsp;<i class="fa fa-info-circle" aria-hidden="true" placement="right" [ngbTooltip]="tapToPaginateOptionTooltip" role="button" tabindex="0"></i>
-                                        <ng-template #tapToPaginateOptionTooltip>Should the sides of the book reader screen allow tapping on it to move to prev/next page</ng-template>
-                                        <span class="sr-only" id="settings-taptopaginate-option-help">Should the sides of the book reader screen allow tapping on it to move to prev/next page</span>
-                                        <div class="form-group">
-                                            <div class="custom-control custom-radio custom-control-inline">
-                                                <input type="radio" id="taptopaginate" formControlName="bookReaderTapToPaginate" class="custom-control-input" [value]="true" aria-labelledby="taptopaginate-label">
-                                                <label class="custom-control-label" for="taptopaginate">True</label>
-                                            </div>
-                                            <div class="custom-control custom-radio custom-control-inline">
-                                                <input type="radio" id="not-taptopaginate" formControlName="bookReaderTapToPaginate" class="custom-control-input" [value]="false" aria-labelledby="taptopaginate-label">
-                                                <label class="custom-control-label" for="not-taptopaginate">False</label>
+                                    <div class="row no-gutters">
+                                        <div class="form-group col-md-6 col-sm-12 pr-2">
+                                            <label id="dark-mode-label">Dark Mode</label>
+                                            <div class="form-group">
+                                                <div class="custom-control custom-radio custom-control-inline">
+                                                    <input type="radio" id="dark-mode" formControlName="bookReaderDarkMode" class="custom-control-input" [value]="true" aria-labelledby="dark-mode-label">
+                                                    <label class="custom-control-label" for="dark-mode">True</label>
+                                                </div>
+                                                <div class="custom-control custom-radio custom-control-inline">
+                                                    <input type="radio" id="not-dark-mode" formControlName="bookReaderDarkMode" class="custom-control-input" [value]="false" aria-labelledby="dark-mode-label">
+                                                    <label class="custom-control-label" for="not-dark-mode">False</label>
+                                                </div>
                                             </div>
                                         </div>
-                                    </div>
-                                    <div class="form-group">
-                                        <label for="settings-fontfamily-option">Font Family</label>&nbsp;<i class="fa fa-info-circle" aria-hidden="true" placement="right" [ngbTooltip]="fontFamilyOptionTooltip" role="button" tabindex="0"></i>
-                                        <ng-template #fontFamilyOptionTooltip>Font familty to load up. Default will load the book's default font</ng-template>
-                                        <span class="sr-only" id="settings-fontfamily-option-help">Font familty to load up. Default will load the book's default font</span>
-                                        <select class="form-control" aria-describedby="settings-fontfamily-option-help" formControlName="bookReaderFontFamily">
-                                            <option *ngFor="let opt of fontFamilies" [value]="opt">{{opt | titlecase}}</option>
-                                        </select>
-                                    </div>
-                                    <div class="form-group">
-                                        <label id="font-size">Font Size</label>
-                                        <div class="custom-slider"><ngx-slider [options]="bookReaderFontSizeOptions" formControlName="bookReaderFontSize" aria-labelledby="font-size"></ngx-slider></div>
-                                    </div>
-                                    <div class="form-group">
-                                        <label>Line Height</label>&nbsp;<i class="fa fa-info-circle" aria-hidden="true" placement="right" [ngbTooltip]="bookLineHeightOptionTooltip" role="button" tabindex="0"></i>
-                                        <ng-template #bookLineHeightOptionTooltip>How much spacing between the lines of the book</ng-template>
-                                        <span class="sr-only" id="settings-booklineheight-option-help">How much spacing between the lines of the book</span>
-                                        <div class="custom-slider"><ngx-slider [options]="bookReaderLineSpacingOptions" formControlName="bookReaderLineSpacing" aria-describedby="settings-booklineheight-option-help"></ngx-slider></div>
-                                    </div>
     
-                                    <div class="form-group">
-                                        <label>Margin</label>&nbsp;<i class="fa fa-info-circle" aria-hidden="true" placement="right" [ngbTooltip]="bookReaderMarginOptionTooltip" role="button" tabindex="0"></i>
-                                        <ng-template #bookReaderMarginOptionTooltip>How much spacing on each side of the screen. This will override to 0 on mobile devices regardless of this setting.</ng-template>
-                                        <span class="sr-only" id="settings-bookmargin-option-help">How much spacing on each side of the screen. This will override to 0 on mobile devices regardless of this setting.</span>
-                                        <div class="custom-slider"><ngx-slider [options]="bookReaderMarginOptions" formControlName="bookReaderMargin" aria-describedby="bookmargin"></ngx-slider></div>
+                                        <div class="form-group col-md-6 col-sm-12">
+                                            <label id="taptopaginate-label">Tap to Paginate</label>&nbsp;<i class="fa fa-info-circle" aria-hidden="true" placement="right" [ngbTooltip]="tapToPaginateOptionTooltip" role="button" tabindex="0"></i>
+                                            <ng-template #tapToPaginateOptionTooltip>Should the sides of the book reader screen allow tapping on it to move to prev/next page</ng-template>
+                                            <span class="sr-only" id="settings-taptopaginate-option-help">Should the sides of the book reader screen allow tapping on it to move to prev/next page</span>
+                                            <div class="form-group">
+                                                <div class="custom-control custom-radio custom-control-inline">
+                                                    <input type="radio" id="taptopaginate" formControlName="bookReaderTapToPaginate" class="custom-control-input" [value]="true" aria-labelledby="taptopaginate-label">
+                                                    <label class="custom-control-label" for="taptopaginate">True</label>
+                                                </div>
+                                                <div class="custom-control custom-radio custom-control-inline">
+                                                    <input type="radio" id="not-taptopaginate" formControlName="bookReaderTapToPaginate" class="custom-control-input" [value]="false" aria-labelledby="taptopaginate-label">
+                                                    <label class="custom-control-label" for="not-taptopaginate">False</label>
+                                                </div>
+                                            </div>
+                                        </div>
                                     </div>
+
+                                    <div class="row no-gutters">
+                                        <div class="form-group col-md-6 col-sm-12 pr-2">
+                                            <label for="settings-book-reading-direction">Book Reading Direction</label>&nbsp;<i class="fa fa-info-circle" aria-hidden="true" placement="right" [ngbTooltip]="bookReadingDirectionTooltip" role="button" tabindex="0"></i>
+                                            <ng-template #bookReadingDirectionTooltip>Direction to click to move to next page. Right to Left means you click on left side of screen to move to next page.</ng-template>
+                                            <span class="sr-only" id="settings-reading-direction-help">Direction to click to move to next page. Right to Left means you click on left side of screen to move to next page.</span>
+                                            <select class="form-control" aria-describedby="settings-reading-direction-help" formControlName="bookReaderReadingDirection">
+                                                <option *ngFor="let opt of readingDirections" [value]="opt.value">{{opt.text | titlecase}}</option>
+                                            </select>
+                                        </div>
+                                        
+                                        
+                                        <div class="form-group col-md-6 col-sm-12">
+                                            <label for="settings-fontfamily-option">Font Family</label>&nbsp;<i class="fa fa-info-circle" aria-hidden="true" placement="right" [ngbTooltip]="fontFamilyOptionTooltip" role="button" tabindex="0"></i>
+                                            <ng-template #fontFamilyOptionTooltip>Font familty to load up. Default will load the book's default font</ng-template>
+                                            <span class="sr-only" id="settings-fontfamily-option-help">Font familty to load up. Default will load the book's default font</span>
+                                            <select class="form-control" aria-describedby="settings-fontfamily-option-help" formControlName="bookReaderFontFamily">
+                                                <option *ngFor="let opt of fontFamilies" [value]="opt">{{opt | titlecase}}</option>
+                                            </select>
+                                        </div>
+                                    </div>
+
+                                    
+
+                                    <div class="row no-gutters">
+                                        <div class="form-group col-md-4 col-sm-12 pr-2">
+                                            <label id="font-size">Font Size</label>
+                                            <div class="custom-slider"><ngx-slider [options]="bookReaderFontSizeOptions" formControlName="bookReaderFontSize" aria-labelledby="font-size"></ngx-slider></div>
+                                        </div>
+                                        <div class="form-group col-md-4 col-sm-12 pr-2">
+                                            <label>Line Height</label>&nbsp;<i class="fa fa-info-circle" aria-hidden="true" placement="right" [ngbTooltip]="bookLineHeightOptionTooltip" role="button" tabindex="0"></i>
+                                            <ng-template #bookLineHeightOptionTooltip>How much spacing between the lines of the book</ng-template>
+                                            <span class="sr-only" id="settings-booklineheight-option-help">How much spacing between the lines of the book</span>
+                                            <div class="custom-slider"><ngx-slider [options]="bookReaderLineSpacingOptions" formControlName="bookReaderLineSpacing" aria-describedby="settings-booklineheight-option-help"></ngx-slider></div>
+                                        </div>
+        
+                                        <div class="form-group col-md-4 col-sm-12">
+                                            <label>Margin</label>&nbsp;<i class="fa fa-info-circle" aria-hidden="true" placement="right" [ngbTooltip]="bookReaderMarginOptionTooltip" role="button" tabindex="0"></i>
+                                            <ng-template #bookReaderMarginOptionTooltip>How much spacing on each side of the screen. This will override to 0 on mobile devices regardless of this setting.</ng-template>
+                                            <span class="sr-only" id="settings-bookmargin-option-help">How much spacing on each side of the screen. This will override to 0 on mobile devices regardless of this setting.</span>
+                                            <div class="custom-slider"><ngx-slider [options]="bookReaderMarginOptions" formControlName="bookReaderMargin" aria-describedby="bookmargin"></ngx-slider></div>
+                                        </div>
+                                    </div>
+
+                                    
     
                                     <div class="float-right mb-3">
                                         <button type="button" class="btn btn-secondary mr-2" (click)="resetForm()" aria-describedby="reading-panel">Reset</button>
@@ -165,23 +188,6 @@
                                 </form>
                             </ng-template>
                         </ngb-panel>
-                    
-<!--     
-
-                    <ngb-panel id="api-panel" title="3rd Party Clients">
-                        <ng-template ngbPanelHeader>
-                            <div class="d-flex align-items-center justify-content-between">
-                              <button ngbPanelToggle class="btn container-fluid text-left pl-0 accordion-header">3rd Party Clients</button>
-                              <span class="pull-right"><i class="fa fa-angle-{{acc.isExpanded('api-panel') ? 'down' : 'up'}}" aria-hidden="true"></i></span>  
-                            </div>
-                          </ng-template>
-                        <ng-template ngbPanelContent>
-                            <p>All 3rd Party clients will either use the API key or the Connection Url below. These are like passwords, keep it private.</p>
-                            <p class="alert alert-warning" role="alert" *ngIf="!opdsEnabled">OPDS is not enabled on this server.</p>
-                            <app-api-key tooltipText="The API key is like a password. Keep it secret, Keep it safe."></app-api-key>
-                            <app-api-key title="OPDS URL" [showRefresh]="false" [transform]="makeUrl"></app-api-key>
-                        </ng-template>
-                    </ngb-panel> -->
                 </ngb-accordion>
               </ng-container>
               <ng-container *ngIf="tab.fragment === 'bookmarks'">

--- a/UI/Web/src/styles.scss
+++ b/UI/Web/src/styles.scss
@@ -52,6 +52,10 @@ body {
   cursor: pointer;
 }
 
+app-root {
+  background-color: inherit;
+}
+
 
 // Utiliities
 @include media-breakpoint-down(xs, (xs: 0, sm: 576px, md: 768px, lg: 992px, xl: 1200px)) {


### PR DESCRIPTION
# Changed
- Changed: Stack multiple user preference controls into the same row

# Fixed
- Fixed: Fixed a regression where custom fonts from books stopped loading in (develop?)
- Fixed: Fixed a bug where going into fullscreen in non-dark mode will cause the background of the reader to go black (develop)
- Fixed: Fixed a rendering issue with margin left/right screwing book's html up. 
- Fixed: Fixed an issue where our custom line-height: 100% would break book's css if using line-height. Now we remove styles (overrides) if they are non valuable.
- Fixed: Fixed an issue where anchors/links wouldn't be blue when reading in non-dark mode
- Fixed: Fixed a bug where when choosing cover images, the word "backcover" would be accepted. This would lead to epubs with both cover and backcover images and no metadata to choose backcover sometimes (Fixes #892 )
- Fixed: Fixed a bug where ReleaseYear on Series could be 1. We now validate that the release year is at least 1000 (a valid year length) before setting for the series. 
- Fixed: Fixed an issue where large images could blow out the screen when reading on mobile. Now images will force to be the max width of the browser. (Fixes #905 )
- Fixed: Fixed an issue where some images in some browsers wouldn't load correctly over https when reading through a reverse proxy. (Fixes #904 )
- Fixed: Fixed an issue when toggling fullscreen mode on book reader, progress would fail to save when scrolling (develop)