### PR TITLE
Time Estimation Cleanup

### DIFF
--- a/API/Controllers/ReaderController.cs
+++ b/API/Controllers/ReaderController.cs
@@ -629,8 +629,39 @@ namespace API.Controllers
         }
 
 
+        /// <summary>
+        /// Given word count, page count, and if the entity is an epub file, this will return the read time.
+        /// </summary>
+        /// <param name="wordCount"></param>
+        /// <param name="pageCount"></param>
+        /// <param name="isEpub"></param>
+        /// <returns>Will always assume no progress as it's not privy</returns>
+        [HttpGet("manual-read-time")]
+        public ActionResult<HourEstimateRangeDto> GetManualReadTime(int wordCount, int pageCount, bool isEpub)
+        {
+
+            if (isEpub)
+            {
+                return Ok(new HourEstimateRangeDto()
+                {
+                    MinHours = (int) Math.Round((wordCount / ReaderService.MinWordsPerHour)),
+                    MaxHours = (int) Math.Round((wordCount / ReaderService.MaxWordsPerHour)),
+                    AvgHours = (int) Math.Round((wordCount / ReaderService.AvgWordsPerHour)),
+                    HasProgress = false
+                });
+            }
+
+            return Ok(new HourEstimateRangeDto()
+            {
+                MinHours = (int) Math.Round((pageCount / ReaderService.MinPagesPerMinute / 60F)),
+                MaxHours = (int) Math.Round((pageCount / ReaderService.MaxPagesPerMinute / 60F)),
+                AvgHours = (int) Math.Round((pageCount / ReaderService.AvgPagesPerMinute / 60F)),
+                HasProgress = false
+            });
+        }
+
         [HttpGet("read-time")]
-        public async Task<ActionResult<HourEstimateRangeDto>> GetEstimateToRead(int seriesId)
+        public async Task<ActionResult<HourEstimateRangeDto>> GetReadTime(int seriesId)
         {
             var userId = await _unitOfWork.UserRepository.GetUserIdByUsernameAsync(User.GetUsername());
             var series = await _unitOfWork.SeriesRepository.GetSeriesDtoByIdAsync(seriesId, userId);

--- a/API/Services/BookmarkService.cs
+++ b/API/Services/BookmarkService.cs
@@ -19,6 +19,7 @@ public interface IBookmarkService
     Task<bool> BookmarkPage(AppUser userWithBookmarks, BookmarkDto bookmarkDto, string imageToBookmark);
     Task<bool> RemoveBookmarkPage(AppUser userWithBookmarks, BookmarkDto bookmarkDto);
     Task<IEnumerable<string>> GetBookmarkFilesById(IEnumerable<int> bookmarkIds);
+    [DisableConcurrentExecution(timeoutInSeconds: 2 * 60 * 60), AutomaticRetry(Attempts = 0)]
     Task ConvertAllBookmarkToWebP();
 
 }
@@ -173,7 +174,6 @@ public class BookmarkService : IBookmarkService
     /// <summary>
     /// This is a long-running job that will convert all bookmarks into WebP. Do not invoke anyway except via Hangfire.
     /// </summary>
-    [DisableConcurrentExecution(timeoutInSeconds: 2 * 60 * 60), AutomaticRetry(Attempts = 0)]
     public async Task ConvertAllBookmarkToWebP()
     {
         var bookmarkDirectory =

--- a/API/Services/MetadataService.cs
+++ b/API/Services/MetadataService.cs
@@ -27,6 +27,8 @@ public interface IMetadataService
     /// </summary>
     /// <param name="libraryId"></param>
     /// <param name="forceUpdate"></param>
+    [DisableConcurrentExecution(timeoutInSeconds: 60 * 60 * 60)]
+    [AutomaticRetry(Attempts = 0, OnAttemptsExceeded = AttemptsExceededAction.Delete)]
     Task RefreshMetadata(int libraryId, bool forceUpdate = false);
     /// <summary>
     /// Performs a forced refresh of metadata just for a series and it's nested entities
@@ -196,8 +198,6 @@ public class MetadataService : IMetadataService
     /// <remarks>This can be heavy on memory first run</remarks>
     /// <param name="libraryId"></param>
     /// <param name="forceUpdate">Force updating cover image even if underlying file has not been modified or chapter already has a cover image</param>
-    [DisableConcurrentExecution(timeoutInSeconds: 60 * 60 * 60)]
-    [AutomaticRetry(Attempts = 0, OnAttemptsExceeded = AttemptsExceededAction.Delete)]
     public async Task RefreshMetadata(int libraryId, bool forceUpdate = false)
     {
         var library = await _unitOfWork.LibraryRepository.GetLibraryForIdAsync(libraryId, LibraryIncludes.None);

--- a/API/Services/Tasks/Scanner/ParseScannedFiles.cs
+++ b/API/Services/Tasks/Scanner/ParseScannedFiles.cs
@@ -164,27 +164,44 @@ namespace API.Services.Tasks.Scanner
             info.Series = MergeName(info);
 
             var normalizedSeries = Parser.Parser.Normalize(info.Series);
+            var normalizedSortSeries = Parser.Parser.Normalize(info.SeriesSort);
             var normalizedLocalizedSeries = Parser.Parser.Normalize(info.LocalizedSeries);
-            var existingKey = _scannedSeries.Keys.FirstOrDefault(ps =>
-                ps.Format == info.Format && (ps.NormalizedName == normalizedSeries
-                                             || ps.NormalizedName == normalizedLocalizedSeries));
-            existingKey ??= new ParsedSeries()
-            {
-                Format = info.Format,
-                Name = info.Series,
-                NormalizedName = normalizedSeries
-            };
 
-            _scannedSeries.AddOrUpdate(existingKey, new List<ParserInfo>() {info}, (_, oldValue) =>
+            try
             {
-                oldValue ??= new List<ParserInfo>();
-                if (!oldValue.Contains(info))
+                var existingKey = _scannedSeries.Keys.SingleOrDefault(ps =>
+                    ps.Format == info.Format && (ps.NormalizedName.Equals(normalizedSeries)
+                                                 || ps.NormalizedName.Equals(normalizedLocalizedSeries)
+                                                 || ps.NormalizedName.Equals(normalizedSortSeries)));
+                existingKey ??= new ParsedSeries()
                 {
-                    oldValue.Add(info);
-                }
+                    Format = info.Format,
+                    Name = info.Series,
+                    NormalizedName = normalizedSeries
+                };
 
-                return oldValue;
-            });
+                _scannedSeries.AddOrUpdate(existingKey, new List<ParserInfo>() {info}, (_, oldValue) =>
+                {
+                    oldValue ??= new List<ParserInfo>();
+                    if (!oldValue.Contains(info))
+                    {
+                        oldValue.Add(info);
+                    }
+
+                    return oldValue;
+                });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogCritical(ex, "{SeriesName} matches against multiple series in the parsed series. This indicates a critical kavita issue. Key will be skipped", info.Series);
+                foreach (var seriesKey in _scannedSeries.Keys.Where(ps =>
+                             ps.Format == info.Format && (ps.NormalizedName.Equals(normalizedSeries)
+                                                          || ps.NormalizedName.Equals(normalizedLocalizedSeries)
+                                                          || ps.NormalizedName.Equals(normalizedSortSeries))))
+                {
+                    _logger.LogCritical("Matches: {SeriesName} matches on {SeriesKey}", info.Series, seriesKey.Name);
+                }
+            }
         }
 
         /// <summary>

--- a/API/Services/Tasks/Scanner/ParseScannedFiles.cs
+++ b/API/Services/Tasks/Scanner/ParseScannedFiles.cs
@@ -231,7 +231,7 @@ namespace API.Services.Tasks.Scanner
             }
             catch (Exception ex)
             {
-                _logger.LogCritical(ex, "Multiple series detected for {SeriesName}! This is critical to fix! There should only be 1", info.Series);
+                _logger.LogCritical(ex, "Multiple series detected for {SeriesName} ({File})! This is critical to fix! There should only be 1", info.Series, info.FullFilePath);
                 var values = _scannedSeries.Where(p =>
                     (Parser.Parser.Normalize(p.Key.NormalizedName) == normalizedSeries ||
                      Parser.Parser.Normalize(p.Key.NormalizedName) == normalizedLocalSeries) &&
@@ -240,6 +240,7 @@ namespace API.Services.Tasks.Scanner
                 {
                     _logger.LogCritical("Duplicate Series in DB matches with {SeriesName}: {DuplicateName}", info.Series, pair.Key.Name);
                 }
+
             }
 
             return info.Series;

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -28,8 +28,14 @@ public interface IScannerService
     /// cover images if forceUpdate is true.
     /// </summary>
     /// <param name="libraryId">Library to scan against</param>
+    [DisableConcurrentExecution(60 * 60 * 60)]
+    [AutomaticRetry(Attempts = 0, OnAttemptsExceeded = AttemptsExceededAction.Delete)]
     Task ScanLibrary(int libraryId);
+    [DisableConcurrentExecution(60 * 60 * 60)]
+    [AutomaticRetry(Attempts = 0, OnAttemptsExceeded = AttemptsExceededAction.Delete)]
     Task ScanLibraries();
+    [DisableConcurrentExecution(60 * 60 * 60)]
+    [AutomaticRetry(Attempts = 3, OnAttemptsExceeded = AttemptsExceededAction.Delete)]
     Task ScanSeries(int libraryId, int seriesId, CancellationToken token);
 }
 
@@ -63,8 +69,6 @@ public class ScannerService : IScannerService
         _wordCountAnalyzerService = wordCountAnalyzerService;
     }
 
-    [DisableConcurrentExecution(timeoutInSeconds: 60 * 60 * 60)]
-    [AutomaticRetry(Attempts = 0, OnAttemptsExceeded = AttemptsExceededAction.Delete)]
     public async Task ScanSeries(int libraryId, int seriesId, CancellationToken token)
     {
         var sw = new Stopwatch();
@@ -247,8 +251,6 @@ public class ScannerService : IScannerService
     }
 
 
-    [DisableConcurrentExecution(timeoutInSeconds: 60 * 60 * 60 * 4)]
-    [AutomaticRetry(Attempts = 0, OnAttemptsExceeded = AttemptsExceededAction.Delete)]
     public async Task ScanLibraries()
     {
         _logger.LogInformation("Starting Scan of All Libraries");
@@ -267,8 +269,7 @@ public class ScannerService : IScannerService
     /// ie) all entities will be rechecked for new cover images and comicInfo.xml changes
     /// </summary>
     /// <param name="libraryId"></param>
-    [DisableConcurrentExecution(60 * 60 * 60)]
-    [AutomaticRetry(Attempts = 0, OnAttemptsExceeded = AttemptsExceededAction.Delete)]
+
     public async Task ScanLibrary(int libraryId)
     {
         Library library;

--- a/API/config/appsettings.Development.json
+++ b/API/config/appsettings.Development.json
@@ -5,7 +5,7 @@
   "TokenKey": "super secret unguessable key",
   "Logging": {
     "LogLevel": {
-      "Default": "Information",
+      "Default": "Debug",
       "Microsoft": "Information",
       "Microsoft.Hosting.Lifetime": "Error",
       "Hangfire": "Information",

--- a/UI/Web/src/app/_services/reader.service.ts
+++ b/UI/Web/src/app/_services/reader.service.ts
@@ -137,6 +137,10 @@ export class ReaderService {
     return this.httpClient.get<HourEstimateRange>(this.baseUrl + 'reader/read-time?seriesId=' + seriesId);
   }
 
+  getManualTimeToRead(wordCount: number, pageCount: number, isEpub: boolean) {
+    return this.httpClient.get<HourEstimateRange>(this.baseUrl + 'reader/manual-read-time?wordCount=' + wordCount + '&pageCount=' + pageCount + '&isEpub=' + isEpub);
+  }
+
   /**
    * Captures current body color and forces background color to be black. Call @see resetOverrideStyles() on destroy of component to revert changes
    */

--- a/UI/Web/src/app/_services/reader.service.ts
+++ b/UI/Web/src/app/_services/reader.service.ts
@@ -133,6 +133,10 @@ export class ReaderService {
     return this.httpClient.get<HourEstimateRange>(this.baseUrl + 'reader/time-left?seriesId=' + seriesId);
   }
 
+  getTimeToRead(seriesId: number) {
+    return this.httpClient.get<HourEstimateRange>(this.baseUrl + 'reader/read-time?seriesId=' + seriesId);
+  }
+
   /**
    * Captures current body color and forces background color to be black. Call @see resetOverrideStyles() on destroy of component to revert changes
    */

--- a/UI/Web/src/app/cards/card-detail-drawer/card-detail-drawer.component.html
+++ b/UI/Web/src/app/cards/card-detail-drawer/card-detail-drawer.component.html
@@ -70,7 +70,7 @@
                             <ng-container *ngIf="chapter.files[0].format === MangaFormat.EPUB && chapterMetadata !== undefined && chapterMetadata.wordCount > 0 || chapter.files[0].format !== MangaFormat.EPUB">
                                 <div class="col-auto mb-2">
                                     <app-icon-and-title [clickable]="false" fontClasses="fa-regular fa-clock">
-                                        {{minHoursToRead}}{{maxHoursToRead !== minHoursToRead ? ('-' + maxHoursToRead) : ''}} Hour{{minHoursToRead > 1 ? 's' : ''}}
+                                        {{readingTime.minHours}}{{readingTime.maxHours !== readingTime.minHours ? ('-' + readingTime.maxHours) : ''}} Hour{{readingTime.minHours > 1 ? 's' : ''}}
                                     </app-icon-and-title>
                                 </div>
                             </ng-container>

--- a/UI/Web/src/app/cards/card-detail-drawer/card-detail-drawer.component.html
+++ b/UI/Web/src/app/cards/card-detail-drawer/card-detail-drawer.component.html
@@ -52,7 +52,7 @@
                             <ng-container *ngIf="chapter.pages">
                                 <div class="col-auto mb-2">
                                     <app-icon-and-title [clickable]="false" fontClasses="fa-regular fa-file-lines" title="Pages">
-                                        {{chapter.pages}} Pages
+                                        {{chapter.pages | number:''}} Pages
                                     </app-icon-and-title>
                                 </div>
                                 <div class="vr d-none d-lg-block m-2"></div>
@@ -229,7 +229,7 @@
                                         <span>{{file.filePath}}</span>
                                         <div class="row g-0">
                                             <div class="col">
-                                                Pages: {{file.pages}}
+                                                Pages: {{file.pages | number:''}}
                                             </div>
                                             <div class="col" *ngIf="data.hasOwnProperty('created')">
                                                 Added: {{(data.created | date: 'short') || '-'}}

--- a/UI/Web/src/app/cards/card-detail-drawer/card-detail-drawer.component.ts
+++ b/UI/Web/src/app/cards/card-detail-drawer/card-detail-drawer.component.ts
@@ -80,6 +80,7 @@ export class CardDetailDrawerComponent implements OnInit {
   minHoursToRead: number = 1;
   maxHoursToRead: number = 1;
   
+  
 
   get MangaFormat() {
     return MangaFormat;
@@ -120,6 +121,8 @@ export class CardDetailDrawerComponent implements OnInit {
 
       this.metadataService.getAgeRating(this.chapterMetadata.ageRating).subscribe(ageRating => this.ageRating = ageRating);
       
+      //TODO: (for chapter) this.readerService.getTimeToRead(this.series.id).subscribe((time) => this.readingTime = time);
+
       if (this.chapter.files[0].format === MangaFormat.EPUB && this.chapterMetadata.wordCount > 0) {
         this.minHoursToRead = parseInt(Math.round(this.chapterMetadata.wordCount / MAX_WORDS_PER_HOUR) + '', 10) || 1;
         this.maxHoursToRead = parseInt(Math.round(this.chapterMetadata.wordCount / MIN_WORDS_PER_HOUR) + '', 10) || 1;

--- a/UI/Web/src/app/series-detail/series-metadata-detail/series-metadata-detail.component.html
+++ b/UI/Web/src/app/series-detail/series-metadata-detail/series-metadata-detail.component.html
@@ -67,6 +67,7 @@
                     </app-icon-and-title>
                 </div>    
             </ng-container>
+            <div class="vr d-none d-lg-block m-2"></div>
         </ng-container>
         <ng-template #showPages>
             <div class="d-none d-md-block col-lg-1 col-md-4 col-sm-4 col-4 mb-2">
@@ -76,20 +77,18 @@
             </div>
         </ng-template>    
         
-        <div class="vr d-none d-lg-block m-2"></div>
-
         
 
         <ng-container *ngIf="series.format === MangaFormat.EPUB && series.wordCount > 0 || series.format !== MangaFormat.EPUB">
             <div class="col-lg-1 col-md-4 col-sm-4 col-4 mb-2">
                 <app-icon-and-title [clickable]="false" fontClasses="fa-regular fa-clock">
-                    {{minHoursToRead}}{{maxHoursToRead !== minHoursToRead ? ('-' + maxHoursToRead) : ''}} Hour{{minHoursToRead > 1 ? 's' : ''}}
+                    {{readingTime.minHours}}{{readingTime.maxHours !== readingTime.minHours ? ('-' + readingTime.maxHours) : ''}} Hour{{readingTime.minHours > 1 ? 's' : ''}}
                 </app-icon-and-title>
             </div>
         </ng-container>
 
 
-        <ng-container *ngIf="readingTimeLeft.hasProgress && readingTimeLeft.minHours !== 1 && readingTimeLeft.maxHours !== 1 && readingTimeLeft.avgHours !== 0">
+        <ng-container *ngIf="readingTimeLeft.hasProgress && readingTimeLeft.avgHours !== 0 ">
             <div class="vr d-none d-lg-block m-2"></div>
             <div class="col-lg-1 col-md-4 col-sm-4 col-4 mb-2">
                 <app-icon-and-title [clickable]="false" fontClasses="fa-solid fa-clock">

--- a/UI/Web/src/app/series-detail/series-metadata-detail/series-metadata-detail.component.html
+++ b/UI/Web/src/app/series-detail/series-metadata-detail/series-metadata-detail.component.html
@@ -72,7 +72,7 @@
         <ng-template #showPages>
             <div class="d-none d-md-block col-lg-1 col-md-4 col-sm-4 col-4 mb-2">
                 <app-icon-and-title [clickable]="false" fontClasses="fa-regular fa-file-lines">
-                    {{series.pages}} Pages
+                    {{series.pages | number:''}} Pages
                 </app-icon-and-title>
             </div>
         </ng-template>    

--- a/UI/Web/src/app/series-detail/series-metadata-detail/series-metadata-detail.component.ts
+++ b/UI/Web/src/app/series-detail/series-metadata-detail/series-metadata-detail.component.ts
@@ -29,8 +29,9 @@ export class SeriesMetadataDetailComponent implements OnInit, OnChanges {
   isCollapsed: boolean = true;
   hasExtendedProperites: boolean = false;
 
-  minHoursToRead: number = 1;
-  maxHoursToRead: number = 1;
+  // minHoursToRead: number = 1;
+  // maxHoursToRead: number = 1;
+  readingTime: HourEstimateRange = {maxHours: 1, minHours: 1, avgHours: 1, hasProgress: false};
   readingTimeLeft: HourEstimateRange = {maxHours: 1, minHours: 1, avgHours: 1, hasProgress: false};
 
   /**
@@ -71,14 +72,15 @@ export class SeriesMetadataDetailComponent implements OnInit, OnChanges {
     
     if (this.series !== null) {
       this.readerService.getTimeLeft(this.series.id).subscribe((timeLeft) => this.readingTimeLeft = timeLeft);
+      this.readerService.getTimeToRead(this.series.id).subscribe((time) => this.readingTime = time);
 
-      if (this.series.format === MangaFormat.EPUB && this.series.wordCount > 0) {
-        this.minHoursToRead = parseInt(Math.round(this.series.wordCount / MAX_WORDS_PER_HOUR) + '', 10) || 1;
-        this.maxHoursToRead = parseInt(Math.round(this.series.wordCount / MIN_WORDS_PER_HOUR) + '', 10) || 1;
-      } else if (this.series.format !== MangaFormat.EPUB) {
-        this.minHoursToRead = parseInt(Math.round((this.series.pages / MIN_PAGES_PER_MINUTE) / 60) + '', 10) || 1;
-        this.maxHoursToRead = parseInt(Math.round((this.series.pages / MAX_PAGES_PER_MINUTE) / 60) + '', 10) || 1;
-      }
+      // if (this.series.format === MangaFormat.EPUB && this.series.wordCount > 0) {
+      //   this.minHoursToRead = parseInt(Math.round(this.series.wordCount / MAX_WORDS_PER_HOUR) + '', 10) || 1;
+      //   this.maxHoursToRead = parseInt(Math.round(this.series.wordCount / MIN_WORDS_PER_HOUR) + '', 10) || 1;
+      // } else if (this.series.format !== MangaFormat.EPUB) {
+      //   this.minHoursToRead = parseInt(Math.round((this.series.pages / MIN_PAGES_PER_MINUTE) / 60) + '', 10) || 1;
+      //   this.maxHoursToRead = parseInt(Math.round((this.series.pages / MAX_PAGES_PER_MINUTE) / 60) + '', 10) || 1;
+      // }
     }
   }
 

--- a/UI/Web/src/app/series-detail/series-metadata-detail/series-metadata-detail.component.ts
+++ b/UI/Web/src/app/series-detail/series-metadata-detail/series-metadata-detail.component.ts
@@ -29,8 +29,6 @@ export class SeriesMetadataDetailComponent implements OnInit, OnChanges {
   isCollapsed: boolean = true;
   hasExtendedProperites: boolean = false;
 
-  // minHoursToRead: number = 1;
-  // maxHoursToRead: number = 1;
   readingTime: HourEstimateRange = {maxHours: 1, minHours: 1, avgHours: 1, hasProgress: false};
   readingTimeLeft: HourEstimateRange = {maxHours: 1, minHours: 1, avgHours: 1, hasProgress: false};
 
@@ -73,14 +71,6 @@ export class SeriesMetadataDetailComponent implements OnInit, OnChanges {
     if (this.series !== null) {
       this.readerService.getTimeLeft(this.series.id).subscribe((timeLeft) => this.readingTimeLeft = timeLeft);
       this.readerService.getTimeToRead(this.series.id).subscribe((time) => this.readingTime = time);
-
-      // if (this.series.format === MangaFormat.EPUB && this.series.wordCount > 0) {
-      //   this.minHoursToRead = parseInt(Math.round(this.series.wordCount / MAX_WORDS_PER_HOUR) + '', 10) || 1;
-      //   this.maxHoursToRead = parseInt(Math.round(this.series.wordCount / MIN_WORDS_PER_HOUR) + '', 10) || 1;
-      // } else if (this.series.format !== MangaFormat.EPUB) {
-      //   this.minHoursToRead = parseInt(Math.round((this.series.pages / MIN_PAGES_PER_MINUTE) / 60) + '', 10) || 1;
-      //   this.maxHoursToRead = parseInt(Math.round((this.series.pages / MAX_PAGES_PER_MINUTE) / 60) + '', 10) || 1;
-      // }
     }
   }
 


### PR DESCRIPTION
# Changed
- Changed: Moved scheduler annotations to interface level, which supposedly is how to get concurrent tasks to not run. 
- Changed: There is more logging in this build for when duplicates occur (develop)
- Changed: Page count will now use commas when showing large numbers (develop)

# Fixed
- Fixed: Misc bug fixes for the time estimation code (develop)


