### PR TITLE
ComicInfo Volume Parsing Change

### DIFF
--- a/API.Tests/Services/ArchiveServiceTests.cs
+++ b/API.Tests/Services/ArchiveServiceTests.cs
@@ -30,13 +30,6 @@ namespace API.Tests.Services
             _archiveService = new ArchiveService(_logger, _directoryService, new ImageService(Substitute.For<ILogger<ImageService>>(), _directoryService));
         }
 
-        // [Fact]
-        // public void CleanComicInfo_ShouldMapVolumeAndChapterNormally()
-        // {
-        //     // TODO: Implement this
-        //     Assert.False(true);
-        // }
-
         [Theory]
         [InlineData("flat file.zip", false)]
         [InlineData("file in folder in folder.zip", true)]

--- a/API/Services/ArchiveService.cs
+++ b/API/Services/ArchiveService.cs
@@ -322,15 +322,15 @@ namespace API.Services
             info.Publisher = Parser.Parser.CleanAuthor(info.Publisher);
             info.Characters = Parser.Parser.CleanAuthor(info.Characters);
 
-            if (!string.IsNullOrEmpty(info.Web))
-            {
-                // ComicVine stores the Issue number in Number field and does not use Volume.
-                if (!info.Web.Contains("https://comicvine.gamespot.com/")) return;
-                if (info.Volume.Equals("1"))
-                {
-                    info.Volume = Parser.Parser.DefaultVolume;
-                }
-            }
+            // if (!string.IsNullOrEmpty(info.Web))
+            // {
+            //     // ComicVine stores the Issue number in Number field and does not use Volume.
+            //     if (!info.Web.Contains("https://comicvine.gamespot.com/")) return;
+            //     if (info.Volume.Equals("1"))
+            //     {
+            //         info.Volume = Parser.Parser.DefaultVolume;
+            //     }
+            // }
         }
 
         /// <summary>


### PR DESCRIPTION
# Changed
- Changed: If ComicInfo.xml web field has comicInfo and Volume was 1, I was defaulting to 0 due a way a tool tagged. Due to this tool improperly tagging this hack was applied. The hack has been removed and if your ComicInfo.xml says Volume 1, we assume volume 1 and will perform grouping. 
