### PR TITLE
Misc Fixes

### DIFF
--- a/API.Tests/Helpers/CacheHelperTests.cs
+++ b/API.Tests/Helpers/CacheHelperTests.cs
@@ -1,13 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.IO.Abstractions;
 using System.IO.Abstractions.TestingHelpers;
 using API.Entities;
 using API.Helpers;
 using API.Services;
-using Microsoft.Extensions.Logging;
-using NSubstitute;
 using Xunit;
 
 namespace API.Tests.Helpers;

--- a/API.Tests/Helpers/ParserInfoHelperTests.cs
+++ b/API.Tests/Helpers/ParserInfoHelperTests.cs
@@ -1,0 +1,75 @@
+﻿using System.Collections.Generic;
+using API.Entities;
+using API.Entities.Enums;
+using API.Entities.Metadata;
+using API.Helpers;
+using API.Parser;
+using API.Services.Tasks.Scanner;
+using Xunit;
+
+namespace API.Tests.Helpers;
+
+public class ParserInfoHelperTests
+{
+    #region SeriesHasMatchingParserInfoFormat
+
+    [Fact]
+    public void SeriesHasMatchingParserInfoFormat_ShouldBeFalse()
+    {
+        var infos = new Dictionary<ParsedSeries, List<ParserInfo>>();
+
+        ParserInfoFactory.AddToParsedInfo(infos, new ParserInfo() {Series = "Darker than Black", Volumes = "1", Format = MangaFormat.Archive});
+        //AddToParsedInfo(infos, new ParserInfo() {Series = "Darker than Black", Volumes = "1", Format = MangaFormat.Epub});
+
+        var series = new Series()
+        {
+            Name = "Darker Than Black",
+            LocalizedName = "Darker Than Black",
+            OriginalName = "Darker Than Black",
+            Volumes = new List<Volume>()
+            {
+                new Volume()
+                {
+                    Number = 1,
+                    Name = "1"
+                }
+            },
+            NormalizedName = API.Parser.Parser.Normalize("Darker Than Black"),
+            Metadata = new SeriesMetadata(),
+            Format = MangaFormat.Epub
+        };
+
+        Assert.False(ParserInfoHelpers.SeriesHasMatchingParserInfoFormat(series, infos));
+    }
+
+    [Fact]
+    public void SeriesHasMatchingParserInfoFormat_ShouldBeTrue()
+    {
+        var infos = new Dictionary<ParsedSeries, List<ParserInfo>>();
+
+        ParserInfoFactory.AddToParsedInfo(infos, new ParserInfo() {Series = "Darker than Black", Volumes = "1", Format = MangaFormat.Archive});
+        ParserInfoFactory.AddToParsedInfo(infos, new ParserInfo() {Series = "Darker than Black", Volumes = "1", Format = MangaFormat.Epub});
+
+        var series = new Series()
+        {
+            Name = "Darker Than Black",
+            LocalizedName = "Darker Than Black",
+            OriginalName = "Darker Than Black",
+            Volumes = new List<Volume>()
+            {
+                new Volume()
+                {
+                    Number = 1,
+                    Name = "1"
+                }
+            },
+            NormalizedName = API.Parser.Parser.Normalize("Darker Than Black"),
+            Metadata = new SeriesMetadata(),
+            Format = MangaFormat.Epub
+        };
+
+        Assert.True(ParserInfoHelpers.SeriesHasMatchingParserInfoFormat(series, infos));
+    }
+
+    #endregion
+}

--- a/API.Tests/Parser/ComicParserTests.cs
+++ b/API.Tests/Parser/ComicParserTests.cs
@@ -124,6 +124,8 @@ namespace API.Tests.Parser
         [InlineData("Conquistador_Tome_2", "2")]
         [InlineData("Max_l_explorateur-_Tome_0", "0")]
         [InlineData("Chevaliers d'Héliopolis T3 - Rubedo, l'oeuvre au rouge (Jodorowsky & Jérémy)", "3")]
+        [InlineData("Adventure Time (2012)/Adventure Time #1 (2012)", "0")]
+        [InlineData("Adventure Time TPB (2012)/Adventure Time v01 (2012).cbz", "1")]
         public void ParseComicVolumeTest(string filename, string expected)
         {
             Assert.Equal(expected, API.Parser.Parser.ParseComicVolume(filename));
@@ -167,6 +169,8 @@ namespace API.Tests.Parser
         [InlineData("2000 AD 0366 [1984-04-28] (flopbie)", "366")]
         [InlineData("Daredevil - v6 - 10 - (2019)", "10")]
         [InlineData("Batman Beyond 2016 - Chapter 001.cbz", "1")]
+        [InlineData("Adventure Time (2012)/Adventure Time #1 (2012)", "1")]
+        [InlineData("Adventure Time TPB (2012)/Adventure Time v01 (2012).cbz", "0")]
         public void ParseComicChapterTest(string filename, string expected)
         {
             Assert.Equal(expected, API.Parser.Parser.ParseComicChapter(filename));

--- a/API.Tests/Parser/ParserInfoTests.cs
+++ b/API.Tests/Parser/ParserInfoTests.cs
@@ -20,7 +20,7 @@ namespace API.Tests.Parser
                 Title = "darker than black",
                 Volumes = "0"
             };
-            
+
             var p2 = new ParserInfo()
             {
                 Chapters = "1",
@@ -32,7 +32,7 @@ namespace API.Tests.Parser
                 Title = "Darker Than Black",
                 Volumes = "0"
             };
-            
+
             var expected = new ParserInfo()
             {
                 Chapters = "1",
@@ -45,11 +45,11 @@ namespace API.Tests.Parser
                 Volumes = "0"
             };
             p1.Merge(p2);
-            
+
             AssertSame(expected, p1);
 
         }
-        
+
         [Fact]
         public void MergeFromTest2()
         {
@@ -64,7 +64,7 @@ namespace API.Tests.Parser
                 Title = "darker than black",
                 Volumes = "0"
             };
-            
+
             var p2 = new ParserInfo()
             {
                 Chapters = "0",
@@ -76,7 +76,7 @@ namespace API.Tests.Parser
                 Title = "Darker Than Black",
                 Volumes = "1"
             };
-            
+
             var expected = new ParserInfo()
             {
                 Chapters = "1",
@@ -93,9 +93,9 @@ namespace API.Tests.Parser
             AssertSame(expected, p1);
 
         }
-        
 
-        private void AssertSame(ParserInfo expected, ParserInfo actual)
+
+        private static void AssertSame(ParserInfo expected, ParserInfo actual)
         {
             Assert.Equal(expected.Chapters, actual.Chapters);
             Assert.Equal(expected.Volumes, actual.Volumes);

--- a/API.Tests/Services/DirectoryServiceTests.cs
+++ b/API.Tests/Services/DirectoryServiceTests.cs
@@ -16,19 +16,7 @@ namespace API.Tests.Services
 
     public class DirectoryServiceTests
     {
-        private readonly DirectoryService _directoryService;
         private readonly ILogger<DirectoryService> _logger = Substitute.For<ILogger<DirectoryService>>();
-
-        public DirectoryServiceTests()
-        {
-            var filesystem = new MockFileSystem()
-            {
-
-            };
-
-            _directoryService = new DirectoryService(_logger, filesystem);
-        }
-
 
         #region TraverseTreeParallelForEach
         [Fact]

--- a/API/Entities/Chapter.cs
+++ b/API/Entities/Chapter.cs
@@ -46,7 +46,6 @@ namespace API.Entities
         /// </summary>
         public AgeRating AgeRating { get; set; }
 
-
         /// <summary>
         /// Chapter title
         /// </summary>

--- a/API/Helpers/ParserInfoHelpers.cs
+++ b/API/Helpers/ParserInfoHelpers.cs
@@ -1,0 +1,50 @@
+﻿using System.Collections.Generic;
+using API.Entities;
+using API.Entities.Enums;
+using API.Extensions;
+using API.Parser;
+using API.Services.Tasks.Scanner;
+
+namespace API.Helpers;
+
+public static class ParserInfoHelpers
+{
+    /// <summary>
+    /// Checks each parser info to see if there is a name match and if so, checks if the format matches the Series object.
+    /// This accounts for if the Series has an Unknown type and if so, considers it matching.
+    /// </summary>
+    /// <param name="series"></param>
+    /// <param name="parsedSeries"></param>
+    /// <returns></returns>
+    public static bool SeriesHasMatchingParserInfoFormat(Series series,
+        Dictionary<ParsedSeries, List<ParserInfo>> parsedSeries)
+    {
+        var format = MangaFormat.Unknown;
+        foreach (var pSeries in parsedSeries.Keys)
+        {
+            var name = pSeries.Name;
+            var normalizedName = Parser.Parser.Normalize(name);
+
+            //if (series.NameInParserInfo(pSeries.))
+            if (normalizedName == series.NormalizedName ||
+                normalizedName == Parser.Parser.Normalize(series.Name) ||
+                name == series.Name || name == series.LocalizedName ||
+                name == series.OriginalName ||
+                normalizedName == Parser.Parser.Normalize(series.OriginalName))
+            {
+                format = pSeries.Format;
+                if (format == series.Format)
+                {
+                    return true;
+                }
+            }
+        }
+
+        if (series.Format == MangaFormat.Unknown && format != MangaFormat.Unknown)
+        {
+            return true;
+        }
+
+        return format == series.Format;
+    }
+}

--- a/API/Services/MetadataService.cs
+++ b/API/Services/MetadataService.cs
@@ -97,6 +97,16 @@ public class MetadataService : IMetadataService
             chapter.TitleName = comicInfo.Title.Trim();
         }
 
+        if (!string.IsNullOrEmpty(comicInfo.Summary))
+        {
+            chapter.Summary = comicInfo.Summary;
+        }
+
+        if (!string.IsNullOrEmpty(comicInfo.LanguageISO))
+        {
+            chapter.Language = comicInfo.LanguageISO;
+        }
+
         if (comicInfo.Year > 0)
         {
             var day = Math.Max(comicInfo.Day, 1);
@@ -227,7 +237,7 @@ public class MetadataService : IMetadataService
     }
 
     /// <summary>
-    /// Updates metadata for Series
+    /// Updates cover image for Series
     /// </summary>
     /// <param name="series"></param>
     /// <param name="forceUpdate">Force updating cover image even if underlying file has not been modified or chapter already has a cover image</param>

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -467,44 +467,10 @@ public class ScannerService : IScannerService
 
     public static IEnumerable<Series> FindSeriesNotOnDisk(IEnumerable<Series> existingSeries, Dictionary<ParsedSeries, List<ParserInfo>> parsedSeries)
     {
-        var foundSeries = parsedSeries.Select(s => s.Key.Name).ToList();
-        return existingSeries.Where(es => !es.NameInList(foundSeries) && !SeriesHasMatchingParserInfoFormat(es, parsedSeries));
+        return existingSeries.Where(es => !ParserInfoHelpers.SeriesHasMatchingParserInfoFormat(es, parsedSeries));
     }
 
-    /// <summary>
-    /// Checks each parser info to see if there is a name match and if so, checks if the format matches the Series object.
-    /// This accounts for if the Series has an Unknown type and if so, considers it matching.
-    /// </summary>
-    /// <param name="series"></param>
-    /// <param name="parsedSeries"></param>
-    /// <returns></returns>
-    private static bool SeriesHasMatchingParserInfoFormat(Series series,
-        Dictionary<ParsedSeries, List<ParserInfo>> parsedSeries)
-    {
-        var format = MangaFormat.Unknown;
-        foreach (var pSeries in parsedSeries.Keys)
-        {
-            var name = pSeries.Name;
-            var normalizedName = Parser.Parser.Normalize(name);
 
-            if (normalizedName == series.NormalizedName ||
-                normalizedName == Parser.Parser.Normalize(series.Name) ||
-                name == series.Name || name == series.LocalizedName ||
-                name == series.OriginalName ||
-                normalizedName == Parser.Parser.Normalize(series.OriginalName))
-            {
-                format = pSeries.Format;
-                break;
-            }
-        }
-
-        if (series.Format == MangaFormat.Unknown && format != MangaFormat.Unknown)
-        {
-            return true;
-        }
-
-        return format == series.Format;
-    }
 
     private void UpdateVolumes(Series series, IList<ParserInfo> parsedInfos)
     {

--- a/UI/Web/src/app/book-reader/book-reader/book-reader.component.ts
+++ b/UI/Web/src/app/book-reader/book-reader/book-reader.component.ts
@@ -812,7 +812,7 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       this.setPageNum(this.pageNum - 1);
     }
 
-    if (this.pageNum >= this.maxPages - 1) {
+    if (this.pageNum === this.maxPages - 1) {
       // Move to next volume/chapter automatically
       this.loadNextChapter();
     }


### PR DESCRIPTION

# Fixed
- Fixed: Fixed a bug where scanner would not delete a series if another series with same name but different format was added in that same scan (Fixes #885 )
- Fixed: Fixed some missing metadata generation for Chapter's language and summary (develop)