### PR TITLE
Bulk Selection fix with Storyline Tab

### DIFF
--- a/API/Services/ReaderService.cs
+++ b/API/Services/ReaderService.cs
@@ -317,6 +317,8 @@ public class ReaderService : IReaderService
             .OrderBy(c => float.Parse(c.Number))
             .ToList();
 
+
+
         var currentlyReadingChapter = nonSpecialChapters.FirstOrDefault(chapter => chapter.PagesRead < chapter.Pages);
 
 
@@ -330,8 +332,7 @@ public class ReaderService : IReaderService
             {
                 if (chapter.PagesRead < chapter.Pages)
                 {
-                    currentlyReadingChapter = chapter;
-                    break;
+                    return chapter;
                 }
             }
         }

--- a/UI/Web/src/app/book-reader/book-reader/book-reader.component.ts
+++ b/UI/Web/src/app/book-reader/book-reader/book-reader.component.ts
@@ -663,9 +663,16 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       page = 0;
     }
 
+    // BUG: Last page is not counting as read
     if (!(page === 0 || page === this.maxPages - 1)) {
       page -= 1;
     }
+
+    // // Due to the fact that we start at image 0, but page 1, we need the last page to have progress as page + 1 to be completed
+    // let tempPageNum = this.pageNum;
+    // if (this.pageNum == this.maxPages - 1) {
+    //   tempPageNum = this.pageNum + 1;
+    // }
 
     this.pageNum = page;
     this.loadPage();

--- a/UI/Web/src/app/series-detail/series-detail.component.html
+++ b/UI/Web/src/app/series-detail/series-detail.component.html
@@ -87,7 +87,7 @@
                           <div *ngFor="let chapter of storyChapters; let idx = index; trackBy: trackByChapterIdentity">
                               <app-card-item class="col-auto" *ngIf="!chapter.isSpecial" [entity]="chapter" [title]="formatChapterTitle(chapter)" (click)="openChapter(chapter)"
                               [imageUrl]="imageService.getChapterCoverImage(chapter.id) + '&offset=' + coverImageOffset"
-                              [read]="chapter.pagesRead" [total]="chapter.pages" [actions]="chapterActions" (selection)="bulkSelectionService.handleCardSelection('chapter', idx, chapters.length, $event)" [selected]="bulkSelectionService.isCardSelected('chapter', idx)" [allowSelection]="true"></app-card-item>
+                              [read]="chapter.pagesRead" [total]="chapter.pages" [actions]="chapterActions" (selection)="bulkSelectionService.handleCardSelection('chapter', idx, storyChapters.length, $event)" [selected]="bulkSelectionService.isCardSelected('chapter', idx)" [allowSelection]="true"></app-card-item>
                           </div>
                     </div>
                 </ng-template>


### PR DESCRIPTION
# Fixed
- Fixed: Fixed a bulk selection bug where storyline tab wasn't properly selecting multiple cards in the correct order with shift.
