### PR TITLE
In directory picker, when a node is loaded, clear the filter

### DIFF
--- a/UI/Web/src/app/admin/_modals/directory-picker/directory-picker.component.ts
+++ b/UI/Web/src/app/admin/_modals/directory-picker/directory-picker.component.ts
@@ -77,6 +77,7 @@ export class DirectoryPickerComponent implements OnInit {
 
   loadChildren(path: string) {
     this.libraryService.listDirectories(path).subscribe(folders => {
+      this.filterQuery = '';
       this.folders = folders;
     }, err => {
       // If there was an error, pop off last directory added to stack


### PR DESCRIPTION
# Fixed
- Fixed: In directory picker, clear the filter when you load a folder
