### PR TITLE
Duplicate Bookmark names will allow downloading

### DIFF
--- a/API/Services/DirectoryService.cs
+++ b/API/Services/DirectoryService.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
@@ -354,6 +354,7 @@ namespace API.Services
        /// <summary>
        /// Copies files to a destination directory. If the destination directory doesn't exist, this will create it.
        /// </summary>
+       /// <remarks>If a file already exists in dest, this will rename as (2). It does not support multiple iterations of this. Overwriting is not supported.</remarks>
        /// <param name="filePaths"></param>
        /// <param name="directoryPath"></param>
        /// <param name="prepend">An optional string to prepend to the target file's name</param>
@@ -370,7 +371,16 @@ namespace API.Services
                    var fileInfo = FileSystem.FileInfo.FromFileName(file);
                    if (fileInfo.Exists)
                    {
-                       fileInfo.CopyTo(FileSystem.Path.Join(directoryPath, prepend + fileInfo.Name));
+                       // TODO: I need to handle if file already exists and allow either an overwrite or prepend (2) to it
+                       try
+                       {
+                           fileInfo.CopyTo(FileSystem.Path.Join(directoryPath, prepend + fileInfo.Name));
+                       }
+                       catch (IOException ex)
+                       {
+                           _logger.LogError(ex, "File copy, dest already exists. Appending (2)");
+                           fileInfo.CopyTo(FileSystem.Path.Join(directoryPath, prepend + FileSystem.Path.GetFileNameWithoutExtension(fileInfo.Name) + " (2)" + FileSystem.Path.GetExtension(fileInfo.Name)));
+                       }
                    }
                    else
                    {


### PR DESCRIPTION
# Changed
- Changed: CopyFilesToDirectory will now allow for one duplicate copy over and put (2). This allows for old bookmarks to handle duplicates on download.
