### PR TITLE
Bugfix/reader issues

### DIFF
--- a/API/API.csproj
+++ b/API/API.csproj
@@ -46,7 +46,7 @@
     <PackageReference Include="Hangfire.AspNetCore" Version="1.7.29" />
     <PackageReference Include="Hangfire.MaximumConcurrentExecutions" Version="1.1.0" />
     <PackageReference Include="Hangfire.MemoryStorage.Core" Version="1.4.0" />
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.42" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.43" />
     <PackageReference Include="MarkdownDeep.NET.Core" Version="1.5.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="6.0.5" />
@@ -63,14 +63,14 @@
     <PackageReference Include="NetVips.Native" Version="8.12.2" />
     <PackageReference Include="NReco.Logging.File" Version="1.1.5" />
     <PackageReference Include="SharpCompress" Version="0.31.0" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.1" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.39.0.47922">
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.2" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.40.0.48530">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.1" />
     <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.18.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.19.0" />
     <PackageReference Include="System.IO.Abstractions" Version="17.0.15" />
     <PackageReference Include="VersOne.Epub" Version="3.1.1" />
   </ItemGroup>

--- a/API/Services/BookService.cs
+++ b/API/Services/BookService.cs
@@ -246,12 +246,16 @@ namespace API.Services
         private static void ScopeImages(HtmlDocument doc, EpubBookRef book, string apiBase)
         {
             var images = doc.DocumentNode.SelectNodes("//img")
-                         ?? doc.DocumentNode.SelectNodes("//image");
+                         ?? doc.DocumentNode.SelectNodes("//image") ?? doc.DocumentNode.SelectNodes("//svg");
 
             if (images == null) return;
 
+
+            var parent = images.First().ParentNode;
+
             foreach (var image in images)
             {
+
                 string key = null;
                 if (image.Attributes["src"] != null)
                 {
@@ -269,6 +273,7 @@ namespace API.Services
                 image.Attributes.Add(key, $"{apiBase}" + imageFile);
 
                 // Add a custom class that the reader uses to ensure images stay within reader
+                parent.AddClass("kavita-scale-width-container");
                 image.AddClass("kavita-scale-width");
             }
 

--- a/API/config/appsettings.Development.json
+++ b/API/config/appsettings.Development.json
@@ -5,7 +5,7 @@
   "TokenKey": "super secret unguessable key",
   "Logging": {
     "LogLevel": {
-      "Default": "Debug",
+      "Default": "Critical",
       "Microsoft": "Information",
       "Microsoft.Hosting.Lifetime": "Error",
       "Hangfire": "Information",

--- a/Kavita.Common/Kavita.Common.csproj
+++ b/Kavita.Common/Kavita.Common.csproj
@@ -12,7 +12,7 @@
       <PackageReference Include="Flurl.Http" Version="3.2.4" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
       <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
-      <PackageReference Include="SonarAnalyzer.CSharp" Version="8.39.0.47922">
+      <PackageReference Include="SonarAnalyzer.CSharp" Version="8.40.0.48530">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>

--- a/Kavita.Common/Kavita.Common.csproj
+++ b/Kavita.Common/Kavita.Common.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net6.0</TargetFramework>
         <Company>kavitareader.com</Company>
         <Product>Kavita</Product>
-        <AssemblyVersion>0.5.3.10</AssemblyVersion>
+        <AssemblyVersion>0.5.3.11</AssemblyVersion>
         <NeutralLanguage>en</NeutralLanguage>
     </PropertyGroup>
 

--- a/UI/Web/src/app/_services/action-factory.service.ts
+++ b/UI/Web/src/app/_services/action-factory.service.ts
@@ -65,6 +65,10 @@ export enum Action {
    * Open Series detail page for said series
    */
   ViewSeries = 13,
+  /**
+   * Open the reader for entity
+   */
+  Read = 14,
 }
 
 export interface ActionItem<T> {

--- a/UI/Web/src/app/app.component.ts
+++ b/UI/Web/src/app/app.component.ts
@@ -36,13 +36,11 @@ export class AppComponent implements OnInit {
   }
 
   @HostListener('window:resize', ['$event'])
-  onResize(){
-    this.setDocHeight();
-  }
-
   @HostListener('window:orientationchange', ['$event'])
-  onOrientationChange() {
-    this.setDocHeight();
+  setDocHeight() {
+    // Sets a CSS variable for the actual device viewport height. Needed for mobile dev.
+    const vh = window.innerHeight * 0.01;
+    this.document.documentElement.style.setProperty('--vh', `${vh}px`);
   }
 
   ngOnInit(): void {
@@ -58,11 +56,5 @@ export class AppComponent implements OnInit {
       this.messageHub.createHubConnection(user, this.accountService.hasAdminRole(user));
       this.libraryService.getLibraryNames().pipe(take(1)).subscribe(() => {/* No Operation */});
     } 
-  }
-
-  setDocHeight() {
-    // Sets a CSS variable for the actual device viewport height. Needed for mobile dev.
-    let vh = window.innerHeight * 0.01;
-    this.document.documentElement.style.setProperty('--vh', `${vh}px`);
   }
 }

--- a/UI/Web/src/app/book-reader/book-reader/book-reader.component.html
+++ b/UI/Web/src/app/book-reader/book-reader/book-reader.component.html
@@ -91,7 +91,7 @@
                 [innerHtml]="page" *ngIf="page !== undefined" (click)="toggleMenu($event)" (mousedown)="mouseDown($event)"></div>
 
 
-            <div *ngIf="page !== undefined && (scrollbarNeeded || layoutMode !== BookPageLayoutMode.Default)" (click)="$event.stopPropagation();" class="bottom-bar">
+            <div *ngIf="page !== undefined && (scrollbarNeeded || layoutMode !== BookPageLayoutMode.Default)" (click)="$event.stopPropagation();" [ngClass]="{'bottom-bar': layoutMode !== BookPageLayoutMode.Default}">
                 <ng-container [ngTemplateOutlet]="actionBar"></ng-container>
             </div>
         </div>

--- a/UI/Web/src/app/book-reader/book-reader/book-reader.component.html
+++ b/UI/Web/src/app/book-reader/book-reader/book-reader.component.html
@@ -72,7 +72,7 @@
         </app-drawer>
     </div>
 
-    <div #readingSection class="reading-section {{ColumnLayout}}" [@isLoading]="isLoading ? true : false">
+    <div #readingSection class="reading-section {{ColumnLayout}}" [ngClass]="{'immersive' : immersiveMode || !actionBarVisible}" [@isLoading]="isLoading ? true : false">
         
         <ng-container *ngIf="clickToPaginate">
             <div class="left {{clickOverlayClass('left')}} no-observe" [ngClass]="{'immersive' : immersiveMode}"
@@ -84,9 +84,10 @@
                  tabindex="-1" [ngStyle]="{height: PageHeightForPagination}"></div>
         </ng-container>
 
-        <div class="book-container {{ColumnLayout}}">
+        <div class="book-container" [ngClass]="{'immersive' : immersiveMode}"> <!--  {{ColumnLayout}}-->
 
-            <div #readingHtml class="book-content {{ColumnLayout}}" [ngStyle]="{'max-height': ColumnHeight, 'column-width': ColumnWidth}" [ngClass]="{'immersive': immersiveMode && actionBarVisible}"
+            <div #readingHtml class="book-content {{ColumnLayout}}" [ngStyle]="{'max-height': ColumnHeight, 'column-width': ColumnWidth}" 
+                [ngClass]="{'immersive': immersiveMode && actionBarVisible}"
                 [innerHtml]="page" *ngIf="page !== undefined" (click)="toggleMenu($event)" (mousedown)="mouseDown($event)"></div>
 
 

--- a/UI/Web/src/app/book-reader/book-reader/book-reader.component.html
+++ b/UI/Web/src/app/book-reader/book-reader/book-reader.component.html
@@ -75,21 +75,22 @@
     <div #readingSection class="reading-section {{ColumnLayout}}" [@isLoading]="isLoading ? true : false">
         
         <ng-container *ngIf="clickToPaginate">
-            <div class="left {{clickOverlayClass('left')}} no-observe" 
+            <div class="left {{clickOverlayClass('left')}} no-observe" [ngClass]="{'immersive' : immersiveMode}"
                 (click)="movePage(readingDirection === ReadingDirection.LeftToRight ? PAGING_DIRECTION.BACKWARDS : PAGING_DIRECTION.FORWARD)"
                  tabindex="-1" [ngStyle]="{height: PageHeightForPagination}"></div>
-            <div class="{{scrollbarNeeded ? 'right-with-scrollbar' : 'right'}} {{clickOverlayClass('right')}} no-observe"
+            <div class="{{scrollbarNeeded ? 'right-with-scrollbar' : 'right'}} {{clickOverlayClass('right')}} no-observe"  
+                [ngClass]="{'immersive' : immersiveMode}"
                 (click)="movePage(readingDirection === ReadingDirection.LeftToRight ? PAGING_DIRECTION.FORWARD : PAGING_DIRECTION.BACKWARDS)"
                  tabindex="-1" [ngStyle]="{height: PageHeightForPagination}"></div>
         </ng-container>
 
         <div class="book-container {{ColumnLayout}}">
 
-            <div #readingHtml class="book-content {{ColumnLayout}}" [ngStyle]="{'max-height': ColumnHeight, 'column-width': ColumnWidth}"
+            <div #readingHtml class="book-content {{ColumnLayout}}" [ngStyle]="{'max-height': ColumnHeight, 'column-width': ColumnWidth}" [ngClass]="{'immersive': immersiveMode && actionBarVisible}"
                 [innerHtml]="page" *ngIf="page !== undefined" (click)="toggleMenu($event)" (mousedown)="mouseDown($event)"></div>
 
 
-            <div *ngIf="page !== undefined && (scrollbarNeeded || layoutMode !== BookPageLayoutMode.Default)" (click)="$event.stopPropagation();">
+            <div *ngIf="page !== undefined && (scrollbarNeeded || layoutMode !== BookPageLayoutMode.Default)" (click)="$event.stopPropagation();" class="bottom-bar">
                 <ng-container [ngTemplateOutlet]="actionBar"></ng-container>
             </div>
         </div>

--- a/UI/Web/src/app/book-reader/book-reader/book-reader.component.scss
+++ b/UI/Web/src/app/book-reader/book-reader/book-reader.component.scss
@@ -265,10 +265,10 @@ $action-bar-height: 38px;
 
 .right {
     position: absolute;
-    right: 0px; // with scrollbar: 17px
+    right: 0px;
     top: $action-bar-height;
-    width: 20%; // with scrollbar: 18%
-
+    width: 20%;
+    border: none !important;
     z-index: 2;
     cursor: pointer;
     background: transparent;
@@ -283,6 +283,7 @@ $action-bar-height: 38px;
     z-index: 2;
     cursor: pointer;
     background: transparent;
+    border: none !important;
 }
 
 .left {
@@ -291,7 +292,7 @@ $action-bar-height: 38px;
     top: $action-bar-height;
     width: 20%;
     background: transparent;
-
+    border: none !important;
     z-index: 2;
     cursor: pointer;
 }

--- a/UI/Web/src/app/book-reader/book-reader/book-reader.component.scss
+++ b/UI/Web/src/app/book-reader/book-reader/book-reader.component.scss
@@ -268,10 +268,12 @@ $action-bar-height: 38px;
     right: 0px;
     top: $action-bar-height;
     width: 20%;
-    border: none !important;
     z-index: 2;
     cursor: pointer;
     background: transparent;
+    border-color: transparent;
+    border: none !important;
+    opacity: 0;
 }
 
 // This class pushes the click area to the left a bit to let users click the scrollbar
@@ -283,7 +285,9 @@ $action-bar-height: 38px;
     z-index: 2;
     cursor: pointer;
     background: transparent;
+    border-color: transparent;
     border: none !important;
+    opacity: 0;
 }
 
 .left {
@@ -292,7 +296,9 @@ $action-bar-height: 38px;
     top: $action-bar-height;
     width: 20%;
     background: transparent;
+    border-color: transparent;
     border: none !important;
+    opacity: 0;
     z-index: 2;
     cursor: pointer;
 }

--- a/UI/Web/src/app/book-reader/book-reader/book-reader.component.scss
+++ b/UI/Web/src/app/book-reader/book-reader/book-reader.component.scss
@@ -59,6 +59,8 @@ $action-bar-height: 38px;
 }
 
 .drawer-body {
+    overflow: auto;
+
     .reader-pills {
         justify-content: center;
         margin: 0 0.25rem;
@@ -244,6 +246,11 @@ $action-bar-height: 38px;
     }
 }
 
+// This is applied to images in the backend
+::ng-deep .kavita-scale-width-container {
+    width: auto;
+    max-height: calc((var(--vh)*100) - 116px) !important;
+}
 
 // This is applied to images in the backend
 ::ng-deep .kavita-scale-width {

--- a/UI/Web/src/app/book-reader/book-reader/book-reader.component.scss
+++ b/UI/Web/src/app/book-reader/book-reader/book-reader.component.scss
@@ -130,6 +130,7 @@ $action-bar-height: 38px;
     overflow: auto;
     height: calc(var(--vh, 1vh) * 100);
     position: relative;
+    // This is completely invisible, everything else renders over it
 
     &.column-layout-1 {
         height: calc(var(--vh) * 100);
@@ -147,6 +148,8 @@ $action-bar-height: 38px;
     padding-top: $action-bar-height;
     position: relative;
 
+    background-color: green !important;
+
     &.column-layout-1 {
         height: calc((var(--vh, 1vh) * 100) - $action-bar-height);
     }
@@ -154,11 +157,17 @@ $action-bar-height: 38px;
     &.column-layout-2 {
         height: calc((var(--vh, 1vh) * 100) - $action-bar-height);
     }
+
+    &.immersive {
+        height: calc((var(--vh, 1vh) * 100));
+    }
 }
 
 .book-container {
     position: relative;
     height: 100%;
+
+    background-color: purple !important;
 
     &.column-layout-1 {
         height: calc((var(--vh, 1vh) * 100) - $action-bar-height);
@@ -173,13 +182,18 @@ $action-bar-height: 38px;
     position: relative;
     padding: 20px 0;
     margin: 0px 0px;
+    background-color: red !important;
 
     &.column-layout-1 {
-        height: calc((var(--vh) * 100) - calc($action-bar-height * 2));
+        height: calc((var(--vh) * 100) - calc($action-bar-height)); //  * 2
     }
 
     &.column-layout-2 {
-        height: calc((var(--vh) * 100) - calc($action-bar-height * 2));
+        height: calc((var(--vh) * 100) - calc($action-bar-height)); //  * 2
+    }
+
+    &.immersive {
+        height: calc((var(--vh, 1vh) * 100) - $action-bar-height);
     }
 
     a, :link {
@@ -203,6 +217,12 @@ $action-bar-height: 38px;
     box-shadow: var(--drawer-pagination-horizontal-rule);
 }
 
+.bottom-bar {
+    position: fixed;
+    width: 100%;
+    bottom: 0px;
+}
+
 
 
 // This is essentially fitting the text to height and when you press next you are scrolling over by page width
@@ -213,10 +233,6 @@ $action-bar-height: 38px;
         overflow: hidden;
         word-break: break-word;
         overflow-wrap: break-word;
-
-        &.debug {
-            column-rule: 20px solid rebeccapurple;
-        }
     }
 
     
@@ -229,10 +245,6 @@ $action-bar-height: 38px;
         overflow: hidden;
         word-break: break-word;
         overflow-wrap: break-word;
-
-        &.debug {
-            column-rule: 20px solid rebeccapurple;
-        }
     }
 
     
@@ -275,12 +287,16 @@ $action-bar-height: 38px;
     right: 0px;
     top: $action-bar-height;
     width: 20%;
-    z-index: 2;
+    z-index: 3;
     cursor: pointer;
     background: transparent;
     border-color: transparent;
     border: none !important;
     opacity: 0;
+
+    &.immersive {
+        top: 0px;
+    }
 }
 
 // This class pushes the click area to the left a bit to let users click the scrollbar
@@ -289,12 +305,16 @@ $action-bar-height: 38px;
     right: 17px;
     top: $action-bar-height;
     width: 18%;
-    z-index: 2;
+    z-index: 3;
     cursor: pointer;
     background: transparent;
     border-color: transparent;
     border: none !important;
     opacity: 0;
+
+    &.immersive {
+        top: 0px;
+    }
 }
 
 .left {
@@ -306,15 +326,19 @@ $action-bar-height: 38px;
     border-color: transparent;
     border: none !important;
     opacity: 0;
-    z-index: 2;
+    z-index: 3;
     cursor: pointer;
+
+    &.immersive {
+        top: 0px;
+    }
 }
 
 
 
 .highlight {
-    background-color: rgba(65, 225, 100, 0.5) !important;
-    animation: fadein .5s both;
+  background-color: rgba(65, 225, 100, 0.5) !important;
+  animation: fadein .5s both;
 }
 .highlight-2 {
   background-color: rgba(65, 105, 225, 0.5) !important;
@@ -340,13 +364,13 @@ $action-bar-height: 38px;
         background-color: unset;
 
         &:hover, &:focus {
-            border-color: var(--br-actionbar-button-hover-border-color); // #545b62;
+            border-color: var(--br-actionbar-button-hover-border-color);
         }
     }
 
     span {
         background-color: unset;
-        color: var(--br-actionbar-button-text-color); // #6c757d;
+        color: var(--br-actionbar-button-text-color); 
     }
 
     i {

--- a/UI/Web/src/app/book-reader/book-reader/book-reader.component.scss
+++ b/UI/Web/src/app/book-reader/book-reader/book-reader.component.scss
@@ -146,9 +146,10 @@ $action-bar-height: 38px;
     //overflow: auto;  // This will break progress reporting
     height: 100vh;
     padding-top: $action-bar-height;
+    padding-bottom: $action-bar-height;
     position: relative;
 
-    background-color: green !important;
+    //background-color: green !important;
 
     &.column-layout-1 {
         height: calc((var(--vh, 1vh) * 100) - $action-bar-height);
@@ -160,6 +161,8 @@ $action-bar-height: 38px;
 
     &.immersive {
         height: calc((var(--vh, 1vh) * 100));
+        //padding-top: 0px;
+        //padding-bottom: 0px;
     }
 }
 
@@ -167,7 +170,7 @@ $action-bar-height: 38px;
     position: relative;
     height: 100%;
 
-    background-color: purple !important;
+    //background-color: purple !important;
 
     &.column-layout-1 {
         height: calc((var(--vh, 1vh) * 100) - $action-bar-height);
@@ -182,7 +185,7 @@ $action-bar-height: 38px;
     position: relative;
     padding: 20px 0;
     margin: 0px 0px;
-    background-color: red !important;
+    //background-color: red !important;
 
     &.column-layout-1 {
         height: calc((var(--vh) * 100) - calc($action-bar-height)); //  * 2
@@ -261,7 +264,8 @@ $action-bar-height: 38px;
 // This is applied to images in the backend
 ::ng-deep .kavita-scale-width-container {
     width: auto;
-    max-height: calc((var(--vh)*100) - 116px) !important;
+    // * 4 is just for extra buffer which is needed based on testing.  --book-reader-content-max-height is set by us on calculation of columnHeight
+    max-height: calc(var(--book-reader-content-max-height) - ($action-bar-height * 4)), calc((var(--vh)*100) - ($action-bar-height * 4)) !important;
 }
 
 // This is applied to images in the backend
@@ -293,6 +297,8 @@ $action-bar-height: 38px;
     border-color: transparent;
     border: none !important;
     opacity: 0;
+    outline: none;
+    //background-color: aqua;
 
     &.immersive {
         top: 0px;
@@ -311,6 +317,8 @@ $action-bar-height: 38px;
     border-color: transparent;
     border: none !important;
     opacity: 0;
+    outline: none;
+    //background-color: aqua;
 
     &.immersive {
         top: 0px;
@@ -325,9 +333,11 @@ $action-bar-height: 38px;
     background: transparent;
     border-color: transparent;
     border: none !important;
-    opacity: 0;
     z-index: 3;
     cursor: pointer;
+    opacity: 0;
+    outline: none;
+    //background-color: aqua;
 
     &.immersive {
         top: 0px;

--- a/UI/Web/src/app/book-reader/book-reader/book-reader.component.ts
+++ b/UI/Web/src/app/book-reader/book-reader/book-reader.component.ts
@@ -352,7 +352,9 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
   get ColumnHeight() {
     if (this.layoutMode !== BookPageLayoutMode.Default) {
       // Take the height after page loads, subtract the top/bottom bar
-      return this.windowHeight  - ((this.topOffset * (this.immersiveMode ? 0 : 1)) * 2) + 'px';
+      const height = this.windowHeight  - (this.topOffset * 2);
+      this.document.documentElement.style.setProperty('--book-reader-content-max-height', `${height}px`);
+      return height + 'px';
     }
     return 'unset';
   }
@@ -362,9 +364,9 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       case BookPageLayoutMode.Default:
         return '';
       case BookPageLayoutMode.Column1:
-        return 'column-layout-1' + (this.immersiveMode ? ' immersive' : '');
+        return 'column-layout-1';
       case BookPageLayoutMode.Column2:
-        return 'column-layout-2' + (this.immersiveMode ? ' immersive' : '');
+        return 'column-layout-2';
     }
   }
 
@@ -373,7 +375,9 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       return (this.readingSectionElemRef?.nativeElement?.scrollHeight || 0) - ((this.topOffset * (this.immersiveMode ? 0 : 1)) * 2) + 'px';
     }
 
-    return this.ColumnHeight;
+    //return this.ColumnHeight;
+    if (this.immersiveMode) return this.windowHeight + 'px';
+    return (this.windowHeight) - (this.topOffset * 2) + 'px';
   }
 
 
@@ -808,7 +812,7 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
     const images = this.readingSectionElemRef?.nativeElement.querySelectorAll('img') || [];
 
     if (this.layoutMode !== BookPageLayoutMode.Default) {
-      const height = this.ColumnHeight;
+      const height = (parseInt(this.ColumnHeight.replace('px', ''), 10) - (this.topOffset * 2)) + 'px';
       Array.from(images).forEach(img => {
         this.renderer.setStyle(img, 'max-height', height);
       });
@@ -1230,7 +1234,7 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       if (this.immersiveMode) {
         this.renderer.setStyle(this.readingSectionElemRef, 'height', 'calc(var(--vh, 1vh) * 100)', RendererStyleFlags2.Important);
       } else {
-        this.renderer.setStyle(this.readingSectionElemRef, 'height', 'calc(var(--vh, 1vh) * 100 - 38px)', RendererStyleFlags2.Important);
+        this.renderer.setStyle(this.readingSectionElemRef, 'height', 'calc(var(--vh, 1vh) * 100 - ' + this.topOffset + 'px)', RendererStyleFlags2.Important);
       }
     });
   }

--- a/UI/Web/src/app/book-reader/book-reader/book-reader.component.ts
+++ b/UI/Web/src/app/book-reader/book-reader/book-reader.component.ts
@@ -352,7 +352,7 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
   get ColumnHeight() {
     if (this.layoutMode !== BookPageLayoutMode.Default) {
       // Take the height after page loads, subtract the top/bottom bar
-      return this.windowHeight - (this.topOffset *2) + 'px';
+      return this.windowHeight  - ((this.topOffset * (this.immersiveMode ? 0 : 1)) * 2) + 'px';
     }
     return 'unset';
   }
@@ -362,15 +362,15 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       case BookPageLayoutMode.Default:
         return '';
       case BookPageLayoutMode.Column1:
-        return 'column-layout-1';
+        return 'column-layout-1' + (this.immersiveMode ? ' immersive' : '');
       case BookPageLayoutMode.Column2:
-        return 'column-layout-2';
+        return 'column-layout-2' + (this.immersiveMode ? ' immersive' : '');
     }
   }
 
   get PageHeightForPagination() {
     if (this.layoutMode === BookPageLayoutMode.Default) {
-      return (this.readingSectionElemRef?.nativeElement?.scrollHeight || 0) - (this.topOffset * 2) + 'px';
+      return (this.readingSectionElemRef?.nativeElement?.scrollHeight || 0) - ((this.topOffset * (this.immersiveMode ? 0 : 1)) * 2) + 'px';
     }
 
     return this.ColumnHeight;
@@ -1220,6 +1220,19 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
     if (this.immersiveMode && !this.drawerOpen) {
       this.actionBarVisible = false;
     }
+    console.log('Update Immersive Mode');
+    this.updateReadingSectionHeight();
+  }
+
+  updateReadingSectionHeight() {
+    setTimeout(() => {
+      console.log('setting height on ', this.readingSectionElemRef)
+      if (this.immersiveMode) {
+        this.renderer.setStyle(this.readingSectionElemRef, 'height', 'calc(var(--vh, 1vh) * 100)', RendererStyleFlags2.Important);
+      } else {
+        this.renderer.setStyle(this.readingSectionElemRef, 'height', 'calc(var(--vh, 1vh) * 100 - 38px)', RendererStyleFlags2.Important);
+      }
+    });
   }
 
   // Table of Contents

--- a/UI/Web/src/app/book-reader/book-reader/book-reader.component.ts
+++ b/UI/Web/src/app/book-reader/book-reader/book-reader.component.ts
@@ -375,7 +375,6 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       return (this.readingSectionElemRef?.nativeElement?.scrollHeight || 0) - ((this.topOffset * (this.immersiveMode ? 0 : 1)) * 2) + 'px';
     }
 
-    //return this.ColumnHeight;
     if (this.immersiveMode) return this.windowHeight + 'px';
     return (this.windowHeight) - (this.topOffset * 2) + 'px';
   }
@@ -1213,6 +1212,12 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       return;
     }
     setTimeout(() => {this.scrollbarNeeded = this.readingHtml.nativeElement.clientHeight > this.reader.nativeElement.clientHeight;});
+
+    // When I switch layout, I might need to resume the progress point. 
+    if (mode === BookPageLayoutMode.Default) {
+      const lastSelector = this.lastSeenScrollPartPath;
+      setTimeout(() => this.scrollTo(lastSelector));
+    }
   }
 
   updateReadingDirection(readingDirection: ReadingDirection) {
@@ -1224,7 +1229,7 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
     if (this.immersiveMode && !this.drawerOpen) {
       this.actionBarVisible = false;
     }
-    console.log('Update Immersive Mode');
+
     this.updateReadingSectionHeight();
   }
 

--- a/UI/Web/src/app/cards/card-detail-drawer/card-detail-drawer.component.html
+++ b/UI/Web/src/app/cards/card-detail-drawer/card-detail-drawer.component.html
@@ -51,7 +51,7 @@
                         <div class="row g-0 mt-4 mb-3">
                             <ng-container *ngIf="chapter.pages">
                                 <div class="col-auto mb-2">
-                                    <app-icon-and-title [clickable]="false" fontClasses="fa-regular fa-file-lines" title="Pages">
+                                    <app-icon-and-title label="Print Length" [clickable]="false" fontClasses="fa-regular fa-file-lines" title="Pages">
                                         {{chapter.pages | number:''}} Pages
                                     </app-icon-and-title>
                                 </div>
@@ -60,7 +60,7 @@
 
                             <ng-container *ngIf="chapterMetadata !== undefined && chapterMetadata.releaseDate">
                                 <div class="col-auto mb-2">
-                                    <app-icon-and-title [clickable]="false" fontClasses="fa-regular fa-calendar" title="Release">
+                                    <app-icon-and-title label="Release Date" [clickable]="false" fontClasses="fa-regular fa-calendar" title="Release">
                                         {{chapterMetadata.releaseDate | date:'shortDate'}}
                                     </app-icon-and-title>
                                 </div>
@@ -69,7 +69,7 @@
 
                             <ng-container *ngIf="chapter.files[0].format === MangaFormat.EPUB && chapterMetadata !== undefined && chapterMetadata.wordCount > 0 || chapter.files[0].format !== MangaFormat.EPUB">
                                 <div class="col-auto mb-2">
-                                    <app-icon-and-title [clickable]="false" fontClasses="fa-regular fa-clock">
+                                    <app-icon-and-title label="Read Time" [clickable]="false" fontClasses="fa-regular fa-clock">
                                         {{readingTime.minHours}}{{readingTime.maxHours !== readingTime.minHours ? ('-' + readingTime.maxHours) : ''}} Hour{{readingTime.minHours > 1 ? 's' : ''}}
                                     </app-icon-and-title>
                                 </div>
@@ -78,7 +78,7 @@
                             <ng-container *ngIf="chapter.files[0].format === MangaFormat.EPUB && chapterMetadata !== undefined && chapterMetadata.wordCount > 0">
                                 <div class="vr d-none d-lg-block m-2"></div>
                                 <div class="col-auto mb-2">
-                                    <app-icon-and-title [clickable]="false" fontClasses="fa-solid fa-book-open">
+                                    <app-icon-and-title label="Word Count" [clickable]="false" fontClasses="fa-solid fa-book-open">
                                         {{chapterMetadata.wordCount | compactNumber}} Words
                                     </app-icon-and-title>
                                 </div>    
@@ -88,7 +88,7 @@
                                 <ng-container *ngIf="ageRating !== '' && ageRating !== 'Unknown'">
                                     <div class="vr d-none d-lg-block m-2"></div>
                                     <div class="col-auto">
-                                        <app-icon-and-title [clickable]="false" fontClasses="fas fa-eye" title="Age Rating">
+                                        <app-icon-and-title label="Age Rating" [clickable]="false" fontClasses="fas fa-eye" title="Age Rating">
                                             {{ageRating}}
                                         </app-icon-and-title>
                                     </div>
@@ -185,7 +185,7 @@
                     <div class="row g-0 mb-3">
                         <ng-container *ngIf="chapter.created && chapter.created !== '' && (chapter.created | date: 'shortDate') !== '1/1/01'">
                             <div class="col-auto">
-                                <app-icon-and-title [clickable]="false" fontClasses="fa-solid fa-file-import" title="Date Added">
+                                <app-icon-and-title label="Date Added" [clickable]="false" fontClasses="fa-solid fa-file-import" title="Date Added">
                                     Created: {{chapter.created | date:'short' || '-'}}
                                 </app-icon-and-title>
                             </div>
@@ -194,7 +194,7 @@
                         <ng-container>
                             <div class="vr d-none d-lg-block m-2"></div>
                             <div class="col-auto">
-                                <app-icon-and-title [clickable]="false" fontClasses="fa-solid fa-fingerprint" title="ID">
+                                <app-icon-and-title label="ID" [clickable]="false" fontClasses="fa-solid fa-fingerprint" title="ID">
                                     ID: {{data.id}}
                                 </app-icon-and-title>
                             </div>

--- a/UI/Web/src/app/cards/card-detail-drawer/card-detail-drawer.component.html
+++ b/UI/Web/src/app/cards/card-detail-drawer/card-detail-drawer.component.html
@@ -49,16 +49,16 @@
                         </div>
                         
                         <div class="row g-0 mt-4 mb-3">
-                            <ng-container *ngIf="chapter.pages">
+                            <ng-container *ngIf="totalPages > 0">
                                 <div class="col-auto mb-2">
                                     <app-icon-and-title label="Print Length" [clickable]="false" fontClasses="fa-regular fa-file-lines" title="Pages">
-                                        {{chapter.pages | number:''}} Pages
+                                        {{totalPages | number:''}} Pages
                                     </app-icon-and-title>
                                 </div>
                                 <div class="vr d-none d-lg-block m-2"></div>
                             </ng-container>
 
-                            <ng-container *ngIf="chapterMetadata !== undefined && chapterMetadata.releaseDate">
+                            <ng-container *ngIf="chapterMetadata !== undefined && chapterMetadata.releaseDate && (chapterMetadata.releaseDate | date: 'shortDate') !== '1/1/01'">
                                 <div class="col-auto mb-2">
                                     <app-icon-and-title label="Release Date" [clickable]="false" fontClasses="fa-regular fa-calendar" title="Release">
                                         {{chapterMetadata.releaseDate | date:'shortDate'}}

--- a/UI/Web/src/app/cards/card-detail-drawer/card-detail-drawer.component.html
+++ b/UI/Web/src/app/cards/card-detail-drawer/card-detail-drawer.component.html
@@ -94,6 +94,24 @@
                                     </div>
                                 </ng-container>
                             </ng-container>
+
+                            <ng-container *ngIf="chapter.created && chapter.created !== '' && (chapter.created | date: 'shortDate') !== '1/1/01'">
+                                <div class="vr d-none d-lg-block m-2"></div>
+                                <div class="col-auto">
+                                    <app-icon-and-title label="Date Added" [clickable]="false" fontClasses="fa-solid fa-file-import" title="Date Added">
+                                        {{chapter.created | date:'short' || '-'}}
+                                    </app-icon-and-title>
+                                </div>
+                            </ng-container>
+    
+                            <ng-container>
+                                <div class="vr d-none d-lg-block m-2"></div>
+                                <div class="col-auto">
+                                    <app-icon-and-title label="ID" [clickable]="false" fontClasses="fa-solid fa-fingerprint" title="ID">
+                                        {{data.id}}
+                                    </app-icon-and-title>
+                                </div>
+                            </ng-container>
                         </div>
 
                         
@@ -182,24 +200,6 @@
             <li [ngbNavItem]="tabs[TabID.Files]">
                 <a ngbNavLink>{{tabs[TabID.Files].title}}</a>
                 <ng-template ngbNavContent>
-                    <div class="row g-0 mb-3">
-                        <ng-container *ngIf="chapter.created && chapter.created !== '' && (chapter.created | date: 'shortDate') !== '1/1/01'">
-                            <div class="col-auto">
-                                <app-icon-and-title label="Date Added" [clickable]="false" fontClasses="fa-solid fa-file-import" title="Date Added">
-                                    Created: {{chapter.created | date:'short' || '-'}}
-                                </app-icon-and-title>
-                            </div>
-                        </ng-container>
-
-                        <ng-container>
-                            <div class="vr d-none d-lg-block m-2"></div>
-                            <div class="col-auto">
-                                <app-icon-and-title label="ID" [clickable]="false" fontClasses="fa-solid fa-fingerprint" title="ID">
-                                    ID: {{data.id}}
-                                </app-icon-and-title>
-                            </div>
-                        </ng-container>
-                    </div>
                     <h4 *ngIf="!utilityService.isChapter(data)">{{utilityService.formatChapterName(libraryType) + 's'}}</h4>
                     <ul class="list-unstyled">
                         <li class="d-flex my-4" *ngFor="let chapter of chapters">

--- a/UI/Web/src/app/cards/card-detail-drawer/card-detail-drawer.component.html
+++ b/UI/Web/src/app/cards/card-detail-drawer/card-detail-drawer.component.html
@@ -43,8 +43,13 @@
                             <div class="d-none d-md-block col-md-2 col-lg-1">            
                                 <app-image class="me-2" width="74px" [imageUrl]="chapter.coverImage"></app-image>
                             </div> 
-                            <div *ngIf="summary$ | async as summary" class="col-md-10 col-lg-11">
-                                <app-read-more [text]="summary" [maxLength]="250"></app-read-more>
+                            <div class="col-md-10 col-lg-11">
+                                <ng-container *ngIf="summary$ | async as summary; else noSummary">
+                                    <app-read-more [text]="summary" [maxLength]="250"></app-read-more>
+                                </ng-container>
+                                <ng-template #noSummary>
+                                    No Summary available.
+                                </ng-template>
                             </div>
                         </div>
                         

--- a/UI/Web/src/app/cards/card-detail-drawer/card-detail-drawer.component.scss
+++ b/UI/Web/src/app/cards/card-detail-drawer/card-detail-drawer.component.scss
@@ -12,5 +12,5 @@
 
 .tab-content {
   overflow: auto;
-  height: calc(45vh - 63px); // drawer height - offcanvas heading height
+  height: calc(40vh - 63px); // drawer height - offcanvas heading height
 }

--- a/UI/Web/src/app/cards/card-detail-drawer/card-detail-drawer.component.ts
+++ b/UI/Web/src/app/cards/card-detail-drawer/card-detail-drawer.component.ts
@@ -265,6 +265,7 @@ export class CardDetailDrawerComponent implements OnInit {
     } else {
       this.router.navigate(['library', this.libraryId, 'series', this.seriesId, 'manga', chapter.id]);
     }
+    this.close();
   }
 
 }

--- a/UI/Web/src/app/cards/card-detail-drawer/card-detail-drawer.component.ts
+++ b/UI/Web/src/app/cards/card-detail-drawer/card-detail-drawer.component.ts
@@ -81,6 +81,10 @@ export class CardDetailDrawerComponent implements OnInit {
   readingTime: HourEstimateRange = {maxHours: 1, minHours: 1, avgHours: 1, hasProgress: false};
   minHoursToRead: number = 1;
   maxHoursToRead: number = 1;
+  /**
+   * We use a separate variable because if this is a volume, we need a sum of all chapters
+   */
+  totalPages: number = 0;
   
   
 
@@ -123,13 +127,13 @@ export class CardDetailDrawerComponent implements OnInit {
 
       this.metadataService.getAgeRating(this.chapterMetadata.ageRating).subscribe(ageRating => this.ageRating = ageRating);
       
-      let totalPages = this.chapter.pages;
+      this.totalPages = this.chapter.pages;
       if (!this.isChapter) {
         // Need to account for multiple chapters if this is a volume
-        totalPages = this.utilityService.asVolume(this.data).chapters.map(c => c.pages).reduce((sum, d) => sum + d);
+        this.totalPages = this.utilityService.asVolume(this.data).chapters.map(c => c.pages).reduce((sum, d) => sum + d);
       }
 
-      this.readerService.getManualTimeToRead(this.chapterMetadata.wordCount, totalPages, this.chapter.files[0].format === MangaFormat.EPUB).subscribe((time) => this.readingTime = time);
+      this.readerService.getManualTimeToRead(this.chapterMetadata.wordCount, this.totalPages, this.chapter.files[0].format === MangaFormat.EPUB).subscribe((time) => this.readingTime = time);
     });
 
 

--- a/UI/Web/src/app/cards/card-detail-layout/card-detail-layout.component.html
+++ b/UI/Web/src/app/cards/card-detail-layout/card-detail-layout.component.html
@@ -14,13 +14,18 @@
 </div>
 
 <app-metadata-filter [filterSettings]="filterSettings" [filterOpen]="filterOpen" (applyFilter)="applyMetadataFilter($event)"></app-metadata-filter>
+<ng-container [ngTemplateOutlet]="paginationTemplate" [ngTemplateOutletContext]="{ id: 'top' }"></ng-container>
 <div class="content-container">
+    
     <div class="card-container">
         <ng-container [ngTemplateOutlet]="cardTemplate"></ng-container>
     </div>
     
-    <ng-container [ngTemplateOutlet]="paginationTemplate" [ngTemplateOutletContext]="{ id: 'bottom' }"></ng-container>
+    
+    <ng-container *ngIf="pagination && items.length > 0 && pagination.totalPages > 1" [ngTemplateOutlet]="jumpBar" [ngTemplateOutletContext]="{ id: 'jumpbar' }"></ng-container>
 </div>
+<ng-container [ngTemplateOutlet]="paginationTemplate" [ngTemplateOutletContext]="{ id: 'bottom' }"></ng-container>
+
 <ng-template #cardTemplate>
 
     <div class="grid row g-0 mb-3" >
@@ -34,8 +39,51 @@
 </ng-template>
 
 <ng-template #paginationTemplate let-id="id">
-    <ng-container *ngIf="pagination && items.length > 0 && id == 'bottom' && pagination.totalPages > 1 " [ngTemplateOutlet]="jumpBar"></ng-container>
+
+    <div class="d-flex justify-content-center mb-0" *ngIf="pagination && items.length > 0">
+        <ngb-pagination
+            *ngIf="pagination.totalPages > 1"
+            [maxSize]="8"
+            [rotate]="true"
+            [ellipses]="false"
+            [(page)]="pagination.currentPage"
+            [pageSize]="pagination.itemsPerPage"
+            (pageChange)="onPageChange($event)"
+            [collectionSize]="pagination.totalItems">
+
+            <ng-template ngbPaginationPages let-page let-pages="pages" *ngIf="pagination.totalItems / pagination.itemsPerPage > 20">
+                <li class="ngb-custom-pages-item" *ngIf="pagination.totalPages > 1">
+                    <div class="d-flex flex-nowrap px-2">
+                    <label
+                        id="paginationInputLabel-{{id}}"
+                        for="paginationInput-{{id}}"
+                        class="col-form-label me-2 ms-1 form-label"
+                    >Page</label>
+                    <input #i
+                        type="text"
+                        inputmode="numeric"
+                        pattern="[0-9]*"
+                        class="form-control custom-pages-input"
+                        id="paginationInput-{{id}}"
+                        [value]="page"
+                        (keyup.enter)="selectPageStr(i.value)"
+                        (blur)="selectPageStr(i.value)"
+                        (input)="formatInput($any($event).target)"
+                        attr.aria-labelledby="paginationInputLabel-{{id}} paginationDescription-{{id}}"
+                        [ngStyle]="{width: (0.5 + pagination.currentPage + '').length + 'rem'} "
+                    />
+                    <span id="paginationDescription-{{id}}" class="col-form-label text-nowrap px-2">
+                        of {{pagination.totalPages}}</span>
+                    </div>
+                </li>
+            </ng-template>
+
+        </ngb-pagination>
+    </div>
+
+    <!-- <ng-container *ngIf="pagination && items.length > 0 && id == 'bottom' && pagination.totalPages > 1 " [ngTemplateOutlet]="jumpBar"></ng-container> -->
 </ng-template>
+
 
 <div class="mx-auto" *ngIf="isLoading" style="width: 200px;">
     <div class="spinner-border text-secondary loading" role="status">

--- a/UI/Web/src/app/cards/card-detail-layout/card-detail-layout.component.html
+++ b/UI/Web/src/app/cards/card-detail-layout/card-detail-layout.component.html
@@ -12,23 +12,23 @@
         </h2>
     </div>
 </div>
-
 <app-metadata-filter [filterSettings]="filterSettings" [filterOpen]="filterOpen" (applyFilter)="applyMetadataFilter($event)"></app-metadata-filter>
-<ng-container [ngTemplateOutlet]="paginationTemplate" [ngTemplateOutletContext]="{ id: 'top' }"></ng-container>
-<div class="content-container">
-    
-    <div class="card-container">
-        <ng-container [ngTemplateOutlet]="cardTemplate"></ng-container>
+<div class="viewport-container">
+    <div class="content-container">
+        <ng-container [ngTemplateOutlet]="paginationTemplate" [ngTemplateOutletContext]="{ id: 'top' }"></ng-container>
+
+        <div class="card-container mt-2 mb-2">
+            <ng-container [ngTemplateOutlet]="cardTemplate"></ng-container>
+        </div>
+
+        <ng-container [ngTemplateOutlet]="paginationTemplate" [ngTemplateOutletContext]="{ id: 'bottom' }"></ng-container>
     </div>
-    
-    
+
     <ng-container *ngIf="pagination && items.length > 0 && pagination.totalPages > 1" [ngTemplateOutlet]="jumpBar" [ngTemplateOutletContext]="{ id: 'jumpbar' }"></ng-container>
 </div>
-<ng-container [ngTemplateOutlet]="paginationTemplate" [ngTemplateOutletContext]="{ id: 'bottom' }"></ng-container>
-
 <ng-template #cardTemplate>
 
-    <div class="grid row g-0 mb-3" >
+    <div class="grid row g-0" >
         <div class="card col-auto mt-2 mb-2" *ngFor="let item of items; trackBy:trackByIdentity; index as i" id="jumpbar-index--{{i}}" [attr.jumpbar-index]="i">
             <ng-container [ngTemplateOutlet]="itemTemplate" [ngTemplateOutletContext]="{ $implicit: item, idx: i }"></ng-container>
         </div>

--- a/UI/Web/src/app/cards/card-detail-layout/card-detail-layout.component.scss
+++ b/UI/Web/src/app/cards/card-detail-layout/card-detail-layout.component.scss
@@ -1,12 +1,23 @@
-.content-container {
-    display: inline-flex;
+.viewport-container {
+    display: flex;
+    flex-direction: row;
     width: 100%;
-    height: calc((var(--vh) *100) - 152px);
+    height: calc((var(--vh) *100) - 162px);
+    margin-bottom: 10px;
+}
+
+.content-container {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: 100%;
+    margin-bottom: 10px;
 }
 
 .card-container {
     display: inline-block;
     width: 100%;
+    overflow-y: auto;
 }
 
 .grid {
@@ -15,10 +26,15 @@
     grid-gap: 0.5rem;
     justify-content: space-around;
     width: 100%;
-    max-height: calc((var(--vh) *100) - 152px);
     overflow-y: auto;
     overflow-x: hidden;
     align-items: start;
+}
+
+@media (max-width: 576px) {
+    .grid {
+        grid-gap: 0.3rem;
+    }
 }
 
 .jump-bar {

--- a/UI/Web/src/app/cards/card-item/card-actionables/card-actionables.component.html
+++ b/UI/Web/src/app/cards/card-item/card-actionables/card-actionables.component.html
@@ -7,4 +7,5 @@
         <button ngbDropdownItem *ngFor="let action of adminActions" (click)="performAction($event, action)">{{action.title}}</button>
       </div>
     </div>
+    <!-- TODO: If we are not on desktop, then let's open a bottom drawer instead-->
 </ng-container>

--- a/UI/Web/src/app/manga-reader/manga-reader.component.html
+++ b/UI/Web/src/app/manga-reader/manga-reader.component.html
@@ -41,13 +41,13 @@
 
             <div class="pagination-area">
                 <!-- Pagination controls and screen hints-->
-                <div class="{{readerMode === ReaderMode.LeftRight ? 'left' : 'top'}} {{clickOverlayClass('left')}}" (click)="handlePageChange($event, 'left')" [ngStyle]="{'height': (readerMode === ReaderMode.LeftRight ? ImageHeight: 25 + '%')}">
+                <div class="{{readerMode === ReaderMode.LeftRight ? 'left' : 'top'}} {{clickOverlayClass('left')}}" (click)="handlePageChange($event, 'left')" [ngStyle]="{'height': (readerMode === ReaderMode.LeftRight ? ImageHeight: '25%')}">
                     <div *ngIf="showClickOverlay">
                         <i class="fa fa-angle-{{readingDirection === ReadingDirection.RightToLeft ? 'double-' : ''}}{{readerMode === ReaderMode.LeftRight ? 'left' : 'up'}}"
                          title="Previous Page" aria-hidden="true"></i>
                     </div>
                 </div>
-                <div class="{{readerMode === ReaderMode.LeftRight ? 'right' : 'bottom'}} {{clickOverlayClass('right')}}" (click)="handlePageChange($event, 'right')" [ngStyle]="{'height': (readerMode === ReaderMode.LeftRight ? ImageHeight: 25 + '%'), 'left': (readerMode === ReaderMode.LeftRight && (this.generalSettingsForm.get('fittingOption')?.value === FITTING_OPTION.ORIGINAL) ? ImageWidth: 'inherit')}">
+                <div class="{{readerMode === ReaderMode.LeftRight ? 'right' : 'bottom'}} {{clickOverlayClass('right')}}" (click)="handlePageChange($event, 'right')" [ngStyle]="{'height': (readerMode === ReaderMode.LeftRight ? ImageHeight: '25%'), 'left': (readerMode === ReaderMode.LeftRight && (this.generalSettingsForm.get('fittingOption')?.value === FITTING_OPTION.ORIGINAL) ? ImageWidth: 'inherit'), 'right': rightPaginationOffset + 'px'}">
                     <div *ngIf="showClickOverlay">
                         <i class="fa fa-angle-{{readingDirection === ReadingDirection.LeftToRight ? 'double-' : ''}}{{readerMode === ReaderMode.LeftRight ? 'right' : 'down'}}"
                          title="Next Page" aria-hidden="true"></i>

--- a/UI/Web/src/app/manga-reader/manga-reader.component.scss
+++ b/UI/Web/src/app/manga-reader/manga-reader.component.scss
@@ -248,8 +248,8 @@ img {
       width: 100%;
   }
 
-  //$pagination-bg: rgba(0, 0, 0, 0);
-  $pagination-bg: rgba(0, 0, 255, 0.4); // DEBUG CODE
+  $pagination-bg: rgba(0, 0, 0, 0);
+  //$pagination-bg: rgba(0, 0, 255, 0.4); // DEBUG CODE
 
   .pagination-area {
     cursor: pointer;

--- a/UI/Web/src/app/manga-reader/manga-reader.component.scss
+++ b/UI/Web/src/app/manga-reader/manga-reader.component.scss
@@ -248,8 +248,8 @@ img {
       width: 100%;
   }
 
-  $pagination-bg: rgba(0, 0, 0, 0);
-  //$pagination-bg: rgba(0, 0, 255, 0.4);
+  //$pagination-bg: rgba(0, 0, 0, 0);
+  $pagination-bg: rgba(0, 0, 255, 0.4); // DEBUG CODE
 
   .pagination-area {
     cursor: pointer;

--- a/UI/Web/src/app/manga-reader/manga-reader.module.ts
+++ b/UI/Web/src/app/manga-reader/manga-reader.module.ts
@@ -2,7 +2,7 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MangaReaderComponent } from './manga-reader.component';
 import { ReactiveFormsModule } from '@angular/forms';
-import { NgbButtonsModule, NgbDropdownModule } from '@ng-bootstrap/ng-bootstrap';
+import { NgbDropdownModule } from '@ng-bootstrap/ng-bootstrap';
 import { MangaReaderRoutingModule } from './manga-reader.router.module';
 import { SharedModule } from '../shared/shared.module';
 import { NgxSliderModule } from '@angular-slider/ngx-slider';
@@ -19,7 +19,6 @@ import { ReaderSharedModule } from '../reader-shared/reader-shared.module';
     MangaReaderRoutingModule,
     ReactiveFormsModule,
 
-    NgbButtonsModule,
     NgbDropdownModule,
     NgxSliderModule,
     SharedModule,

--- a/UI/Web/src/app/series-detail/series-detail.component.html
+++ b/UI/Web/src/app/series-detail/series-detail.component.html
@@ -73,12 +73,12 @@
                     <div class="card-container row g-0">
                         <ng-container *ngFor="let volume of volumes; let idx = index; trackBy: trackByVolumeIdentity">
                             <app-card-item class="col-auto mt-2 mb-2" *ngIf="volume.number != 0" [entity]="volume" [title]="volume.name" (click)="openVolume(volume)"
-                            [imageUrl]="imageService.getVolumeCoverImage(volume.id) + '&offset=' + coverImageOffset"
+                            [imageUrl]="imageService.getVolumeCoverImage(volume.id)"
                             [read]="volume.pagesRead" [total]="volume.pages" [actions]="volumeActions" (selection)="bulkSelectionService.handleCardSelection('volume', idx, volumes.length, $event)" [selected]="bulkSelectionService.isCardSelected('volume', idx)" [allowSelection]="true"></app-card-item>
                         </ng-container>
                         <ng-container *ngFor="let chapter of storyChapters; let idx = index; trackBy: trackByChapterIdentity">
                             <app-card-item class="col-auto mt-2 mb-2" *ngIf="!chapter.isSpecial" [entity]="chapter" [title]="chapter.title" (click)="openChapter(chapter)"
-                            [imageUrl]="imageService.getChapterCoverImage(chapter.id) + '&offset=' + coverImageOffset"
+                            [imageUrl]="imageService.getChapterCoverImage(chapter.id)"
                             [read]="chapter.pagesRead" [total]="chapter.pages" [actions]="chapterActions" (selection)="bulkSelectionService.handleCardSelection('chapter', idx, storyChapters.length, $event)" [selected]="bulkSelectionService.isCardSelected('chapter', idx)" [allowSelection]="true"></app-card-item>
                         </ng-container>
                     </div>
@@ -90,7 +90,7 @@
                     <div class="card-container row g-0">
                         <ng-container *ngFor="let item of volumes; let idx = index; trackBy: trackByVolumeIdentity">
                             <app-card-item class="col-auto mt-2 mb-2" [entity]="item" [title]="item.name" (click)="openVolume(item)"
-                                  [imageUrl]="imageService.getVolumeCoverImage(item.id) + '&offset=' + coverImageOffset"
+                                  [imageUrl]="imageService.getVolumeCoverImage(item.id)"
                                   [read]="item.pagesRead" [total]="item.pages" [actions]="volumeActions" 
                                   (selection)="bulkSelectionService.handleCardSelection('volume', idx, volumes.length, $event)" 
                                   [selected]="bulkSelectionService.isCardSelected('volume', idx)" [allowSelection]="true">
@@ -105,7 +105,7 @@
                     <div class="card-container row g-0">
                         <ng-container *ngFor="let item of chapters; let idx = index; trackBy: trackByChapterIdentity">
                             <app-card-item class="col-auto mt-2 mb-2" *ngIf="!item.isSpecial" [entity]="item" [title]="item.title" (click)="openChapter(item)"
-                            [imageUrl]="imageService.getChapterCoverImage(item.id) + '&offset=' + coverImageOffset"
+                            [imageUrl]="imageService.getChapterCoverImage(item.id)"
                             [read]="item.pagesRead" [total]="item.pages" [actions]="chapterActions" 
                             (selection)="bulkSelectionService.handleCardSelection('chapter', idx, chapters.length, $event)"
                             [selected]="bulkSelectionService.isCardSelected('chapter', idx)" [allowSelection]="true"></app-card-item>

--- a/UI/Web/src/app/series-detail/series-detail.component.ts
+++ b/UI/Web/src/app/series-detail/series-detail.component.ts
@@ -4,7 +4,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { NgbModal, NgbNavChangeEvent, NgbOffcanvas } from '@ng-bootstrap/ng-bootstrap';
 import { ToastrService } from 'ngx-toastr';
 import { forkJoin, Subject } from 'rxjs';
-import { finalize, take, takeUntil, takeWhile } from 'rxjs/operators';
+import { finalize, mergeMap, take, takeUntil, takeWhile } from 'rxjs/operators';
 import { BulkSelectionService } from '../cards/bulk-selection.service';
 import { CardDetailsModalComponent } from '../cards/_modals/card-details-modal/card-details-modal.component';
 import { EditSeriesModalComponent } from '../cards/_modals/edit-series-modal/edit-series-modal.component';
@@ -95,11 +95,6 @@ export class SeriesDetailComponent implements OnInit, OnDestroy {
    */
   seriesImage: string = '';
   downloadInProgress: boolean = false;
-
-  /**
-   * Tricks the cover images for volume/chapter cards to update after we update one of them
-   */
-  coverImageOffset: number = 0;
 
   /**
    * If an action is currently being done, don't let the user kick off another action
@@ -357,8 +352,6 @@ export class SeriesDetailComponent implements OnInit, OnDestroy {
   }
 
   loadSeries(seriesId: number) {
-    this.coverImageOffset = 0;
-
     this.seriesService.getMetadata(seriesId).subscribe(metadata => this.seriesMetadata = metadata);
     this.readingListService.getReadingListsForSeries(seriesId).subscribe(lists => {
       this.readingLists = lists;
@@ -567,11 +560,6 @@ export class SeriesDetailComponent implements OnInit, OnDestroy {
     drawerRef.componentInstance.parentName = this.series?.name;
     drawerRef.componentInstance.seriesId = this.series?.id;
     drawerRef.componentInstance.libraryId = this.series?.libraryId;
-    drawerRef.closed.subscribe((result: {coverImageUpdate: boolean}) => {
-      if (result.coverImageUpdate) {
-        this.coverImageOffset += 1;
-      }
-    });
   }
 
   openEditSeriesModal() {

--- a/UI/Web/src/app/series-detail/series-metadata-detail/series-metadata-detail.component.html
+++ b/UI/Web/src/app/series-detail/series-metadata-detail/series-metadata-detail.component.html
@@ -6,7 +6,7 @@
 <div class="row g-0 mb-4 mt-3">
      <ng-container *ngIf="seriesMetadata.ageRating">
         <div class="col-lg-1 col-md-4 col-sm-4 col-4 mb-3">
-            <app-icon-and-title [clickable]="true" fontClasses="fas fa-eye" (click)="goTo(FilterQueryParam.AgeRating, seriesMetadata.ageRating)" title="Age Rating">
+            <app-icon-and-title label="Age Rating" [clickable]="true" fontClasses="fas fa-eye" (click)="goTo(FilterQueryParam.AgeRating, seriesMetadata.ageRating)" title="Age Rating">
                 {{metadataService.getAgeRating(this.seriesMetadata.ageRating) | async}}
             </app-icon-and-title>
         </div>
@@ -15,7 +15,7 @@
     <ng-container *ngIf="series">
         <ng-container *ngIf="seriesMetadata.releaseYear > 0">
             <div class="col-lg-1 col-md-4 col-sm-4 col-4 mb-3">
-                <app-icon-and-title [clickable]="false" fontClasses="fa-regular fa-calendar" title="Release Year">
+                <app-icon-and-title label="Release Year" [clickable]="false" fontClasses="fa-regular fa-calendar" title="Release Year">
                     {{seriesMetadata.releaseYear}}
                 </app-icon-and-title>
             </div>
@@ -24,7 +24,7 @@
 
         <ng-container *ngIf="seriesMetadata.language !== null">
             <div class="col-lg-1 col-md-4 col-sm-4 col-4 mb-3">
-                <app-icon-and-title [clickable]="true" fontClasses="fas fa-language" (click)="goTo(FilterQueryParam.Languages, seriesMetadata.language)" title="Language">
+                <app-icon-and-title label="Language" [clickable]="true" fontClasses="fas fa-language" (click)="goTo(FilterQueryParam.Languages, seriesMetadata.language)" title="Language">
                     {{seriesMetadata.language | defaultValue:'en' | languageName | async}}
                 </app-icon-and-title>
             </div>
@@ -33,7 +33,7 @@
 
         <ng-container>
             <div class="d-none d-md-block col-lg-1 col-md-4 col-sm-4 col-4 mb-2">
-                <app-icon-and-title [clickable]="true" fontClasses="fa-solid fa-hourglass-empty" (click)="goTo(FilterQueryParam.PublicationStatus, seriesMetadata.publicationStatus)" title="Publication Status ({{seriesMetadata.maxCount}} / {{seriesMetadata.totalCount}})">
+                <app-icon-and-title label="Publication" [clickable]="true" fontClasses="fa-solid fa-hourglass-empty" (click)="goTo(FilterQueryParam.PublicationStatus, seriesMetadata.publicationStatus)" title="Publication Status ({{seriesMetadata.maxCount}} / {{seriesMetadata.totalCount}})">
                     {{seriesMetadata.publicationStatus | publicationStatus}}
                 </app-icon-and-title>
             </div>
@@ -42,7 +42,7 @@
 
         <ng-container>
             <div class="d-none d-md-block col-lg-1 col-md-4 col-sm-4 col-4 mb-2">
-                <app-icon-and-title [clickable]="true" [fontClasses]="'fa ' + utilityService.mangaFormatIcon(series.format)" (click)="goTo(FilterQueryParam.Format, series.format)" title="Format">
+                <app-icon-and-title label="Format" [clickable]="true" [fontClasses]="'fa ' + utilityService.mangaFormatIcon(series.format)" (click)="goTo(FilterQueryParam.Format, series.format)" title="Format">
                     {{utilityService.mangaFormat(series.format)}}
                 </app-icon-and-title>
             </div>
@@ -51,7 +51,7 @@
 
         <ng-container *ngIf="series.latestReadDate && series.latestReadDate !== '' && (series.latestReadDate | date: 'shortDate') !== '1/1/01'">
             <div class="d-none d-md-block col-lg-1 col-md-4 col-sm-4 col-4 mb-2">
-                <app-icon-and-title [clickable]="false" fontClasses="fa-regular fa-clock" title="Last Read">
+                <app-icon-and-title label="Last Read" [clickable]="false" fontClasses="fa-regular fa-clock" title="Last Read">
                     {{series.latestReadDate | date:'shortDate'}}
                 </app-icon-and-title>
             </div>
@@ -62,7 +62,7 @@
         <ng-container *ngIf="series.format === MangaFormat.EPUB; else showPages">
             <ng-container *ngIf="series.wordCount > 0">
                 <div class="col-lg-1 col-md-4 col-sm-4 col-4 mb-2">
-                    <app-icon-and-title [clickable]="false" fontClasses="fa-solid fa-book-open">
+                    <app-icon-and-title label="Word Count" [clickable]="false" fontClasses="fa-solid fa-book-open">
                         {{series.wordCount | compactNumber}} Words
                     </app-icon-and-title>
                 </div>
@@ -72,7 +72,7 @@
         </ng-container>
         <ng-template #showPages>
             <div class="d-none d-md-block col-lg-1 col-md-4 col-sm-4 col-4 mb-2">
-                <app-icon-and-title [clickable]="false" fontClasses="fa-regular fa-file-lines">
+                <app-icon-and-title label="Print Length" [clickable]="false" fontClasses="fa-regular fa-file-lines">
                     {{series.pages | number:''}} Pages
                 </app-icon-and-title>
             </div>
@@ -83,7 +83,7 @@
 
         <ng-container *ngIf="series.format === MangaFormat.EPUB && series.wordCount > 0 || series.format !== MangaFormat.EPUB">
             <div class="col-lg-1 col-md-4 col-sm-4 col-4 mb-2">
-                <app-icon-and-title [clickable]="false" fontClasses="fa-regular fa-clock">
+                <app-icon-and-title label="Read Time" [clickable]="false" fontClasses="fa-regular fa-clock">
                     {{readingTime.minHours}}{{readingTime.maxHours !== readingTime.minHours ? ('-' + readingTime.maxHours) : ''}} Hour{{readingTime.minHours > 1 ? 's' : ''}}
                 </app-icon-and-title>
             </div>
@@ -93,7 +93,7 @@
         <ng-container *ngIf="readingTimeLeft.hasProgress && readingTimeLeft.avgHours !== 0 ">
             <div class="vr d-none d-lg-block m-2"></div>
             <div class="col-lg-1 col-md-4 col-sm-4 col-4 mb-2">
-                <app-icon-and-title [clickable]="false" fontClasses="fa-solid fa-clock">
+                <app-icon-and-title label="Read Left" [clickable]="false" fontClasses="fa-solid fa-clock">
                     ~{{readingTimeLeft.avgHours}} Hour{{readingTimeLeft.avgHours > 1 ? 's' : ''}} Left
                 </app-icon-and-title>
             </div>

--- a/UI/Web/src/app/series-detail/series-metadata-detail/series-metadata-detail.component.html
+++ b/UI/Web/src/app/series-detail/series-metadata-detail/series-metadata-detail.component.html
@@ -33,9 +33,11 @@
 
         <ng-container>
             <div class="d-none d-md-block col-lg-1 col-md-4 col-sm-4 col-4 mb-2">
-                <app-icon-and-title label="Publication" [clickable]="true" fontClasses="fa-solid fa-hourglass-empty" (click)="goTo(FilterQueryParam.PublicationStatus, seriesMetadata.publicationStatus)" title="Publication Status ({{seriesMetadata.maxCount}} / {{seriesMetadata.totalCount}})">
-                    {{seriesMetadata.publicationStatus | publicationStatus}}
-                </app-icon-and-title>
+                <ng-container *ngIf="seriesMetadata.publicationStatus | publicationStatus as pubStatus">
+                    <app-icon-and-title label="Publication" [clickable]="true" fontClasses="fa-solid fa-hourglass-{{pubStatus === 'Ongoing' ? 'empty' : 'end'}}" (click)="goTo(FilterQueryParam.PublicationStatus, seriesMetadata.publicationStatus)" title="Publication Status ({{seriesMetadata.maxCount}} / {{seriesMetadata.totalCount}})">
+                        {{pubStatus}}
+                    </app-icon-and-title>
+                </ng-container>
             </div>
             <div class="vr m-2 d-none d-lg-block"></div>
         </ng-container>

--- a/UI/Web/src/app/shared/icon-and-title/icon-and-title.component.html
+++ b/UI/Web/src/app/shared/icon-and-title/icon-and-title.component.html
@@ -1,5 +1,8 @@
 <div class="d-flex justify-content-center align-self-center align-items-center icon-and-title" [ngClass]="{'clickable': clickable}" [attr.role]="clickable ? 'button' : ''"
     (click)="handleClick($event)">
+    <div class="label" *ngIf="label && label.length > 0">
+        {{label}}
+    </div>
     <i class="{{fontClasses}} mx-auto icon" aria-hidden="true" [title]="title"></i>
 
     <div class="text">

--- a/UI/Web/src/app/shared/icon-and-title/icon-and-title.component.scss
+++ b/UI/Web/src/app/shared/icon-and-title/icon-and-title.component.scss
@@ -12,4 +12,10 @@
 .text {
     padding-top: 5px;
     text-align: center;
+    font-weight: bold;
+}
+
+.label {
+    padding-bottom: 5px;
+    text-align: center;
 }

--- a/UI/Web/src/app/shared/icon-and-title/icon-and-title.component.scss
+++ b/UI/Web/src/app/shared/icon-and-title/icon-and-title.component.scss
@@ -12,10 +12,10 @@
 .text {
     padding-top: 5px;
     text-align: center;
-    font-weight: bold;
 }
 
 .label {
     padding-bottom: 5px;
     text-align: center;
+    font-weight: bold;
 }

--- a/UI/Web/src/app/shared/icon-and-title/icon-and-title.component.ts
+++ b/UI/Web/src/app/shared/icon-and-title/icon-and-title.component.ts
@@ -11,6 +11,7 @@ export class IconAndTitleComponent implements OnInit {
    */
   @Input() clickable: boolean = true;
   @Input() title: string = '';
+  @Input() label: string = '';
   /**
    * Font classes used to display font
    */

--- a/UI/Web/src/app/sidenav/side-nav/side-nav.component.html
+++ b/UI/Web/src/app/sidenav/side-nav/side-nav.component.html
@@ -12,11 +12,11 @@
         <app-side-nav-item icon="fa-list-ol" title="Reading Lists" link="/lists/"></app-side-nav-item>
         <app-side-nav-item icon="fa-bookmark" title="Bookmarks" link="/bookmarks/"></app-side-nav-item>
         <app-side-nav-item icon="fa-regular fa-rectangle-list" title="All Series" link="/all-series/"></app-side-nav-item>
-        <div class="mb-2 mt-3 ms-2 me-2" *ngIf="libraries.length > 10">
+        <div class="mb-2 mt-3 ms-2 me-2" *ngIf="libraries.length > 10 && !(navService?.sideNavCollapsed$ | async)">
             <label for="filter" class="form-label visually-hidden">Filter</label>
-            <div class="input-group">
+            <div class="form-group">
                 <input id="filter" autocomplete="off" class="form-control" [(ngModel)]="filterQuery" type="text" aria-describedby="reset-input">
-                <button class="btn btn-outline-secondary" type="button" id="reset-input" (click)="filterQuery = '';">Clear</button>
+                <button type="button" aria-label="Clear" class="btn-close" id="reset-input" (click)="filterQuery = '';"></button>
             </div>
         </div>
         <app-side-nav-item *ngFor="let library of libraries | filter: filterLibrary" [link]="'/library/' + library.id + '/'"

--- a/UI/Web/src/app/sidenav/side-nav/side-nav.component.scss
+++ b/UI/Web/src/app/sidenav/side-nav/side-nav.component.scss
@@ -71,3 +71,10 @@
         }
     }
 }
+
+.btn-close {
+    margin-top: -28px;
+    font-size: 0.8rem;
+    position: absolute;
+    right: 16px;
+}

--- a/UI/Web/src/styles.scss
+++ b/UI/Web/src/styles.scss
@@ -65,7 +65,9 @@ label, select, .clickable {
 
 // Needed for fullscreen
 app-root {
-  background-color: inherit;
+  background-color: transparent;
+  scrollbar-width: 14px;
+  scrollbar-color: var(--primary-color-scrollbar);
 }
 
 ::-webkit-scrollbar {


### PR DESCRIPTION
# Added
- Added: On Volume details added a distinct Read action rather than having hidden knowledge of clicking the poster for the chapter would let the user read it.

# Changed
- Changed: Icon and Text design now has a label to help identify what the information is (develop)
- Changed: Icon and Text design has been tweaked to provide some bolding on the label (develop)
- Changed: Ensure volume details shows pages from all chapters and not just the first one (develop)
- Changed: Non-ongoing series will now use an hourglass that is more full than if ongoing (develop)
- Changed: Series detail uses the builtin cover image refreshing mechanism rather than some old, initial implementation, resulting in a much more reliable refresh mechanism.
- Changed: Side nav filter (when there are more than 10 libraries) now uses a clear button within the input field.


# Fixed
- Fixed: Fixed a bug when fit to height and there is overflow on horizontal, the pagination area is stuck to the original width and after scrolling right, the pagination area doesn't move on manga reader.
- Fixed: E-ink readers would show an outline on the pagination area on book reader when using white mode
- Fixed: Fixed some issues where the new detail drawer wouldn't show enough (develop)
- Fixed: Fixed a bug with showing images on column layout in book reader, where the recent PR to scale it down so it doesn't overflow to a virtual page failed in some cases (develop)
- Fixed: Fixed a bug when switching from column layout to default, the progress would get reset and current line wouldn't be scrolled to (Fixes #1300 )
- Fixed: Side nav filter (when there are more than 10 libraries) now hides when the side nav is collapsed. 
- Fixed: When opening a chapter to read from Volume details drawer, close the drawer (develop)
