### PR TITLE
On Deck tweaks + Bugfixes

### DIFF
--- a/API.Tests/Parser/ParserTest.cs
+++ b/API.Tests/Parser/ParserTest.cs
@@ -208,6 +208,9 @@ namespace API.Tests.Parser
         [InlineData("MACOSX/Love Hina/", false)]
         [InlineData("._Love Hina/Love Hina/", true)]
         [InlineData("@Recently-Snapshot/Love Hina/", true)]
+        [InlineData("@recycle/Love Hina/", true)]
+        [InlineData("@recycle/Love Hina/", true)]
+        [InlineData("E:/Test/__MACOSX/Love Hina/", true)]
         public void HasBlacklistedFolderInPathTest(string inputPath, bool expected)
         {
             Assert.Equal(expected, HasBlacklistedFolderInPath(inputPath));

--- a/API.Tests/Services/DirectoryServiceTests.cs
+++ b/API.Tests/Services/DirectoryServiceTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Abstractions.TestingHelpers;
@@ -753,6 +753,22 @@ namespace API.Tests.Services
             Assert.Equal(2, ds.GetFiles(testDirectory).Count());
             Assert.False(fileSystem.FileExists($"{testDirectory}subdir/data-3.webp"));
             Assert.True(fileSystem.Directory.Exists($"{testDirectory}subdir/"));
+        }
+
+        [Fact]
+        public void Flatten_ShouldFlatten_WithoutMacosx()
+        {
+            const string testDirectory = "/manga/";
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(testDirectory);
+            fileSystem.AddFile($"{testDirectory}data-1.jpg", new MockFileData("abc"));
+            fileSystem.AddFile($"{testDirectory}subdir/data-3.webp", new MockFileData("abc"));
+            fileSystem.AddFile($"{testDirectory}__MACOSX/data-4.webp", new MockFileData("abc"));
+
+            var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), fileSystem);
+            ds.Flatten($"{testDirectory}");
+            Assert.Equal(2, ds.GetFiles(testDirectory).Count());
+            Assert.False(fileSystem.FileExists($"{testDirectory}data-4.webp"));
         }
 
         #endregion

--- a/API/Parser/Parser.cs
+++ b/API/Parser/Parser.cs
@@ -1003,7 +1003,7 @@ namespace API.Parser
 
         public static bool HasBlacklistedFolderInPath(string path)
         {
-            return path.Contains("__MACOSX") || path.StartsWith("@Recently-Snapshot") || path.StartsWith("._");
+            return path.Contains("__MACOSX") || path.StartsWith("@Recently-Snapshot") || path.StartsWith("@recycle") || path.StartsWith("._");
         }
 
 

--- a/API/Services/DirectoryService.cs
+++ b/API/Services/DirectoryService.cs
@@ -703,7 +703,7 @@ namespace API.Services
         }
 
 
-        private void FlattenDirectory(IDirectoryInfo root, IDirectoryInfo directory, ref int directoryIndex)
+        private static void FlattenDirectory(IFileSystemInfo root, IDirectoryInfo directory, ref int directoryIndex)
         {
             if (!root.FullName.Equals(directory.FullName))
             {
@@ -725,6 +725,9 @@ namespace API.Services
 
             foreach (var subDirectory in directory.EnumerateDirectories().OrderByNatural(d => d.FullName))
             {
+                // We need to check if the directory is not a blacklisted (ie __MACOSX)
+                if (Parser.Parser.HasBlacklistedFolderInPath(subDirectory.FullName)) continue;
+
                 FlattenDirectory(root, subDirectory, ref directoryIndex);
             }
         }

--- a/API/Services/EmailService.cs
+++ b/API/Services/EmailService.cs
@@ -149,8 +149,9 @@ public class EmailService : IEmailService
         return true;
     }
 
-    private static bool IsLocalIpAddress(string host)
+    private static bool IsLocalIpAddress(string url)
     {
+        var host = url.Split(':')[0];
         try
         {
             // get host IP addresses

--- a/API/Services/EmailService.cs
+++ b/API/Services/EmailService.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 using API.Data;
 using API.DTOs.Email;
@@ -40,14 +42,22 @@ public class EmailService : IEmailService
             cli.Settings.HttpClientFactory = new UntrustedCertClientFactory());
     }
 
+    /// <summary>
+    /// Test if this instance is accessible outside the network
+    /// </summary>
+    /// <remarks>This will do some basic filtering to auto return false if the emailUrl is a LAN ip</remarks>
+    /// <param name="emailUrl"></param>
+    /// <returns></returns>
     public async Task<EmailTestResultDto> TestConnectivity(string emailUrl)
     {
-        // FlurlHttp.ConfigureClient(emailUrl, cli =>
-        //     cli.Settings.HttpClientFactory = new UntrustedCertClientFactory());
-
         var result = new EmailTestResultDto();
         try
         {
+            if (IsLocalIpAddress(emailUrl))
+            {
+                result.Successful = false;
+                result.ErrorMessage = "This is a local IP address";
+            }
             result.Successful = await SendEmailWithGet(emailUrl + "/api/email/test");
         }
         catch (KavitaException ex)
@@ -72,6 +82,7 @@ public class EmailService : IEmailService
     public async Task<bool> CheckIfAccessible(string host)
     {
         // This is the only exception for using the default because we need an external service to check if the server is accessible for emails
+        if (IsLocalIpAddress(host)) return false;
         return await SendEmailWithGet(DefaultApiUrl + "/api/email/reachable?host=" + host);
     }
 
@@ -136,6 +147,35 @@ public class EmailService : IEmailService
             return false;
         }
         return true;
+    }
+
+    private static bool IsLocalIpAddress(string host)
+    {
+        try
+        {
+            // get host IP addresses
+            var hostIPs = Dns.GetHostAddresses(host);
+            // get local IP addresses
+            var localIPs = Dns.GetHostAddresses(Dns.GetHostName());
+
+            // test if any host IP equals to any local IP or to localhost
+            foreach (var hostIp in hostIPs)
+            {
+                // is localhost
+                if (IPAddress.IsLoopback(hostIp)) return true;
+                // is local address
+                if (localIPs.Contains(hostIp))
+                {
+                    return true;
+                }
+            }
+        }
+        catch
+        {
+            // ignored
+        }
+
+        return false;
     }
 
 }

--- a/UI/Web/src/app/library/library.component.html
+++ b/UI/Web/src/app/library/library.component.html
@@ -12,25 +12,25 @@
 </app-carousel-reel>
 
 <!-- TODO: Refactor this so we can use series actions here -->
-<app-carousel-reel [items]="recentlyUpdatedSeries" title="Recently Updated Series">
+<app-carousel-reel [items]="recentlyUpdatedSeries" title="Recently Updated Series"  (sectionClick)="handleSectionClick($event)">
     <ng-template #carouselItem let-item let-position="idx">
         <app-card-item [entity]="item" [title]="item.seriesName" [imageUrl]="imageService.getSeriesCoverImage(item.seriesId)" 
         [supressArchiveWarning]="true" (clicked)="handleRecentlyAddedChapterClick(item)" [count]="item.count"></app-card-item>
     </ng-template>
 </app-carousel-reel>
 
-<app-carousel-reel [items]="recentlyAddedSeries" title="Recently Added Series" (sectionClick)="handleSectionClick($event)">
+<app-carousel-reel [items]="recentlyAddedSeries" title="Newly Added Series">
     <ng-template #carouselItem let-item let-position="idx">
         <app-series-card [data]="item" [libraryId]="item.libraryId" (dataChanged)="loadRecentlyAddedSeries()"></app-series-card>
     </ng-template>
 </app-carousel-reel>
 
-<app-carousel-reel [items]="recentlyAddedChapters" title="Recently Added" (sectionClick)="handleSectionClick($event)">
+<!-- <app-carousel-reel [items]="recentlyAddedChapters" title="Recently Added" (sectionClick)="handleSectionClick($event)">
     <ng-template #carouselItem let-item let-position="idx">
         <app-card-item [entity]="item" [title]="item.title" [subtitle]="item.seriesName" [imageUrl]="imageService.getRecentlyAddedItem(item)" 
         [supressArchiveWarning]="true" (clicked)="handleRecentlyAddedChapterClick(item)"></app-card-item>
     </ng-template>
-</app-carousel-reel>
+</app-carousel-reel> -->
 
 <app-carousel-reel [items]="libraries" title="Libraries" (sectionClick)="handleSectionClick($event)">
     <ng-template #carouselItem let-item let-position="idx">

--- a/UI/Web/src/app/library/library.component.ts
+++ b/UI/Web/src/app/library/library.component.ts
@@ -138,7 +138,7 @@ export class LibraryComponent implements OnInit, OnDestroy {
   handleSectionClick(sectionTitle: string) {
     if (sectionTitle.toLowerCase() === 'collections') {
       this.router.navigate(['collections']);
-    } else if (sectionTitle.toLowerCase() === 'recently added') {
+    } else if (sectionTitle.toLowerCase() === 'recently updated series') {
       this.router.navigate(['recently-added']);
     } else if (sectionTitle.toLowerCase() === 'on deck') {
       this.router.navigate(['on-deck']);

--- a/UI/Web/src/app/shared/confirm.service.ts
+++ b/UI/Web/src/app/shared/confirm.service.ts
@@ -41,7 +41,7 @@ export class ConfirmService {
         return resolve(result);
       });
       modalRef.dismissed.pipe(take(1)).subscribe(() => {
-        return reject(false);
+        return resolve(false);
       });
     });
 
@@ -65,7 +65,7 @@ export class ConfirmService {
         return resolve(result);
       });
       modalRef.dismissed.pipe(take(1)).subscribe(() => {
-        return reject(false);
+        return resolve(false);
       });
     })
   }


### PR DESCRIPTION
# Changed
- Changed: Tweaked on deck to only show series that have progress within 30 days. 

# Fixed
- Fixed: Fixed a bug where archives with __MACOSX inside would break the reader during flattening (Fixes #1134 )
- Fixed: Fixed a bug where confirm service rejection wasn't handled correctly
- Fixed: Fixed an issue where checking if server was available for email services on a local ip or loopback wouldn't fail correctly

