### PR TITLE
Metadata Performance Scan

### DIFF
--- a/API/Services/MetadataService.cs
+++ b/API/Services/MetadataService.cs
@@ -81,7 +81,7 @@ public class MetadataService : IMetadataService
         var firstFile = chapter.Files.OrderBy(x => x.Chapter).FirstOrDefault();
         if (firstFile == null || _cacheHelper.HasFileNotChangedSinceCreationOrLastScan(chapter, forceUpdate, firstFile)) return;
 
-        UpdateChapterFromComicInfo(chapter, allPeople, allTags, allGenres, firstFile);
+        //UpdateChapterFromComicInfo(chapter, allPeople, allTags, allGenres, firstFile);
         firstFile.UpdateLastModified();
     }
 

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -744,9 +744,9 @@ public class ScannerService : IScannerService
         var comicInfo = info;
         if (info == null)
         {
-            comicInfo = _readingItemService.GetComicInfo(firstFile.FilePath, firstFile.Format);
+            comicInfo = _readingItemService.GetComicInfo(firstFile.FilePath);
         }
-        //var comicInfo = _readingItemService.GetComicInfo(firstFile.FilePath, firstFile.Format);
+
         if (comicInfo == null) return;
 
         chapter.AgeRating = ComicInfo.ConvertAgeRatingToEnum(comicInfo.AgeRating);

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using API.Comparators;
 using API.Data;
+using API.Data.Metadata;
 using API.Data.Repositories;
 using API.Entities;
 using API.Entities.Enums;
@@ -42,11 +43,13 @@ public class ScannerService : IScannerService
     private readonly IFileService _fileService;
     private readonly IDirectoryService _directoryService;
     private readonly IReadingItemService _readingItemService;
+    private readonly ICacheHelper _cacheHelper;
     private readonly NaturalSortComparer _naturalSort = new ();
 
     public ScannerService(IUnitOfWork unitOfWork, ILogger<ScannerService> logger,
         IMetadataService metadataService, ICacheService cacheService, IHubContext<MessageHub> messageHub,
-        IFileService fileService, IDirectoryService directoryService, IReadingItemService readingItemService)
+        IFileService fileService, IDirectoryService directoryService, IReadingItemService readingItemService,
+        ICacheHelper cacheHelper)
     {
         _unitOfWork = unitOfWork;
         _logger = logger;
@@ -56,6 +59,7 @@ public class ScannerService : IScannerService
         _fileService = fileService;
         _directoryService = directoryService;
         _readingItemService = readingItemService;
+        _cacheHelper = cacheHelper;
     }
 
     [DisableConcurrentExecution(timeoutInSeconds: 360)]
@@ -75,6 +79,10 @@ public class ScannerService : IScannerService
             _logger.LogError("Some of the root folders for library are not accessible. Please check that drives are connected and rescan. Scan will be aborted");
             return;
         }
+
+        var allPeople = await _unitOfWork.PersonRepository.GetAllPeople();
+        var allGenres = await _unitOfWork.GenreRepository.GetAllGenresAsync();
+        var allTags = await _unitOfWork.TagRepository.GetAllTagsAsync();
 
         var dirs = _directoryService.FindHighestDirectoriesFromFiles(folderPaths, files.Select(f => f.FilePath).ToList());
 
@@ -140,7 +148,7 @@ public class ScannerService : IScannerService
 
         try
         {
-            UpdateSeries(series, parsedSeries);
+            UpdateSeries(series, parsedSeries, allPeople, allTags, allGenres);
             await CommitAndSend(totalFiles, parsedSeries, sw, scanElapsedTime, series);
         }
         catch (Exception ex)
@@ -296,6 +304,10 @@ public class ScannerService : IScannerService
         var stopwatch = Stopwatch.StartNew();
         var totalTime = 0L;
 
+        var allPeople = await _unitOfWork.PersonRepository.GetAllPeople();
+        var allGenres = await _unitOfWork.GenreRepository.GetAllGenresAsync();
+        var allTags = await _unitOfWork.TagRepository.GetAllTagsAsync();
+
         // Update existing series
         _logger.LogInformation("[ScannerService] Updating existing series for {LibraryName}. Total Items: {TotalSize}. Total Chunks: {TotalChunks} with {ChunkSize} size",
             library.Name, chunkInfo.TotalSize, chunkInfo.TotalChunks, chunkInfo.ChunkSize);
@@ -334,7 +346,7 @@ public class ScannerService : IScannerService
             var librarySeries = cleanedSeries.ToList();
             Parallel.ForEach(librarySeries, (series) =>
             {
-                UpdateSeries(series, parsedSeries);
+                UpdateSeries(series, parsedSeries, allPeople, allTags, allGenres);
             });
 
             try
@@ -407,11 +419,12 @@ public class ScannerService : IScannerService
             newSeries.Add(s);
         }
 
+
         var i = 0;
         foreach(var series in newSeries)
         {
             _logger.LogDebug("[ScannerService] Processing series {SeriesName}", series.OriginalName);
-            UpdateSeries(series, parsedSeries);
+            UpdateSeries(series, parsedSeries, allPeople, allTags, allGenres);
             _unitOfWork.SeriesRepository.Attach(series);
             try
             {
@@ -440,14 +453,14 @@ public class ScannerService : IScannerService
             newSeries.Count, stopwatch.ElapsedMilliseconds, library.Name);
     }
 
-    private void UpdateSeries(Series series, Dictionary<ParsedSeries, List<ParserInfo>> parsedSeries)
+    private void UpdateSeries(Series series, Dictionary<ParsedSeries, List<ParserInfo>> parsedSeries, ICollection<Person> allPeople, ICollection<Tag> allTags, ICollection<Genre> allGenres)
     {
         try
         {
             _logger.LogInformation("[ScannerService] Processing series {SeriesName}", series.OriginalName);
 
             var parsedInfos = ParseScannedFiles.GetInfosByName(parsedSeries, series);
-            UpdateVolumes(series, parsedInfos);
+            UpdateVolumes(series, parsedInfos, allPeople, allTags, allGenres);
             series.Pages = series.Volumes.Sum(v => v.Pages);
 
             series.NormalizedName = Parser.Parser.Normalize(series.Name);
@@ -472,7 +485,7 @@ public class ScannerService : IScannerService
 
 
 
-    private void UpdateVolumes(Series series, IList<ParserInfo> parsedInfos)
+    private void UpdateVolumes(Series series, IList<ParserInfo> parsedInfos, ICollection<Person> allPeople, ICollection<Tag> allTags, ICollection<Genre> allGenres)
     {
         var startingVolumeCount = series.Volumes.Count;
         // Add new volumes and update chapters per volume
@@ -492,6 +505,22 @@ public class ScannerService : IScannerService
             var infos = parsedInfos.Where(p => p.Volumes == volumeNumber).ToArray();
             UpdateChapters(volume, infos);
             volume.Pages = volume.Chapters.Sum(c => c.Pages);
+
+            // Update all the metadata on the Chapters
+            foreach (var chapter in volume.Chapters)
+            {
+                var firstFile = chapter.Files.OrderBy(x => x.Chapter).FirstOrDefault();
+                if (firstFile == null || _cacheHelper.HasFileNotChangedSinceCreationOrLastScan(chapter, false, firstFile)) continue;
+                try
+                {
+                    var firstChapterInfo = infos.SingleOrDefault(i => i.FullFilePath.Equals(firstFile.FilePath));
+                    UpdateChapterFromComicInfo(chapter, allPeople, allTags, allGenres, firstChapterInfo?.ComicInfo);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "There was some issue when updating chapter's metadata");
+                }
+            }
         }
 
         // Remove existing volumes that aren't in parsedInfos
@@ -593,11 +622,6 @@ public class ScannerService : IScannerService
         }
     }
 
-    private MangaFile CreateMangaFile(ParserInfo info)
-    {
-        return DbFactory.MangaFile(info.FullFilePath, info.Format, _readingItemService.GetNumberOfPages(info.FullFilePath, info.Format));
-    }
-
     private void AddOrUpdateFileForChapter(Chapter chapter, ParserInfo info)
     {
         chapter.Files ??= new List<MangaFile>();
@@ -607,14 +631,166 @@ public class ScannerService : IScannerService
             existingFile.Format = info.Format;
             if (!_fileService.HasFileBeenModifiedSince(existingFile.FilePath, existingFile.LastModified) && existingFile.Pages != 0) return;
             existingFile.Pages = _readingItemService.GetNumberOfPages(info.FullFilePath, info.Format);
-            //existingFile.UpdateLastModified(); // We skip updating DB here so that metadata refresh can do it
+            // We skip updating DB here with last modified time so that metadata refresh can do it
         }
         else
         {
-            var file = CreateMangaFile(info);
+            var file = DbFactory.MangaFile(info.FullFilePath, info.Format, _readingItemService.GetNumberOfPages(info.FullFilePath, info.Format));
             if (file == null) return;
 
             chapter.Files.Add(file);
+        }
+    }
+
+    private void UpdateChapterFromComicInfo(Chapter chapter, ICollection<Person> allPeople, ICollection<Tag> allTags, ICollection<Genre> allGenres, ComicInfo? info)
+    {
+        var firstFile = chapter.Files.OrderBy(x => x.Chapter).FirstOrDefault();
+        if (firstFile == null ||
+            _cacheHelper.HasFileNotChangedSinceCreationOrLastScan(chapter, false, firstFile)) return;
+
+        var comicInfo = info;
+        if (info == null)
+        {
+            comicInfo = _readingItemService.GetComicInfo(firstFile.FilePath, firstFile.Format);
+        }
+        //var comicInfo = _readingItemService.GetComicInfo(firstFile.FilePath, firstFile.Format);
+        if (comicInfo == null) return;
+
+        chapter.AgeRating = ComicInfo.ConvertAgeRatingToEnum(comicInfo.AgeRating);
+
+        if (!string.IsNullOrEmpty(comicInfo.Title))
+        {
+            chapter.TitleName = comicInfo.Title.Trim();
+        }
+
+        if (!string.IsNullOrEmpty(comicInfo.Summary))
+        {
+            chapter.Summary = comicInfo.Summary;
+        }
+
+        if (!string.IsNullOrEmpty(comicInfo.LanguageISO))
+        {
+            chapter.Language = comicInfo.LanguageISO;
+        }
+
+        if (comicInfo.Count > 0)
+        {
+            chapter.TotalCount = comicInfo.Count;
+        }
+
+        if (!string.IsNullOrEmpty(comicInfo.Number) && int.Parse(comicInfo.Number) > 0)
+        {
+            chapter.Count = int.Parse(comicInfo.Number);
+        }
+
+
+
+
+        if (comicInfo.Year > 0)
+        {
+            var day = Math.Max(comicInfo.Day, 1);
+            var month = Math.Max(comicInfo.Month, 1);
+            chapter.ReleaseDate = DateTime.Parse($"{month}/{day}/{comicInfo.Year}");
+        }
+
+        if (!string.IsNullOrEmpty(comicInfo.Colorist))
+        {
+            var people = comicInfo.Colorist.Split(",");
+            PersonHelper.RemovePeople(chapter.People, people, PersonRole.Colorist);
+            PersonHelper.UpdatePeople(allPeople, people, PersonRole.Colorist,
+                person => PersonHelper.AddPersonIfNotExists(chapter.People, person));
+        }
+
+        if (!string.IsNullOrEmpty(comicInfo.Characters))
+        {
+            var people = comicInfo.Characters.Split(",");
+            PersonHelper.RemovePeople(chapter.People, people, PersonRole.Character);
+            PersonHelper.UpdatePeople(allPeople, people, PersonRole.Character,
+                person => PersonHelper.AddPersonIfNotExists(chapter.People, person));
+        }
+
+        if (!string.IsNullOrEmpty(comicInfo.Translator))
+        {
+            var people = comicInfo.Translator.Split(",");
+            PersonHelper.RemovePeople(chapter.People, people, PersonRole.Translator);
+            PersonHelper.UpdatePeople(allPeople, people, PersonRole.Translator,
+                person => PersonHelper.AddPersonIfNotExists(chapter.People, person));
+        }
+
+        if (!string.IsNullOrEmpty(comicInfo.Tags))
+        {
+            var tags = comicInfo.Tags.Split(",").Select(s => s.Trim()).ToList();
+            // Remove all tags that aren't matching between chapter tags and metadata
+            TagHelper.KeepOnlySameTagBetweenLists(chapter.Tags, tags.Select(t => DbFactory.Tag(t, false)).ToList());
+            TagHelper.UpdateTag(allTags, tags, false,
+                (tag, added) =>
+                {
+                    chapter.Tags.Add(tag);
+                });
+        }
+
+        if (!string.IsNullOrEmpty(comicInfo.Writer))
+        {
+            var people = comicInfo.Writer.Split(",");
+            PersonHelper.RemovePeople(chapter.People, people, PersonRole.Writer);
+            PersonHelper.UpdatePeople(allPeople, people, PersonRole.Writer,
+                person => PersonHelper.AddPersonIfNotExists(chapter.People, person));
+        }
+
+        if (!string.IsNullOrEmpty(comicInfo.Editor))
+        {
+            var people = comicInfo.Editor.Split(",");
+            PersonHelper.RemovePeople(chapter.People, people, PersonRole.Editor);
+            PersonHelper.UpdatePeople(allPeople, people, PersonRole.Editor,
+                person => PersonHelper.AddPersonIfNotExists(chapter.People, person));
+        }
+
+        if (!string.IsNullOrEmpty(comicInfo.Inker))
+        {
+            var people = comicInfo.Inker.Split(",");
+            PersonHelper.RemovePeople(chapter.People, people, PersonRole.Inker);
+            PersonHelper.UpdatePeople(allPeople, people, PersonRole.Inker,
+                person => PersonHelper.AddPersonIfNotExists(chapter.People, person));
+        }
+
+        if (!string.IsNullOrEmpty(comicInfo.Letterer))
+        {
+            var people = comicInfo.Letterer.Split(",");
+            PersonHelper.RemovePeople(chapter.People, people, PersonRole.Letterer);
+            PersonHelper.UpdatePeople(allPeople, people, PersonRole.Letterer,
+                person => PersonHelper.AddPersonIfNotExists(chapter.People, person));
+        }
+
+        if (!string.IsNullOrEmpty(comicInfo.Penciller))
+        {
+            var people = comicInfo.Penciller.Split(",");
+            PersonHelper.RemovePeople(chapter.People, people, PersonRole.Penciller);
+            PersonHelper.UpdatePeople(allPeople, people, PersonRole.Penciller,
+                person => PersonHelper.AddPersonIfNotExists(chapter.People, person));
+        }
+
+        if (!string.IsNullOrEmpty(comicInfo.CoverArtist))
+        {
+            var people = comicInfo.CoverArtist.Split(",");
+            PersonHelper.RemovePeople(chapter.People, people, PersonRole.CoverArtist);
+            PersonHelper.UpdatePeople(allPeople, people, PersonRole.CoverArtist,
+                person => PersonHelper.AddPersonIfNotExists(chapter.People, person));
+        }
+
+        if (!string.IsNullOrEmpty(comicInfo.Publisher))
+        {
+            var people = comicInfo.Publisher.Split(",");
+            PersonHelper.RemovePeople(chapter.People, people, PersonRole.Publisher);
+            PersonHelper.UpdatePeople(allPeople, people, PersonRole.Publisher,
+                person => PersonHelper.AddPersonIfNotExists(chapter.People, person));
+        }
+
+        if (!string.IsNullOrEmpty(comicInfo.Genre))
+        {
+            var genres = comicInfo.Genre.Split(",");
+            GenreHelper.KeepOnlySameGenreBetweenLists(chapter.Genres, genres.Select(g => DbFactory.Genre(g, false)).ToList());
+            GenreHelper.UpdateGenre(allGenres, genres, false,
+                genre => chapter.Genres.Add(genre));
         }
     }
 }


### PR DESCRIPTION
# Changed
- Changed: (Performance) Moved all of the ComicInfo.xml DB updates into the Scan Loop from the Metadata Service. This allows us to avoid an additional N file reads/parses (N = number of chapters) and more efficient batching of DB updates. 
- Changed: (Performance) Reduced the amount of redundant checks when processing files

Closes #901 
