### PR TITLE
Remove old migrations

### DIFF
--- a/API/Data/MigrateBookmarks.cs
+++ b/API/Data/MigrateBookmarks.cs
@@ -14,7 +14,8 @@ namespace API.Data;
 public static class MigrateBookmarks
 {
     /// <summary>
-    /// This will migrate existing bookmarks to bookmark folder based
+    /// This will migrate existing bookmarks to bookmark folder based.
+    /// If the bookmarks folder already exists, this will not run.
     /// </summary>
     /// <remarks>Bookmark directory is configurable. This will always use the default bookmark directory.</remarks>
     /// <param name="directoryService"></param>

--- a/API/Data/MigrateChangePasswordRoles.cs
+++ b/API/Data/MigrateChangePasswordRoles.cs
@@ -5,11 +5,23 @@ using Microsoft.AspNetCore.Identity;
 
 namespace API.Data;
 
+/// <summary>
+/// New role introduced in v0.5.1. Adds the role to all users.
+/// </summary>
 public static class MigrateChangePasswordRoles
 {
+    /// <summary>
+    /// Will not run if any users have the ChangePassword role already
+    /// </summary>
+    /// <param name="unitOfWork"></param>
+    /// <param name="userManager"></param>
     public static async Task Migrate(IUnitOfWork unitOfWork, UserManager<AppUser> userManager)
     {
-        foreach (var user in await unitOfWork.UserRepository.GetAllUsers())
+        var usersWithRole = await userManager.GetUsersInRoleAsync(PolicyConstants.ChangePasswordRole);
+        if (usersWithRole.Count != 0) return;
+
+        var allUsers = await unitOfWork.UserRepository.GetAllUsers();
+        foreach (var user in allUsers)
         {
             await userManager.RemoveFromRoleAsync(user, "ChangePassword");
             await userManager.AddToRoleAsync(user, PolicyConstants.ChangePasswordRole);

--- a/API/Program.cs
+++ b/API/Program.cs
@@ -36,7 +36,7 @@ namespace API
 
 
             var directoryService = new DirectoryService(null, new FileSystem());
-            MigrateConfigFiles.Migrate(isDocker, directoryService);
+            //MigrateConfigFiles.Migrate(isDocker, directoryService);
 
             // Before anything, check if JWT has been generated properly or if user still has default
             if (!Configuration.CheckIfJwtTokenSet() &&

--- a/API/Startup.cs
+++ b/API/Startup.cs
@@ -144,7 +144,6 @@ namespace API
                 {
                     // Apply all migrations on startup
                     var logger = serviceProvider.GetRequiredService<ILogger<Program>>();
-                    var context = serviceProvider.GetRequiredService<DataContext>();
                     var userManager = serviceProvider.GetRequiredService<UserManager<AppUser>>();
 
 
@@ -152,30 +151,7 @@ namespace API
                         logger, cacheService);
 
                     // Only run this if we are upgrading
-                    var usersWithRole = await userManager.GetUsersInRoleAsync(PolicyConstants.ChangePasswordRole);
-                    if (usersWithRole.Count == 0)
-                    {
-                        await MigrateChangePasswordRoles.Migrate(unitOfWork, userManager);
-                    }
-
-                    var requiresCoverImageMigration = !Directory.Exists(directoryService.CoverImageDirectory);
-                    try
-                    {
-                        // If this is a new install, tables wont exist yet
-                        if (requiresCoverImageMigration)
-                        {
-                            MigrateCoverImages.ExtractToImages(context, directoryService, imageService);
-                        }
-                    }
-                    catch (Exception)
-                    {
-                        requiresCoverImageMigration = false;
-                    }
-
-                    if (requiresCoverImageMigration)
-                    {
-                        await MigrateCoverImages.UpdateDatabaseWithImages(context, directoryService);
-                    }
+                    await MigrateChangePasswordRoles.Migrate(unitOfWork, userManager);
                 }).GetAwaiter()
                     .GetResult();
             }


### PR DESCRIPTION
# Removed
- Removed: Removed old manual migrations (config change, cover images) that are from many releases ago. If you're updating from over 10 releases ago, you may loose cover images. 
