### PR TITLE
Fix image aspect ratio when image has inline style

### DIFF
--- a/UI/Web/src/app/book-reader/book-reader/book-reader.component.scss
+++ b/UI/Web/src/app/book-reader/book-reader/book-reader.component.scss
@@ -180,6 +180,8 @@ $primary-color: #0062cc;
 
 ::ng-deep .scale-width {
     max-width: 100%;
+    object-fit: contain;
+    object-position: top center;
 }
 
 


### PR DESCRIPTION
# Fixed
- Fixed: Fixed a rendering issue in book reader where an image would loose its aspect ratio if it has an inline style, e.g. `height: (x)vh`

I've created a fiddle which demonstrates the fix https://jsfiddle.net/02od8bw4/
Issue discussed on Discord, affects RE:Zero Light Novel Vol. 1 (Amazon ID B01CO4B14I).
