### PR TITLE
Misc Bugfixes

### DIFF
--- a/API.Tests/Parser/BookParserTests.cs
+++ b/API.Tests/Parser/BookParserTests.cs
@@ -6,6 +6,7 @@ namespace API.Tests.Parser
     {
         [Theory]
         [InlineData("Gifting The Wonderful World With Blessings! - 3 Side Stories [yuNS][Unknown]", "Gifting The Wonderful World With Blessings!")]
+        [InlineData("BBC Focus 00 The Science of Happiness 2nd Edition (2018)", "BBC Focus 00 The Science of Happiness 2nd Edition")]
         public void ParseSeriesTest(string filename, string expected)
         {
             Assert.Equal(expected, API.Parser.Parser.ParseSeries(filename));

--- a/API.Tests/Parser/MangaParserTests.cs
+++ b/API.Tests/Parser/MangaParserTests.cs
@@ -159,7 +159,6 @@ namespace API.Tests.Parser
         [InlineData("The 100 Girlfriends Who Really, Really, Really, Really, Really Love You - Vol. 03 Ch. 023.5 - Volume 3 Extras.cbz", "The 100 Girlfriends Who Really, Really, Really, Really, Really Love You")]
         [InlineData("Kimi no Koto ga Daidaidaidaidaisuki na 100-nin no Kanojo Chapter 1-10", "Kimi no Koto ga Daidaidaidaidaisuki na 100-nin no Kanojo")]
         [InlineData("The Duke of Death and His Black Maid - Ch. 177 - The Ball (3).cbz", "The Duke of Death and His Black Maid")]
-        [InlineData("A Compendium of Ghosts - 031 - The Third Story_ Part 12 (Digital) (Cobalt001)", "A Compendium of Ghosts")]
         [InlineData("The Duke of Death and His Black Maid - Vol. 04 Ch. 054.5 - V4 Omake", "The Duke of Death and His Black Maid")]
         [InlineData("Vol. 04 Ch. 054.5", "")]
         [InlineData("Great_Teacher_Onizuka_v16[TheSpectrum]", "Great Teacher Onizuka")]
@@ -168,6 +167,7 @@ namespace API.Tests.Parser
         [InlineData("Kaiju No. 8 036 (2021) (Digital)", "Kaiju No. 8")]
         [InlineData("Seraph of the End - Vampire Reign 093  (2020) (Digital) (LuCaZ).cbz", "Seraph of the End - Vampire Reign")]
         [InlineData("Love Hina - Volume 01 [Scans].pdf", "Love Hina")]
+        [InlineData("It's Witching Time! 001 (Digital) (Anonymous1234)", "It's Witching Time!")]
         public void ParseSeriesTest(string filename, string expected)
         {
             Assert.Equal(expected, API.Parser.Parser.ParseSeries(filename));

--- a/API.Tests/Services/BookmarkServiceTests.cs
+++ b/API.Tests/Services/BookmarkServiceTests.cs
@@ -11,6 +11,7 @@ using API.DTOs.Reader;
 using API.Entities;
 using API.Entities.Enums;
 using API.Services;
+using API.SignalR;
 using AutoMapper;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
@@ -156,7 +157,7 @@ public class BookmarkServiceTests
 
 
         var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), filesystem);
-        var bookmarkService = new BookmarkService(Substitute.For<ILogger<BookmarkService>>(), _unitOfWork, ds);
+        var bookmarkService = new BookmarkService(Substitute.For<ILogger<BookmarkService>>(), _unitOfWork, ds, Substitute.For<IArchiveService>(), Substitute.For<IEventHub>());
         var user = await _unitOfWork.UserRepository.GetUserByIdAsync(1, AppUserIncludes.Bookmarks);
 
         var result = await bookmarkService.BookmarkPage(user, new BookmarkDto()
@@ -226,7 +227,7 @@ public class BookmarkServiceTests
 
 
         var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), filesystem);
-        var bookmarkService = new BookmarkService(Substitute.For<ILogger<BookmarkService>>(), _unitOfWork, ds);
+        var bookmarkService = new BookmarkService(Substitute.For<ILogger<BookmarkService>>(), _unitOfWork, ds, Substitute.For<IArchiveService>(), Substitute.For<IEventHub>());
         var user = await _unitOfWork.UserRepository.GetUserByIdAsync(1, AppUserIncludes.Bookmarks);
 
         var result = await bookmarkService.RemoveBookmarkPage(user, new BookmarkDto()
@@ -318,7 +319,7 @@ public class BookmarkServiceTests
 
 
         var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), filesystem);
-        var bookmarkService = new BookmarkService(Substitute.For<ILogger<BookmarkService>>(), _unitOfWork, ds);
+        var bookmarkService = new BookmarkService(Substitute.For<ILogger<BookmarkService>>(), _unitOfWork, ds, Substitute.For<IArchiveService>(), Substitute.For<IEventHub>());
 
         await bookmarkService.DeleteBookmarkFiles(new [] {new AppUserBookmark()
         {
@@ -333,5 +334,66 @@ public class BookmarkServiceTests
         Assert.Equal(2, ds.GetFiles(BookmarkDirectory, searchOption:SearchOption.AllDirectories).Count());
         Assert.False(ds.FileSystem.FileInfo.FromFileName(Path.Join(BookmarkDirectory, "1/1/1/0001.jpg")).Exists);
     }
+    #endregion
+
+    #region GetBookmarkFilesById
+
+    [Fact]
+    public async Task GetBookmarkFilesById_ShouldMatchActualFiles()
+    {
+        var filesystem = CreateFileSystem();
+        filesystem.AddFile($"{CacheDirectory}1/0001.jpg", new MockFileData("123"));
+
+        // Delete all Series to reset state
+        await ResetDB();
+
+        _context.Series.Add(new Series()
+        {
+            Name = "Test",
+            Library = new Library() {
+                Name = "Test LIb",
+                Type = LibraryType.Manga,
+            },
+            Volumes = new List<Volume>()
+            {
+                new Volume()
+                {
+                    Chapters = new List<Chapter>()
+                    {
+                        new Chapter()
+                        {
+
+                        }
+                    }
+                }
+            }
+        });
+
+        _context.AppUser.Add(new AppUser()
+        {
+            UserName = "Joe"
+        });
+
+        await _context.SaveChangesAsync();
+
+
+        var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), filesystem);
+        var bookmarkService = new BookmarkService(Substitute.For<ILogger<BookmarkService>>(), _unitOfWork, ds, Substitute.For<IArchiveService>(), Substitute.For<IEventHub>());
+        var user = await _unitOfWork.UserRepository.GetUserByIdAsync(1, AppUserIncludes.Bookmarks);
+
+        await bookmarkService.BookmarkPage(user, new BookmarkDto()
+        {
+            ChapterId = 1,
+            Page = 1,
+            SeriesId = 1,
+            VolumeId = 1
+        }, $"{CacheDirectory}1/0001.jpg");
+
+        var files = await bookmarkService.GetBookmarkFilesById(1, new[] {1});
+        var actualFiles = ds.GetFiles(BookmarkDirectory, searchOption: SearchOption.AllDirectories);
+        Assert.Equal(files.Select(API.Parser.Parser.NormalizePath).ToList(), actualFiles.Select(API.Parser.Parser.NormalizePath).ToList());
+    }
+
+
     #endregion
 }

--- a/API.Tests/Services/BookmarkServiceTests.cs
+++ b/API.Tests/Services/BookmarkServiceTests.cs
@@ -157,7 +157,7 @@ public class BookmarkServiceTests
 
 
         var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), filesystem);
-        var bookmarkService = new BookmarkService(Substitute.For<ILogger<BookmarkService>>(), _unitOfWork, ds, Substitute.For<IArchiveService>(), Substitute.For<IEventHub>());
+        var bookmarkService = new BookmarkService(Substitute.For<ILogger<BookmarkService>>(), _unitOfWork, ds);
         var user = await _unitOfWork.UserRepository.GetUserByIdAsync(1, AppUserIncludes.Bookmarks);
 
         var result = await bookmarkService.BookmarkPage(user, new BookmarkDto()
@@ -227,7 +227,7 @@ public class BookmarkServiceTests
 
 
         var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), filesystem);
-        var bookmarkService = new BookmarkService(Substitute.For<ILogger<BookmarkService>>(), _unitOfWork, ds, Substitute.For<IArchiveService>(), Substitute.For<IEventHub>());
+        var bookmarkService = new BookmarkService(Substitute.For<ILogger<BookmarkService>>(), _unitOfWork, ds);
         var user = await _unitOfWork.UserRepository.GetUserByIdAsync(1, AppUserIncludes.Bookmarks);
 
         var result = await bookmarkService.RemoveBookmarkPage(user, new BookmarkDto()
@@ -319,7 +319,7 @@ public class BookmarkServiceTests
 
 
         var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), filesystem);
-        var bookmarkService = new BookmarkService(Substitute.For<ILogger<BookmarkService>>(), _unitOfWork, ds, Substitute.For<IArchiveService>(), Substitute.For<IEventHub>());
+        var bookmarkService = new BookmarkService(Substitute.For<ILogger<BookmarkService>>(), _unitOfWork, ds);
 
         await bookmarkService.DeleteBookmarkFiles(new [] {new AppUserBookmark()
         {
@@ -378,7 +378,7 @@ public class BookmarkServiceTests
 
 
         var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), filesystem);
-        var bookmarkService = new BookmarkService(Substitute.For<ILogger<BookmarkService>>(), _unitOfWork, ds, Substitute.For<IArchiveService>(), Substitute.For<IEventHub>());
+        var bookmarkService = new BookmarkService(Substitute.For<ILogger<BookmarkService>>(), _unitOfWork, ds);
         var user = await _unitOfWork.UserRepository.GetUserByIdAsync(1, AppUserIncludes.Bookmarks);
 
         await bookmarkService.BookmarkPage(user, new BookmarkDto()

--- a/API.Tests/Services/ReaderServiceTests.cs
+++ b/API.Tests/Services/ReaderServiceTests.cs
@@ -1568,7 +1568,7 @@ public class ReaderServiceTests
     }
 
     [Fact]
-    public async Task MarkChaptersUntilAsRead_ShouldNotReadOnlyVolumesWithChapter0()
+    public async Task MarkChaptersUntilAsRead_ShouldMarkAsRead_OnlyVolumesWithChapter0()
     {
         _context.Series.Add(new Series()
         {
@@ -1604,7 +1604,7 @@ public class ReaderServiceTests
         await _context.SaveChangesAsync();
 
         // Validate correct chapters have read status
-        Assert.False(await _unitOfWork.AppUserProgressRepository.UserHasProgress(LibraryType.Manga, 1));
+        Assert.True(await _unitOfWork.AppUserProgressRepository.UserHasProgress(LibraryType.Manga, 1));
     }
 
     #endregion

--- a/API/Parser/Parser.cs
+++ b/API/Parser/Parser.cs
@@ -120,7 +120,7 @@ namespace API.Parser
                 RegexTimeout),
             // Gokukoku no Brynhildr - c001-008 (v01) [TrinityBAKumA], Black Bullet - v4 c17 [batoto]
             new Regex(
-                @"(?<Series>.*)( - )(?:v|vo|c)\d",
+                @"(?<Series>.*)( - )(?:v|vo|c|chapters)\d",
                 MatchOptions, RegexTimeout),
             // Kedouin Makoto - Corpse Party Musume, Chapter 19 [Dametrans].zip
             new Regex(
@@ -153,16 +153,7 @@ namespace API.Parser
                 MatchOptions, RegexTimeout),
             // Historys Strongest Disciple Kenichi_v11_c90-98.zip, Killing Bites Vol. 0001 Ch. 0001 - Galactica Scanlations (gb)
             new Regex(
-                @"(?<Series>.*) (\b|_|-)(v|ch\.?|c)\d+",
-                MatchOptions, RegexTimeout),
-            //Ichinensei_ni_Nacchattara_v01_ch01_[Taruby]_v1.1.zip must be before [Suihei Kiki]_Kasumi_Otoko_no_Ko_[Taruby]_v1.1.zip
-            // due to duplicate version identifiers in file.
-            new Regex(
-                @"(?<Series>.*)(v|s)\d+(-\d+)?(_|\s)",
-                MatchOptions, RegexTimeout),
-            //[Suihei Kiki]_Kasumi_Otoko_no_Ko_[Taruby]_v1.1.zip
-            new Regex(
-                @"(?<Series>.*)(v|s)\d+(-\d+)?",
+                @"(?<Series>.*) (\b|_|-)(v|ch\.?|c|s)\d+",
                 MatchOptions, RegexTimeout),
             // Hinowa ga CRUSH! 018 (2019) (Digital) (LuCaZ).cbz
             new Regex(
@@ -170,7 +161,7 @@ namespace API.Parser
                 MatchOptions, RegexTimeout),
             // Goblin Slayer - Brand New Day 006.5 (2019) (Digital) (danke-Empire)
             new Regex(
-                @"(?<Series>.*) (?<Chapter>\d+(?:.\d+|-\d+)?) \(\d{4}\)",
+                @"(?<Series>.*) (-)?(?<Chapter>\d+(?:.\d+|-\d+)?) \(\d{4}\)",
                 MatchOptions, RegexTimeout),
             // Noblesse - Episode 429 (74 Pages).7z
             new Regex(
@@ -183,6 +174,23 @@ namespace API.Parser
             // Tonikaku Kawaii (Ch 59-67) (Ongoing)
             new Regex(
                 @"(?<Series>.*)(\s|_)\((c\s|ch\s|chapter\s)",
+                MatchOptions, RegexTimeout),
+            // Fullmetal Alchemist chapters 101-108
+            new Regex(
+                @"(?<Series>.+?)(\s|_|\-)+?chapters(\s|_|\-)+?\d+(\s|_|\-)+?",
+                MatchOptions, RegexTimeout),
+            // It's Witching Time! 001 (Digital) (Anonymous1234)
+            new Regex(
+                @"(?<Series>.+?)(\s|_|\-)+?\d+(\s|_|\-)\(",
+                MatchOptions, RegexTimeout),
+            //Ichinensei_ni_Nacchattara_v01_ch01_[Taruby]_v1.1.zip must be before [Suihei Kiki]_Kasumi_Otoko_no_Ko_[Taruby]_v1.1.zip
+            // due to duplicate version identifiers in file.
+            new Regex(
+                @"(?<Series>.*)(v|s)\d+(-\d+)?(_|\s)",
+                MatchOptions, RegexTimeout),
+            //[Suihei Kiki]_Kasumi_Otoko_no_Ko_[Taruby]_v1.1.zip
+            new Regex(
+                @"(?<Series>.*)(v|s)\d+(-\d+)?",
                 MatchOptions, RegexTimeout),
             // Black Bullet (This is very loose, keep towards bottom)
             new Regex(

--- a/API/Services/BookmarkService.cs
+++ b/API/Services/BookmarkService.cs
@@ -25,16 +25,12 @@ public class BookmarkService : IBookmarkService
     private readonly ILogger<BookmarkService> _logger;
     private readonly IUnitOfWork _unitOfWork;
     private readonly IDirectoryService _directoryService;
-    private readonly IArchiveService _archiveService;
-    private readonly IEventHub _eventHub;
 
-    public BookmarkService(ILogger<BookmarkService> logger, IUnitOfWork unitOfWork, IDirectoryService directoryService, IArchiveService archiveService, IEventHub eventHub)
+    public BookmarkService(ILogger<BookmarkService> logger, IUnitOfWork unitOfWork, IDirectoryService directoryService)
     {
         _logger = logger;
         _unitOfWork = unitOfWork;
         _directoryService = directoryService;
-        _archiveService = archiveService;
-        _eventHub = eventHub;
     }
 
     /// <summary>

--- a/API/Services/ReaderService.cs
+++ b/API/Services/ReaderService.cs
@@ -394,7 +394,7 @@ public class ReaderService : IReaderService
         {
             var chapters = volume.Chapters
                 .OrderBy(c => float.Parse(c.Number))
-                .Where(c => !c.IsSpecial && Parser.Parser.MaximumNumberFromRange(c.Range) <= chapterNumber && Parser.Parser.MaximumNumberFromRange(c.Range) > 0.0);
+                .Where(c => !c.IsSpecial && Parser.Parser.MaximumNumberFromRange(c.Range) <= chapterNumber);
             MarkChaptersAsRead(user, volume.SeriesId, chapters);
         }
     }

--- a/API/Services/SeriesService.cs
+++ b/API/Services/SeriesService.cs
@@ -105,6 +105,8 @@ public class SeriesService : ISeriesService
                             updateSeriesMetadataDto.SeriesMetadata.SeriesId), false);
                 }
 
+                await _unitOfWork.CollectionTagRepository.RemoveTagsWithoutSeries();
+
                 return true;
             }
         }

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -882,9 +882,9 @@ public class ScannerService : IScannerService
             chapter.TotalCount = comicInfo.Count;
         }
 
-        if (!string.IsNullOrEmpty(comicInfo.Number) && int.Parse(comicInfo.Number) > 0)
+        if (!string.IsNullOrEmpty(comicInfo.Number) && float.Parse(comicInfo.Number) > 0)
         {
-            chapter.Count = int.Parse(comicInfo.Number);
+            chapter.Count = (int) Math.Floor(float.Parse(comicInfo.Number));
         }
 
 

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -439,6 +439,11 @@ public class ScannerService : IScannerService
             try
             {
                 await _unitOfWork.CommitAsync();
+
+                // Update the people, genres, and tags after committing as we might have inserted new ones.
+                allPeople = await _unitOfWork.PersonRepository.GetAllPeople();
+                allGenres = await _unitOfWork.GenreRepository.GetAllGenresAsync();
+                allTags = await _unitOfWork.TagRepository.GetAllTagsAsync();
             }
             catch (Exception ex)
             {
@@ -463,7 +468,6 @@ public class ScannerService : IScannerService
 
             foreach (var series in librarySeries)
             {
-                // TODO: Do I need this? Shouldn't this be NotificationProgress
                 // This is something more like, the series has finished updating in the backend. It may or may not have been modified.
                 await _eventHub.SendMessageAsync(MessageFactory.ScanSeries, MessageFactory.ScanSeriesEvent(series.Id, series.Name));
             }

--- a/UI/Web/src/app/cards/card-detail-layout/card-detail-layout.component.ts
+++ b/UI/Web/src/app/cards/card-detail-layout/card-detail-layout.component.ts
@@ -156,7 +156,8 @@ export class CardDetailLayoutComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    this.trackByIdentity = (index: number, item: any) => `${this.header}_${this.pagination?.currentPage}_${this.updateApplied}`;
+    this.trackByIdentity = (index: number, item: any) => `${this.header}_${this.pagination?.currentPage}_${this.updateApplied}_${item?.libraryId}`;
+
 
     if (this.filterSettings === undefined) {
       this.filterSettings = new FilterSettings();

--- a/UI/Web/src/app/cards/cover-image-chooser/cover-image-chooser.component.html
+++ b/UI/Web/src/app/cards/cover-image-chooser/cover-image-chooser.component.html
@@ -6,15 +6,15 @@
                 <div class="row g-0 mt-3 pb-3" *ngIf="mode === 'all'">
                     <div class="mx-auto">
                         <div class="row g-0 mb-3">
-                            <i class="fa fa-file-upload mx-auto" style="font-size: 24px;" aria-hidden="true"></i>
+                            <i class="fa fa-file-upload mx-auto" style="font-size: 24px; width: 20px;" aria-hidden="true"></i>
                         </div>
                         
                         <div class="row g-0">
-                            <div class="mx-auto">
-                                <a class="col" style="padding-right:0px" href="javascript:void(0)" (click)="mode = 'url'; setupEnterHandler()"><span class="phone-hidden">Enter a </span>Url</a>
-                                <span class="col" style="padding-right:0px">•</span>
+                            <div class="mx-auto" style="width: 350px;">
+                                <a class="col" style="padding-right:0px" href="javascript:void(0)" (click)="changeMode('url')"><span class="phone-hidden">Enter a </span>Url</a>
+                                <span class="col ps-1 pe-1">•</span>
                                 <span class="col" style="padding-right:0px" href="javascript:void(0)">Drag and drop</span>
-                                <span class="col" style="padding-right:0px">•</span>
+                                <span class="col ps-1 pe-1" style="padding-right:0px">•</span>
                                 <a class="col" style="padding-right:0px" href="javascript:void(0)" (click)="openFileSelector()">Upload<span class="phone-hidden"> an image</span></a>
                             </div>
                         </div>
@@ -24,17 +24,14 @@
 
                 <ng-container *ngIf="mode === 'url'">
                     <div class="row g-0 mt-3 pb-3 ms-md-2 me-md-2">
-                        <div class="input-group col-md-10 me-md-2" style="width: 100%">
-                            <!-- TOOD: Bootstrap migration: This should be replaced with just the label-->
-                            <div class="input-group-prepend">
-                                <label class="input-group-text form-label" for="load-image">Url</label>
-                            </div>
-                            <input type="text" autocomplete="off" class="form-control" formControlName="coverImageUrl" placeholder="https://" id="load-image" class="form-control">
+                        <div class="input-group col-auto me-md-2" style="width: 83%">
+                            <label class="input-group-text" for="load-image">Url</label>
+                            <input type="text" autofocus autocomplete="off" class="form-control" formControlName="coverImageUrl" placeholder="https://" id="load-image" class="form-control">
                             <button class="btn btn-outline-secondary" type="button" id="load-image-addon" (click)="loadImage(); mode='all';" [disabled]="form.get('coverImageUrl')?.value.length === 0">
                                 Load
                             </button>
                         </div>
-                        <button class="col btn btn-secondary" href="javascript:void(0)" (click)="mode = 'all'" aria-label="Back">
+                        <button class="btn btn-secondary col-auto" href="javascript:void(0)" (click)="mode = 'all'" aria-label="Back">
                             <i class="fas fa-share" aria-hidden="true" style="transform: rotateY(180deg)"></i>&nbsp;
                             <span class="phone-hidden">Back</span>
                         </button>

--- a/UI/Web/src/app/cards/cover-image-chooser/cover-image-chooser.component.ts
+++ b/UI/Web/src/app/cards/cover-image-chooser/cover-image-chooser.component.ts
@@ -103,6 +103,14 @@ export class CoverImageChooserComponent implements OnInit, OnDestroy {
       this.form.get('coverImageUrl')?.setValue('');
     }
   }
+
+  changeMode(mode: 'url') {
+    this.mode = mode; 
+    this.setupEnterHandler();
+    setTimeout(() => {
+      
+    })
+  }
   
 
 

--- a/UI/Web/src/app/manga-reader/manga-reader.component.ts
+++ b/UI/Web/src/app/manga-reader/manga-reader.component.ts
@@ -892,6 +892,12 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       if (!this.shouldRenderAsFitSplit()) {
         this.setCanvasSize();
         this.ctx.drawImage(this.canvasImage, 0, 0);
+
+        // Reset scroll on non HEIGHT Fits
+        if (this.getFit() !== FITTING_OPTION.HEIGHT) {
+          window.scrollTo(0, 0);
+        }
+
         this.isLoading = false;
         return;
       }


### PR DESCRIPTION
# Added
- Added: Added file parsing support for 'Series 001 (Digital) (Name123)'  (Fixes #1060)

# Changed
- Changed: Removed file parsing support for 'A Compendium of Ghosts - 031 - The Third Story_ Part 12' due to complexity in parsing
- Changed: Changed how a Tachiyomi API works to have Volumes with a single 0 chapter marked as read when MarkChaptersUntilAsRead used.

# Fixed
- Fixed: Fixed a bug where ComicInfo count can be a float and we threw a parse error expecting it to be an int (Fixes #1122 )
- Fixed: Fixed a bug in download bookmarks which didn't properly create the filenames for downloading, resulting in an empty zip
- Fixed: Fixed an issue where card detail layout wouldn't refresh the library name on the card between pages (Fixes #1109 )
- Fixed: Fixed an issue where a check to scrolling page back to top was missing in the manga reader (Fixes #1116 )
- Fixed: Fixed a bug where cleaning up collection tags without Series was missing after editing a series (Fixes #1105 )
- Fixed: Fixed the broken styles on cover chooser after bootstrap upgrade (develop)

Closes #1080
Closes #1086 