### PR TITLE
Hotfix 0.5.2.3 - SortName & Invite User Redirect fix

### DIFF
--- a/API.Tests/Parser/ParserTest.cs
+++ b/API.Tests/Parser/ParserTest.cs
@@ -210,7 +210,6 @@ namespace API.Tests.Parser
         [InlineData("._Love Hina/Love Hina/", true)]
         [InlineData("@Recently-Snapshot/Love Hina/", true)]
         [InlineData("@recycle/Love Hina/", true)]
-        [InlineData("@recycle/Love Hina/", true)]
         [InlineData("E:/Test/__MACOSX/Love Hina/", true)]
         public void HasBlacklistedFolderInPathTest(string inputPath, bool expected)
         {

--- a/API.Tests/Services/DirectoryServiceTests.cs
+++ b/API.Tests/Services/DirectoryServiceTests.cs
@@ -557,6 +557,24 @@ namespace API.Tests.Services
             Assert.Equal(2, ds.GetFiles("/manga/output/").Count());
         }
 
+        [Fact]
+        public void CopyFilesToDirectory_ShouldAppendWhenTargetFileExists()
+        {
+            const string testDirectory = "/manga/";
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddFile($"{testDirectory}file.zip", new MockFileData(""));
+            fileSystem.AddFile($"/manga/output/file (1).zip", new MockFileData(""));
+            fileSystem.AddFile($"/manga/output/file (2).zip", new MockFileData(""));
+
+            var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), fileSystem);
+            ds.CopyFilesToDirectory(new []{$"{testDirectory}file.zip"}, "/manga/output/");
+            ds.CopyFilesToDirectory(new []{$"{testDirectory}file.zip"}, "/manga/output/");
+            var outputFiles = ds.GetFiles("/manga/output/").Select(API.Parser.Parser.NormalizePath).ToList();
+            Assert.Equal(4, outputFiles.Count()); // we have 2 already there and 2 copies
+            // For some reason, this has C:/ on directory even though everything is emulated
+            Assert.True(outputFiles.Contains(API.Parser.Parser.NormalizePath("/manga/output/file (3).zip")) || outputFiles.Contains(API.Parser.Parser.NormalizePath("C:/manga/output/file (3).zip")));
+        }
+
         #endregion
 
         #region ListDirectory

--- a/API/Controllers/AccountController.cs
+++ b/API/Controllers/AccountController.cs
@@ -423,7 +423,6 @@ namespace API.Controllers
 
                 var emailLink = GenerateEmailLink(token, "confirm-email", dto.Email);
                 _logger.LogCritical("[Invite User]: Email Link for {UserName}: {Link}", user.UserName, emailLink);
-
                 var host = _environment.IsDevelopment() ? "localhost:4200" : Request.Host.ToString();
                 var accessible = await _emailService.CheckIfAccessible(host);
                 if (accessible)

--- a/API/Controllers/DownloadController.cs
+++ b/API/Controllers/DownloadController.cs
@@ -26,20 +26,18 @@ namespace API.Controllers
         private readonly IDirectoryService _directoryService;
         private readonly IDownloadService _downloadService;
         private readonly IEventHub _eventHub;
-        private readonly UserManager<AppUser> _userManager;
         private readonly ILogger<DownloadController> _logger;
         private readonly IBookmarkService _bookmarkService;
         private const string DefaultContentType = "application/octet-stream";
 
         public DownloadController(IUnitOfWork unitOfWork, IArchiveService archiveService, IDirectoryService directoryService,
-            IDownloadService downloadService, IEventHub eventHub, UserManager<AppUser> userManager, ILogger<DownloadController> logger, IBookmarkService bookmarkService)
+            IDownloadService downloadService, IEventHub eventHub, ILogger<DownloadController> logger, IBookmarkService bookmarkService)
         {
             _unitOfWork = unitOfWork;
             _archiveService = archiveService;
             _directoryService = directoryService;
             _downloadService = downloadService;
             _eventHub = eventHub;
-            _userManager = userManager;
             _logger = logger;
             _bookmarkService = bookmarkService;
         }

--- a/API/Controllers/OPDSController.cs
+++ b/API/Controllers/OPDSController.cs
@@ -782,6 +782,7 @@ public class OpdsController : BaseApiController
             {
                 CreateLink(FeedLinkRelation.Image, FeedLinkType.Image, $"/api/image/chapter-cover?chapterId={chapterId}"),
                 CreateLink(FeedLinkRelation.Thumbnail, FeedLinkType.Image, $"/api/image/chapter-cover?chapterId={chapterId}"),
+                // We can't not include acc link in the feed, panels doesn't work with just page streaming option. We have to block download directly
                 accLink,
                 CreatePageStreamLink(seriesId, volumeId, chapterId, mangaFile, apiKey)
             },
@@ -791,14 +792,6 @@ public class OpdsController : BaseApiController
                 Type = "text"
             }
         };
-
-        // We can't not show acc link in the feed, panels wont work like that. We have to block download directly
-        // var user = await _unitOfWork.UserRepository.GetUserByIdAsync(await GetUser(apiKey));
-        // if (await _downloadService.HasDownloadPermission(user))
-        // {
-        //     entry.Links.Add(accLink);
-        // }
-
 
         return entry;
     }

--- a/API/Controllers/SeriesController.cs
+++ b/API/Controllers/SeriesController.cs
@@ -145,13 +145,20 @@ namespace API.Controllers
 
             if (series == null) return BadRequest("Series does not exist");
 
-            if (series.Name != updateSeries.Name && await _unitOfWork.SeriesRepository.DoesSeriesNameExistInLibrary(updateSeries.Name, series.Format))
+            var seriesExists =
+                await _unitOfWork.SeriesRepository.DoesSeriesNameExistInLibrary(updateSeries.Name.Trim(), series.LibraryId,
+                    series.Format);
+            if (series.Name != updateSeries.Name && seriesExists)
             {
                 return BadRequest("A series already exists in this library with this name. Series Names must be unique to a library.");
             }
 
             series.Name = updateSeries.Name.Trim();
-            series.SortName = updateSeries.SortName.Trim();
+            if (!string.IsNullOrEmpty(updateSeries.SortName.Trim()))
+            {
+                series.SortName = updateSeries.SortName.Trim();
+            }
+
             series.LocalizedName = updateSeries.LocalizedName.Trim();
 
             series.NameLocked = updateSeries.NameLocked;

--- a/API/DTOs/SeriesMetadataDto.cs
+++ b/API/DTOs/SeriesMetadataDto.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using API.DTOs.CollectionTags;
 using API.DTOs.Metadata;
 using API.Entities.Enums;
@@ -8,7 +9,7 @@ namespace API.DTOs
     public class SeriesMetadataDto
     {
         public int Id { get; set; }
-        public string Summary { get; set; }
+        public string Summary { get; set; } = string.Empty;
         /// <summary>
         /// Collections the Series belongs to
         /// </summary>

--- a/API/Data/DbFactory.cs
+++ b/API/Data/DbFactory.cs
@@ -18,7 +18,7 @@ namespace API.Data
     {
         public static Series Series(string name)
         {
-            return new ()
+            return new Series
             {
                 Name = name,
                 OriginalName = name,

--- a/API/Data/Repositories/SeriesRepository.cs
+++ b/API/Data/Repositories/SeriesRepository.cs
@@ -47,7 +47,7 @@ public interface ISeriesRepository
     void Update(Series series);
     void Remove(Series series);
     void Remove(IEnumerable<Series> series);
-    Task<bool> DoesSeriesNameExistInLibrary(string name, MangaFormat format);
+    Task<bool> DoesSeriesNameExistInLibrary(string name, int libraryId, MangaFormat format);
     /// <summary>
     /// Adds user information like progress, ratings, etc
     /// </summary>
@@ -135,17 +135,12 @@ public class SeriesRepository : ISeriesRepository
     /// <param name="name">Name of series</param>
     /// <param name="format">Format of series</param>
     /// <returns></returns>
-    public async Task<bool> DoesSeriesNameExistInLibrary(string name, MangaFormat format)
+    public async Task<bool> DoesSeriesNameExistInLibrary(string name, int libraryId, MangaFormat format)
     {
-        var libraries = _context.Series
-            .AsNoTracking()
-            .Where(x => x.Name.Equals(name) && x.Format == format)
-            .Select(s => s.LibraryId);
-
         return await _context.Series
             .AsNoTracking()
-            .Where(s => libraries.Contains(s.LibraryId) && s.Name.Equals(name) && s.Format == format)
-            .CountAsync() > 1;
+            .Where(s => s.LibraryId == libraryId && s.Name.Equals(name) && s.Format == format)
+            .AnyAsync();
     }
 
 
@@ -378,7 +373,7 @@ public class SeriesRepository : ISeriesRepository
 
 
     /// <summary>
-    /// Returns Volumes, Metadata, and Collection Tags
+    /// Returns Volumes, Metadata (Incl Genres and People), and Collection Tags
     /// </summary>
     /// <param name="seriesId"></param>
     /// <returns></returns>
@@ -624,13 +619,13 @@ public class SeriesRepository : ISeriesRepository
                     LastReadingProgress = _context.AppUserProgresses
                         .Where(p => p.Id == progress.Id && p.AppUserId == userId)
                         .Max(p => p.LastModified),
-                    // BUG: This is only taking into account chapters that have progress on them, not all chapters in said series
-                    LastChapterCreated = _context.Chapter.Where(c => progress.ChapterId == c.Id).Max(c => c.Created),
-                    //LastChapterCreated = _context.Chapter.Where(c => allChapters.Contains(c.Id)).Max(c => c.Created)
+                    // This is only taking into account chapters that have progress on them, not all chapters in said series
+                    //LastChapterCreated = _context.Chapter.Where(c => progress.ChapterId == c.Id).Max(c => c.Created),
+                    LastChapterCreated = s.Volumes.SelectMany(v => v.Chapters).Max(c => c.Created)
                 });
         if (cutoffOnDate)
         {
-            query = query.Where(d => d.LastReadingProgress >= cutoffProgressPoint);
+            query = query.Where(d => d.LastReadingProgress >= cutoffProgressPoint || d.LastChapterCreated >= cutoffProgressPoint);
         }
 
         // I think I need another Join statement. The problem is the chapters are still limited to progress

--- a/API/Entities/Metadata/SeriesMetadata.cs
+++ b/API/Entities/Metadata/SeriesMetadata.cs
@@ -11,7 +11,7 @@ namespace API.Entities.Metadata
     {
         public int Id { get; set; }
 
-        public string Summary { get; set; }
+        public string Summary { get; set; } = string.Empty;
 
         public ICollection<CollectionTag> CollectionTags { get; set; }
 

--- a/API/Extensions/ApplicationServiceExtensions.cs
+++ b/API/Extensions/ApplicationServiceExtensions.cs
@@ -48,11 +48,6 @@ namespace API.Extensions
             services.AddScoped<IFileService, FileService>();
             services.AddScoped<ICacheHelper, CacheHelper>();
 
-
-            services.AddScoped<IFileSystem, FileSystem>();
-            services.AddScoped<IFileService, FileService>();
-            services.AddScoped<ICacheHelper, CacheHelper>();
-
             services.AddScoped<IPresenceTracker, PresenceTracker>();
             services.AddScoped<IEventHub, EventHub>();
 

--- a/API/Parser/DefaultParser.cs
+++ b/API/Parser/DefaultParser.cs
@@ -142,18 +142,22 @@ public class DefaultParser
               }
             }
 
-            var series = Parser.ParseSeries(folder);
-
-            if ((string.IsNullOrEmpty(series) && i == fallbackFolders.Count - 1))
+            // Generally users group in series folders. Let's try to parse series from the top folder
+            if (!folder.Equals(ret.Series) && i == fallbackFolders.Count - 1)
             {
-                ret.Series = Parser.CleanTitle(folder, type is LibraryType.Comic);
-                break;
-            }
+                var series = Parser.ParseSeries(folder);
 
-            if (!string.IsNullOrEmpty(series))
-            {
-                ret.Series = series;
-                break;
+                if (string.IsNullOrEmpty(series))
+                {
+                    ret.Series = Parser.CleanTitle(folder, type is LibraryType.Comic);
+                    break;
+                }
+
+                if (!string.IsNullOrEmpty(series) && (string.IsNullOrEmpty(ret.Series) || !folder.Contains(ret.Series)))
+                {
+                    ret.Series = series;
+                    break;
+                }
             }
         }
     }

--- a/API/Parser/Parser.cs
+++ b/API/Parser/Parser.cs
@@ -60,6 +60,12 @@ namespace API.Parser
         private static readonly Regex NormalizeRegex = new Regex(@"[^\p{L}0-9\+]",
             MatchOptions, RegexTimeout);
 
+        /// <summary>
+        /// Recognizes the Special token only
+        /// </summary>
+        private static readonly Regex SpecialTokenRegex = new Regex(@"SP\d+",
+            MatchOptions, RegexTimeout);
+
 
         private static readonly Regex[] MangaVolumeRegex = new[]
         {
@@ -976,9 +982,8 @@ namespace API.Parser
         /// <returns></returns>
         public static string CleanSpecialTitle(string name)
         {
-            // TODO: Optimize this code & Test
             if (string.IsNullOrEmpty(name)) return name;
-            var cleaned = new Regex(@"SP\d+").Replace(name.Replace('_', ' '), string.Empty).Trim();
+            var cleaned = SpecialTokenRegex.Replace(name.Replace('_', ' '), string.Empty).Trim();
             var lastIndex = cleaned.LastIndexOf('.');
             if (lastIndex > 0)
             {

--- a/API/Services/DirectoryService.cs
+++ b/API/Services/DirectoryService.cs
@@ -71,6 +71,8 @@ namespace API.Services
        private static readonly Regex ExcludeDirectories = new Regex(
           @"@eaDir|\.DS_Store|\.qpkg",
           RegexOptions.Compiled | RegexOptions.IgnoreCase);
+       private static readonly Regex FileCopyAppend = new Regex(@"\(\d+\)",
+           RegexOptions.Compiled | RegexOptions.IgnoreCase);
        public static readonly string BackupDirectory = Path.Join(Directory.GetCurrentDirectory(), "config", "backups");
 
        public DirectoryService(ILogger<DirectoryService> logger, IFileSystem fileSystem)
@@ -370,24 +372,11 @@ namespace API.Services
                foreach (var file in filePaths)
                {
                    currentFile = file;
+
                    var fileInfo = FileSystem.FileInfo.FromFileName(file);
-                   if (fileInfo.Exists)
-                   {
-                       // TODO: I need to handle if file already exists and allow either an overwrite or prepend (2) to it
-                       try
-                       {
-                           fileInfo.CopyTo(FileSystem.Path.Join(directoryPath, prepend + fileInfo.Name));
-                       }
-                       catch (IOException ex)
-                       {
-                           _logger.LogError(ex, "File copy, dest already exists. Appending (2)");
-                           fileInfo.CopyTo(FileSystem.Path.Join(directoryPath, prepend + FileSystem.Path.GetFileNameWithoutExtension(fileInfo.Name) + " (2)" + FileSystem.Path.GetExtension(fileInfo.Name)));
-                       }
-                   }
-                   else
-                   {
-                       _logger.LogWarning("Tried to copy {File} but it doesn't exist", file);
-                   }
+                   var targetFile = FileSystem.FileInfo.FromFileName(RenameFileForCopy(file, directoryPath, prepend));
+
+                   fileInfo.CopyTo(FileSystem.Path.Join(directoryPath, targetFile.Name));
                }
            }
            catch (Exception ex)
@@ -397,6 +386,42 @@ namespace API.Services
            }
 
            return true;
+       }
+
+       /// <summary>
+       /// Generates the combined filepath given a prepend (optional), output directory path, and a full input file path.
+       /// If the output file already exists, will append (1), (2), etc until it can be written out
+       /// </summary>
+       /// <param name="fileToCopy"></param>
+       /// <param name="directoryPath"></param>
+       /// <param name="prepend"></param>
+       /// <returns></returns>
+       private string RenameFileForCopy(string fileToCopy, string directoryPath, string prepend = "")
+       {
+           var fileInfo = FileSystem.FileInfo.FromFileName(fileToCopy);
+           var filename = prepend + fileInfo.Name;
+
+           var targetFile = FileSystem.FileInfo.FromFileName(FileSystem.Path.Join(directoryPath, filename));
+           if (!targetFile.Exists)
+           {
+               return targetFile.FullName;
+           }
+
+           var noExtension = FileSystem.Path.GetFileNameWithoutExtension(fileInfo.Name);
+           if (FileCopyAppend.IsMatch(noExtension))
+           {
+               var match = FileCopyAppend.Match(noExtension).Value;
+               var matchNumber = match.Replace("(", string.Empty).Replace(")", string.Empty);
+               noExtension = noExtension.Replace(match, $"({int.Parse(matchNumber) + 1})");
+           }
+           else
+           {
+               noExtension += " (1)";
+           }
+
+           var newFilename = prepend + noExtension +
+                             FileSystem.Path.GetExtension(fileInfo.Name);
+           return RenameFileForCopy(FileSystem.Path.Join(directoryPath, newFilename), directoryPath, prepend);
        }
 
        /// <summary>

--- a/API/Services/SeriesService.cs
+++ b/API/Services/SeriesService.cs
@@ -52,102 +52,109 @@ public class SeriesService : ISeriesService
             var allPeople = (await _unitOfWork.PersonRepository.GetAllPeople()).ToList();
             var allTags = (await _unitOfWork.TagRepository.GetAllTagsAsync()).ToList();
 
-            if (series.Metadata == null)
+            series.Metadata ??= DbFactory.SeriesMetadata(updateSeriesMetadataDto.CollectionTags
+                .Select(dto => DbFactory.CollectionTag(dto.Id, dto.Title, dto.Summary, dto.Promoted)).ToList());
+
+            if (series.Metadata.AgeRating != updateSeriesMetadataDto.SeriesMetadata.AgeRating)
             {
-                series.Metadata = DbFactory.SeriesMetadata(updateSeriesMetadataDto.CollectionTags
-                    .Select(dto => DbFactory.CollectionTag(dto.Id, dto.Title, dto.Summary, dto.Promoted)).ToList());
+                series.Metadata.AgeRating = updateSeriesMetadataDto.SeriesMetadata.AgeRating;
+                series.Metadata.AgeRatingLocked = true;
             }
-            else
+
+            if (series.Metadata.PublicationStatus != updateSeriesMetadataDto.SeriesMetadata.PublicationStatus)
             {
-                if (series.Metadata.AgeRating != updateSeriesMetadataDto.SeriesMetadata.AgeRating)
-                {
-                    series.Metadata.AgeRating = updateSeriesMetadataDto.SeriesMetadata.AgeRating;
-                    series.Metadata.AgeRatingLocked = true;
-                }
-
-                if (series.Metadata.PublicationStatus != updateSeriesMetadataDto.SeriesMetadata.PublicationStatus)
-                {
-                    series.Metadata.PublicationStatus = updateSeriesMetadataDto.SeriesMetadata.PublicationStatus;
-                    series.Metadata.PublicationStatusLocked = true;
-                }
-
-                if (series.Metadata.Summary != updateSeriesMetadataDto.SeriesMetadata.Summary.Trim())
-                {
-                    series.Metadata.Summary = updateSeriesMetadataDto.SeriesMetadata?.Summary.Trim();
-                    series.Metadata.SummaryLocked = true;
-                }
-
-                if (series.Metadata.Language != updateSeriesMetadataDto.SeriesMetadata.Language)
-                {
-                    series.Metadata.Language = updateSeriesMetadataDto.SeriesMetadata?.Language;
-                    series.Metadata.LanguageLocked = true;
-                }
-
-
-                series.Metadata.CollectionTags ??= new List<CollectionTag>();
-                UpdateRelatedList(updateSeriesMetadataDto.CollectionTags, series, allCollectionTags, (tag) =>
-                {
-                    series.Metadata.CollectionTags.Add(tag);
-                });
-
-                series.Metadata.Genres ??= new List<Genre>();
-                UpdateGenreList(updateSeriesMetadataDto.SeriesMetadata.Genres, series, allGenres, (genre) =>
-                {
-                    series.Metadata.Genres.Add(genre);
-                }, () => series.Metadata.GenresLocked = true);
-
-                series.Metadata.Tags ??= new List<Tag>();
-                UpdateTagList(updateSeriesMetadataDto.SeriesMetadata.Tags, series, allTags, (tag) =>
-                {
-                    series.Metadata.Tags.Add(tag);
-                }, () => series.Metadata.TagsLocked = true);
-
-                void HandleAddPerson(Person person)
-                {
-                    PersonHelper.AddPersonIfNotExists(series.Metadata.People, person);
-                    allPeople.Add(person);
-                }
-
-                series.Metadata.People ??= new List<Person>();
-                UpdatePeopleList(PersonRole.Writer, updateSeriesMetadataDto.SeriesMetadata.Writers, series, allPeople,
-                    HandleAddPerson,  () => series.Metadata.WriterLocked = true);
-                UpdatePeopleList(PersonRole.Character, updateSeriesMetadataDto.SeriesMetadata.Characters, series, allPeople,
-                    HandleAddPerson,  () => series.Metadata.CharacterLocked = true);
-                UpdatePeopleList(PersonRole.Colorist, updateSeriesMetadataDto.SeriesMetadata.Colorists, series, allPeople,
-                    HandleAddPerson,  () => series.Metadata.ColoristLocked = true);
-                UpdatePeopleList(PersonRole.Editor, updateSeriesMetadataDto.SeriesMetadata.Editors, series, allPeople,
-                    HandleAddPerson,  () => series.Metadata.EditorLocked = true);
-                UpdatePeopleList(PersonRole.Inker, updateSeriesMetadataDto.SeriesMetadata.Inkers, series, allPeople,
-                    HandleAddPerson,  () => series.Metadata.InkerLocked = true);
-                UpdatePeopleList(PersonRole.Letterer, updateSeriesMetadataDto.SeriesMetadata.Letterers, series, allPeople,
-                    HandleAddPerson,  () => series.Metadata.LettererLocked = true);
-                UpdatePeopleList(PersonRole.Penciller, updateSeriesMetadataDto.SeriesMetadata.Pencillers, series, allPeople,
-                    HandleAddPerson,  () => series.Metadata.PencillerLocked = true);
-                UpdatePeopleList(PersonRole.Publisher, updateSeriesMetadataDto.SeriesMetadata.Publishers, series, allPeople,
-                    HandleAddPerson,  () => series.Metadata.PublisherLocked = true);
-                UpdatePeopleList(PersonRole.Translator, updateSeriesMetadataDto.SeriesMetadata.Translators, series, allPeople,
-                    HandleAddPerson,  () => series.Metadata.TranslatorLocked = true);
-                UpdatePeopleList(PersonRole.CoverArtist, updateSeriesMetadataDto.SeriesMetadata.CoverArtists, series, allPeople,
-                    HandleAddPerson,  () => series.Metadata.CoverArtistLocked = true);
-
-                if (!updateSeriesMetadataDto.SeriesMetadata.AgeRatingLocked) series.Metadata.AgeRatingLocked = false;
-                if (!updateSeriesMetadataDto.SeriesMetadata.PublicationStatusLocked) series.Metadata.PublicationStatusLocked = false;
-                if (!updateSeriesMetadataDto.SeriesMetadata.LanguageLocked) series.Metadata.LanguageLocked = false;
-                if (!updateSeriesMetadataDto.SeriesMetadata.GenresLocked) series.Metadata.GenresLocked = false;
-                if (!updateSeriesMetadataDto.SeriesMetadata.TagsLocked) series.Metadata.TagsLocked = false;
-                if (!updateSeriesMetadataDto.SeriesMetadata.CharacterLocked) series.Metadata.CharacterLocked = false;
-                if (!updateSeriesMetadataDto.SeriesMetadata.ColoristLocked) series.Metadata.ColoristLocked = false;
-                if (!updateSeriesMetadataDto.SeriesMetadata.EditorLocked) series.Metadata.EditorLocked = false;
-                if (!updateSeriesMetadataDto.SeriesMetadata.InkerLocked) series.Metadata.InkerLocked = false;
-                if (!updateSeriesMetadataDto.SeriesMetadata.LettererLocked) series.Metadata.LettererLocked = false;
-                if (!updateSeriesMetadataDto.SeriesMetadata.PencillerLocked) series.Metadata.PencillerLocked = false;
-                if (!updateSeriesMetadataDto.SeriesMetadata.PublisherLocked) series.Metadata.PublisherLocked = false;
-                if (!updateSeriesMetadataDto.SeriesMetadata.TranslatorLocked) series.Metadata.TranslatorLocked = false;
-                if (!updateSeriesMetadataDto.SeriesMetadata.CoverArtistLocked) series.Metadata.CoverArtistLocked = false;
-                if (!updateSeriesMetadataDto.SeriesMetadata.WriterLocked) series.Metadata.WriterLocked = false;
-                if (!updateSeriesMetadataDto.SeriesMetadata.SummaryLocked) series.Metadata.SummaryLocked = false;
-
+                series.Metadata.PublicationStatus = updateSeriesMetadataDto.SeriesMetadata.PublicationStatus;
+                series.Metadata.PublicationStatusLocked = true;
             }
+
+            // This shouldn't be needed post v0.5.3 release
+            if (string.IsNullOrEmpty(series.Metadata.Summary))
+            {
+                series.Metadata.Summary = string.Empty;
+            }
+
+            if (string.IsNullOrEmpty(updateSeriesMetadataDto.SeriesMetadata.Summary))
+            {
+                updateSeriesMetadataDto.SeriesMetadata.Summary = string.Empty;
+            }
+
+            if (series.Metadata.Summary != updateSeriesMetadataDto.SeriesMetadata.Summary.Trim())
+            {
+                series.Metadata.Summary = updateSeriesMetadataDto.SeriesMetadata?.Summary.Trim();
+                series.Metadata.SummaryLocked = true;
+            }
+
+            if (series.Metadata.Language != updateSeriesMetadataDto.SeriesMetadata.Language)
+            {
+                series.Metadata.Language = updateSeriesMetadataDto.SeriesMetadata?.Language;
+                series.Metadata.LanguageLocked = true;
+            }
+
+
+            series.Metadata.CollectionTags ??= new List<CollectionTag>();
+            UpdateRelatedList(updateSeriesMetadataDto.CollectionTags, series, allCollectionTags, (tag) =>
+            {
+                series.Metadata.CollectionTags.Add(tag);
+            });
+
+            series.Metadata.Genres ??= new List<Genre>();
+            UpdateGenreList(updateSeriesMetadataDto.SeriesMetadata.Genres, series, allGenres, (genre) =>
+            {
+                series.Metadata.Genres.Add(genre);
+            }, () => series.Metadata.GenresLocked = true);
+
+            series.Metadata.Tags ??= new List<Tag>();
+            UpdateTagList(updateSeriesMetadataDto.SeriesMetadata.Tags, series, allTags, (tag) =>
+            {
+                series.Metadata.Tags.Add(tag);
+            }, () => series.Metadata.TagsLocked = true);
+
+            void HandleAddPerson(Person person)
+            {
+                PersonHelper.AddPersonIfNotExists(series.Metadata.People, person);
+                allPeople.Add(person);
+            }
+
+            series.Metadata.People ??= new List<Person>();
+            UpdatePeopleList(PersonRole.Writer, updateSeriesMetadataDto.SeriesMetadata.Writers, series, allPeople,
+                HandleAddPerson,  () => series.Metadata.WriterLocked = true);
+            UpdatePeopleList(PersonRole.Character, updateSeriesMetadataDto.SeriesMetadata.Characters, series, allPeople,
+                HandleAddPerson,  () => series.Metadata.CharacterLocked = true);
+            UpdatePeopleList(PersonRole.Colorist, updateSeriesMetadataDto.SeriesMetadata.Colorists, series, allPeople,
+                HandleAddPerson,  () => series.Metadata.ColoristLocked = true);
+            UpdatePeopleList(PersonRole.Editor, updateSeriesMetadataDto.SeriesMetadata.Editors, series, allPeople,
+                HandleAddPerson,  () => series.Metadata.EditorLocked = true);
+            UpdatePeopleList(PersonRole.Inker, updateSeriesMetadataDto.SeriesMetadata.Inkers, series, allPeople,
+                HandleAddPerson,  () => series.Metadata.InkerLocked = true);
+            UpdatePeopleList(PersonRole.Letterer, updateSeriesMetadataDto.SeriesMetadata.Letterers, series, allPeople,
+                HandleAddPerson,  () => series.Metadata.LettererLocked = true);
+            UpdatePeopleList(PersonRole.Penciller, updateSeriesMetadataDto.SeriesMetadata.Pencillers, series, allPeople,
+                HandleAddPerson,  () => series.Metadata.PencillerLocked = true);
+            UpdatePeopleList(PersonRole.Publisher, updateSeriesMetadataDto.SeriesMetadata.Publishers, series, allPeople,
+                HandleAddPerson,  () => series.Metadata.PublisherLocked = true);
+            UpdatePeopleList(PersonRole.Translator, updateSeriesMetadataDto.SeriesMetadata.Translators, series, allPeople,
+                HandleAddPerson,  () => series.Metadata.TranslatorLocked = true);
+            UpdatePeopleList(PersonRole.CoverArtist, updateSeriesMetadataDto.SeriesMetadata.CoverArtists, series, allPeople,
+                HandleAddPerson,  () => series.Metadata.CoverArtistLocked = true);
+
+            if (!updateSeriesMetadataDto.SeriesMetadata.AgeRatingLocked) series.Metadata.AgeRatingLocked = false;
+            if (!updateSeriesMetadataDto.SeriesMetadata.PublicationStatusLocked) series.Metadata.PublicationStatusLocked = false;
+            if (!updateSeriesMetadataDto.SeriesMetadata.LanguageLocked) series.Metadata.LanguageLocked = false;
+            if (!updateSeriesMetadataDto.SeriesMetadata.GenresLocked) series.Metadata.GenresLocked = false;
+            if (!updateSeriesMetadataDto.SeriesMetadata.TagsLocked) series.Metadata.TagsLocked = false;
+            if (!updateSeriesMetadataDto.SeriesMetadata.CharacterLocked) series.Metadata.CharacterLocked = false;
+            if (!updateSeriesMetadataDto.SeriesMetadata.ColoristLocked) series.Metadata.ColoristLocked = false;
+            if (!updateSeriesMetadataDto.SeriesMetadata.EditorLocked) series.Metadata.EditorLocked = false;
+            if (!updateSeriesMetadataDto.SeriesMetadata.InkerLocked) series.Metadata.InkerLocked = false;
+            if (!updateSeriesMetadataDto.SeriesMetadata.LettererLocked) series.Metadata.LettererLocked = false;
+            if (!updateSeriesMetadataDto.SeriesMetadata.PencillerLocked) series.Metadata.PencillerLocked = false;
+            if (!updateSeriesMetadataDto.SeriesMetadata.PublisherLocked) series.Metadata.PublisherLocked = false;
+            if (!updateSeriesMetadataDto.SeriesMetadata.TranslatorLocked) series.Metadata.TranslatorLocked = false;
+            if (!updateSeriesMetadataDto.SeriesMetadata.CoverArtistLocked) series.Metadata.CoverArtistLocked = false;
+            if (!updateSeriesMetadataDto.SeriesMetadata.WriterLocked) series.Metadata.WriterLocked = false;
+            if (!updateSeriesMetadataDto.SeriesMetadata.SummaryLocked) series.Metadata.SummaryLocked = false;
+
+
 
             if (!_unitOfWork.HasChanges())
             {
@@ -184,6 +191,7 @@ public class SeriesService : ISeriesService
     private static void UpdateRelatedList(ICollection<CollectionTagDto> tags, Series series, IReadOnlyCollection<CollectionTag> allTags,
         Action<CollectionTag> handleAdd)
     {
+        if (tags == null) return;
         // I want a union of these 2 lists. Return only elements that are in both lists, but the list types are different
         var existingTags = series.Metadata.CollectionTags.ToList();
         foreach (var existing in existingTags)
@@ -216,11 +224,13 @@ public class SeriesService : ISeriesService
 
     private static void UpdateGenreList(ICollection<GenreTagDto> tags, Series series, IReadOnlyCollection<Genre> allTags, Action<Genre> handleAdd, Action onModified)
     {
+        if (tags == null) return;
         var isModified = false;
         // I want a union of these 2 lists. Return only elements that are in both lists, but the list types are different
         var existingTags = series.Metadata.Genres.ToList();
         foreach (var existing in existingTags)
         {
+            // NOTE: Why don't I use a NormalizedName here (outside of memory pressure from string creation)?
             if (tags.SingleOrDefault(t => t.Id == existing.Id) == null)
             {
                 // Remove tag
@@ -232,10 +242,12 @@ public class SeriesService : ISeriesService
         // At this point, all tags that aren't in dto have been removed.
         foreach (var tagTitle in tags.Select(t => t.Title))
         {
-            var existingTag = allTags.SingleOrDefault(t => t.Title == tagTitle);
+            // This should be normalized name
+            var normalizedTitle = Parser.Parser.Normalize(tagTitle);
+            var existingTag = allTags.SingleOrDefault(t => t.NormalizedTitle == normalizedTitle);
             if (existingTag != null)
             {
-                if (series.Metadata.Genres.All(t => t.Title != tagTitle))
+                if (series.Metadata.Genres.All(t => t.NormalizedTitle != normalizedTitle))
                 {
                     handleAdd(existingTag);
                     isModified = true;
@@ -257,6 +269,8 @@ public class SeriesService : ISeriesService
 
     private static void UpdateTagList(ICollection<TagDto> tags, Series series, IReadOnlyCollection<Tag> allTags, Action<Tag> handleAdd, Action onModified)
     {
+        if (tags == null) return;
+
         var isModified = false;
         // I want a union of these 2 lists. Return only elements that are in both lists, but the list types are different
         var existingTags = series.Metadata.Tags.ToList();
@@ -300,6 +314,7 @@ public class SeriesService : ISeriesService
     private static void UpdatePeopleList(PersonRole role, ICollection<PersonDto> tags, Series series, IReadOnlyCollection<Person> allTags,
         Action<Person> handleAdd, Action onModified)
     {
+        if (tags == null) return;
         var isModified = false;
         // I want a union of these 2 lists. Return only elements that are in both lists, but the list types are different
         var existingTags = series.Metadata.People.Where(p => p.Role == role).ToList();

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -523,7 +523,18 @@ public class ScannerService : IScannerService
                 series.Format = parsedInfos[0].Format;
             }
             series.OriginalName ??= parsedInfos[0].Series;
-            if (!series.SortNameLocked) series.SortName = parsedInfos[0].SeriesSort;
+            if (string.IsNullOrEmpty(series.SortName))
+            {
+                series.SortName = series.Name;
+            }
+            if (!series.SortNameLocked)
+            {
+                series.SortName = series.Name;
+                if (!string.IsNullOrEmpty(parsedInfos[0].SeriesSort))
+                {
+                    series.SortName = parsedInfos[0].SeriesSort;
+                }
+            }
 
             await _eventHub.SendMessageAsync(MessageFactory.NotificationProgress, MessageFactory.LibraryScanProgressEvent(library.Name, ProgressEventType.Ended, series.Name));
 

--- a/API/Services/Tasks/VersionUpdaterService.cs
+++ b/API/Services/Tasks/VersionUpdaterService.cs
@@ -54,18 +54,16 @@ public class VersionUpdaterService : IVersionUpdaterService
 {
     private readonly ILogger<VersionUpdaterService> _logger;
     private readonly IEventHub _eventHub;
-    private readonly IPresenceTracker _tracker;
     private readonly Markdown _markdown = new MarkdownDeep.Markdown();
 #pragma warning disable S1075
     private const string GithubLatestReleasesUrl = "https://api.github.com/repos/Kareadita/Kavita/releases/latest";
     private const string GithubAllReleasesUrl = "https://api.github.com/repos/Kareadita/Kavita/releases";
 #pragma warning restore S1075
 
-    public VersionUpdaterService(ILogger<VersionUpdaterService> logger, IEventHub eventHub, IPresenceTracker tracker)
+    public VersionUpdaterService(ILogger<VersionUpdaterService> logger, IEventHub eventHub)
     {
         _logger = logger;
         _eventHub = eventHub;
-        _tracker = tracker;
 
         FlurlHttp.ConfigureClient(GithubLatestReleasesUrl, cli =>
             cli.Settings.HttpClientFactory = new UntrustedCertClientFactory());
@@ -94,12 +92,7 @@ public class VersionUpdaterService : IVersionUpdaterService
     {
         if (update == null || string.IsNullOrEmpty(update.Tag_Name)) return null;
         var updateVersion = new Version(update.Tag_Name.Replace("v", string.Empty));
-        var currentVersion = BuildInfo.Version.ToString();
-
-        if (updateVersion.Revision == -1)
-        {
-            currentVersion = currentVersion.Substring(0, currentVersion.LastIndexOf(".", StringComparison.Ordinal));
-        }
+        var currentVersion = BuildInfo.Version.ToString(4);
 
         return new UpdateNotificationDto()
         {

--- a/API/SignalR/EventHub.cs
+++ b/API/SignalR/EventHub.cs
@@ -36,8 +36,9 @@ public class EventHub : IEventHub
         if (onlyAdmins)
         {
             var admins = await _presenceTracker.GetOnlineAdmins();
-            _messageHub.Clients.Users(admins);
+            users = _messageHub.Clients.Users(admins);
         }
+
 
         await users.SendAsync(method, message);
     }

--- a/API/SignalR/MessageFactory.cs
+++ b/API/SignalR/MessageFactory.cs
@@ -311,7 +311,6 @@ namespace API.SignalR
             {
                 Name = CoverUpdate,
                 Title = "Updating Cover",
-                //SubTitle = series.Name, // TODO: Refactor this
                 Progress = ProgressType.None,
                 Body = new
                 {

--- a/API/SignalR/SignalRMessage.cs
+++ b/API/SignalR/SignalRMessage.cs
@@ -34,6 +34,6 @@ namespace API.SignalR
         /// <summary>
         /// When event took place
         /// </summary>
-        public DateTime EventTime = DateTime.Now;
+        public readonly DateTime EventTime = DateTime.Now;
     }
 }

--- a/Kavita.Common/Kavita.Common.csproj
+++ b/Kavita.Common/Kavita.Common.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net6.0</TargetFramework>
         <Company>kavitareader.com</Company>
         <Product>Kavita</Product>
-        <AssemblyVersion>0.5.2.0</AssemblyVersion>
+        <AssemblyVersion>0.5.2.3</AssemblyVersion>
         <NeutralLanguage>en</NeutralLanguage>
     </PropertyGroup>
 

--- a/UI/Web/package-lock.json
+++ b/UI/Web/package-lock.json
@@ -2418,22 +2418,6 @@
       "integrity": "sha512-wooUZiV92QyoeFxkhqIwH/cfiAAAn+l8fEEuaaEIfJtpjpbShvvlboEVsqb28soeGiFJfLcmsZM3mUFgsG4QBQ==",
       "dev": true
     },
-    "@ngx-lite/nav-drawer": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/@ngx-lite/nav-drawer/-/nav-drawer-0.4.7.tgz",
-      "integrity": "sha512-OqXJhzE88RR5Vtgr0tcuvkKVkzsKZjeXxhjpWOJ9UiC2iCQPDL2rtvag5K/vPKN362Jx0htvr3cmFDjHg/kjdA==",
-      "requires": {
-        "tslib": "^2.0.0"
-      }
-    },
-    "@ngx-lite/util": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@ngx-lite/util/-/util-0.0.1.tgz",
-      "integrity": "sha512-j7pBcF+5OEHExEUBNdlQT5x4sVvHIPwZeMvhlO1TAcAAz9frDsvYgJ1c3eXJYJKJq57o1rH1RESKSJ9YRNpAiw==",
-      "requires": {
-        "tslib": "^2.1.0"
-      }
-    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",

--- a/UI/Web/package.json
+++ b/UI/Web/package.json
@@ -29,8 +29,6 @@
     "@fortawesome/fontawesome-free": "^6.0.0",
     "@microsoft/signalr": "^6.0.2",
     "@ng-bootstrap/ng-bootstrap": "^12.0.0",
-    "@ngx-lite/nav-drawer": "^0.4.7",
-    "@ngx-lite/util": "0.0.1",
     "@popperjs/core": "^2.11.2",
     "@types/file-saver": "^2.0.5",
     "bootstrap": "^5.1.2",

--- a/UI/Web/src/app/_interceptors/error.interceptor.ts
+++ b/UI/Web/src/app/_interceptors/error.interceptor.ts
@@ -116,6 +116,11 @@ export class ErrorInterceptor implements HttpInterceptor {
   }
 
   private handleAuthError(error: any) {
+
+    // Special hack for register url, to not care about auth
+    if (location.href.includes('/registration/confirm-email?token=')) {
+      return;
+    }
     // NOTE: Signin has error.error or error.statusText available. 
     // if statement is due to http/2 spec issue: https://github.com/angular/angular/issues/23334
     this.accountService.logout();

--- a/UI/Web/src/app/admin/manage-users/manage-users.component.html
+++ b/UI/Web/src/app/admin/manage-users/manage-users.component.html
@@ -12,8 +12,8 @@
                     <h4>
                         <span id="member-name--{{idx}}">{{invite.username | titlecase}} </span>
                         <div class="float-end">
-                            <button class="btn btn-danger me-2" (click)="deleteUser(invite)">Cancel</button>
-                            <button class="btn btn-secondary me-2" (click)="resendEmail(invite)">Resend</button>
+                            <button class="btn btn-danger btn-sm me-2" (click)="deleteUser(invite)">Cancel</button>
+                            <button class="btn btn-secondary btn-sm" (click)="resendEmail(invite)">Resend</button>
                         </div>
                     </h4>
 

--- a/UI/Web/src/app/announcements/changelog/changelog.component.html
+++ b/UI/Web/src/app/announcements/changelog/changelog.component.html
@@ -1,19 +1,20 @@
 <div class="changelog">
+  <p class="pb-2">If you do not see an <span class="badge bg-secondary">Installed</span> tag, you are on a nightly release. Only major versions will show as available.</p>
   <ng-container *ngFor="let update of updates; let indx = index;">
     <div class="card w-100 mb-2" style="width: 18rem;">
         <div class="card-body">
           <h4 class="card-title">{{update.updateTitle}}&nbsp;
-              <span class="badge bg-secondary" *ngIf="update.updateVersion === installedVersion">Installed</span>
-              <span class="badge bg-secondary" *ngIf="update.updateVersion > installedVersion">Available</span>
+              <span class="badge bg-secondary" *ngIf="update.updateVersion === update.currentVersion">Installed</span>
+              <span class="badge bg-secondary" *ngIf="update.updateVersion > update.currentVersion">Available</span>
           </h4>
-          <h6 class="card-subtitle mb-2 text-muted">Published: {{update.publishDate | date: 'short'}}</h6>
+          <h6 class="card-subtitle mb-1 mt-1 text-muted">Published: {{update.publishDate | date: 'short'}}</h6>
 
 
           <pre class="card-text update-body">
             <app-read-more [text]="update.updateBody" [maxLength]="500"></app-read-more>
           </pre>
-          <a *ngIf="!update.isDocker && update.updateVersion === installedVersion" href="{{update.updateUrl}}" class="btn disabled btn-{{indx === 0 ? 'primary' : 'secondary'}} float-end" target="_blank">Installed</a>
-          <a *ngIf="!update.isDocker && update.updateVersion !== installedVersion" href="{{update.updateUrl}}" class="btn btn-{{indx === 0 ? 'primary' : 'secondary'}} float-end" target="_blank">Download</a>
+          <a *ngIf="!update.isDocker && update.updateVersion === update.currentVersion" href="{{update.updateUrl}}" class="btn disabled btn-{{indx === 0 ? 'primary' : 'secondary'}} float-end" target="_blank">Installed</a>
+          <a *ngIf="!update.isDocker && update.updateVersion !== update.currentVersion" href="{{update.updateUrl}}" class="btn btn-{{indx === 0 ? 'primary' : 'secondary'}} float-end" target="_blank">Download</a>
         </div>
       </div>
   </ng-container>

--- a/UI/Web/src/app/announcements/changelog/changelog.component.ts
+++ b/UI/Web/src/app/announcements/changelog/changelog.component.ts
@@ -11,23 +11,14 @@ export class ChangelogComponent implements OnInit {
 
   updates: Array<UpdateVersionEvent> = [];
   isLoading: boolean = true;
-  installedVersion: string = '';
 
   constructor(private serverService: ServerService) { }
 
   ngOnInit(): void {
 
-    this.serverService.getServerInfo().subscribe(info => {
-      this.installedVersion = info.kavitaVersion;
-      this.serverService.getChangelog().subscribe(updates => {
-        this.updates = updates;
-        this.isLoading = false;
-
-        if (this.updates.filter(u => u.updateVersion === this.installedVersion).length === 0) {
-          // User is on a nightly version. Tell them the last stable is installed
-          this.installedVersion = this.updates[0].updateVersion;
-        }
-      });
+    this.serverService.getChangelog().subscribe(updates => {
+      this.updates = updates;
+      this.isLoading = false;
     });
     
 

--- a/UI/Web/src/app/nav-header/nav-header.component.html
+++ b/UI/Web/src/app/nav-header/nav-header.component.html
@@ -1,7 +1,7 @@
 <nav class="navbar navbar-expand-md navbar-dark fixed-top" *ngIf="navService?.navbarVisible$ | async">
     <div class="container-fluid">
       <a class="visually-hidden-focusable focus-visible" href="javascript:void(0);" (click)="moveFocus()">Skip to main content</a>
-      <a class="side-nav-toggle" (click)="hideSideNav()"><i class="fas fa-bars"></i></a>
+      <a class="side-nav-toggle" *ngIf="navService?.sideNavVisibility$ | async" (click)="hideSideNav()"><i class="fas fa-bars"></i></a>
       <a class="navbar-brand dark-exempt" routerLink="/library" routerLinkActive="active"><img class="logo" src="../../assets/images/logo.png" alt="kavita icon" aria-hidden="true"/><span class="d-none d-md-inline"> Kavita</span></a>
       <ul class="navbar-nav col me-auto">
         

--- a/UI/Web/src/app/registration/confirm-email/confirm-email.component.ts
+++ b/UI/Web/src/app/registration/confirm-email/confirm-email.component.ts
@@ -31,18 +31,18 @@ export class ConfirmEmailComponent implements OnInit {
 
   constructor(private route: ActivatedRoute, private router: Router, private accountService: AccountService, 
     private toastr: ToastrService, private themeService: ThemeService, private navService: NavService) {
-    this.navService.hideSideNav();
+      this.navService.hideSideNav();
       this.themeService.setTheme(this.themeService.defaultTheme);
-    const token = this.route.snapshot.queryParamMap.get('token');
-    const email = this.route.snapshot.queryParamMap.get('email');
-    if (token == undefined || token === '' || token === null) {
-      // This is not a valid url, redirect to login
-      this.toastr.error('Invalid confirmation email');
-      this.router.navigateByUrl('login');
-      return;
-    }
-    this.token = token;
-    this.registerForm.get('email')?.setValue(email || '');
+      const token = this.route.snapshot.queryParamMap.get('token');
+      const email = this.route.snapshot.queryParamMap.get('email');
+      if (token == undefined || token === '' || token === null) {
+        // This is not a valid url, redirect to login
+        this.toastr.error('Invalid confirmation email');
+        this.router.navigateByUrl('login');
+        return;
+      }
+      this.token = token;
+      this.registerForm.get('email')?.setValue(email || '');
   }
 
   ngOnInit(): void {

--- a/UI/Web/src/app/shared/read-more/read-more.component.html
+++ b/UI/Web/src/app/shared/read-more/read-more.component.html
@@ -1,4 +1,6 @@
 <div>
     <span [innerHTML]="currentText | safeHtml"></span>
-    <a [class.hidden]="hideToggle" *ngIf="text && text.length > maxLength" class="read-more-link" (click)="toggleView()">&nbsp;<i aria-hidden="true" class="fa fa-caret-{{isCollapsed ? 'down' : 'up'}}"></i>&nbsp;Read {{isCollapsed ? 'More' : 'Less'}}</a>
+    <a [class.hidden]="hideToggle" *ngIf="text && text.length > maxLength" class="read-more-link" (click)="toggleView()">
+        &nbsp;<i aria-hidden="true" class="fa fa-caret-{{isCollapsed ? 'down' : 'up'}}"></i>&nbsp;Read {{isCollapsed ? 'More' : 'Less'}}
+    </a>
 </div>

--- a/UI/Web/src/app/sidenav/side-nav/side-nav.component.ts
+++ b/UI/Web/src/app/sidenav/side-nav/side-nav.component.ts
@@ -39,6 +39,7 @@ export class SideNavComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     this.accountService.currentUser$.pipe(take(1)).subscribe(user => {
       this.user = user;
+
       if (this.user) {
         this.isAdmin = this.accountService.hasAdminRole(this.user);
       }
@@ -54,8 +55,6 @@ export class SideNavComponent implements OnInit, OnDestroy {
         this.libraries = libraries;
       });
     });
-
-    
   }
 
   ngOnDestroy(): void {

--- a/UI/Web/src/app/user-login/user-login.component.ts
+++ b/UI/Web/src/app/user-login/user-login.component.ts
@@ -37,7 +37,10 @@ export class UserLoginComponent implements OnInit {
   isLoaded: boolean = false;
 
   constructor(private accountService: AccountService, private router: Router, private memberService: MemberService,
-    private toastr: ToastrService, private navService: NavService, private settingsService: SettingsService, private modalService: NgbModal) { }
+    private toastr: ToastrService, private navService: NavService, private settingsService: SettingsService, private modalService: NgbModal) {
+      this.navService.showNavBar();
+      this.navService.hideSideNav();
+    }
 
   ngOnInit(): void {
     this.navService.showNavBar();


### PR DESCRIPTION
There were some unfortunate issues that slipped through release testing, so please update. The main focus for this hotfix is around SortName on series, which was getting cleared during a scan and not repopulated, thus breaking the sorting logic within Kavita. 

In addition, some issues were found around Invite user, where unauthenticated browsers would not properly show the registration screen. These and a few more bugs reported have been fixed.

**Please note, On Deck is still not functioning as expected from previous release and in this hotfix. It is planned to get a full treatment to align to my vision. Please make due with it as is.** 

Note 2: The hotfix is skipping patch .1 and .2 in order to better align with our nightly users. 

# Changed
- Changed: Slightly tweaked the logic of On Deck to consider chapters in a series that have been created within 30 day cutoff in addition to having been read. This does not fix the inherit issues with it, but serves as a first start. 

# Fixed
- Fixed: Fixed a bug where some events weren't being sent to admin clients only
- Fixed: Fixed a bug where on scan, if SeriesSort wasn't set in ComicInfo, it would get cleared, thus breaking sorting on library detail page (Fixes #1190)
- Fixed: Fixed an issue where when falling back to folder parsing, sometimes when the folder name wouldn't parse well, like 'Foo 500' which parses as 'Foo'. Now the fallback will check if we have a solid series parsed from filename before we attempt to parse a folder. (Fixes #1193 )
- Fixed: Ensure SortName is always being set during a scan loop, even if locked, to ensure that it's never just an empty string (which breaks sorting)
- Fixed: Fixed some errors being thrown from metadata update for files that haven't had a summary set.
- Fixed: Fixed a bug where updating a series name to an existing name in the system wouldn't throw an error (Fixes #1198 )
- Fixed: Hide the side nav hamburger toggle when not authenticated
- Fixed: Fixed some logic issues around determining which releases are installed, available, etc from Announcements page. (Fixes #1084 )
- Fixed: On Firefox, upload cover image via url had different event properties than other browsers and would completely fail.
- Fixed: Confirm email (invitation link) would redirect to login when not authenticated due to side nav having an authenticated call in it. (Fixes #1197 )
