### PR TITLE
Implemented the ability to read format tag and force special status.

### DIFF
--- a/API/Data/Metadata/ComicInfo.cs
+++ b/API/Data/Metadata/ComicInfo.cs
@@ -62,6 +62,11 @@ namespace API.Data.Metadata
         /// Represents the sort order for the title
         /// </summary>
         public string TitleSort { get; set; } = string.Empty;
+        /// <summary>
+        /// This comes from ComicInfo and is free form text. We use this to validate against a set of tags and mark a file as
+        /// special.
+        /// </summary>
+        public string Format { get; set; } = string.Empty;
 
         /// <summary>
         /// The translator, can be comma separated. This is part of ComicInfo.xml draft v2.1

--- a/API/Parser/DefaultParser.cs
+++ b/API/Parser/DefaultParser.cs
@@ -85,7 +85,7 @@ public class DefaultParser
         if (ret.Chapters == Parser.DefaultChapter && ret.Volumes == Parser.DefaultVolume && !string.IsNullOrEmpty(isSpecial))
         {
             ret.IsSpecial = true;
-            ParseFromFallbackFolders(filePath, rootPath, type, ref ret);
+            ParseFromFallbackFolders(filePath, rootPath, type, ref ret); // NOTE: This can cause some complications, we should try to be a bit less aggressive to fallback to folder
         }
 
         // If we are a special with marker, we need to ensure we use the correct series name. we can do this by falling back to Folder name

--- a/API/Parser/Parser.cs
+++ b/API/Parser/Parser.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -511,6 +512,11 @@ namespace API.Parser
                 @"(?!=.+)(\s{2,})(?!=.+)",
                 MatchOptions, RegexTimeout
         );
+
+        private static readonly ImmutableArray<string> FormatTagSpecialKeyowrds = ImmutableArray.Create(
+            "Special", "Reference", "Director's Cut", "Box Set", "Box-Set", "Annual", "Anthology", "Epilogue",
+            "One Shot", "One-Shot", "Prologue", "TPB", "Trade Paper Back", "Omnibus", "Compendium", "Absolute", "Graphic Novel",
+            "GN", "FCBD");
 
         public static MangaFormat ParseFormat(string filePath)
         {
@@ -1033,6 +1039,16 @@ namespace API.Parser
         public static string NormalizePath(string path)
         {
             return path.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        }
+
+        /// <summary>
+        /// Checks against a set of strings to validate if a ComicInfo.Format should receive special treatment
+        /// </summary>
+        /// <param name="comicInfoFormat"></param>
+        /// <returns></returns>
+        public static bool HasComicInfoSpecial(string comicInfoFormat)
+        {
+            return FormatTagSpecialKeyowrds.Contains(comicInfoFormat);
         }
     }
 }

--- a/API/Services/Tasks/Scanner/ParseScannedFiles.cs
+++ b/API/Services/Tasks/Scanner/ParseScannedFiles.cs
@@ -122,6 +122,13 @@ namespace API.Services.Tasks.Scanner
                     info.SeriesSort = info.ComicInfo.TitleSort.Trim();
                 }
 
+                if (!string.IsNullOrEmpty(info.ComicInfo.Format) && Parser.Parser.HasComicInfoSpecial(info.ComicInfo.Format))
+                {
+                    info.IsSpecial = true;
+                    info.Chapters = Parser.Parser.DefaultChapter;
+                    info.Volumes = Parser.Parser.DefaultVolume;
+                }
+
                 if (!string.IsNullOrEmpty(info.ComicInfo.SeriesSort))
                 {
                     info.SeriesSort = info.ComicInfo.SeriesSort.Trim();


### PR DESCRIPTION
# Added
- Added: Kavita can now read the Format tag from ComicInfo and use that to force special status. The following tags will force special: Special, Reference, Director's Cut, Box Set, Box-Set, Annual, Anthology, Epilogue, One Shot, One-Shot, Prologue, TPB, Trade Paper Back, Omnibus, Compendium, Absolute, Graphic Novel, GN, FCBD (Closes #1283)
