### PR TITLE
Scanner not merging with series that has LocalizedName match

### DIFF
--- a/API.Tests/Helpers/SeriesHelperTests.cs
+++ b/API.Tests/Helpers/SeriesHelperTests.cs
@@ -102,6 +102,41 @@ public class SeriesHelperTests
             NormalizedName = API.Parser.Parser.Normalize("SomethingRandom")
         }));
     }
+
+    [Fact]
+    public void FindSeries_ShouldFind_UsingLocalizedName()
+    {
+        var series = DbFactory.Series("Darker than Black");
+        series.LocalizedName = "Something Random";
+        series.Format = MangaFormat.Image;
+        Assert.True(SeriesHelper.FindSeries(series, new ParsedSeries()
+        {
+            Format = MangaFormat.Image,
+            Name = "Something Random",
+            NormalizedName = API.Parser.Parser.Normalize("Something Random")
+        }));
+
+        Assert.True(SeriesHelper.FindSeries(series, new ParsedSeries()
+        {
+            Format = MangaFormat.Image,
+            Name = "Something Random".ToLower(),
+            NormalizedName = API.Parser.Parser.Normalize("Something Random")
+        }));
+
+        Assert.True(SeriesHelper.FindSeries(series, new ParsedSeries()
+        {
+            Format = MangaFormat.Image,
+            Name = "Something Random".ToUpper(),
+            NormalizedName = API.Parser.Parser.Normalize("Something Random")
+        }));
+
+        Assert.True(SeriesHelper.FindSeries(series, new ParsedSeries()
+        {
+            Format = MangaFormat.Image,
+            Name = "SomethingRandom".ToUpper(),
+            NormalizedName = API.Parser.Parser.Normalize("SomethingRandom")
+        }));
+    }
     #endregion
 
     [Fact]

--- a/API/Helpers/SeriesHelper.cs
+++ b/API/Helpers/SeriesHelper.cs
@@ -16,7 +16,9 @@ public static class SeriesHelper
     /// <returns></returns>
     public static bool FindSeries(Series series, ParsedSeries parsedInfoKey)
     {
-        return (series.NormalizedName.Equals(parsedInfoKey.NormalizedName) || Parser.Parser.Normalize(series.OriginalName).Equals(parsedInfoKey.NormalizedName))
+        return (series.NormalizedName.Equals(parsedInfoKey.NormalizedName)
+                || Parser.Parser.Normalize(series.OriginalName).Equals(parsedInfoKey.NormalizedName)
+                || Parser.Parser.Normalize(series.LocalizedName).Equals(parsedInfoKey.NormalizedName))
                && (series.Format == parsedInfoKey.Format || series.Format == MangaFormat.Unknown);
     }
 

--- a/API/Services/Tasks/Scanner/ParseScannedFiles.cs
+++ b/API/Services/Tasks/Scanner/ParseScannedFiles.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using API.Entities;
 using API.Entities.Enums;
+using API.Helpers;
 using API.Parser;
 using Microsoft.Extensions.Logging;
 
@@ -45,17 +46,23 @@ namespace API.Services.Tasks.Scanner
         }
 
         /// <summary>
-        /// Gets the list of parserInfos given a Series. If the series does not exist within, return empty list.
+        /// Gets the list of all parserInfos given a Series (Will match on Name, LocalizedName, OriginalName). If the series does not exist within, return empty list.
         /// </summary>
         /// <param name="parsedSeries"></param>
         /// <param name="series"></param>
         /// <returns></returns>
         public static IList<ParserInfo> GetInfosByName(Dictionary<ParsedSeries, List<ParserInfo>> parsedSeries, Series series)
         {
-            var existingKey = parsedSeries.Keys.FirstOrDefault(ps =>
-                ps.Format == series.Format && ps.NormalizedName.Equals(Parser.Parser.Normalize(series.OriginalName)));
+            var allKeys = parsedSeries.Keys.Where(ps =>
+                SeriesHelper.FindSeries(series, ps));
 
-            return existingKey != null ? parsedSeries[existingKey] : new List<ParserInfo>();
+            var infos = new List<ParserInfo>();
+            foreach (var key in allKeys)
+            {
+                infos.AddRange(parsedSeries[key]);
+            }
+
+            return infos;
         }
 
         /// <summary>

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -145,6 +145,7 @@ public class ScannerService : IScannerService
         // At this point, parsedSeries will have at least one key and we can perform the update. If it still doesn't, just return and don't do anything
         if (parsedSeries.Count == 0) return;
 
+        // Merge any series together that might have different ParsedSeries but belong to another group of ParsedSeries
         try
         {
             UpdateSeries(series, parsedSeries, allPeople, allTags, allGenres, library.Type);
@@ -167,7 +168,7 @@ public class ScannerService : IScannerService
     {
         var keys = parsedSeries.Keys;
         foreach (var key in keys.Where(key =>
-                     !series.NameInParserInfo(parsedSeries[key].FirstOrDefault()) || series.Format != key.Format))
+                      series.Format != key.Format || !SeriesHelper.FindSeries(series, key)))
         {
             parsedSeries.Remove(key);
         }
@@ -460,6 +461,7 @@ public class ScannerService : IScannerService
         {
             _logger.LogInformation("[ScannerService] Processing series {SeriesName}", series.OriginalName);
 
+            // Get all associated ParsedInfos to the series. This includes infos that use a different filename that matches Series LocalizedName
             var parsedInfos = ParseScannedFiles.GetInfosByName(parsedSeries, series);
             UpdateVolumes(series, parsedInfos, allPeople, allTags, allGenres);
             series.Pages = series.Volumes.Sum(v => v.Pages);


### PR DESCRIPTION
# Fixed
- Fixed: Fixed a bug where an existing series A has LocalizedName of B and files named A. A new series with files named B were not merging under Series A. They now properly merge (Fixes #948 )
