### PR TITLE
Don't throw exception on saving progress when nothing changes

### DIFF
--- a/API/Services/ReaderService.cs
+++ b/API/Services/ReaderService.cs
@@ -174,6 +174,7 @@ public class ReaderService : IReaderService
                 _unitOfWork.AppUserProgressRepository.Update(userProgress);
             }
 
+            if (!_unitOfWork.HasChanges()) return true;
             if (await _unitOfWork.CommitAsync())
             {
                 return true;


### PR DESCRIPTION
# Fixed
- Fixed: Don't throw an exception when we are trying to save progress and there is nothing new to save in manga reader (#878) 
