### PR TITLE
Series Detail Enhancements

### DIFF
--- a/API.Tests/Parser/ComicParserTests.cs
+++ b/API.Tests/Parser/ComicParserTests.cs
@@ -186,6 +186,10 @@ namespace API.Tests.Parser
         [InlineData("Asterix - HS - Les 12 travaux d'Astérix", true)]
         [InlineData("Sillage Hors Série - Le Collectionneur - Concordance-DKFR", true)]
         [InlineData("laughs", false)]
+        [InlineData("Annual Days of Summer", false)]
+        [InlineData("Adventure Time 2013 Annual #001 (2013)", true)]
+        [InlineData("Adventure Time 2013_Annual_#001 (2013)", true)]
+        [InlineData("Adventure Time 2013_-_Annual #001 (2013)", true)]
         public void ParseComicSpecialTest(string input, bool expected)
         {
             Assert.Equal(expected, !string.IsNullOrEmpty(API.Parser.Parser.ParseComicSpecial(input)));

--- a/API/Controllers/ReaderController.cs
+++ b/API/Controllers/ReaderController.cs
@@ -365,8 +365,19 @@ namespace API.Controllers
         public async Task<ActionResult<ChapterDto>> GetContinuePoint(int seriesId)
         {
             var userId = await _unitOfWork.UserRepository.GetUserIdByUsernameAsync(User.GetUsername());
-
             return Ok(await _readerService.GetContinuePoint(seriesId, userId));
+        }
+
+        /// <summary>
+        /// Returns if the user has reading progress on the Series
+        /// </summary>
+        /// <param name="seriesId"></param>
+        /// <returns></returns>
+        [HttpGet("has-progress")]
+        public async Task<ActionResult<ChapterDto>> HasProgress(int seriesId)
+        {
+            var userId = await _unitOfWork.UserRepository.GetUserIdByUsernameAsync(User.GetUsername());
+            return Ok(await _unitOfWork.AppUserProgressRepository.HasAnyProgressOnSeriesAsync(seriesId, userId));
         }
 
         /// <summary>

--- a/API/Data/Repositories/AppUserProgressRepository.cs
+++ b/API/Data/Repositories/AppUserProgressRepository.cs
@@ -12,6 +12,7 @@ public interface IAppUserProgressRepository
     Task<int> CleanupAbandonedChapters();
     Task<bool> UserHasProgress(LibraryType libraryType, int userId);
     Task<AppUserProgress> GetUserProgressAsync(int chapterId, int userId);
+    Task<bool> HasAnyProgressOnSeriesAsync(int seriesId, int userId);
 }
 
 public class AppUserProgressRepository : IAppUserProgressRepository
@@ -74,6 +75,12 @@ public class AppUserProgressRepository : IAppUserProgressRepository
             .Where(s => seriesIds.Contains(s.Id) && s.Library.Type == libraryType)
             .AsNoTracking()
             .AnyAsync();
+    }
+
+    public async Task<bool> HasAnyProgressOnSeriesAsync(int seriesId, int userId)
+    {
+        return await _context.AppUserProgresses
+            .AnyAsync(aup => aup.PagesRead > 0 && aup.AppUserId == userId && aup.SeriesId == seriesId);
     }
 
     public async Task<AppUserProgress> GetUserProgressAsync(int chapterId, int userId)

--- a/API/Parser/Parser.cs
+++ b/API/Parser/Parser.cs
@@ -484,7 +484,7 @@ namespace API.Parser
         {
             // All Keywords, does not account for checking if contains volume/chapter identification. Parser.Parse() will handle.
             new Regex(
-                @"(?<Special>Specials?|OneShot|One\-Shot|Extra(?:(\sChapter)?[^\S])|Book \d.+?|Compendium \d.+?|Omnibus \d.+?|[_\s\-]TPB[_\s\-]|FCBD \d.+?|Absolute \d.+?|Preview \d.+?|Art Collection|Side(\s|_)Stories|Bonus|Hors Série|(\W|_|-)HS(\W|_|-)|(\W|_|-)THS(\W|_|-))",
+                @"(?<Special>Specials?|OneShot|One\-Shot|\d.+? Annual|Annual \d.+?|Extra(?:(\sChapter)?[^\S])|Book \d.+?|Compendium \d.+?|Omnibus \d.+?|[_\s\-]TPB[_\s\-]|FCBD \d.+?|Absolute \d.+?|Preview \d.+?|Art Collection|Side(\s|_)Stories|Bonus|Hors Série|(\W|_|-)HS(\W|_|-)|(\W|_|-)THS(\W|_|-))",
                 MatchOptions, RegexTimeout),
         };
 

--- a/API/Parser/Parser.cs
+++ b/API/Parser/Parser.cs
@@ -484,7 +484,7 @@ namespace API.Parser
         {
             // All Keywords, does not account for checking if contains volume/chapter identification. Parser.Parse() will handle.
             new Regex(
-                @"(?<Special>Specials?|OneShot|One\-Shot|\d.+? Annual|Annual \d.+?|Extra(?:(\sChapter)?[^\S])|Book \d.+?|Compendium \d.+?|Omnibus \d.+?|[_\s\-]TPB[_\s\-]|FCBD \d.+?|Absolute \d.+?|Preview \d.+?|Art Collection|Side(\s|_)Stories|Bonus|Hors Série|(\W|_|-)HS(\W|_|-)|(\W|_|-)THS(\W|_|-))",
+                @"(?<Special>Specials?|OneShot|One\-Shot|\d.+?(\W|_|-)Annual|Annual(\W|_|-)\d.+?|Extra(?:(\sChapter)?[^\S])|Book \d.+?|Compendium \d.+?|Omnibus \d.+?|[_\s\-]TPB[_\s\-]|FCBD \d.+?|Absolute \d.+?|Preview \d.+?|Art Collection|Side(\s|_)Stories|Bonus|Hors Série|(\W|_|-)HS(\W|_|-)|(\W|_|-)THS(\W|_|-))",
                 MatchOptions, RegexTimeout),
         };
 

--- a/UI/Web/src/app/_services/reader.service.ts
+++ b/UI/Web/src/app/_services/reader.service.ts
@@ -103,6 +103,10 @@ export class ReaderService {
     return this.httpClient.get<number>(this.baseUrl + 'reader/prev-chapter?seriesId=' + seriesId + '&volumeId=' + volumeId + '&currentChapterId=' + currentChapterId);
   }
 
+  hasSeriesProgress(seriesId: number) {
+    return this.httpClient.get<boolean>(this.baseUrl + 'reader/has-progress?seriesId=' + seriesId);
+  }
+
   getCurrentChapter(seriesId: number) {
     return this.httpClient.get<Chapter>(this.baseUrl + 'reader/continue-point?seriesId=' + seriesId);
   }

--- a/UI/Web/src/app/series-detail/series-detail.component.html
+++ b/UI/Web/src/app/series-detail/series-detail.component.html
@@ -62,7 +62,7 @@
 
     <div>
         <app-bulk-operations [actionCallback]="bulkActionCallback"></app-bulk-operations>
-        <ul ngbNav #nav="ngbNav" [(activeId)]="activeTabId" class="nav-tabs nav-pills" [destroyOnHide]="false">
+        <ul ngbNav #nav="ngbNav" [(activeId)]="activeTabId" class="nav-tabs nav-pills" [destroyOnHide]="false" (navChange)="onNavChange($event)">
             <li [ngbNavItem]="1" *ngIf="hasSpecials">
               <a ngbNavLink>Specials</a>
               <ng-template ngbNavContent>
@@ -75,7 +75,7 @@
                 </div>
               </ng-template>
             </li>
-            <li [ngbNavItem]="2" *ngIf="utilityService.formatChapterName(libraryType) !== 'Book' && (hasNonSpecialVolumeChapters || hasNonSpecialNonVolumeChapters)">
+            <li [ngbNavItem]="2" *ngIf="libraryType !== LibraryType.Book && (hasNonSpecialVolumeChapters || hasNonSpecialNonVolumeChapters)">
                 <a ngbNavLink>Storyline</a>
                 <ng-template ngbNavContent>
                     <div class="row no-gutters">
@@ -92,7 +92,7 @@
                     </div>
                 </ng-template>
             </li>
-            <li [ngbNavItem]="3" *ngIf="utilityService.formatChapterName(libraryType) !== 'Comic' &&hasNonSpecialVolumeChapters">
+            <li [ngbNavItem]="3" *ngIf="libraryType !== LibraryType.Comic && hasNonSpecialVolumeChapters">
                 <a ngbNavLink>Volumes</a>
                 <ng-template ngbNavContent>
                     <div class="row no-gutters">

--- a/UI/Web/src/app/series-detail/series-detail.component.html
+++ b/UI/Web/src/app/series-detail/series-detail.component.html
@@ -75,15 +75,39 @@
                 </div>
               </ng-template>
             </li>
-            <li [ngbNavItem]="2" *ngIf="hasNonSpecialVolumeChapters">
+            <li [ngbNavItem]="2" *ngIf="utilityService.formatChapterName(libraryType) !== 'Book' && (hasNonSpecialVolumeChapters || hasNonSpecialNonVolumeChapters)">
+                <a ngbNavLink>Storyline</a>
+                <ng-template ngbNavContent>
+                    <div class="row no-gutters">
+                        <div *ngFor="let volume of volumes; let idx = index; trackBy: trackByVolumeIdentity">
+                            <app-card-item class="col-auto" *ngIf="volume.number != 0" [entity]="volume" [title]="formatVolumeTitle(volume)" (click)="openVolume(volume)"
+                            [imageUrl]="imageService.getVolumeCoverImage(volume.id) + '&offset=' + coverImageOffset"
+                            [read]="volume.pagesRead" [total]="volume.pages" [actions]="volumeActions" (selection)="bulkSelectionService.handleCardSelection('volume', idx, volumes.length, $event)" [selected]="bulkSelectionService.isCardSelected('volume', idx)" [allowSelection]="true"></app-card-item>
+                        </div>
+                          <div *ngFor="let chapter of storyChapters; let idx = index; trackBy: trackByChapterIdentity">
+                              <app-card-item class="col-auto" *ngIf="!chapter.isSpecial" [entity]="chapter" [title]="formatChapterTitle(chapter)" (click)="openChapter(chapter)"
+                              [imageUrl]="imageService.getChapterCoverImage(chapter.id) + '&offset=' + coverImageOffset"
+                              [read]="chapter.pagesRead" [total]="chapter.pages" [actions]="chapterActions" (selection)="bulkSelectionService.handleCardSelection('chapter', idx, chapters.length, $event)" [selected]="bulkSelectionService.isCardSelected('chapter', idx)" [allowSelection]="true"></app-card-item>
+                          </div>
+                    </div>
+                </ng-template>
+            </li>
+            <li [ngbNavItem]="3" *ngIf="utilityService.formatChapterName(libraryType) !== 'Comic' &&hasNonSpecialVolumeChapters">
+                <a ngbNavLink>Volumes</a>
+                <ng-template ngbNavContent>
+                    <div class="row no-gutters">
+                          <div *ngFor="let volume of volumes; let idx = index; trackBy: trackByVolumeIdentity">
+                                  <app-card-item class="col-auto" *ngIf="volume.number != 0" [entity]="volume" [title]="formatVolumeTitle(volume)" (click)="openVolume(volume)"
+                                  [imageUrl]="imageService.getVolumeCoverImage(volume.id) + '&offset=' + coverImageOffset"
+                                  [read]="volume.pagesRead" [total]="volume.pages" [actions]="volumeActions" (selection)="bulkSelectionService.handleCardSelection('volume', idx, volumes.length, $event)" [selected]="bulkSelectionService.isCardSelected('volume', idx)" [allowSelection]="true"></app-card-item>
+                          </div>
+                    </div>
+                </ng-template>
+              </li>
+            <li [ngbNavItem]="4" *ngIf="hasNonSpecialNonVolumeChapters">
               <a ngbNavLink>{{utilityService.formatChapterName(libraryType) + 's'}}</a>
               <ng-template ngbNavContent>
                   <div class="row no-gutters">
-                        <div *ngFor="let volume of volumes; let idx = index; trackBy: trackByVolumeIdentity">
-                                <app-card-item class="col-auto" *ngIf="volume.number != 0" [entity]="volume" [title]="formatVolumeTitle(volume)" (click)="openVolume(volume)"
-                                [imageUrl]="imageService.getVolumeCoverImage(volume.id) + '&offset=' + coverImageOffset"
-                                [read]="volume.pagesRead" [total]="volume.pages" [actions]="volumeActions" (selection)="bulkSelectionService.handleCardSelection('volume', idx, volumes.length, $event)" [selected]="bulkSelectionService.isCardSelected('volume', idx)" [allowSelection]="true"></app-card-item>
-                        </div>
                         <div *ngFor="let chapter of chapters; let idx = index; trackBy: trackByChapterIdentity">
                             <app-card-item class="col-auto" *ngIf="!chapter.isSpecial" [entity]="chapter" [title]="formatChapterTitle(chapter)" (click)="openChapter(chapter)"
                             [imageUrl]="imageService.getChapterCoverImage(chapter.id) + '&offset=' + coverImageOffset"

--- a/UI/Web/src/app/series-detail/series-detail.component.ts
+++ b/UI/Web/src/app/series-detail/series-detail.component.ts
@@ -359,18 +359,18 @@ export class SeriesDetailComponent implements OnInit, OnDestroy {
 
 
       this.seriesService.getVolumes(this.series.id).subscribe(volumes => {
-        this.storyChapters = volumes.filter(v => v.number === 0).map(v => v.chapters || []).flat().sort(this.utilityService.sortChapters); 
+        const vol0 = this.volumes.filter(v => v.number === 0);
+        this.storyChapters = vol0.map(v => v.chapters || []).flat().sort(this.utilityService.sortChapters); 
         this.chapters = volumes.map(v => v.chapters || []).flat().sort(this.utilityService.sortChapters).filter(c => !c.isSpecial || isNaN(parseInt(c.range, 10))); 
         this.volumes = volumes.sort(this.utilityService.sortVolumes);
         
         this.setContinuePoint();
 
-        const vol0 = this.volumes.filter(v => v.number === 0);
-        this.hasSpecials = vol0.map(v => v.chapters || []).flat().sort(this.utilityService.sortChapters).filter(c => c.isSpecial || isNaN(parseInt(c.range, 10))).length > 0;
+        
+        const specials = vol0.map(v => v.chapters || []).flat().sort(this.utilityService.sortChapters).filter(c => c.isSpecial || isNaN(parseInt(c.range, 10)));
+        this.hasSpecials = specials.length > 0
         if (this.hasSpecials) {
-          this.specials = vol0.map(v => v.chapters || [])
-          .flat()
-          .filter(c => c.isSpecial || isNaN(parseInt(c.range, 10)))
+          this.specials = specials
           .map(c => {
             c.title = this.utilityService.cleanSpecialTitle(c.title);
             c.range = this.utilityService.cleanSpecialTitle(c.range);

--- a/UI/Web/src/app/series-detail/series-detail.component.ts
+++ b/UI/Web/src/app/series-detail/series-detail.component.ts
@@ -1,7 +1,7 @@
 import { Component, HostListener, OnDestroy, OnInit } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 import { ActivatedRoute, Router } from '@angular/router';
-import { NgbModal, NgbRatingConfig } from '@ng-bootstrap/ng-bootstrap';
+import { NgbModal, NgbNavChangeEvent, NgbRatingConfig } from '@ng-bootstrap/ng-bootstrap';
 import { ToastrService } from 'ngx-toastr';
 import { forkJoin, Subject } from 'rxjs';
 import { finalize, take, takeUntil, takeWhile } from 'rxjs/operators';
@@ -223,6 +223,10 @@ export class SeriesDetailComponent implements OnInit, OnDestroy {
     if (event.key === KEY_CODES.SHIFT) {
       this.bulkSelectionService.isShiftDown = false;
     }
+  }
+
+  onNavChange(event: NgbNavChangeEvent) {
+    this.bulkSelectionService.deselectAll();
   }
 
   handleSeriesActionCallback(action: Action, series: Series) {


### PR DESCRIPTION
# Added
- Added: '# Annual' and 'Annual #' to the comic special parsing regex.

# Changed
- Changed: Series Detail view now will show Specials, Storyline, Volumes, and Chapters/Issues as tabs. Storyline is the existing view which has all items grouped and rendered next to each other. Volumes will show just volumes and Chapters/Issues will show all issues. If they were bundled in a volume, they will be flattened. Note: If you see Chapter 0, that is likely an indicator of a pure volume file without any chapter information. You can either rename file to include the chapter or ignore.