### PR TITLE
Major Search Enhancements

### DIFF
--- a/API.Benchmark/ParseScannedFilesBenchmarks.cs
+++ b/API.Benchmark/ParseScannedFilesBenchmarks.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using System.IO.Abstractions;
+using System.Threading.Tasks;
 using API.Entities.Enums;
 using API.Parser;
 using API.Services;
@@ -46,7 +47,7 @@ namespace API.Benchmark
         /// Generate a list of Series and another list with
         /// </summary>
         [Benchmark]
-        public void MergeName()
+        public async Task MergeName()
         {
             var libraryPath = Path.Join(Directory.GetCurrentDirectory(),
                 "../../../Services/Test Data/ScannerService/Manga");
@@ -61,7 +62,7 @@ namespace API.Benchmark
                 Title = "A Town Where You Live",
                 Volumes = "1"
             };
-            _parseScannedFiles.ScanLibrariesForSeries(LibraryType.Manga, new [] {libraryPath}, "Manga");
+            await _parseScannedFiles.ScanLibrariesForSeries(LibraryType.Manga, new [] {libraryPath}, "Manga");
             _parseScannedFiles.MergeName(p1);
         }
     }

--- a/API.Tests/Parser/DefaultParserTests.cs
+++ b/API.Tests/Parser/DefaultParserTests.cs
@@ -122,7 +122,7 @@ public class DefaultParserTests
         filepath = @"E:\Manga\Tenjo Tenge (Color)\Tenjo Tenge {Full Contact Edition} v01 (2011) (Digital) (ASTC).cbz";
         expected.Add(filepath, new ParserInfo
         {
-            Series = "Tenjo Tenge", Volumes = "1", Edition = "Full Contact Edition",
+            Series = "Tenjo Tenge {Full Contact Edition}", Volumes = "1", Edition = "",
             Chapters = "0", Filename = "Tenjo Tenge {Full Contact Edition} v01 (2011) (Digital) (ASTC).cbz", Format = MangaFormat.Archive,
             FullFilePath = filepath
         });

--- a/API.Tests/Parser/MangaParserTests.cs
+++ b/API.Tests/Parser/MangaParserTests.cs
@@ -170,6 +170,7 @@ namespace API.Tests.Parser
         [InlineData("It's Witching Time! 001 (Digital) (Anonymous1234)", "It's Witching Time!")]
         [InlineData("Zettai Karen Children v02 c003 - The Invisible Guardian (2) [JS Scans]", "Zettai Karen Children")]
         [InlineData("My Charms Are Wasted on Kuroiwa Medaka - Ch. 37.5 - Volume Extras", "My Charms Are Wasted on Kuroiwa Medaka")]
+        [InlineData("Highschool of the Dead - Full Color Edition v02 [Uasaha] (Yen Press)", "Highschool of the Dead - Full Color Edition")]
         public void ParseSeriesTest(string filename, string expected)
         {
             Assert.Equal(expected, API.Parser.Parser.ParseSeries(filename));
@@ -253,13 +254,13 @@ namespace API.Tests.Parser
 
         [Theory]
         [InlineData("Tenjou Tenge Omnibus", "Omnibus")]
-        [InlineData("Tenjou Tenge {Full Contact Edition}", "Full Contact Edition")]
-        [InlineData("Tenjo Tenge {Full Contact Edition} v01 (2011) (Digital) (ASTC).cbz", "Full Contact Edition")]
+        [InlineData("Tenjou Tenge {Full Contact Edition}", "")]
+        [InlineData("Tenjo Tenge {Full Contact Edition} v01 (2011) (Digital) (ASTC).cbz", "")]
         [InlineData("Wotakoi - Love is Hard for Otaku Omnibus v01 (2018) (Digital) (danke-Empire)", "Omnibus")]
         [InlineData("To Love Ru v01 Uncensored (Ch.001-007)", "Uncensored")]
         [InlineData("Chobits Omnibus Edition v01 [Dark Horse]", "Omnibus Edition")]
         [InlineData("[dmntsf.net] One Piece - Digital Colored Comics Vol. 20 Ch. 177 - 30 Million vs 81 Million.cbz", "")]
-        [InlineData("AKIRA - c003 (v01) [Full Color] [Darkhorse].cbz", "Full Color")]
+        [InlineData("AKIRA - c003 (v01) [Full Color] [Darkhorse].cbz", "")]
         [InlineData("Love Hina Omnibus v05 (2015) (Digital-HD) (Asgard-Empire).cbz", "Omnibus")]
         public void ParseEditionTest(string input, string expected)
         {

--- a/API.Tests/Parser/ParserTest.cs
+++ b/API.Tests/Parser/ParserTest.cs
@@ -63,6 +63,7 @@ namespace API.Tests.Parser
         [InlineData("- The Title", false, "The Title")]
         [InlineData("[Suihei Kiki]_Kasumi_Otoko_no_Ko_[Taruby]_v1.1", false, "Kasumi Otoko no Ko v1.1")]
         [InlineData("Batman - Detective Comics - Rebirth Deluxe Edition Book 04 (2019) (digital) (Son of Ultron-Empire)", true, "Batman - Detective Comics - Rebirth Deluxe Edition")]
+        [InlineData("Something - Full Color Edition", false, "Something - Full Color Edition")]
         public void CleanTitleTest(string input, bool isComic, string expected)
         {
             Assert.Equal(expected, CleanTitle(input, isComic));

--- a/API.Tests/Services/CleanupServiceTests.cs
+++ b/API.Tests/Services/CleanupServiceTests.cs
@@ -364,7 +364,7 @@ public class CleanupServiceTests
     #region CleanupBackups
 
     [Fact]
-    public void CleanupBackups_LeaveOneFile_SinceAllAreExpired()
+    public async Task CleanupBackups_LeaveOneFile_SinceAllAreExpired()
     {
         var filesystem = CreateFileSystem();
         var filesystemFile = new MockFileData("")
@@ -378,12 +378,12 @@ public class CleanupServiceTests
         var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), filesystem);
         var cleanupService = new CleanupService(_logger, _unitOfWork, _messageHub,
             ds);
-        cleanupService.CleanupBackups();
+        await cleanupService.CleanupBackups();
         Assert.Single(ds.GetFiles(BackupDirectory, searchOption: SearchOption.AllDirectories));
     }
 
     [Fact]
-    public void CleanupBackups_LeaveLestExpired()
+    public async Task CleanupBackups_LeaveLestExpired()
     {
         var filesystem = CreateFileSystem();
         var filesystemFile = new MockFileData("")
@@ -400,7 +400,7 @@ public class CleanupServiceTests
         var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), filesystem);
         var cleanupService = new CleanupService(_logger, _unitOfWork, _messageHub,
             ds);
-        cleanupService.CleanupBackups();
+        await cleanupService.CleanupBackups();
         Assert.True(filesystem.File.Exists($"{BackupDirectory}randomfile.zip"));
     }
 

--- a/API/Controllers/RecommendedController.cs
+++ b/API/Controllers/RecommendedController.cs
@@ -30,6 +30,7 @@ public class RecommendedController : BaseApiController
 
         userParams ??= new UserParams();
         var series = await _unitOfWork.SeriesRepository.GetQuickReads(user.Id, libraryId, userParams);
+
         Response.AddPaginationHeader(series.CurrentPage, series.PageSize, series.TotalCount, series.TotalPages);
         return Ok(series);
     }
@@ -46,6 +47,7 @@ public class RecommendedController : BaseApiController
 
         userParams ??= new UserParams();
         var series = await _unitOfWork.SeriesRepository.GetHighlyRated(user.Id, libraryId, userParams);
+        await _unitOfWork.SeriesRepository.AddSeriesModifiers(user.Id, series);
         Response.AddPaginationHeader(series.CurrentPage, series.PageSize, series.TotalCount, series.TotalPages);
         return Ok(series);
     }
@@ -62,6 +64,8 @@ public class RecommendedController : BaseApiController
 
         userParams ??= new UserParams();
         var series = await _unitOfWork.SeriesRepository.GetMoreIn(user.Id, libraryId, genreId, userParams);
+        await _unitOfWork.SeriesRepository.AddSeriesModifiers(user.Id, series);
+
         Response.AddPaginationHeader(series.CurrentPage, series.PageSize, series.TotalCount, series.TotalPages);
         return Ok(series);
     }

--- a/API/Controllers/SeriesController.cs
+++ b/API/Controllers/SeriesController.cs
@@ -344,7 +344,7 @@ namespace API.Controllers
 
         /// <summary>
         /// Returns the series for the MangaFile id. If the user does not have access (shouldn't happen by the UI),
-        /// hen null is returned
+        /// then null is returned
         /// </summary>
         /// <param name="mangaFileId"></param>
         /// <returns></returns>
@@ -353,6 +353,19 @@ namespace API.Controllers
         {
             var userId = await _unitOfWork.UserRepository.GetUserIdByUsernameAsync(User.GetUsername());
             return Ok(await _unitOfWork.SeriesRepository.GetSeriesForMangaFile(mangaFileId, userId));
+        }
+
+        /// <summary>
+        /// Returns the series for the Chapter id. If the user does not have access (shouldn't happen by the UI),
+        /// then null is returned
+        /// </summary>
+        /// <param name="chapterId"></param>
+        /// <returns></returns>
+        [HttpGet("series-for-chapter")]
+        public async Task<ActionResult<SeriesDto>> GetSeriesForChapter(int chapterId)
+        {
+            var userId = await _unitOfWork.UserRepository.GetUserIdByUsernameAsync(User.GetUsername());
+            return Ok(await _unitOfWork.SeriesRepository.GetSeriesForChapter(chapterId, userId));
         }
 
         /// <summary>

--- a/API/Controllers/SeriesController.cs
+++ b/API/Controllers/SeriesController.cs
@@ -343,6 +343,19 @@ namespace API.Controllers
         }
 
         /// <summary>
+        /// Returns the series for the MangaFile id. If the user does not have access (shouldn't happen by the UI),
+        /// hen null is returned
+        /// </summary>
+        /// <param name="mangaFileId"></param>
+        /// <returns></returns>
+        [HttpGet("series-for-mangafile")]
+        public async Task<ActionResult<SeriesDto>> GetSeriesForMangaFile(int mangaFileId)
+        {
+            var userId = await _unitOfWork.UserRepository.GetUserIdByUsernameAsync(User.GetUsername());
+            return Ok(await _unitOfWork.SeriesRepository.GetSeriesForMangaFile(mangaFileId, userId));
+        }
+
+        /// <summary>
         /// Fetches the related series for a given series
         /// </summary>
         /// <param name="seriesId"></param>

--- a/API/DTOs/MangaFileDto.cs
+++ b/API/DTOs/MangaFileDto.cs
@@ -4,9 +4,10 @@ namespace API.DTOs
 {
     public class MangaFileDto
     {
+        public int Id { get; init; }
         public string FilePath { get; init; }
         public int Pages { get; init; }
         public MangaFormat Format { get; init; }
-        
+
     }
 }

--- a/API/DTOs/Search/SearchResultGroupDto.cs
+++ b/API/DTOs/Search/SearchResultGroupDto.cs
@@ -17,5 +17,7 @@ public class SearchResultGroupDto
     public IEnumerable<PersonDto> Persons { get; set; }
     public IEnumerable<GenreTagDto> Genres { get; set; }
     public IEnumerable<TagDto> Tags { get; set; }
+    public IEnumerable<MangaFileDto> Files { get; set; }
+
 
 }

--- a/API/DTOs/Search/SearchResultGroupDto.cs
+++ b/API/DTOs/Search/SearchResultGroupDto.cs
@@ -18,6 +18,7 @@ public class SearchResultGroupDto
     public IEnumerable<GenreTagDto> Genres { get; set; }
     public IEnumerable<TagDto> Tags { get; set; }
     public IEnumerable<MangaFileDto> Files { get; set; }
+    public IEnumerable<ChapterDto> Chapters { get; set; }
 
 
 }

--- a/API/Data/Repositories/SeriesRepository.cs
+++ b/API/Data/Repositories/SeriesRepository.cs
@@ -353,6 +353,7 @@ public class SeriesRepository : ISeriesRepository
             .Where(sm => seriesIds.Contains(sm.SeriesId))
             .SelectMany(sm => sm.People.Where(t => EF.Functions.Like(t.Name, $"%{searchQuery}%")))
             .AsSplitQuery()
+            .Take(maxRecords)
             .Distinct()
             .ProjectTo<PersonDto>(_mapper.ConfigurationProvider)
             .ToListAsync();
@@ -363,6 +364,7 @@ public class SeriesRepository : ISeriesRepository
             .AsSplitQuery()
             .OrderBy(t => t.Title)
             .Distinct()
+            .Take(maxRecords)
             .ProjectTo<GenreTagDto>(_mapper.ConfigurationProvider)
             .ToListAsync();
 
@@ -372,6 +374,7 @@ public class SeriesRepository : ISeriesRepository
             .AsSplitQuery()
             .OrderBy(t => t.Title)
             .Distinct()
+            .Take(maxRecords)
             .ProjectTo<TagDto>(_mapper.ConfigurationProvider)
             .ToListAsync();
 
@@ -385,7 +388,7 @@ public class SeriesRepository : ISeriesRepository
         result.Files = await _context.MangaFile
             .Where(m => EF.Functions.Like(m.FilePath, $"%{searchQuery}%") && fileIds.Contains(m.Id))
             .AsSplitQuery()
-            .Take(10)
+            .Take(maxRecords)
             .ProjectTo<MangaFileDto>(_mapper.ConfigurationProvider)
             .ToListAsync();
 
@@ -395,7 +398,7 @@ public class SeriesRepository : ISeriesRepository
             .Where(c => EF.Functions.Like(c.TitleName, $"%{searchQuery}%"))
             .Where(c => c.Files.All(f => fileIds.Contains(f.Id)))
             .AsSplitQuery()
-            .Take(10)
+            .Take(maxRecords)
             .ProjectTo<ChapterDto>(_mapper.ConfigurationProvider)
             .ToListAsync();
 

--- a/API/Parser/Parser.cs
+++ b/API/Parser/Parser.cs
@@ -453,19 +453,11 @@ namespace API.Parser
         private static readonly Regex[] MangaEditionRegex = {
             // Tenjo Tenge {Full Contact Edition} v01 (2011) (Digital) (ASTC).cbz
             new Regex(
-                @"(?<Edition>({|\(|\[).* Edition(}|\)|\]))",
-                MatchOptions, RegexTimeout),
-            // Tenjo Tenge {Full Contact Edition} v01 (2011) (Digital) (ASTC).cbz
-            new Regex(
                 @"(\b|_)(?<Edition>Omnibus(( |_)?Edition)?)(\b|_)?",
                 MatchOptions, RegexTimeout),
             // To Love Ru v01 Uncensored (Ch.001-007)
             new Regex(
                 @"(\b|_)(?<Edition>Uncensored)(\b|_)",
-                MatchOptions, RegexTimeout),
-            // AKIRA - c003 (v01) [Full Color] [Darkhorse].cbz
-            new Regex(
-                @"(\b|_)(?<Edition>Full(?: |_)Color)(\b|_)?",
                 MatchOptions, RegexTimeout),
         };
 

--- a/API/Services/ArchiveService.cs
+++ b/API/Services/ArchiveService.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using System.Xml.Serialization;
 using API.Archive;

--- a/API/Services/Tasks/Scanner/ParseScannedFiles.cs
+++ b/API/Services/Tasks/Scanner/ParseScannedFiles.cs
@@ -133,7 +133,14 @@ namespace API.Services.Tasks.Scanner
                 }
             }
 
-            TrackSeries(info);
+            try
+            {
+                TrackSeries(info);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "There was an exception that occurred during tracking {FilePath}. Skipping this file", info.FullFilePath);
+            }
         }
 
 
@@ -183,8 +190,9 @@ namespace API.Services.Tasks.Scanner
         {
             var normalizedSeries = Parser.Parser.Normalize(info.Series);
             var normalizedLocalSeries = Parser.Parser.Normalize(info.LocalizedSeries);
+            // We use FirstOrDefault because this was introduced late in development and users might have 2 series with both names
             var existingName =
-                _scannedSeries.SingleOrDefault(p =>
+                _scannedSeries.FirstOrDefault(p =>
                         (Parser.Parser.Normalize(p.Key.NormalizedName) == normalizedSeries ||
                          Parser.Parser.Normalize(p.Key.NormalizedName) == normalizedLocalSeries) && p.Key.Format == info.Format)
                 .Key;

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -195,7 +195,7 @@ public class ScannerService : IScannerService
         // Check if any of the folder roots are not available (ie disconnected from network, etc) and fail if any of them are
         if (folders.Any(f => !_directoryService.IsDriveMounted(f)))
         {
-            _logger.LogError("Some of the root folders for library ({LibraryName} are not accessible. Please check that drives are connected and rescan. Scan will be aborted", libraryName);
+            _logger.LogCritical("Some of the root folders for library ({LibraryName} are not accessible. Please check that drives are connected and rescan. Scan will be aborted", libraryName);
 
             await _eventHub.SendMessageAsync(MessageFactory.Error,
                 MessageFactory.ErrorEvent("Some of the root folders for library are not accessible. Please check that drives are connected and rescan. Scan will be aborted",
@@ -267,6 +267,7 @@ public class ScannerService : IScannerService
         if (!await CheckMounts(library.Name, library.Folders.Select(f => f.Path).ToList()))
         {
             _logger.LogCritical("Some of the root folders for library are not accessible. Please check that drives are connected and rescan. Scan will be aborted");
+
             return;
         }
 

--- a/UI/Web/src/app/_models/manga-file.ts
+++ b/UI/Web/src/app/_models/manga-file.ts
@@ -1,6 +1,7 @@
 import { MangaFormat } from './manga-format';
 
 export interface MangaFile {
+    id: number;
     filePath: string;
     pages: number;
     format: MangaFormat;

--- a/UI/Web/src/app/_models/search/search-result-group.ts
+++ b/UI/Web/src/app/_models/search/search-result-group.ts
@@ -1,3 +1,4 @@
+import { Chapter } from "../chapter";
 import { Library } from "../library";
 import { MangaFile } from "../manga-file";
 import { SearchResult } from "../search-result";
@@ -12,6 +13,7 @@ export class SearchResultGroup {
     genres: Array<Tag> = [];
     tags: Array<Tag> = [];
     files: Array<MangaFile> = [];
+    chapters: Array<Chapter> = [];
 
     reset() {
         this.libraries = [];
@@ -22,5 +24,6 @@ export class SearchResultGroup {
         this.genres = [];
         this.tags = [];
         this.files = [];
+        this.chapters = []; 
     }
 }

--- a/UI/Web/src/app/_models/search/search-result-group.ts
+++ b/UI/Web/src/app/_models/search/search-result-group.ts
@@ -1,4 +1,5 @@
 import { Library } from "../library";
+import { MangaFile } from "../manga-file";
 import { SearchResult } from "../search-result";
 import { Tag } from "../tag";
 
@@ -10,6 +11,7 @@ export class SearchResultGroup {
     persons: Array<Tag> = [];
     genres: Array<Tag> = [];
     tags: Array<Tag> = [];
+    files: Array<MangaFile> = [];
 
     reset() {
         this.libraries = [];
@@ -19,5 +21,6 @@ export class SearchResultGroup {
         this.persons = [];
         this.genres = [];
         this.tags = [];
+        this.files = [];
     }
 }

--- a/UI/Web/src/app/_services/metadata.service.ts
+++ b/UI/Web/src/app/_services/metadata.service.ts
@@ -1,17 +1,15 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable, of } from 'rxjs';
+import { of } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { environment } from 'src/environments/environment';
 import { UtilityService } from '../shared/_services/utility.service';
-import { TypeaheadSettings } from '../typeahead/typeahead-settings';
-import { ChapterMetadata } from '../_models/chapter-metadata';
 import { Genre } from '../_models/genre';
 import { AgeRating } from '../_models/metadata/age-rating';
 import { AgeRatingDto } from '../_models/metadata/age-rating-dto';
 import { Language } from '../_models/metadata/language';
 import { PublicationStatusDto } from '../_models/metadata/publication-status-dto';
-import { Person, PersonRole } from '../_models/person';
+import { Person } from '../_models/person';
 import { Tag } from '../_models/tag';
 
 @Injectable({

--- a/UI/Web/src/app/_services/series.service.ts
+++ b/UI/Web/src/app/_services/series.service.ts
@@ -76,8 +76,8 @@ export class SeriesService {
     return this.httpClient.get<ChapterMetadata>(this.baseUrl + 'series/chapter-metadata?chapterId=' + chapterId);
   }
 
-  getData(id: number) {
-    return of(id);
+  getSeriesForMangaFile(mangaFileId: number) {
+    return this.httpClient.get<Series | null>(this.baseUrl + 'series/series-for-mangafile?mangaFileId=' + mangaFileId);
   }
 
   delete(seriesId: number) {

--- a/UI/Web/src/app/_services/series.service.ts
+++ b/UI/Web/src/app/_services/series.service.ts
@@ -80,6 +80,10 @@ export class SeriesService {
     return this.httpClient.get<Series | null>(this.baseUrl + 'series/series-for-mangafile?mangaFileId=' + mangaFileId);
   }
 
+  getSeriesForChapter(chapterId: number) {
+    return this.httpClient.get<Series | null>(this.baseUrl + 'series/series-for-chapter?chapterId=' + chapterId);
+  }
+
   delete(seriesId: number) {
     return this.httpClient.delete<boolean>(this.baseUrl + 'series/' + seriesId);
   }

--- a/UI/Web/src/app/admin/invite-user/invite-user.component.html
+++ b/UI/Web/src/app/admin/invite-user/invite-user.component.html
@@ -7,7 +7,7 @@
 <div class="modal-body">
     <p>
         Invite a user to your server. Enter their email in and we will send them an email to create an account. If you do not want to use our email service, you can host your own 
-        email service or use a fake email (Forgot User will not work). 
+        email service or use a fake email (Forgot User will not work). A link will be presented regardless and can be used to setup the email account manually.
     </p>
 
     <form [formGroup]="inviteForm" *ngIf="emailLink === ''">
@@ -37,7 +37,7 @@
     <ng-container *ngIf="emailLink !== ''">
         <h4>User invited</h4>
         <p>You can use the following link below to setup the account for your user or use the copy button. You may need to log out before using the link to register a new user.
-            If your server is externallyaccessible, an email will have been sent to the user and the links can be used by them to finish setting up their account.
+            If your server is externally accessible, an email will have been sent to the user and the links can be used by them to finish setting up their account.
         </p>
         <a class="email-link" href="{{emailLink}}" target="_blank">Setup user's account</a>
         <app-api-key title="Invite Url" tooltipText="Copy this and paste in a new tab. You may need to log out." [showRefresh]="false" [transform]="makeLink"></app-api-key>

--- a/UI/Web/src/app/admin/invite-user/invite-user.component.html
+++ b/UI/Web/src/app/admin/invite-user/invite-user.component.html
@@ -6,7 +6,8 @@
 </div>
 <div class="modal-body">
     <p>
-        Invite a user to your server. Enter their email in and we will send them an email to create an account.
+        Invite a user to your server. Enter their email in and we will send them an email to create an account. If you do not want to use our email service, you can host your own 
+        email service or use a fake email (Forgot User will not work). 
     </p>
 
     <form [formGroup]="inviteForm" *ngIf="emailLink === ''">
@@ -44,6 +45,10 @@
 
 </div>
 <div class="modal-footer">
+    <!-- <div class="form-check form-switch">
+        <input id="stat-collection" type="checkbox" aria-label="Stat Collection" class="form-check-input" formControlName="allowStatCollection" role="switch">
+        <label for="stat-collection" class="form-check-label">Send Data</label>
+    </div> -->
     <button type="button" class="btn btn-secondary" (click)="close()">
         Cancel
     </button>

--- a/UI/Web/src/app/admin/manage-settings/manage-settings.component.html
+++ b/UI/Web/src/app/admin/manage-settings/manage-settings.component.html
@@ -42,7 +42,7 @@
             <label for="stat-collection"  class="form-label" aria-describedby="collection-info">Allow Anonymous Usage Collection</label>
             <p class="accent" id="collection-info">Send anonymous usage and error information to Kavita's servers. This includes information on your browser, error reporting as well as OS and runtime version. We will use this information to prioritize features, bug fixes, and preformance tuning. Requires restart to take effect. See <a href="https://wiki.kavitareader.com/en/faq" target="_blank" referrerpolicy="no-refer">wiki</a> for what is collected.</p>
             <div class="form-check form-switch">
-                <input id="stat-collection" type="checkbox" aria-label="Stat Collection" class="form-check-input" formControlName="allowStatCollection">
+                <input id="stat-collection" type="checkbox" aria-label="Stat Collection" class="form-check-input" formControlName="allowStatCollection" role="switch">
                 <label for="stat-collection" class="form-check-label">Send Data</label>
             </div>
         </div>

--- a/UI/Web/src/app/app-routing.module.ts
+++ b/UI/Web/src/app/app-routing.module.ts
@@ -77,7 +77,7 @@ const routes: Routes = [
     loadChildren: () => import('../app/dev-only/dev-only.module').then(m => m.DevOnlyModule)
   },
   {path: 'login', loadChildren: () => import('../app/registration/registration.module').then(m => m.RegistrationModule)},
-  {path: '**', loadChildren: () => import('../app/dashboard/dashboard.module').then(m => m.DashboardModule), pathMatch: 'full'},
+  {path: '**', pathMatch: 'full', redirectTo: 'libraries'},
 ];
 
 @NgModule({

--- a/UI/Web/src/app/library-detail/library-recommended/library-recommended.component.html
+++ b/UI/Web/src/app/library-detail/library-recommended/library-recommended.component.html
@@ -1,4 +1,7 @@
 
+
+<!-- TODO: If there is nothing, then show a message -->
+
 <ng-container *ngIf="onDeck$ | async as onDeck">
     <app-carousel-reel [items]="onDeck" title="On Deck">
         <ng-template #carouselItem let-item let-position="idx">

--- a/UI/Web/src/app/library-detail/library-recommended/library-recommended.component.ts
+++ b/UI/Web/src/app/library-detail/library-recommended/library-recommended.component.ts
@@ -45,6 +45,8 @@ export class LibraryRecommendedComponent implements OnInit {
     this.genre$.subscribe(genre => {
       this.moreIn$ = this.recommendationService.getMoreIn(this.libraryId, genre.id).pipe(map(p => p.result), shareReplay());
     });
+
+    
     
   }
 

--- a/UI/Web/src/app/nav/events-widget/events-widget.component.html
+++ b/UI/Web/src/app/nav/events-widget/events-widget.component.html
@@ -48,7 +48,7 @@
                 <ng-container *ngFor="let message of progressUpdates">
                     <li class="list-group-item dark-menu-item" *ngIf="message.progress === 'indeterminate' || message.progress === 'none'; else progressEvent">
                         <div class="h6 mb-1">{{message.title}}</div>
-                        <div class="accent-text mb-1" *ngIf="message.subTitle !== ''">{{message.subTitle}}</div>
+                        <div class="accent-text mb-1" *ngIf="message.subTitle !== ''" [title]="message.subTitle">{{message.subTitle}}</div>
                         <div class="progress-container row g-0 align-items-center">
                             <div class="progress" style="height: 5px;" *ngIf="message.progress === 'indeterminate'">
                                 <div class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar" style="width: 100%" [attr.aria-valuenow]="100" aria-valuemin="0" aria-valuemax="100"></div>

--- a/UI/Web/src/app/nav/grouped-typeahead/grouped-typeahead.component.html
+++ b/UI/Web/src/app/nav/grouped-typeahead/grouped-typeahead.component.html
@@ -85,8 +85,19 @@
                 </ul>
             </ng-container>
 
+            <ng-container *ngIf="fileTemplate !== undefined && grouppedData.files.length > 0">
+                <li class="list-group-item section-header"><h5>Files</h5></li>
+                <ul class="list-group results">
+                    <li *ngFor="let option of grouppedData.files; let index = index;" (click)="handleResultlick(option)" tabindex="0"
+                        class="list-group-item" role="option">
+                        <ng-container [ngTemplateOutlet]="fileTemplate" [ngTemplateOutletContext]="{ $implicit: option, idx: index }"></ng-container>
+                    </li>
+                </ul>
+            </ng-container>
+
             <ng-container *ngIf="noResultsTemplate != undefined && searchTerm.length > 0 && !grouppedData.persons.length && !grouppedData.collections.length 
-                && !grouppedData.series.length && !grouppedData.persons.length && !grouppedData.tags.length && !grouppedData.genres.length && !grouppedData.libraries.length">
+                && !grouppedData.series.length && !grouppedData.persons.length && !grouppedData.tags.length && !grouppedData.genres.length && !grouppedData.libraries.length
+                && !grouppedData.files.length">
               <ul class="list-group results">
                 <li class="list-group-item">
                   <ng-container [ngTemplateOutlet]="noResultsTemplate"></ng-container>

--- a/UI/Web/src/app/nav/grouped-typeahead/grouped-typeahead.component.html
+++ b/UI/Web/src/app/nav/grouped-typeahead/grouped-typeahead.component.html
@@ -85,6 +85,16 @@
                 </ul>
             </ng-container>
 
+            <ng-container *ngIf="chapterTemplate !== undefined && grouppedData.chapters.length > 0">
+                <li class="list-group-item section-header"><h5>Chapters</h5></li>
+                <ul class="list-group results">
+                    <li *ngFor="let option of grouppedData.chapters; let index = index;" (click)="handleResultlick(option)" tabindex="0"
+                        class="list-group-item" role="option">
+                        <ng-container [ngTemplateOutlet]="chapterTemplate" [ngTemplateOutletContext]="{ $implicit: option, idx: index }"></ng-container>
+                    </li>
+                </ul>
+            </ng-container>
+
             <ng-container *ngIf="fileTemplate !== undefined && grouppedData.files.length > 0">
                 <li class="list-group-item section-header"><h5>Files</h5></li>
                 <ul class="list-group results">
@@ -95,9 +105,7 @@
                 </ul>
             </ng-container>
 
-            <ng-container *ngIf="noResultsTemplate != undefined && searchTerm.length > 0 && !grouppedData.persons.length && !grouppedData.collections.length 
-                && !grouppedData.series.length && !grouppedData.persons.length && !grouppedData.tags.length && !grouppedData.genres.length && !grouppedData.libraries.length
-                && !grouppedData.files.length">
+            <ng-container *ngIf="!hasData && searchTerm.length > 0">
               <ul class="list-group results">
                 <li class="list-group-item">
                   <ng-container [ngTemplateOutlet]="noResultsTemplate"></ng-container>

--- a/UI/Web/src/app/nav/grouped-typeahead/grouped-typeahead.component.scss
+++ b/UI/Web/src/app/nav/grouped-typeahead/grouped-typeahead.component.scss
@@ -68,7 +68,7 @@ form {
     }
 
     &.focused {
-        width: 100%;
+        width: 99%;
         border-color: var(--input-focused-border-color);
     }
 

--- a/UI/Web/src/app/nav/grouped-typeahead/grouped-typeahead.component.ts
+++ b/UI/Web/src/app/nav/grouped-typeahead/grouped-typeahead.component.ts
@@ -59,6 +59,7 @@ export class GroupedTypeaheadComponent implements OnInit, OnDestroy {
   @ContentChild('noResultsTemplate') noResultsTemplate!: TemplateRef<any>;
   @ContentChild('libraryTemplate') libraryTemplate!: TemplateRef<any>;
   @ContentChild('readingListTemplate') readingListTemplate!: TemplateRef<any>;
+  @ContentChild('fileTemplate') fileTemplate!: TemplateRef<any>;
   
 
   hasFocus: boolean = false;

--- a/UI/Web/src/app/nav/grouped-typeahead/grouped-typeahead.component.ts
+++ b/UI/Web/src/app/nav/grouped-typeahead/grouped-typeahead.component.ts
@@ -60,6 +60,7 @@ export class GroupedTypeaheadComponent implements OnInit, OnDestroy {
   @ContentChild('libraryTemplate') libraryTemplate!: TemplateRef<any>;
   @ContentChild('readingListTemplate') readingListTemplate!: TemplateRef<any>;
   @ContentChild('fileTemplate') fileTemplate!: TemplateRef<any>;
+  @ContentChild('chapterTemplate') chapterTemplate!: TemplateRef<any>;
   
 
   hasFocus: boolean = false;
@@ -75,7 +76,11 @@ export class GroupedTypeaheadComponent implements OnInit, OnDestroy {
   }
 
   get hasData() {
-    return this.grouppedData.persons.length || this.grouppedData.collections.length || this.grouppedData.series.length || this.grouppedData.persons.length || this.grouppedData.tags.length || this.grouppedData.genres.length;
+    return !(this.noResultsTemplate != undefined && !this.grouppedData.persons.length && !this.grouppedData.collections.length 
+      && !this.grouppedData.series.length && !this.grouppedData.persons.length && !this.grouppedData.tags.length && !this.grouppedData.genres.length && !this.grouppedData.libraries.length
+      && !this.grouppedData.files.length && !this.grouppedData.chapters.length);
+
+    //return this.grouppedData.persons.length || this.grouppedData.collections.length || this.grouppedData.series.length || this.grouppedData.persons.length || this.grouppedData.tags.length || this.grouppedData.genres.length;
   }
 
 

--- a/UI/Web/src/app/nav/nav-header/nav-header.component.html
+++ b/UI/Web/src/app/nav/nav-header/nav-header.component.html
@@ -44,6 +44,15 @@
               </div>
             </ng-template>
 
+            <ng-template #fileTemplate let-item>
+              <div style="display: flex;padding: 5px;" (click)="clickFileSearchResult(item)">
+                <div class="ms-1">
+                  <app-series-format [format]="item.format"></app-series-format>
+                  <span>{{item.filePath}}</span>
+                </div>
+              </div>
+            </ng-template>
+
             <ng-template #collectionTemplate let-item>
               <div style="display: flex;padding: 5px;" (click)="clickCollectionSearchResult(item)">
                 <div style="width: 24px" class="me-1">

--- a/UI/Web/src/app/nav/nav-header/nav-header.component.html
+++ b/UI/Web/src/app/nav/nav-header/nav-header.component.html
@@ -39,16 +39,7 @@
                   <ng-template #localizedName>
                     <span [innerHTML]="item.localizedName"></span>
                   </ng-template>
-                  <div class="form-text" style="font-size: 0.8rem;">in {{item.libraryName}}</div>
-                </div>
-              </div>
-            </ng-template>
-
-            <ng-template #fileTemplate let-item>
-              <div style="display: flex;padding: 5px;" (click)="clickFileSearchResult(item)">
-                <div class="ms-1">
-                  <app-series-format [format]="item.format"></app-series-format>
-                  <span>{{item.filePath}}</span>
+                  <div class="text-light fst-italic" style="font-size: 0.8rem;">in {{item.libraryName}}</div>
                 </div>
               </div>
             </ng-template>
@@ -93,7 +84,7 @@
                 <div class="ms-1">
                   
                   <div [innerHTML]="item.name"></div>
-                  <div>{{item.role | personRole}}</div>
+                  <div class="text-light fst-italic">{{item.role | personRole}}</div>
                 </div>
               </div>
             </ng-template>
@@ -102,6 +93,28 @@
               <div style="display: flex;padding: 5px;" class="clickable" (click)="goTo('genres', item.id)">
                 <div class="ms-1">
                   <div [innerHTML]="item.title"></div>
+                </div>
+              </div>
+            </ng-template>
+
+            
+
+            <ng-template #chapterTemplate let-item>
+              <div style="display: flex;padding: 5px;" class="clickable" (click)="clickChapterSearchResult(item)">
+                <div class="ms-1">
+                  <ng-container *ngIf="item.files.length > 0">
+                    <app-series-format [format]="item.files[0].format"></app-series-format>
+                  </ng-container>
+                  <span>{{item.titleName}}</span>
+                </div>
+              </div>
+            </ng-template>
+
+            <ng-template #fileTemplate let-item>
+              <div style="display: flex;padding: 5px;" (click)="clickFileSearchResult(item)">
+                <div class="ms-1">
+                  <app-series-format [format]="item.format"></app-series-format>
+                  <span>{{item.filePath}}</span>
                 </div>
               </div>
             </ng-template>

--- a/UI/Web/src/app/nav/nav-header/nav-header.component.ts
+++ b/UI/Web/src/app/nav/nav-header/nav-header.component.ts
@@ -3,6 +3,7 @@ import { Component, HostListener, Inject, OnDestroy, OnInit, ViewChild } from '@
 import { Router } from '@angular/router';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
+import { Chapter } from 'src/app/_models/chapter';
 import { MangaFile } from 'src/app/_models/manga-file';
 import { ScrollService } from 'src/app/_services/scroll.service';
 import { SeriesService } from 'src/app/_services/series.service';
@@ -159,6 +160,15 @@ export class NavHeaderComponent implements OnInit, OnDestroy {
   clickFileSearchResult(item: MangaFile) {
     this.clearSearch();
     this.seriesService.getSeriesForMangaFile(item.id).subscribe(series => {
+      if (series !== undefined && series !== null) {
+        this.router.navigate(['library', series.libraryId, 'series', series.id]);
+      }
+    })
+  }
+
+  clickChapterSearchResult(item: Chapter) {
+    this.clearSearch();
+    this.seriesService.getSeriesForChapter(item.id).subscribe(series => {
       if (series !== undefined && series !== null) {
         this.router.navigate(['library', series.libraryId, 'series', series.id]);
       }

--- a/UI/Web/src/app/nav/nav-header/nav-header.component.ts
+++ b/UI/Web/src/app/nav/nav-header/nav-header.component.ts
@@ -3,7 +3,9 @@ import { Component, HostListener, Inject, OnDestroy, OnInit, ViewChild } from '@
 import { Router } from '@angular/router';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
+import { MangaFile } from 'src/app/_models/manga-file';
 import { ScrollService } from 'src/app/_services/scroll.service';
+import { SeriesService } from 'src/app/_services/series.service';
 import { FilterQueryParam } from '../../shared/_services/filter-utilities.service';
 import { CollectionTag } from '../../_models/collection-tag';
 import { Library } from '../../_models/library';
@@ -48,7 +50,7 @@ export class NavHeaderComponent implements OnInit, OnDestroy {
 
   constructor(public accountService: AccountService, private router: Router, public navService: NavService,
     private libraryService: LibraryService, public imageService: ImageService, @Inject(DOCUMENT) private document: Document,
-    private scrollService: ScrollService) { }
+    private scrollService: ScrollService, private seriesService: SeriesService) { }
 
   ngOnInit(): void {}
 
@@ -152,6 +154,15 @@ export class NavHeaderComponent implements OnInit, OnDestroy {
     const libraryId = item.libraryId;
     const seriesId = item.seriesId;
     this.router.navigate(['library', libraryId, 'series', seriesId]);
+  }
+
+  clickFileSearchResult(item: MangaFile) {
+    this.clearSearch();
+    this.seriesService.getSeriesForMangaFile(item.id).subscribe(series => {
+      if (series !== undefined && series !== null) {
+        this.router.navigate(['library', series.libraryId, 'series', series.id]);
+      }
+    })
   }
 
   clickLibraryResult(item: Library) {

--- a/UI/Web/src/app/nav/nav.module.ts
+++ b/UI/Web/src/app/nav/nav.module.ts
@@ -8,6 +8,7 @@ import { SharedModule } from '../shared/shared.module';
 import { PipeModule } from '../pipe/pipe.module';
 import { TypeaheadModule } from '../typeahead/typeahead.module';
 import { ReactiveFormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
 
 
 
@@ -20,6 +21,7 @@ import { ReactiveFormsModule } from '@angular/forms';
   imports: [
     CommonModule,
     ReactiveFormsModule,
+    RouterModule,
 
     NgbDropdownModule,
     NgbPopoverModule,


### PR DESCRIPTION
# Added
- Added: Users can now search directly for files within Kavita. Clicking on the file will open the respective series.
- Added: Users can now search against Chapters with TitleName set. TitleName is extracted from the Title field in ComicInfo or the book name from Epubs (i.e. if you search 'Stone' and have a series of Harry Potter, 'Harry Potter and the Sorcerer's Stone' will show up as it's the 2nd book in the series)

# Changed
- Changed: Pull user reading progress for some of the recommended stuff (develop)
- Changed: Removed cleaning some edition tags from Series name, like Full Color Edition or Full Contact Edition.
- Changed: Adjusted some styling in the search results screen
- Changed: Search results are now limited to 15 in each category that is searched against. 
- Changed: Wrote some extra messaging in the invite user flow to help users understand they can use fake emails or use the link generated after to setup an account for the user

# Fixed
- Fixed: Fixed a bug around redirection from invalid urls from last PR (develop)
- Fixed: Fixed a bug where search bar when focused would expand just a bit too much
- Fixed: Fixed a bug where some links in nav bar wouldn't go anywhere (develop)
- Fixed: Fixed an issue where with the new LocalizedSeries tag, merging could fail if the user had a series with the Series name and a series with the LocalizedSeries name. (develop)
- Fixed: Fixed typing lag when interacting with a typeahead
