### PR TITLE
Fixed Parser.Parser.Normalize returns empty string

### DIFF
--- a/API.Tests/Parser/ParserTest.cs
+++ b/API.Tests/Parser/ParserTest.cs
@@ -139,6 +139,7 @@ namespace API.Tests.Parser
         [InlineData("Darker Than_Black", "darkerthanblack")]
         [InlineData("Citrus", "citrus")]
         [InlineData("Citrus+", "citrus+")]
+        [InlineData("카비타", "카비타")]
         [InlineData("", "")]
         public void NormalizeTest(string input, string expected)
         {

--- a/API/Parser/Parser.cs
+++ b/API/Parser/Parser.cs
@@ -946,7 +946,8 @@ namespace API.Parser
 
         public static string Normalize(string name)
         {
-            return NormalizeRegex.Replace(name, string.Empty).ToLower();
+            var normalized = NormalizeRegex.Replace(name, string.Empty).ToLower();
+            return string.IsNullOrEmpty(normalized) ? name : normalized;
         }
 
 


### PR DESCRIPTION
# Fixed
- Fixed: When normalizing series names, if the series has no alphanumeric characters (ie non-roman), return the original name back rather than empty string.

