### PR TITLE
Release Shakeout Part 1

### DIFF
--- a/API.Tests/Comparers/SortComparerZeroLastTests.cs
+++ b/API.Tests/Comparers/SortComparerZeroLastTests.cs
@@ -1,0 +1,17 @@
+﻿using System.Linq;
+using API.Comparators;
+using Xunit;
+
+namespace API.Tests.Comparers;
+
+public class SortComparerZeroLastTests
+{
+    [Theory]
+    [InlineData(new[] {0, 1, 2,}, new[] {1, 2, 0})]
+    [InlineData(new[] {3, 1, 2}, new[] {1, 2, 3})]
+    [InlineData(new[] {0, 0, 1}, new[] {1, 0, 0})]
+    public void SortComparerZeroLastTest(int[] input, int[] expected)
+    {
+        Assert.Equal(expected, input.OrderBy(f => f, new SortComparerZeroLast()).ToArray());
+    }
+}

--- a/API.Tests/Services/ReaderServiceTests.cs
+++ b/API.Tests/Services/ReaderServiceTests.cs
@@ -1625,6 +1625,11 @@ public class ReaderServiceTests
                     EntityFactory.CreateChapter("2", false, new List<MangaFile>(), 1),
                     EntityFactory.CreateChapter("3", false, new List<MangaFile>(), 1),
                 }),
+                EntityFactory.CreateVolume("1", new List<Chapter>()
+                {
+                    EntityFactory.CreateChapter("11", false, new List<MangaFile>(), 1),
+                    EntityFactory.CreateChapter("22", false, new List<MangaFile>(), 1),
+                }),
             }
         });
 
@@ -1638,33 +1643,13 @@ public class ReaderServiceTests
         var readerService = new ReaderService(_unitOfWork, Substitute.For<ILogger<ReaderService>>());
 
         // Save progress on first volume chapters and 1st of second volume
-        await readerService.SaveReadingProgress(new ProgressDto()
-        {
-            PageNum = 1,
-            ChapterId = 1,
-            SeriesId = 1,
-            VolumeId = 1
-        }, 1);
-        await readerService.SaveReadingProgress(new ProgressDto()
-        {
-            PageNum = 1,
-            ChapterId = 2,
-            SeriesId = 1,
-            VolumeId = 1
-        }, 1);
-        await readerService.SaveReadingProgress(new ProgressDto()
-        {
-            PageNum = 1,
-            ChapterId = 3,
-            SeriesId = 1,
-            VolumeId = 1
-        }, 1);
-
+        var user = await _unitOfWork.UserRepository.GetUserByIdAsync(1, AppUserIncludes.Progress);
+        await readerService.MarkSeriesAsRead(user, 1);
         await _context.SaveChangesAsync();
 
         var nextChapter = await readerService.GetContinuePoint(1, 1);
 
-        Assert.Equal("1", nextChapter.Range);
+        Assert.Equal("11", nextChapter.Range);
     }
 
     [Fact]

--- a/API/Comparators/ChapterSortComparer.cs
+++ b/API/Comparators/ChapterSortComparer.cs
@@ -45,4 +45,18 @@ namespace API.Comparators
             return x.CompareTo(y);
         }
     }
+
+    public class SortComparerZeroLast : IComparer<double>
+    {
+        public int Compare(double x, double y)
+        {
+            if (x == 0.0 && y == 0.0) return 0;
+            // if x is 0, it comes last
+            if (x == 0.0) return 1;
+            // if y is 0, it comes last
+            if (y == 0.0) return -1;
+
+            return x.CompareTo(y);
+        }
+    }
 }

--- a/UI/Web/src/app/book-reader/book-reader/book-reader.component.ts
+++ b/UI/Web/src/app/book-reader/book-reader/book-reader.component.ts
@@ -740,7 +740,8 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       setTimeout(() => {
         this.addLinkClickHandlers();
         this.updateReaderStyles();
-        this.topOffset = this.stickyTopElemRef.nativeElement?.offsetHeight;
+        // We need to get the offset after we ensure the title has rendered
+        requestAnimationFrame(() => this.topOffset = this.stickyTopElemRef.nativeElement?.getBoundingClientRect().height);
 
         const imgs = this.readingSectionElemRef.nativeElement.querySelectorAll('img');
         if (imgs === null || imgs.length === 0) {

--- a/UI/Web/src/app/series-detail/series-detail.component.html
+++ b/UI/Web/src/app/series-detail/series-detail.component.html
@@ -31,6 +31,12 @@
                         </span>
                     </button>
                 </div>
+                <div class="col-auto ms-2">
+                    <div class="card-actions">
+                        <app-card-actionables [disabled]="actionInProgress" (actionHandler)="performAction($event)" [actions]="seriesActions" [labelBy]="series.name" iconClass="fa-ellipsis-h" btnClass="btn-secondary"></app-card-actionables>
+                    </div>
+                </div>
+                
                 <div class="col-auto ms-2" *ngIf="isAdmin || hasDownloadingRole">
                     <button class="btn btn-secondary" (click)="downloadSeries()" title="Download Series" [disabled]="downloadInProgress">
                         <ng-container *ngIf="downloadInProgress; else notDownloading">


### PR DESCRIPTION
# Changed
- Changed: Added back actions button on series detail (develop)

# Fixed
- Fixed: Fixed a bug where top action bar could result in covering up the book contents when the title is really long (develop)
- Fixed: Fixed a bug in Get Continue Point where in some edge conditions, the first chapter of the first volume wasn't being selected when the whole series was read.