### PR TITLE
Metadata Optimizations

### DIFF
--- a/API.Tests/Helpers/CacheHelperTests.cs
+++ b/API.Tests/Helpers/CacheHelperTests.cs
@@ -89,22 +89,6 @@ public class CacheHelperTests
             false, false));
     }
 
-    // [Fact]
-    // public void ShouldUpdateCoverImage_ShouldNotUpdateOnSecondRunWithCoverImageSetNotLocked_Robbie()
-    // {
-    //     // Represents first run
-    //     var file = new MangaFile()
-    //     {
-    //         FilePath = "YOUR REAL Path here",
-    //         LastModified = DateTime.Now
-    //     };
-    //     var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), new FileSystem());
-    //     var fileService = new FileService(ds.FileSystem);
-    //     var cacheHelper = new CacheHelper(fileService);
-    //     Assert.False(cacheHelper.ShouldUpdateCoverImage("the existing cover image, full path", file, DateTime.Now.Subtract(TimeSpan.FromMinutes(1)),
-    //         false, false));
-    // }
-
     [Fact]
     public void ShouldUpdateCoverImage_ShouldNotUpdateOnSecondRunWithCoverImageSetLocked()
     {

--- a/API.Tests/Helpers/CacheHelperTests.cs
+++ b/API.Tests/Helpers/CacheHelperTests.cs
@@ -1,10 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Abstractions;
 using System.IO.Abstractions.TestingHelpers;
 using API.Entities;
 using API.Helpers;
 using API.Services;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
 using Xunit;
 
 namespace API.Tests.Helpers;
@@ -72,6 +75,35 @@ public class CacheHelperTests
         Assert.False(_cacheHelper.ShouldUpdateCoverImage(_testCoverPath, file, DateTime.Now.Subtract(TimeSpan.FromMinutes(1)),
             false, false));
     }
+
+    [Fact]
+    public void ShouldUpdateCoverImage_ShouldNotUpdateOnSecondRunWithCoverImageSetNotLocked_2()
+    {
+        // Represents first run
+        var file = new MangaFile()
+        {
+            FilePath = TestCoverArchive,
+            LastModified = DateTime.Now
+        };
+        Assert.False(_cacheHelper.ShouldUpdateCoverImage(_testCoverPath, file, DateTime.Now,
+            false, false));
+    }
+
+    // [Fact]
+    // public void ShouldUpdateCoverImage_ShouldNotUpdateOnSecondRunWithCoverImageSetNotLocked_Robbie()
+    // {
+    //     // Represents first run
+    //     var file = new MangaFile()
+    //     {
+    //         FilePath = "YOUR REAL Path here",
+    //         LastModified = DateTime.Now
+    //     };
+    //     var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), new FileSystem());
+    //     var fileService = new FileService(ds.FileSystem);
+    //     var cacheHelper = new CacheHelper(fileService);
+    //     Assert.False(cacheHelper.ShouldUpdateCoverImage("the existing cover image, full path", file, DateTime.Now.Subtract(TimeSpan.FromMinutes(1)),
+    //         false, false));
+    // }
 
     [Fact]
     public void ShouldUpdateCoverImage_ShouldNotUpdateOnSecondRunWithCoverImageSetLocked()

--- a/API.Tests/Parser/ParserTest.cs
+++ b/API.Tests/Parser/ParserTest.cs
@@ -79,7 +79,7 @@ namespace API.Tests.Parser
         [InlineData("src: local(\"/fonts/OpenSans-Regular-webfont.woff2\")", new [] {"src: local(\"", "/fonts/OpenSans-Regular-webfont.woff2", "\")"})]
         public void FontCssCorrectlySeparates(string input, string[] expected)
         {
-            Assert.Equal(expected, FontSrcUrlRegex.Match(input).Groups.Values.Select(g => g.Value).Where((s, i) => i > 0).ToArray());
+            Assert.Equal(expected, FontSrcUrlRegex.Match(input).Groups.Values.Select(g => g.Value).Where((_, i) => i > 0).ToArray());
         }
 
 

--- a/API.Tests/Services/DirectoryServiceTests.cs
+++ b/API.Tests/Services/DirectoryServiceTests.cs
@@ -53,6 +53,39 @@ namespace API.Tests.Services
         }
 
         [Fact]
+        public void TraverseTreeParallelForEach_LongDirectory_ShouldBe1()
+        {
+            var fileSystem = new MockFileSystem();
+            // Create a super long path
+            var testDirectory = "/manga/";
+            for (var i = 0; i < 200; i++)
+            {
+                testDirectory = fileSystem.FileSystem.Path.Join(testDirectory, "supercalifragilisticexpialidocious");
+            }
+
+
+            fileSystem.AddFile(fileSystem.FileSystem.Path.Join(testDirectory, "file_{29}.jpg"), new MockFileData(""));
+
+            var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), fileSystem);
+            var files = new List<string>();
+            try
+            {
+                var fileCount = ds.TraverseTreeParallelForEach("/manga/", s => files.Add(s),
+                    API.Parser.Parser.ImageFileExtensions, _logger);
+                Assert.Equal(1, fileCount);
+            }
+            catch (Exception ex)
+            {
+                Assert.False(true);
+            }
+
+
+            Assert.Equal(1, files.Count);
+        }
+
+
+
+        [Fact]
         public void TraverseTreeParallelForEach_DontCountExcludedDirectories_ShouldBe28()
         {
             var testDirectory = "/manga/";

--- a/API.Tests/Services/DirectoryServiceTests.cs
+++ b/API.Tests/Services/DirectoryServiceTests.cs
@@ -64,7 +64,7 @@ namespace API.Tests.Services
             }
 
 
-            fileSystem.AddFile(fileSystem.FileSystem.Path.Join(testDirectory, "file_{29}.jpg"), new MockFileData(""));
+            fileSystem.AddFile(fileSystem.FileSystem.Path.Join(testDirectory, "file_29.jpg"), new MockFileData(""));
 
             var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), fileSystem);
             var files = new List<string>();

--- a/API/Comparators/NaturalSortComparer.cs
+++ b/API/Comparators/NaturalSortComparer.cs
@@ -23,7 +23,7 @@ namespace API.Comparators
             _isAscending = inAscendingOrder;
         }
 
-        int IComparer<string>.Compare(string x, string y)
+        int IComparer<string>.Compare(string? x, string? y)
         {
             if (x == y) return 0;
 

--- a/API/DTOs/ChapterDto.cs
+++ b/API/DTOs/ChapterDto.cs
@@ -62,6 +62,14 @@ namespace API.DTOs
         /// </summary>
         /// <remarks>Metadata field</remarks>
         public string TitleName { get; set; }
+        /// <summary>
+        /// Summary for the Chapter/Issue
+        /// </summary>
+        public string Summary { get; set; }
+        /// <summary>
+        /// Language for the Chapter/Issue
+        /// </summary>
+        public string Language { get; set; }
         public ICollection<PersonDto> Writers { get; set; } = new List<PersonDto>();
         public ICollection<PersonDto> Penciller { get; set; } = new List<PersonDto>();
         public ICollection<PersonDto> Inker { get; set; } = new List<PersonDto>();

--- a/API/Data/DbFactory.cs
+++ b/API/Data/DbFactory.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using API.Data.Metadata;
 using API.Entities;
 using API.Entities.Enums;
@@ -118,7 +119,7 @@ namespace API.Data
                 FilePath = filePath,
                 Format = format,
                 Pages = pages,
-                LastModified = DateTime.Now //File.GetLastWriteTime(filePath)
+                LastModified = File.GetLastWriteTime(filePath) // NOTE: Changed this from DateTime.Now
             };
         }
 

--- a/API/Data/Metadata/ComicInfo.cs
+++ b/API/Data/Metadata/ComicInfo.cs
@@ -85,5 +85,6 @@ namespace API.Data.Metadata
                 .SingleOrDefault(t => t.ToDescription().ToUpperInvariant().Equals(value.ToUpperInvariant()), Entities.Enums.AgeRating.Unknown);
         }
 
+
     }
 }

--- a/API/Data/Migrations/20220107232822_ChapterMetadataOptimization.Designer.cs
+++ b/API/Data/Migrations/20220107232822_ChapterMetadataOptimization.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using API.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace API.Data.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20220107232822_ChapterMetadataOptimization")]
+    partial class ChapterMetadataOptimization
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "6.0.0");

--- a/API/Data/Migrations/20220107232822_ChapterMetadataOptimization.cs
+++ b/API/Data/Migrations/20220107232822_ChapterMetadataOptimization.cs
@@ -1,0 +1,108 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace API.Data.Migrations
+{
+    public partial class ChapterMetadataOptimization : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Chapter_Genre_GenreId",
+                table: "Chapter");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Chapter_GenreId",
+                table: "Chapter");
+
+            migrationBuilder.DropColumn(
+                name: "GenreId",
+                table: "Chapter");
+
+            migrationBuilder.DropColumn(
+                name: "FullscreenMode",
+                table: "AppUserPreferences");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Language",
+                table: "Chapter",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Summary",
+                table: "Chapter",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "ChapterGenre",
+                columns: table => new
+                {
+                    ChaptersId = table.Column<int>(type: "INTEGER", nullable: false),
+                    GenresId = table.Column<int>(type: "INTEGER", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ChapterGenre", x => new { x.ChaptersId, x.GenresId });
+                    table.ForeignKey(
+                        name: "FK_ChapterGenre_Chapter_ChaptersId",
+                        column: x => x.ChaptersId,
+                        principalTable: "Chapter",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_ChapterGenre_Genre_GenresId",
+                        column: x => x.GenresId,
+                        principalTable: "Genre",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ChapterGenre_GenresId",
+                table: "ChapterGenre",
+                column: "GenresId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ChapterGenre");
+
+            migrationBuilder.DropColumn(
+                name: "Language",
+                table: "Chapter");
+
+            migrationBuilder.DropColumn(
+                name: "Summary",
+                table: "Chapter");
+
+            migrationBuilder.AddColumn<int>(
+                name: "GenreId",
+                table: "Chapter",
+                type: "INTEGER",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "FullscreenMode",
+                table: "AppUserPreferences",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Chapter_GenreId",
+                table: "Chapter",
+                column: "GenreId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Chapter_Genre_GenreId",
+                table: "Chapter",
+                column: "GenreId",
+                principalTable: "Genre",
+                principalColumn: "Id");
+        }
+    }
+}

--- a/API/Data/Repositories/SeriesRepository.cs
+++ b/API/Data/Repositories/SeriesRepository.cs
@@ -156,6 +156,11 @@ public class SeriesRepository : ISeriesRepository
 
             .Include(s => s.Volumes)
             .ThenInclude(v => v.Chapters)
+            .ThenInclude(c => c.Genres)
+
+            .Include(s => s.Volumes)
+            .ThenInclude(v => v.Chapters)
+            .ThenInclude(c => c.Tags)
 
             .Include(s => s.Volumes)
             .ThenInclude(v => v.Chapters)
@@ -186,7 +191,12 @@ public class SeriesRepository : ISeriesRepository
 
             .Include(s => s.Volumes)
             .ThenInclude(v => v.Chapters)
-            .ThenInclude(cm => cm.Tags)
+            .ThenInclude(c => c.Tags)
+
+            .Include(s => s.Volumes)
+            .ThenInclude(v => v.Chapters)
+            .ThenInclude(c => c.Genres)
+
 
             .Include(s => s.Metadata)
             .ThenInclude(m => m.Tags)

--- a/API/Data/Repositories/SeriesRepository.cs
+++ b/API/Data/Repositories/SeriesRepository.cs
@@ -600,6 +600,7 @@ public class SeriesRepository : ISeriesRepository
             .Include(m => m.People)
             .AsNoTracking()
             .ProjectTo<SeriesMetadataDto>(_mapper.ConfigurationProvider)
+            .AsSplitQuery()
             .SingleOrDefaultAsync();
 
         if (metadataDto != null)

--- a/API/Entities/AppUserBookmark.cs
+++ b/API/Entities/AppUserBookmark.cs
@@ -12,10 +12,11 @@ namespace API.Entities
         public int VolumeId { get; set; }
         public int SeriesId { get; set; }
         public int ChapterId { get; set; }
+
         /// <summary>
         /// Filename in the Bookmark Directory
         /// </summary>
-        public string FileName { get; set; }
+        public string FileName { get; set; } = string.Empty;
 
 
         // Relationships

--- a/API/Entities/Chapter.cs
+++ b/API/Entities/Chapter.cs
@@ -56,12 +56,24 @@ namespace API.Entities
         /// Date which chapter was released
         /// </summary>
         public DateTime ReleaseDate { get; set; }
+        /// <summary>
+        /// Summary for the Chapter/Issue
+        /// </summary>
+        public string Summary { get; set; }
+        /// <summary>
+        /// Language for the Chapter/Issue
+        /// </summary>
+        public string Language { get; set; }
 
 
         /// <summary>
         /// All people attached at a Chapter level. Usually Comics will have different people per issue.
         /// </summary>
         public ICollection<Person> People { get; set; } = new List<Person>();
+        /// <summary>
+        /// Genres for the Chapter
+        /// </summary>
+        public ICollection<Genre> Genres { get; set; } = new List<Genre>();
         public ICollection<Tag> Tags { get; set; } = new List<Tag>();
 
 

--- a/API/Entities/MangaFile.cs
+++ b/API/Entities/MangaFile.cs
@@ -23,6 +23,7 @@ namespace API.Entities
         /// <summary>
         /// Last time underlying file was modified
         /// </summary>
+        /// <remarks>This gets updated anytime the file is scanned</remarks>
         public DateTime LastModified { get; set; }
 
 
@@ -32,11 +33,10 @@ namespace API.Entities
 
 
         /// <summary>
-        /// Updates the Last Modified time of the underlying file
+        /// Updates the Last Modified time of the underlying file to the LastWriteTime
         /// </summary>
         public void UpdateLastModified()
         {
-            // Should this be DateTime.Now ?
             LastModified = File.GetLastWriteTime(FilePath);
         }
     }

--- a/API/Helpers/CacheHelper.cs
+++ b/API/Helpers/CacheHelper.cs
@@ -43,7 +43,7 @@ public class CacheHelper : ICacheHelper
         if (isCoverLocked && fileExists) return false;
         if (forceUpdate) return true;
         if (firstFile == null) return true;
-        return (_fileService.HasFileBeenModifiedSince(coverPath, chapterCreated)) || !fileExists;
+        return (_fileService.HasFileBeenModifiedSince(firstFile.FilePath, firstFile.LastModified)) || !fileExists;
     }
 
     /// <summary>

--- a/API/Services/MetadataService.cs
+++ b/API/Services/MetadataService.cs
@@ -28,7 +28,7 @@ public interface IMetadataService
     /// <param name="forceUpdate"></param>
     Task RefreshMetadata(int libraryId, bool forceUpdate = false);
     /// <summary>
-    /// Performs a forced refresh of metatdata just for a series and it's nested entities
+    /// Performs a forced refresh of metadata just for a series and it's nested entities
     /// </summary>
     /// <param name="libraryId"></param>
     /// <param name="seriesId"></param>

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -641,6 +641,7 @@ public class ScannerService : IScannerService
             existingFile.Format = info.Format;
             if (!_fileService.HasFileBeenModifiedSince(existingFile.FilePath, existingFile.LastModified) && existingFile.Pages != 0) return;
             existingFile.Pages = _readingItemService.GetNumberOfPages(info.FullFilePath, info.Format);
+            existingFile.UpdateLastModified();
         }
         else
         {

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -641,7 +641,7 @@ public class ScannerService : IScannerService
             existingFile.Format = info.Format;
             if (!_fileService.HasFileBeenModifiedSince(existingFile.FilePath, existingFile.LastModified) && existingFile.Pages != 0) return;
             existingFile.Pages = _readingItemService.GetNumberOfPages(info.FullFilePath, info.Format);
-            existingFile.UpdateLastModified();
+            //existingFile.UpdateLastModified(); // We skip updating DB here so that metadata refresh can do it
         }
         else
         {

--- a/UI/Web/src/app/admin/changelog/changelog.component.html
+++ b/UI/Web/src/app/admin/changelog/changelog.component.html
@@ -3,11 +3,11 @@
     <div class="card w-100 mb-2" style="width: 18rem;">
         <div class="card-body">
           <h4 class="card-title">{{update.updateTitle}}&nbsp;
-              <span class="badge badge-secondary" *ngIf="update.updateVersion === update.currentVersion">Installed</span>
-              <span class="badge badge-secondary" *ngIf="update.updateVersion > update.currentVersion">Available</span>
+              <span class="badge badge-secondary" *ngIf="update.updateVersion === installedVersion">Installed</span>
+              <span class="badge badge-secondary" *ngIf="update.updateVersion > installedVersion">Available</span>
           </h4>
           <h6 class="card-subtitle mb-2 text-muted">Published: {{update.publishDate | date: 'short'}}</h6>
-          
+
           <pre class="card-text update-body" [innerHtml]="update.updateBody | safeHtml"></pre>
           <a *ngIf="!update.isDocker" href="{{update.updateUrl}}" class="btn btn-{{indx === 0 ? 'primary' : 'secondary'}} float-right" target="_blank">Download</a>
         </div>

--- a/UI/Web/src/app/admin/changelog/changelog.component.ts
+++ b/UI/Web/src/app/admin/changelog/changelog.component.ts
@@ -11,13 +11,26 @@ export class ChangelogComponent implements OnInit {
 
   updates: Array<UpdateVersionEvent> = [];
   isLoading: boolean = true;
+  installedVersion: string = '';
 
   constructor(private serverService: ServerService) { }
 
   ngOnInit(): void {
-    this.serverService.getChangelog().subscribe(updates => {
-      this.updates = updates;
-      this.isLoading = false;
+
+    this.serverService.getServerInfo().subscribe(info => {
+      this.installedVersion = info.kavitaVersion;
+      this.serverService.getChangelog().subscribe(updates => {
+        this.updates = updates;
+        this.isLoading = false;
+
+        if (this.updates.filter(u => u.updateVersion === this.installedVersion).length === 0) {
+          // User is on a nightly version. Tell them the last stable is installed
+          this.installedVersion = this.updates[0].updateVersion;
+        }
+      });
     });
+    
+
+    
   }
 }

--- a/UI/Web/src/app/cards/card-detail-layout/card-detail-layout.component.html
+++ b/UI/Web/src/app/cards/card-detail-layout/card-detail-layout.component.html
@@ -38,11 +38,13 @@
     </div>
 
     <ng-template #filterSection>
+        <ng-template #globalFilterTooltip>This is library agnostic</ng-template>
         <div class="filter-section mx-auto pb-3">
             <div class="row justify-content-center no-gutters">
                 <div class="col-md-2 mr-3" *ngIf="!filterSettings.formatDisabled">
                     <div class="form-group">
-                        <label for="format">Format</label>
+                        <label for="format">Format</label>&nbsp;<i class="fa fa-info-circle" aria-hidden="true" placement="right" [ngbTooltip]="globalFilterTooltip" role="button" tabindex="0"></i>
+                        <span class="sr-only" id="filter-global-format-help"><ng-container [ngTemplateOutlet]="globalFilterTooltip"></ng-container></span>
                         <app-typeahead (selectedData)="updateFormatFilters($event)" [settings]="formatSettings" [reset]="resetTypeaheads">
                             <ng-template #badgeItem let-item let-position="idx">
                                 {{item.title}}
@@ -70,7 +72,8 @@
     
                 <div class="col-md-2 mr-3" *ngIf="!filterSettings.collectionDisabled">
                     <div class="form-group">
-                        <label for="collections">Collections</label>
+                        <label for="collections">Collections</label>&nbsp;<i class="fa fa-info-circle" aria-hidden="true" placement="right" [ngbTooltip]="globalFilterTooltip" role="button" tabindex="0"></i>
+                        <span class="sr-only" id="filter-global-collections-help"><ng-container [ngTemplateOutlet]="globalFilterTooltip"></ng-container></span>
                         <app-typeahead (selectedData)="updateCollectionFilters($event)" [settings]="collectionSettings" [reset]="resetTypeaheads">
                             <ng-template #badgeItem let-item let-position="idx">
                                 {{item.title}}

--- a/UI/Web/src/app/cards/card-detail-layout/card-detail-layout.component.ts
+++ b/UI/Web/src/app/cards/card-detail-layout/card-detail-layout.component.ts
@@ -84,7 +84,7 @@ export class CardDetailLayoutComponent implements OnInit, OnDestroy {
   libraries: Array<FilterItem<Library>> = [];
   genres: Array<FilterItem<Genre>> = [];
   persons: Array<FilterItem<Person>> = [];
-  collectionTags: Array<FilterItem<CollectionTag>> = [];
+  //collectionTags: Array<FilterItem<CollectionTag>> = [];
 
   readProgressGroup!: FormGroup;
   sortGroup!: FormGroup;
@@ -329,9 +329,11 @@ export class CardDetailLayoutComponent implements OnInit, OnDestroy {
       return options.filter(m => m.title.toLowerCase() === f);
     }
     if (this.filterSettings.presetCollectionId > 0) {
-      this.collectionSettings.savedData = this.collectionTags.filter(item => item.value.id === this.filterSettings.presetCollectionId);
-      this.filter.collectionTags = this.collectionSettings.savedData.map(item => item.value.id);
-      this.resetTypeaheads.next(true);
+      this.collectionSettings.fetchFn('').subscribe(tags => {
+        this.collectionSettings.savedData = tags.filter(item => item.value.id === this.filterSettings.presetCollectionId);
+        this.filter.collectionTags = this.collectionSettings.savedData.map(item => item.value.id);
+        this.resetTypeaheads.next(true);
+      });
     }
   }
 


### PR DESCRIPTION
# Added
- Added: Added a tooltip on the format and collection filters to inform the user they are server wide and don't filter by library like other filters (develop)

# Changed
- Changed: Refactored a lot of code around when we update chapter cover images
- Changed: (Performance) Implemented some optimizations to reduce the cover generation on second loads when files change
- Changed: (Performance) Reduced N file reads for ComicInfo when populating Series metadata, where N is the number of Chapters per series. 
- Changed: (Performance) Sped up how quickly we load a series with metadata

# Fixed
- Fixed: Fixed a bug where on cloud mounts, some files can constantly regenerate covers on scan, despite nothing changing
- Fixed: Fixed a bug where filters on collections weren't auto-selecting said collection tag
- Fixed: Fixed a bug on Changelog where multiple releases could show as Installed. For nightly users, show the last stable as installed. (Fixes #897 )

Closes #774 
