### PR TITLE
Library page resetting

### DIFF
--- a/UI/Web/src/app/library-detail/library-detail.component.ts
+++ b/UI/Web/src/app/library-detail/library-detail.component.ts
@@ -140,7 +140,8 @@ export class LibraryDetailComponent implements OnInit, OnDestroy {
 
   updateFilter(data: SeriesFilter) {
     this.filter = data;
-    if (this.pagination !== undefined && this.pagination !== null) {
+    const page = this.getPage();
+    if (page === undefined || page === null) {
       this.pagination.currentPage = 1;
       this.onPageChange(this.pagination);
     } else {


### PR DESCRIPTION
# Fixed
- Fixed: Fixed an issue where the pagination would reset to 1 on the library-details page when refreshing or navigating directly to a specific page number.