### PR TITLE
Adding bug-report YAML template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,103 @@
+name: Bug Report
+description: Create a report to help us improve
+title: ""
+labels: ["needs-triage"]
+assignees:
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: markdown
+    attributes:
+      value: |
+        If you have a feature request, please go to our [Feature Requests](https://feats.kavitareader.com) page.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what steps you took so we can try to reproduce.
+      placeholder: Tell us what you see!
+      value: ""
+    validations:
+      required: true
+  - type: textarea
+    id: what-was-expected
+    attributes:
+      label: What did you expect?
+      description: What did you expect to happen?
+      placeholder: Tell us what you expected to see!
+      value: ""
+    validations:
+      required: true
+  - type: textarea
+    id: version
+    attributes:
+      label: Version
+      description: What version of our software are you running?
+      placeholder: Can be found by going to Server Settings > System
+      value: ""
+    validations:
+      required: true
+  - type: dropdown
+    id: OS
+    attributes:
+      label: What OS is Kavita being run on?
+      multiple: false
+      options:
+        - Docker
+        - Windows
+        - Linux
+        - Mac
+  - type: dropdown
+    id: desktop-OS
+    attributes:
+      label: If issue being seen on Desktop, what OS are you running where you see the issue?
+      multiple: false
+      options:
+        - Windows
+        - Linux
+        - Mac
+  - type: dropdown
+    id: desktop-browsers
+    attributes:
+      label: If issue being seen on Desktop, what browsers are you seeing the problem on?
+      multiple: true
+      options:
+        - Firefox
+        - Chrome
+        - Safari
+        - Microsoft Edge
+  - type: dropdown
+    id: mobile-OS
+    attributes:
+      label: If issue being seen on Mobile, what OS are you running where you see the issue?
+      multiple: false
+      options:
+        - Android
+        - iOS
+  - type: dropdown
+    id: mobile-browsers
+    attributes:
+      label: If issue being seen on Mobile, what browsers are you seeing the problem on?
+      multiple: true
+      options:
+        - Firefox
+        - Chrome
+        - Safari
+        - Microsoft Edge
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell
+  - type: textarea
+    id: anything-else
+    attributes:
+      label: Additional Notes
+      description: Any other information about the issue not covered in this form?
+      placeholder: e.g. Running Kavita on a raspberry pi
+      value: ""
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
**This is a github repo change only and does not affect the application.**

A while ago Github launched a public beta of their new template format using YAML syntax. As per the [documentation](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-templates) I have tried to convert the existing bug-report template to this new format.

I have also added a config.yml as per the documentation, which allows us the option to turn off blank issues.