### PR TITLE
Migration Safety

### DIFF
--- a/API/API.csproj
+++ b/API/API.csproj
@@ -49,13 +49,13 @@
     <PackageReference Include="MarkdownDeep.NET.Core" Version="1.5.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="6.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.0">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.0" />
     <PackageReference Include="NetVips" Version="2.1.0" />

--- a/API/Program.cs
+++ b/API/Program.cs
@@ -62,7 +62,33 @@ namespace API
                 if (pendingMigrations.Any())
                 {
                     logger.LogInformation("Performing backup as migrations are needed. Backup will be kavita.db in temp folder");
-                    directoryService.CopyFileToDirectory(directoryService.FileSystem.Path.Join(directoryService.ConfigDirectory, "kavita.db"), directoryService.TempDirectory);
+                    string currentVersion = null;
+                    try
+                    {
+                        currentVersion =
+                            (await context.ServerSetting.SingleOrDefaultAsync(s =>
+                                s.Key == ServerSettingKey.InstallVersion))?.Value;
+                    }
+                    catch
+                    {
+                        // ignored
+                    }
+
+                    if (string.IsNullOrEmpty(currentVersion))
+                    {
+                        currentVersion = "vUnknown";
+                    }
+
+                    var migrationDirectory = directoryService.FileSystem.Path.Join(directoryService.TempDirectory,
+                        "migration", currentVersion);
+                    directoryService.ExistOrCreate(migrationDirectory);
+
+                    if (!directoryService.FileSystem.File.Exists(
+                            directoryService.FileSystem.Path.Join(migrationDirectory, "kavita.db")))
+                    {
+                        directoryService.CopyFileToDirectory(directoryService.FileSystem.Path.Join(directoryService.ConfigDirectory, "kavita.db"), migrationDirectory);
+                        logger.LogInformation("Database backed up to {MigrationDirectory}", migrationDirectory);
+                    }
                 }
 
                 await context.Database.MigrateAsync();
@@ -82,7 +108,8 @@ namespace API
             catch (Exception ex)
             {
                 var logger = services.GetRequiredService<ILogger<Program>>();
-                logger.LogCritical(ex, "An error occurred during migration");
+                logger.LogCritical(ex, "A migration failed during startup. Please check config/temp/ for a backup and try again");
+                return;
             }
 
             await host.RunAsync();


### PR DESCRIPTION
# Changed
- Changed: When migrations occur, create a temp/migration/version/kavita.db backup, attempt to run migrations and if any fail, restore the temp/migration/version/kavita.db backup and exit immediately with verbose logging. (Closes #966 )
