### PR TITLE
Reader Fixes

### DIFF
--- a/API/Controllers/DownloadController.cs
+++ b/API/Controllers/DownloadController.cs
@@ -153,7 +153,7 @@ namespace API.Controllers
             var files = (await _unitOfWork.UserRepository.GetAllBookmarksByIds(downloadBookmarkDto.Bookmarks
                 .Select(b => b.Id)
                 .ToList()))
-                .Select(b => _directoryService.FileSystem.Path.Join(bookmarkDirectory, b.FileName));
+                .Select(b => Parser.Parser.NormalizePath(_directoryService.FileSystem.Path.Join(bookmarkDirectory, b.FileName)));
 
             var (fileBytes, _) = await _archiveService.CreateZipForDownload(files,
                 tempFolder);

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -226,14 +226,14 @@ public class ScannerService : IScannerService
         // Check if any of the folder roots are not available (ie disconnected from network, etc) and fail if any of them are
         if (library.Folders.Any(f => !_directoryService.IsDriveMounted(f.Path)))
         {
-            _logger.LogError("Some of the root folders for library are not accessible. Please check that drives are connected and rescan. Scan will be aborted");
+            _logger.LogCritical("Some of the root folders for library are not accessible. Please check that drives are connected and rescan. Scan will be aborted");
             return;
         }
 
         // For Docker instances check if any of the folder roots are not available (ie disconnected volumes, etc) and fail if any of them are
         if (library.Folders.Any(f => _directoryService.IsDirectoryEmpty(f.Path)))
         {
-            _logger.LogError("Some of the root folders for the library are empty. " +
+            _logger.LogCritical("Some of the root folders for the library are empty. " +
                              "Either your mount has been disconnected or you are trying to delete all series in the library. " +
                              "Scan will be aborted. " +
                              "Check that your mount is connected or change the library's root folder and rescan");

--- a/UI/Web/src/app/book-reader/book-reader/book-reader.component.html
+++ b/UI/Web/src/app/book-reader/book-reader/book-reader.component.html
@@ -1,4 +1,4 @@
-<div class="container-flex {{darkMode ? 'dark-mode' : ''}}" style="overflow: auto;" #reader>
+<div class="container-flex {{darkMode ? 'dark-mode' : ''}} reader-container" [ngStyle]="{overflow: (isFullscreen ? 'auto' : 'visible')}" #reader>
     <div class="fixed-top" #stickyTop>
         <a class="sr-only sr-only-focusable focus-visible" href="javascript:void(0);" (click)="moveFocus()">Skip to main content</a>
         <ng-container [ngTemplateOutlet]="actionBar"></ng-container>
@@ -116,10 +116,8 @@
         <div #readingHtml class="book-content" [ngStyle]="{'padding-bottom': topOffset + 20 + 'px', 'margin': '0px 0px'}" 
             [innerHtml]="page" *ngIf="page !== undefined"></div>
 
-        <div class="left {{clickOverlayClass('left')}} no-observe" (click)="prevPage()" *ngIf="clickToPaginate">
-        </div>
-        <div class="right {{clickOverlayClass('right')}} no-observe" (click)="nextPage()" *ngIf="clickToPaginate">
-        </div>
+        <div class="left {{clickOverlayClass('left')}} no-observe" (click)="prevPage()" *ngIf="clickToPaginate" tabindex="-1"></div>
+        <div class="right {{clickOverlayClass('right')}} no-observe" (click)="nextPage()" *ngIf="clickToPaginate" tabindex="-1"></div>
         
         <div *ngIf="page !== undefined && scrollbarNeeded">
             <ng-container [ngTemplateOutlet]="actionBar"></ng-container>

--- a/UI/Web/src/app/book-reader/book-reader/book-reader.component.scss
+++ b/UI/Web/src/app/book-reader/book-reader/book-reader.component.scss
@@ -159,6 +159,10 @@ $primary-color: #0062cc;
     //overflow: auto;  // This will break progress reporting
 }
 
+.reader-container {
+    outline: none; // Only the reading section itself shouldn't receive any outline. We use it to shift focus in fullscreen mode
+}
+
 .book-content {
     position: relative;
 }

--- a/UI/Web/src/app/book-reader/book-reader/book-reader.component.ts
+++ b/UI/Web/src/app/book-reader/book-reader/book-reader.component.ts
@@ -747,6 +747,12 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
     } else {
       this.scrollService.scrollTo(0, this.reader.nativeElement);
     }
+
+    // On fullscreen we need to click the document before arrow keys will scroll down.
+    if (this.isFullscreen) {
+      this.renderer.setAttribute(this.reader.nativeElement, 'tabIndex', '0');
+      this.reader.nativeElement.focus();
+    }
   }
 
   setPageNum(pageNum: number) {

--- a/UI/Web/src/app/manga-reader/infinite-scroller/infinite-scroller.component.scss
+++ b/UI/Web/src/app/manga-reader/infinite-scroller/infinite-scroller.component.scss
@@ -25,6 +25,10 @@
     width: 100% !important;
 }
 
+// .img-container {
+//     overflow: auto;
+// }
+
 
 @keyframes move-up-down {
     0%, 100% {

--- a/UI/Web/src/app/manga-reader/infinite-scroller/infinite-scroller.component.ts
+++ b/UI/Web/src/app/manga-reader/infinite-scroller/infinite-scroller.component.ts
@@ -63,6 +63,7 @@ export class InfiniteScrollerComponent implements OnInit, OnChanges, OnDestroy {
 
   @Input() goToPage: ReplaySubject<number> = new ReplaySubject<number>();
   @Input() bookmarkPage: ReplaySubject<number> = new ReplaySubject<number>();
+  @Input() fullscreenToggled: ReplaySubject<boolean> = new ReplaySubject<boolean>();
   
   /**
    * Stores and emits all the src urls
@@ -182,6 +183,13 @@ export class InfiniteScrollerComponent implements OnInit, OnChanges, OnDestroy {
             this.renderer.removeClass(image, 'bookmark-effect');
           }, 1000);
         }
+      });
+    }
+
+    if (this.fullscreenToggled) {
+      this.fullscreenToggled.pipe(takeUntil(this.onDestroy)).subscribe(isFullscreen => {
+        this.debugLog('[FullScreen] Fullscreen mode: ', isFullscreen);
+        this.setPageNum(this.pageNum, true);
       });
     }
   }

--- a/UI/Web/src/app/manga-reader/infinite-scroller/infinite-scroller.component.ts
+++ b/UI/Web/src/app/manga-reader/infinite-scroller/infinite-scroller.component.ts
@@ -152,7 +152,8 @@ export class InfiniteScrollerComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   ngOnInit(): void {
-    fromEvent(window, 'scroll')
+    const reader = document.querySelector('.reader') || window;
+    fromEvent(reader, 'scroll')
     .pipe(debounceTime(20), takeUntil(this.onDestroy)) 
     .subscribe((event) => this.handleScrollEvent(event));
 

--- a/UI/Web/src/app/manga-reader/manga-reader.component.html
+++ b/UI/Web/src/app/manga-reader/manga-reader.component.html
@@ -1,4 +1,4 @@
-<div class="reader" #reader>
+<div class="reader" #reader [ngStyle]="{overflow: (isFullscreen ? 'auto' : 'visible')}">
     <div class="fixed-top overlay" *ngIf="menuOpen" [@slideFromTop]="menuOpen">
         <div style="display: flex; margin-top: 5px;">
             <button class="btn btn-icon" style="height: 100%" title="Back" (click)="closeReader()">

--- a/UI/Web/src/app/manga-reader/manga-reader.component.html
+++ b/UI/Web/src/app/manga-reader/manga-reader.component.html
@@ -36,7 +36,8 @@
             [urlProvider]="getPageUrl" 
             (loadNextChapter)="loadNextChapter()" 
             (loadPrevChapter)="loadPrevChapter()"
-            [bookmarkPage]="showBookmarkEffectEvent"></app-infinite-scroller>
+            [bookmarkPage]="showBookmarkEffectEvent"
+            [fullscreenToggled]="fullscreenEvent"></app-infinite-scroller>
         </div>
         <ng-container *ngIf="readerMode === READER_MODE.MANGA_LR || readerMode === READER_MODE.MANGA_UD">
             <div class="pagination-area {{readerMode === READER_MODE.MANGA_LR ? 'right' : 'bottom'}} {{clickOverlayClass('right')}}" (click)="handlePageChange($event, 'right')">

--- a/UI/Web/src/app/manga-reader/manga-reader.component.ts
+++ b/UI/Web/src/app/manga-reader/manga-reader.component.ts
@@ -873,6 +873,7 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       if (!this.shouldRenderAsFitSplit()) {
         this.setCanvasSize();
         this.ctx.drawImage(this.canvasImage, 0, 0);
+        this.isLoading = false;
         return;
       }
       

--- a/UI/Web/src/app/manga-reader/manga-reader.component.ts
+++ b/UI/Web/src/app/manga-reader/manga-reader.component.ts
@@ -131,6 +131,10 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
    * An event emiter when a bookmark on a page change occurs. Used soley by the webtoon reader.
    */
    showBookmarkEffectEvent: ReplaySubject<number> = new ReplaySubject<number>();
+   /**
+   * An event emiter when fullscreen mode is toggled. Used soley by the webtoon reader.
+   */
+   fullscreenEvent: ReplaySubject<boolean> = new ReplaySubject<boolean>();
   /**
    * If the menu is open/visible.
    */
@@ -1080,12 +1084,14 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       this.readerService.exitFullscreen(() => {
         this.isFullscreen = false;
         this.firstPageRendered = false;
+        this.fullscreenEvent.next(false);
         this.render();
       });
     } else {
       this.readerService.enterFullscreen(this.reader.nativeElement, () => {
         this.isFullscreen = true;
         this.firstPageRendered = false;
+        this.fullscreenEvent.next(true);
         this.render();
       });
     }


### PR DESCRIPTION
# Changed
- Changed: Tweaked how On Deck sorting works to try and better sort series with new chapters. (#873 )
- Changed: When the scanner stops a scan due to empty folders or disconnected drives, log as a critical message

# Fixed
- Fixed: Fixed an issue in the book reader where using key up/down to scroll broke due to changes with fullscreen mode (Fixes #928 )
- Fixed: Fixed an issue in manga reader where webtoon reader broke when in fullscreen mode (develop)
- Fixed: Fixed an issue  in manga reader where when toggling fullscreen, infinite scroller scrolls to a different page (develop)
- Fixed: Fixed an issue where sometimes cause underlying canvas to retain an old image, while a new one renders on top in manga reader (develop)

Closes #930 
