### PR TITLE
Swagger, Tachiyomi, and some new settings

### DIFF
--- a/API/API.csproj
+++ b/API/API.csproj
@@ -44,37 +44,37 @@
     <PackageReference Include="ExCSS" Version="4.1.0" />
     <PackageReference Include="Flurl" Version="3.0.6" />
     <PackageReference Include="Flurl.Http" Version="3.2.4" />
-    <PackageReference Include="Hangfire" Version="1.7.29" />
-    <PackageReference Include="Hangfire.AspNetCore" Version="1.7.29" />
+    <PackageReference Include="Hangfire" Version="1.7.30" />
+    <PackageReference Include="Hangfire.AspNetCore" Version="1.7.30" />
     <PackageReference Include="Hangfire.MaximumConcurrentExecutions" Version="1.1.0" />
     <PackageReference Include="Hangfire.MemoryStorage.Core" Version="1.4.0" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.43" />
     <PackageReference Include="MarkdownDeep.NET.Core" Version="1.5.0.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.5" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="6.0.5" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="6.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.6" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.5">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.6" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.0" />
     <PackageReference Include="NetVips" Version="2.1.0" />
     <PackageReference Include="NetVips.Native" Version="8.12.2" />
     <PackageReference Include="NReco.Logging.File" Version="1.1.5" />
-    <PackageReference Include="SharpCompress" Version="0.31.0" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.2" />
+    <PackageReference Include="SharpCompress" Version="0.32.1" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="8.40.0.48530">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.1" />
     <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.19.0" />
-    <PackageReference Include="System.IO.Abstractions" Version="17.0.15" />
-    <PackageReference Include="VersOne.Epub" Version="3.1.1" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.20.0" />
+    <PackageReference Include="System.IO.Abstractions" Version="17.0.18" />
+    <PackageReference Include="VersOne.Epub" Version="3.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/API/API.csproj
+++ b/API/API.csproj
@@ -5,15 +5,17 @@
     <TargetFramework>net6.0</TargetFramework>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DebugSymbols>false</DebugSymbols>
     <ApplicationIcon>../favicon.ico</ApplicationIcon>
+    <DocumentationFile>bin\$(Configuration)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
-    <DocumentationFile>bin\Debug\API.xml</DocumentationFile>
+      <DocumentationFile>bin\$(Configuration)\$(AssemblyName).xml</DocumentationFile>
     <NoWarn>1701;1702;1591</NoWarn>
   </PropertyGroup>
 
@@ -134,6 +136,9 @@
     </Content>
     <Content Remove="covers\**" />
     <Content Remove="config\covers\**" />
+    <Content Update="bin\$(Configuration)\$(AssemblyName).xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
   <ItemGroup>

--- a/API/Controllers/AccountController.cs
+++ b/API/Controllers/AccountController.cs
@@ -207,6 +207,11 @@ namespace API.Controllers
             return dto;
         }
 
+        /// <summary>
+        /// Refreshes the user's JWT token
+        /// </summary>
+        /// <param name="tokenRequestDto"></param>
+        /// <returns></returns>
         [HttpPost("refresh-token")]
         public async Task<ActionResult<TokenRequestDto>> RefreshToken([FromBody] TokenRequestDto tokenRequestDto)
         {

--- a/API/Controllers/AdminController.cs
+++ b/API/Controllers/AdminController.cs
@@ -14,6 +14,10 @@ namespace API.Controllers
             _userManager = userManager;
         }
 
+        /// <summary>
+        /// Checks if an admin exists on the system. This is essentially a check to validate if the system has been setup.
+        /// </summary>
+        /// <returns></returns>
         [HttpGet("exists")]
         public async Task<ActionResult<bool>> AdminExists()
         {

--- a/API/Controllers/BookController.cs
+++ b/API/Controllers/BookController.cs
@@ -33,6 +33,12 @@ namespace API.Controllers
             _cacheService = cacheService;
         }
 
+        /// <summary>
+        /// Retrieves information for the PDF and Epub reader
+        /// </summary>
+        /// <remarks>This only applies to Epub or PDF files</remarks>
+        /// <param name="chapterId"></param>
+        /// <returns></returns>
         [HttpGet("{chapterId}/book-info")]
         public async Task<ActionResult<BookInfoDto>> GetBookInfo(int chapterId)
         {
@@ -64,8 +70,6 @@ namespace API.Controllers
                     break;
                 case MangaFormat.Unknown:
                     break;
-                default:
-                    throw new ArgumentOutOfRangeException();
             }
 
             return Ok(new BookInfoDto()
@@ -83,6 +87,12 @@ namespace API.Controllers
             });
         }
 
+        /// <summary>
+        /// This is an entry point to fetch resources from within an epub chapter/book.
+        /// </summary>
+        /// <param name="chapterId"></param>
+        /// <param name="file"></param>
+        /// <returns></returns>
         [HttpGet("{chapterId}/book-resources")]
         public async Task<ActionResult> GetBookPageResources(int chapterId, [FromQuery] string file)
         {
@@ -102,7 +112,7 @@ namespace API.Controllers
 
         /// <summary>
         /// This will return a list of mappings from ID -> page num. ID will be the xhtml key and page num will be the reading order
-        /// this is used to rewrite anchors in the book text so that we always load properly in FE
+        /// this is used to rewrite anchors in the book text so that we always load properly in our reader.
         /// </summary>
         /// <remarks>This is essentially building the table of contents</remarks>
         /// <param name="chapterId"></param>
@@ -229,6 +239,13 @@ namespace API.Controllers
             }
         }
 
+        /// <summary>
+        /// This returns a single page within the epub book. All html will be rewritten to be scoped within our reader,
+        /// all css is scoped, etc.
+        /// </summary>
+        /// <param name="chapterId"></param>
+        /// <param name="page"></param>
+        /// <returns></returns>
         [HttpGet("{chapterId}/book-page")]
         public async Task<ActionResult<string>> GetBookPage(int chapterId, [FromQuery] int page)
         {

--- a/API/Controllers/DownloadController.cs
+++ b/API/Controllers/DownloadController.cs
@@ -18,6 +18,9 @@ using Microsoft.Extensions.Logging;
 
 namespace API.Controllers
 {
+    /// <summary>
+    /// All APIs related to downloading entities from the system. Requires Download Role or Admin Role.
+    /// </summary>
     [Authorize(Policy="RequireDownloadRole")]
     public class DownloadController : BaseApiController
     {
@@ -42,6 +45,11 @@ namespace API.Controllers
             _bookmarkService = bookmarkService;
         }
 
+        /// <summary>
+        /// For a given volume, return the size in bytes
+        /// </summary>
+        /// <param name="volumeId"></param>
+        /// <returns></returns>
         [HttpGet("volume-size")]
         public async Task<ActionResult<long>> GetVolumeSize(int volumeId)
         {
@@ -49,6 +57,11 @@ namespace API.Controllers
             return Ok(_directoryService.GetTotalSize(files.Select(c => c.FilePath)));
         }
 
+        /// <summary>
+        /// For a given chapter, return the size in bytes
+        /// </summary>
+        /// <param name="chapterId"></param>
+        /// <returns></returns>
         [HttpGet("chapter-size")]
         public async Task<ActionResult<long>> GetChapterSize(int chapterId)
         {
@@ -56,6 +69,11 @@ namespace API.Controllers
             return Ok(_directoryService.GetTotalSize(files.Select(c => c.FilePath)));
         }
 
+        /// <summary>
+        /// For a series, return the size in bytes
+        /// </summary>
+        /// <param name="seriesId"></param>
+        /// <returns></returns>
         [HttpGet("series-size")]
         public async Task<ActionResult<long>> GetSeriesSize(int seriesId)
         {
@@ -64,7 +82,11 @@ namespace API.Controllers
         }
 
 
-
+        /// <summary>
+        /// Downloads all chapters within a volume.
+        /// </summary>
+        /// <param name="volumeId"></param>
+        /// <returns></returns>
         [Authorize(Policy="RequireDownloadRole")]
         [HttpGet("volume")]
         public async Task<ActionResult> DownloadVolume(int volumeId)

--- a/API/Controllers/ImageController.cs
+++ b/API/Controllers/ImageController.cs
@@ -10,7 +10,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace API.Controllers
 {
     /// <summary>
-    /// Responsible for servicing up images stored in the DB
+    /// Responsible for servicing up images stored in Kavita for entities
     /// </summary>
     public class ImageController : BaseApiController
     {

--- a/API/Controllers/ReaderController.cs
+++ b/API/Controllers/ReaderController.cs
@@ -191,6 +191,11 @@ namespace API.Controllers
         }
 
 
+        /// <summary>
+        /// Marks a Series as read. All volumes and chapters will be marked as read during this process.
+        /// </summary>
+        /// <param name="markReadDto"></param>
+        /// <returns></returns>
         [HttpPost("mark-read")]
         public async Task<ActionResult> MarkRead(MarkReadDto markReadDto)
         {
@@ -204,7 +209,7 @@ namespace API.Controllers
 
 
         /// <summary>
-        /// Marks a Series as Unread (progress)
+        /// Marks a Series as Unread. All volumes and chapters will be marked as unread during this process.
         /// </summary>
         /// <param name="markReadDto"></param>
         /// <returns></returns>

--- a/API/Controllers/TachiyomiController.cs
+++ b/API/Controllers/TachiyomiController.cs
@@ -35,7 +35,7 @@ public class TachiyomiController : BaseApiController
     /// Given the series Id, this should return the latest chapter that has been fully read.
     /// </summary>
     /// <param name="seriesId"></param>
-    /// <returns></returns>
+    /// <returns>ChapterDTO of latest chapter. Only Chapter number is used by consuming app. All other fields may be missing.</returns>
     [HttpGet("latest-chapter")]
     public async Task<ActionResult<ChapterDto>> GetLatestChapter(int seriesId)
     {
@@ -61,7 +61,13 @@ public class TachiyomiController : BaseApiController
             var looseLeafChapterVolume = volumes.FirstOrDefault(v => v.Number == 0);
             if (looseLeafChapterVolume == null)
             {
-                return Ok(_mapper.Map<ChapterDto>(volumes.Last().Chapters.First()));
+                var volumeChapter = _mapper.Map<ChapterDto>(volumes.Last().Chapters.First());
+                return Ok(new ChapterDto()
+                {
+                    Number = $"{int.Parse(volumeChapter.Number) * 100f}"
+                });
+                // volumeChapter.Number = $"{int.Parse(volumeChapter.Number) * 100f}";
+                // return Ok();
             }
 
             var lastChapter = looseLeafChapterVolume.Chapters.OrderBy(c => float.Parse(c.Number), new ChapterSortComparer()).Last();

--- a/API/Controllers/TachiyomiController.cs
+++ b/API/Controllers/TachiyomiController.cs
@@ -58,7 +58,7 @@ public class TachiyomiController : BaseApiController
             var looseLeafChapterVolume = volumes.FirstOrDefault(v => v.Number == 0);
             if (looseLeafChapterVolume == null)
             {
-                return Ok($"{volumes.Last().Number * 100f}");
+                return Ok(volumes.Last().Chapters.First());
             }
 
             var lastChapter = looseLeafChapterVolume.Chapters.OrderBy(c => float.Parse(c.Number), new ChapterSortComparer()).Last();

--- a/API/Controllers/TachiyomiController.cs
+++ b/API/Controllers/TachiyomiController.cs
@@ -9,6 +9,7 @@ using API.DTOs;
 using API.Entities;
 using API.Extensions;
 using API.Services;
+using AutoMapper;
 using Microsoft.AspNetCore.Mvc;
 
 namespace API.Controllers;
@@ -21,11 +22,13 @@ public class TachiyomiController : BaseApiController
 {
     private readonly IUnitOfWork _unitOfWork;
     private readonly IReaderService _readerService;
+    private readonly IMapper _mapper;
 
-    public TachiyomiController(IUnitOfWork unitOfWork, IReaderService readerService)
+    public TachiyomiController(IUnitOfWork unitOfWork, IReaderService readerService, IMapper mapper)
     {
         _unitOfWork = unitOfWork;
         _readerService = readerService;
+        _mapper = mapper;
     }
 
     /// <summary>
@@ -58,11 +61,11 @@ public class TachiyomiController : BaseApiController
             var looseLeafChapterVolume = volumes.FirstOrDefault(v => v.Number == 0);
             if (looseLeafChapterVolume == null)
             {
-                return Ok(volumes.Last().Chapters.First());
+                return Ok(_mapper.Map<ChapterDto>(volumes.Last().Chapters.First()));
             }
 
             var lastChapter = looseLeafChapterVolume.Chapters.OrderBy(c => float.Parse(c.Number), new ChapterSortComparer()).Last();
-            return Ok(lastChapter.Number);
+            return Ok(_mapper.Map<ChapterDto>(lastChapter));
         }
 
         var prevChapter = await _unitOfWork.ChapterRepository.GetChapterDtoAsync(prevChapterId);

--- a/API/Controllers/TachiyomiController.cs
+++ b/API/Controllers/TachiyomiController.cs
@@ -21,6 +21,11 @@ public class TachiyomiController : BaseApiController
         _readerService = readerService;
     }
 
+    /// <summary>
+    /// Given the series Id, this should return the latest chapter that has been fully read.
+    /// </summary>
+    /// <param name="seriesId"></param>
+    /// <returns></returns>
     [HttpGet("latest-chapter")]
     public async Task<ActionResult<ChapterDto>> GetLatestChapter(int seriesId)
     {

--- a/API/Controllers/TachiyomiController.cs
+++ b/API/Controllers/TachiyomiController.cs
@@ -66,8 +66,6 @@ public class TachiyomiController : BaseApiController
                 {
                     Number = $"{int.Parse(volumeChapter.Number) * 100f}"
                 });
-                // volumeChapter.Number = $"{int.Parse(volumeChapter.Number) * 100f}";
-                // return Ok();
             }
 
             var lastChapter = looseLeafChapterVolume.Chapters.OrderBy(c => float.Parse(c.Number), new ChapterSortComparer()).Last();

--- a/API/Controllers/TachiyomiController.cs
+++ b/API/Controllers/TachiyomiController.cs
@@ -61,7 +61,7 @@ public class TachiyomiController : BaseApiController
             var looseLeafChapterVolume = volumes.FirstOrDefault(v => v.Number == 0);
             if (looseLeafChapterVolume == null)
             {
-                var volumeChapter = _mapper.Map<ChapterDto>(volumes.Last().Chapters.First());
+                var volumeChapter = _mapper.Map<ChapterDto>(volumes.Last().Chapters.OrderBy(c => float.Parse(c.Number), new ChapterSortComparerZeroFirst()).Last());
                 return Ok(new ChapterDto()
                 {
                     Number = $"{int.Parse(volumeChapter.Number) * 100f}"

--- a/API/Controllers/TachiyomiController.cs
+++ b/API/Controllers/TachiyomiController.cs
@@ -64,12 +64,16 @@ public class TachiyomiController : BaseApiController
                 var volumeChapter = _mapper.Map<ChapterDto>(volumes.Last().Chapters.OrderBy(c => float.Parse(c.Number), new ChapterSortComparerZeroFirst()).Last());
                 return Ok(new ChapterDto()
                 {
-                    Number = $"{int.Parse(volumeChapter.Number) * 100f}"
+                    Number = $"{int.Parse(volumeChapter.Number) / 100f}"
                 });
             }
 
             var lastChapter = looseLeafChapterVolume.Chapters.OrderBy(c => float.Parse(c.Number), new ChapterSortComparer()).Last();
-            return Ok(_mapper.Map<ChapterDto>(lastChapter));
+            return Ok(new ChapterDto()
+            {
+                Number = $"{int.Parse(lastChapter.Number) / 100f}"
+            });
+            //return Ok(_mapper.Map<ChapterDto>(lastChapter));
         }
 
         var prevChapter = await _unitOfWork.ChapterRepository.GetChapterDtoAsync(prevChapterId);

--- a/API/Controllers/UsersController.cs
+++ b/API/Controllers/UsersController.cs
@@ -95,6 +95,7 @@ namespace API.Controllers
             existingPreferences.BookReaderLayoutMode = preferencesDto.BookReaderLayoutMode;
             existingPreferences.BookReaderImmersiveMode = preferencesDto.BookReaderImmersiveMode;
             existingPreferences.GlobalPageLayoutMode = preferencesDto.GlobalPageLayoutMode;
+            existingPreferences.BlurUnreadSummaries = preferencesDto.BlurUnreadSummaries;
             existingPreferences.Theme = await _unitOfWork.SiteThemeRepository.GetThemeById(preferencesDto.Theme.Id);
 
             // TODO: Remove this code - this overrides layout mode to be single until the mode is released

--- a/API/DTOs/UpdateLibraryDto.cs
+++ b/API/DTOs/UpdateLibraryDto.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using API.Entities.Enums;
 
 namespace API.DTOs
 {
@@ -6,6 +7,7 @@ namespace API.DTOs
     {
         public int Id { get; init; }
         public string Name { get; init; }
+        public LibraryType Type { get; set; }
         public IEnumerable<string> Folders { get; init; }
     }
 }

--- a/API/DTOs/UserPreferencesDto.cs
+++ b/API/DTOs/UserPreferencesDto.cs
@@ -88,5 +88,10 @@ namespace API.DTOs
         /// </summary>
         /// <remarks>Defaults to Cards</remarks>
         public PageLayoutMode GlobalPageLayoutMode { get; set; } = PageLayoutMode.Cards;
+        /// <summary>
+        /// UI Site Global Setting: If unread summaries should be blurred until expanded or unless user has read it already
+        /// </summary>
+        /// <remarks>Defaults to false</remarks>
+        public bool BlurUnreadSummaries { get; set; } = false;
     }
 }

--- a/API/Data/Migrations/20220625215526_BlurUnreadSummaries.Designer.cs
+++ b/API/Data/Migrations/20220625215526_BlurUnreadSummaries.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using API.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace API.Data.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20220625215526_BlurUnreadSummaries")]
+    partial class BlurUnreadSummaries
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "6.0.6");

--- a/API/Data/Migrations/20220625215526_BlurUnreadSummaries.cs
+++ b/API/Data/Migrations/20220625215526_BlurUnreadSummaries.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace API.Data.Migrations
+{
+    public partial class BlurUnreadSummaries : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "BlurUnreadSummaries",
+                table: "AppUserPreferences",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "BlurUnreadSummaries",
+                table: "AppUserPreferences");
+        }
+    }
+}

--- a/API/Entities/AppUserPreferences.cs
+++ b/API/Entities/AppUserPreferences.cs
@@ -93,6 +93,11 @@ namespace API.Entities
         /// </summary>
         /// <remarks>Defaults to Cards</remarks>
         public PageLayoutMode GlobalPageLayoutMode { get; set; } = PageLayoutMode.Cards;
+        /// <summary>
+        /// UI Site Global Setting: If unread summaries should be blurred until expanded or unless user has read it already
+        /// </summary>
+        /// <remarks>Defaults to false</remarks>
+        public bool BlurUnreadSummaries { get; set; } = false;
 
         public AppUser AppUser { get; set; }
         public int AppUserId { get; set; }

--- a/API/Services/BookService.cs
+++ b/API/Services/BookService.cs
@@ -585,8 +585,7 @@ namespace API.Services
                         }
                     }
 
-                    if (!string.IsNullOrEmpty(series) && !string.IsNullOrEmpty(seriesIndex) &&
-                        (!string.IsNullOrEmpty(specialName) || groupPosition.Equals("series") || groupPosition.Equals("set")))
+                    if (!string.IsNullOrEmpty(series) && !string.IsNullOrEmpty(seriesIndex) ) //
                     {
                         if (string.IsNullOrEmpty(specialName))
                         {
@@ -606,7 +605,7 @@ namespace API.Services
                         };
 
                         // Don't set titleSort if the book belongs to a group
-                        if (!string.IsNullOrEmpty(titleSort) && string.IsNullOrEmpty(seriesIndex))
+                        if (!string.IsNullOrEmpty(titleSort) && string.IsNullOrEmpty(seriesIndex) && (groupPosition.Equals("series") || groupPosition.Equals("set")))
                         {
                             info.SeriesSort = titleSort;
                         }

--- a/API/Services/BookService.cs
+++ b/API/Services/BookService.cs
@@ -585,7 +585,7 @@ namespace API.Services
                         }
                     }
 
-                    if (!string.IsNullOrEmpty(series) && !string.IsNullOrEmpty(seriesIndex) )
+                    if (!string.IsNullOrEmpty(series) && !string.IsNullOrEmpty(seriesIndex))
                     {
                         if (string.IsNullOrEmpty(specialName))
                         {

--- a/API/Services/BookService.cs
+++ b/API/Services/BookService.cs
@@ -585,7 +585,7 @@ namespace API.Services
                         }
                     }
 
-                    if (!string.IsNullOrEmpty(series) && !string.IsNullOrEmpty(seriesIndex) ) //
+                    if (!string.IsNullOrEmpty(series) && !string.IsNullOrEmpty(seriesIndex) )
                     {
                         if (string.IsNullOrEmpty(specialName))
                         {

--- a/API/Services/TokenService.cs
+++ b/API/Services/TokenService.cs
@@ -74,18 +74,15 @@ public class TokenService : ITokenService
         var tokenContent = tokenHandler.ReadJwtToken(request.Token);
         var username = tokenContent.Claims.FirstOrDefault(q => q.Type == JwtRegisteredClaimNames.NameId)?.Value;
         var user = await _userManager.FindByNameAsync(username);
+        if (user == null) return null; // This forces a logout
         var isValid = await _userManager.VerifyUserTokenAsync(user, TokenOptions.DefaultProvider, "RefreshToken", request.RefreshToken);
-        if (isValid)
-        {
-            return new TokenRequestDto()
-            {
-                Token = await CreateToken(user),
-                RefreshToken = await CreateRefreshToken(user)
-            };
-        }
 
         await _userManager.UpdateSecurityStampAsync(user);
 
-        return null;
+        return new TokenRequestDto()
+        {
+            Token = await CreateToken(user),
+            RefreshToken = await CreateRefreshToken(user)
+        };
     }
 }

--- a/API/Startup.cs
+++ b/API/Startup.cs
@@ -241,9 +241,6 @@ namespace API
                 ContentTypeProvider = new FileExtensionContentTypeProvider()
             });
 
-
-
-
             app.Use(async (context, next) =>
             {
                 context.Response.GetTypedHeaders().CacheControl =

--- a/API/Startup.cs
+++ b/API/Startup.cs
@@ -60,17 +60,16 @@ namespace API
             services.AddIdentityServices(_config);
             services.AddSwaggerGen(c =>
             {
-                c.SwaggerDoc("v1", new OpenApiInfo { Title = "Kavita API", Version = "v1" });
-
-                c.SwaggerDoc("Kavita API", new OpenApiInfo()
+                c.SwaggerDoc("v1", new OpenApiInfo()
                 {
                     Description = "Kavita provides a set of APIs that are authenticated by JWT. JWT token can be copied from local storage.",
                     Title = "Kavita API",
                     Version = "v1",
                 });
 
+
                 var filePath = Path.Combine(AppContext.BaseDirectory, "API.xml");
-                c.IncludeXmlComments(filePath);
+                c.IncludeXmlComments(filePath, true);
                 c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme {
                     In = ParameterLocation.Header,
                     Description = "Please insert JWT with Bearer into field",
@@ -96,6 +95,19 @@ namespace API
                     Description = "Local Server",
                     Url = "http://localhost:5000/",
                 });
+
+                c.AddServer(new OpenApiServer()
+                {
+                    Url = "https://demo.kavitareader.com/",
+                    Description = "Kavita Demo"
+                });
+
+                c.AddServer(new OpenApiServer()
+                {
+                    Url = "http://" + GetLocalIpAddress() + ":5000/",
+                    Description = "Local IP"
+                });
+
             });
             services.AddResponseCompression(options =>
             {

--- a/UI/Web/src/app/_models/preferences/preferences.ts
+++ b/UI/Web/src/app/_models/preferences/preferences.ts
@@ -33,6 +33,7 @@ export interface Preferences {
     // Global
     theme: SiteTheme;
     globalPageLayoutMode: PageLayoutMode;
+    blurUnreadSummaries: boolean;
 }
 
 export const readingDirections = [{text: 'Left to Right', value: ReadingDirection.LeftToRight}, {text: 'Right to Left', value: ReadingDirection.RightToLeft}];

--- a/UI/Web/src/app/_services/account.service.ts
+++ b/UI/Web/src/app/_services/account.service.ts
@@ -92,8 +92,9 @@ export class AccountService implements OnDestroy {
       this.themeService.setTheme(this.themeService.defaultTheme);
     }
 
-    this.currentUserSource.next(user);
     this.currentUser = user;
+    this.currentUserSource.next(user);
+    
     if (this.currentUser !== undefined) {
       this.startRefreshTokenTimer();
     } else {

--- a/UI/Web/src/app/_services/message-hub.service.ts
+++ b/UI/Web/src/app/_services/message-hub.service.ts
@@ -203,7 +203,6 @@ export class MessageHubService {
     });
 
     this.hubConnection.on(EVENTS.UserUpdate, resp => {
-      console.log('got UserUpdate', resp);
       this.messagesSource.next({
         event: EVENTS.UserUpdate,
         payload: resp.body as UserUpdateEvent

--- a/UI/Web/src/app/admin/_modals/library-editor-modal/library-editor-modal.component.html
+++ b/UI/Web/src/app/admin/_modals/library-editor-modal/library-editor-modal.component.html
@@ -19,7 +19,7 @@
             <label for="library-type" class="form-label">Type</label>&nbsp;<i class="fa fa-info-circle" placement="right" [ngbTooltip]="typeTooltip" role="button" tabindex="0"></i>
             <ng-template #typeTooltip>Library type determines how filenames are parsed and if the UI shows Chapters (Manga) vs Issues (Comics). Book work the same way as Manga but fall back to embedded data.</ng-template>
             <span class="visually-hidden" id="library-type-help">Library type determines how filenames are parsed and if the UI shows Chapters (Manga) vs Issues (Comics). Book work the same way as Manga but fall back to embedded data.</span>
-            <select class="form-select" id="library-type" formControlName="type" [attr.disabled]="this.library" aria-describedby="library-type-help">
+            <select class="form-select" id="library-type" formControlName="type" aria-describedby="library-type-help"> <!-- [attr.disabled]="this.library" -->
                 <option [value]="i" *ngFor="let opt of libraryTypes; let i = index">{{opt}}</option>
             </select>
         </div>

--- a/UI/Web/src/app/admin/_modals/library-editor-modal/library-editor-modal.component.ts
+++ b/UI/Web/src/app/admin/_modals/library-editor-modal/library-editor-modal.component.ts
@@ -2,6 +2,7 @@ import { Component, Input, OnInit } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { NgbActiveModal, NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { ToastrService } from 'ngx-toastr';
+import { ConfirmService } from 'src/app/shared/confirm.service';
 import { Library } from 'src/app/_models/library';
 import { LibraryService } from 'src/app/_services/library.service';
 import { SettingsService } from '../../settings.service';
@@ -28,7 +29,7 @@ export class LibraryEditorModalComponent implements OnInit {
 
 
   constructor(private modalService: NgbModal, private libraryService: LibraryService, public modal: NgbActiveModal, private settingService: SettingsService,
-    private toastr: ToastrService) { }
+    private toastr: ToastrService, private confirmService: ConfirmService) { }
 
   ngOnInit(): void {
 
@@ -45,7 +46,7 @@ export class LibraryEditorModalComponent implements OnInit {
     this.madeChanges = true;
   }
 
-  submitLibrary() {
+  async submitLibrary() {
     const model = this.libraryForm.value;
     model.folders = this.selectedFolders;
 
@@ -57,6 +58,12 @@ export class LibraryEditorModalComponent implements OnInit {
       model.id = this.library.id;
       model.folders = model.folders.map((item: string) => item.startsWith('\\') ? item.substr(1, item.length) : item);
       model.type = parseInt(model.type, 10);
+
+      if (model.type !== this.library.type) {
+        if (!await this.confirmService.confirm(`Changing library type will trigger a new scan with different parsing rules and may lead to 
+        series being re-created and hence you may loose progress and bookmarks. You should backup before you do this. Are you sure you want to continue?`)) return;
+      }
+
       this.libraryService.update(model).subscribe(() => {
         this.close(true);
       }, err => {

--- a/UI/Web/src/app/admin/manage-settings/manage-settings.component.html
+++ b/UI/Web/src/app/admin/manage-settings/manage-settings.component.html
@@ -29,7 +29,7 @@
             </div>
 
             <div class="col-md-4 col-sm-12 pe-2">
-                <label for="backup-tasks" class="form-label">Backup Tasks</label>&nbsp;<i class="fa fa-info-circle" placement="right" [ngbTooltip]="backupTasksTooltip" role="button" tabindex="0"></i>
+                <label for="backup-tasks" class="form-label">Days of Backups</label>&nbsp;<i class="fa fa-info-circle" placement="right" [ngbTooltip]="backupTasksTooltip" role="button" tabindex="0"></i>
                 <ng-template #backupTasksTooltip>The number of backups to maintain. Default is 30, minumum is 1, maximum is 30.</ng-template>
                 <span class="visually-hidden" id="backup-tasks-help">The number of backups to maintain. Default is 30, minumum is 1, maximum is 30.</span>
                 <input id="backup-tasks" aria-describedby="backup-tasks-help" class="form-control" formControlName="totalBackups" type="number" step="1" min="1" max="30" onkeypress="return event.charCode >= 48 && event.charCode <= 57">
@@ -67,7 +67,7 @@
 
         <div class="mb-3">
             <label for="swagger-ui" class="form-label" aria-describedby="swaggerui-info">Expose Swagger UI</label>
-            <p class="accent" id="swaggerui-info">Allows Swagger UI to be exposed via swagger/ on your server. Authentication is not required, but a valid JWT token is. Requires a restart to take effect.</p>
+            <p class="accent" id="swaggerui-info">Allows Swagger UI to be exposed via swagger/ on your server. Authentication is not required, but a valid JWT token is. Requires a restart to take effect. Swagger is hosted on yourip:5000/swagger</p>
             <div class="form-check form-switch">
                 <input id="swagger-ui" type="checkbox" class="form-check-input" formControlName="enableSwaggerUi" role="switch">
                 <label for="swagger-ui" class="form-check-label">Enable Swagger UI</label>

--- a/UI/Web/src/app/cards/list-item/list-item.component.html
+++ b/UI/Web/src/app/cards/list-item/list-item.component.html
@@ -28,7 +28,7 @@
             <h6 class="text-muted" [ngClass]="{'subtitle-with-actionables' : actions.length > 0}" style="font-size: 0.75rem" *ngIf="Title != '' && showTitle">{{Title}}</h6>
             <ng-container *ngIf="summary.length > 0">
                 <div class="mt-2 ps-2">
-                    <app-read-more [text]="summary" [maxLength]="250"></app-read-more>
+                    <app-read-more [text]="summary" [blur]="pagesRead === 0" [maxLength]="250"></app-read-more>
                 </div>
             </ng-container>
             <div class="ps-2 d-none d-md-inline-block">

--- a/UI/Web/src/app/cards/list-item/list-item.component.html
+++ b/UI/Web/src/app/cards/list-item/list-item.component.html
@@ -28,7 +28,7 @@
             <h6 class="text-muted" [ngClass]="{'subtitle-with-actionables' : actions.length > 0}" style="font-size: 0.75rem" *ngIf="Title != '' && showTitle">{{Title}}</h6>
             <ng-container *ngIf="summary.length > 0">
                 <div class="mt-2 ps-2">
-                    <app-read-more [text]="summary" [blur]="pagesRead === 0" [maxLength]="250"></app-read-more>
+                    <app-read-more [text]="summary" [blur]="pagesRead === 0 && blur" [maxLength]="250"></app-read-more>
                 </div>
             </ng-container>
             <div class="ps-2 d-none d-md-inline-block">

--- a/UI/Web/src/app/cards/list-item/list-item.component.ts
+++ b/UI/Web/src/app/cards/list-item/list-item.component.ts
@@ -62,6 +62,10 @@ export class ListItemComponent implements OnInit {
    * Show's the title if avaible on entity
    */
   @Input() showTitle: boolean = true;
+  /**
+   * Blur the summary for the list item
+   */
+  @Input() blur: boolean = false;
 
   @Output() read: EventEmitter<void> = new EventEmitter<void>();
 

--- a/UI/Web/src/app/nav/events-widget/events-widget.component.html
+++ b/UI/Web/src/app/nav/events-widget/events-widget.component.html
@@ -1,9 +1,12 @@
 <ng-container *ngIf="isAdmin">
     
-    <button type="button" class="btn btn-icon {{activeEvents > 0 ? 'colored' : ''}}" 
-        [ngbPopover]="popContent" title="Activity" placement="bottom" [popoverClass]="'nav-events'" [autoClose]="'outside'">
-        <i aria-hidden="true" class="fa fa-wave-square nav"></i>
-    </button>
+    <ng-container *ngIf="errors$ | async as errors">
+        <button type="button" class="btn btn-icon" [ngClass]="{'colored': activeEvents > 0, 'colored-error': errors.length > 0}" 
+            [ngbPopover]="popContent" title="Activity" placement="bottom" [popoverClass]="'nav-events'" [autoClose]="'outside'">
+            <i aria-hidden="true" class="fa fa-wave-square nav"></i>
+        </button>
+    </ng-container>
+    
 
     <ng-template #popContent>
         <ul class="list-group list-group-flush dark-menu">

--- a/UI/Web/src/app/nav/events-widget/events-widget.component.scss
+++ b/UI/Web/src/app/nav/events-widget/events-widget.component.scss
@@ -66,6 +66,11 @@
     border-radius: 60px;
 }
 
+.colored-error {
+    background-color: var(--error-color) !important;
+    border-radius: 60px;
+}
+
 .update-available {
     cursor: pointer;
     

--- a/UI/Web/src/app/series-detail/series-detail.component.html
+++ b/UI/Web/src/app/series-detail/series-detail.component.html
@@ -96,7 +96,7 @@
                 </div>
                 <div class="col-auto ms-2">
                     <ngb-rating class="rating-star" [(rate)]="series!.userRating" (rateChange)="updateRating($event)" (click)="promptToReview()"></ngb-rating>
-                    <button *ngIf="series?.userRating || series.userRating" class="btn btn-sm btn-icon" (click)="openReviewModal(true)" placement="top" ngbTooltip="Edit Review" attr.aria-label="Edit Review"><i class="fa fa-pen" aria-hidden="true"></i></button>
+                    <button *ngIf="series?.userRating || series.userRating" class="btn btn-sm btn-icon" (click)="openReviewModal(true)" placement="bottom" ngbTooltip="Edit Review" attr.aria-label="Edit Review"><i class="fa fa-pen" aria-hidden="true"></i></button>
                 </div>
             </div>
             <div class="row g-0">

--- a/UI/Web/src/app/series-detail/series-detail.component.html
+++ b/UI/Web/src/app/series-detail/series-detail.component.html
@@ -142,7 +142,8 @@
                                         <app-list-item [imageUrl]="imageService.getVolumeCoverImage(item.volume.id)"
                                             [seriesName]="series.name" [entity]="item.volume" *ngIf="item.volume.number != 0"
                                             [actions]="volumeActions" [libraryType]="libraryType" imageWidth="130px" imageHeight=""
-                                            [pagesRead]="item.volume.pagesRead" [totalPages]="item.volume.pages" (read)="openVolume(item.volume)">
+                                            [pagesRead]="item.volume.pagesRead" [totalPages]="item.volume.pages" (read)="openVolume(item.volume)"
+                                            [blur]="user?.preferences?.blurUnreadSummaries || false">
                                             <ng-container title>
                                                 <app-entity-title [libraryType]="libraryType" [entity]="item.volume" [seriesName]="series.name" [prioritizeTitleName]="false"></app-entity-title>
                                             </ng-container>
@@ -152,7 +153,8 @@
                                         <app-list-item [imageUrl]="imageService.getChapterCoverImage(item.chapter.id)"
                                             [seriesName]="series.name" [entity]="item.chapter" *ngIf="!item.chapter.isSpecial"
                                             [actions]="chapterActions" [libraryType]="libraryType" imageWidth="130px" imageHeight=""
-                                            [pagesRead]="item.chapter.pagesRead" [totalPages]="item.chapter.pages" (read)="openChapter(item.chapter)">
+                                            [pagesRead]="item.chapter.pagesRead" [totalPages]="item.chapter.pages" (read)="openChapter(item.chapter)"
+                                            [blur]="user?.preferences?.blurUnreadSummaries || false">
                                                 <ng-container title>
                                                     <app-entity-title [libraryType]="libraryType" [entity]="item.chapter" [seriesName]="series.name" [prioritizeTitleName]="false"></app-entity-title>
                                                 </ng-container>
@@ -185,7 +187,8 @@
                                     <app-list-item [imageUrl]="imageService.getVolumeCoverImage(volume.id)"
                                     [seriesName]="series.name" [entity]="volume" *ngIf="volume.number != 0"
                                     [actions]="volumeActions" [libraryType]="libraryType" imageWidth="130px" imageHeight=""
-                                    [pagesRead]="volume.pagesRead" [totalPages]="volume.pages" (read)="openVolume(volume)">
+                                    [pagesRead]="volume.pagesRead" [totalPages]="volume.pages" (read)="openVolume(volume)"
+                                    [blur]="user?.preferences?.blurUnreadSummaries || false">
                                         <ng-container title>
                                             <app-entity-title [libraryType]="libraryType" [entity]="volume" [seriesName]="series.name"></app-entity-title>
                                         </ng-container>
@@ -222,7 +225,7 @@
                                     [seriesName]="series.name" [entity]="chapter" *ngIf="!chapter.isSpecial"
                                     [actions]="chapterActions" [libraryType]="libraryType" imageWidth="130px" imageHeight=""
                                     [pagesRead]="chapter.pagesRead" [totalPages]="chapter.pages" (read)="openChapter(chapter)"
-                                    [includeVolume]="true">
+                                    [includeVolume]="true" [blur]="user?.preferences?.blurUnreadSummaries || false">
                                         <ng-container title>
                                             <app-entity-title [libraryType]="libraryType" [entity]="chapter" [seriesName]="series.name" [includeVolume]="true"  [prioritizeTitleName]="false"></app-entity-title>
                                         </ng-container>
@@ -254,7 +257,8 @@
                                 <app-list-item [imageUrl]="imageService.getChapterCoverImage(chapter.id)"
                                 [seriesName]="series.name" [entity]="chapter"
                                 [actions]="chapterActions" [libraryType]="libraryType" imageWidth="130px" imageHeight=""
-                                [pagesRead]="chapter.pagesRead" [totalPages]="chapter.pages" (read)="openChapter(chapter)">
+                                [pagesRead]="chapter.pagesRead" [totalPages]="chapter.pages" (read)="openChapter(chapter)"
+                                [blur]="user?.preferences?.blurUnreadSummaries || false">
                                     <ng-container title>
                                         {{chapter.title || chapter.range}}
                                     </ng-container>
@@ -287,4 +291,3 @@
         </div>
     </div>
 </div>
-

--- a/UI/Web/src/app/series-detail/series-detail.component.ts
+++ b/UI/Web/src/app/series-detail/series-detail.component.ts
@@ -38,6 +38,7 @@ import { CardDetailDrawerComponent } from '../cards/card-detail-drawer/card-deta
 import { FormControl, FormGroup } from '@angular/forms';
 import { PageLayoutMode } from '../_models/page-layout-mode';
 import { DOCUMENT } from '@angular/common';
+import { User } from '../_models/user';
 
 interface RelatedSeris {
   series: Series;
@@ -154,6 +155,7 @@ export class SeriesDetailComponent implements OnInit, OnDestroy, AfterViewInit {
   });
 
   isAscendingSort: boolean = false; // TODO: Get this from User preferences
+  user: User | undefined;
 
   bulkActionCallback = (action: Action, data: any) => {
     if (this.series === undefined) {
@@ -252,6 +254,7 @@ export class SeriesDetailComponent implements OnInit, OnDestroy, AfterViewInit {
     this.router.routeReuseStrategy.shouldReuseRoute = () => false;
     this.accountService.currentUser$.pipe(take(1)).subscribe(user => {
       if (user) {
+        this.user = user;
         this.isAdmin = this.accountService.hasAdminRole(user);
         this.hasDownloadingRole = this.accountService.hasDownloadRole(user);
         this.renderMode = user.preferences.globalPageLayoutMode;

--- a/UI/Web/src/app/shared/read-more/read-more.component.html
+++ b/UI/Web/src/app/shared/read-more/read-more.component.html
@@ -1,5 +1,5 @@
 <div>
-    <span [innerHTML]="currentText | safeHtml"></span>
+    <span [innerHTML]="currentText | safeHtml" [ngClass]="{'blur-text': blur && isCollapsed}"></span>
     <a [class.hidden]="hideToggle" *ngIf="text && text.length > maxLength" class="read-more-link" (click)="toggleView()">
         &nbsp;<i aria-hidden="true" class="fa fa-caret-{{isCollapsed ? 'down' : 'up'}}"></i>&nbsp;Read {{isCollapsed ? 'More' : 'Less'}}
     </a>

--- a/UI/Web/src/app/shared/read-more/read-more.component.scss
+++ b/UI/Web/src/app/shared/read-more/read-more.component.scss
@@ -1,6 +1,4 @@
-// .read-more-link {
-//     font-weight: bold;
-//     text-decoration: none;
-//     cursor: pointer;
-//     color: var(--body-text-color) !important;
-// }
+.blur-text {
+  color: transparent;
+  text-shadow: 0 0 5px var(--body-text-color);
+}

--- a/UI/Web/src/app/shared/read-more/read-more.component.ts
+++ b/UI/Web/src/app/shared/read-more/read-more.component.ts
@@ -9,6 +9,10 @@ export class ReadMoreComponent implements OnChanges {
 
   @Input() text!: string;
   @Input() maxLength: number = 250;
+  /**
+   * If the field is collapsed and blur true, text will not be readable
+   */
+  @Input() blur: boolean = false;
   currentText!: string;
   hideToggle: boolean = true;
 

--- a/UI/Web/src/app/user-settings/user-preferences/user-preferences.component.html
+++ b/UI/Web/src/app/user-settings/user-preferences/user-preferences.component.html
@@ -34,6 +34,16 @@
                                                 <option *ngFor="let opt of pageLayoutModes" [value]="opt.value">{{opt.text | titlecase}}</option>
                                             </select>
                                         </div>
+
+                                        <div class="col-md-6 col-sm-12 pe-2 mb-2">
+                                            <div class="form-check form-switch">
+                                                <input type="checkbox" id="auto-close" role="switch" formControlName="blurUnreadSummaries" class="form-check-input" aria-describedby="blurUnreadSummaries" [value]="true" aria-labelledby="auto-close-label">
+                                                <label class="form-check-label" for="auto-close">Blur Unread Summaries</label><i class="fa fa-info-circle ms-1" aria-hidden="true" placement="right" [ngbTooltip]="blurUnreadSummariesTooltip" role="button" tabindex="0"></i>
+                                            </div>
+                                            
+                                            <ng-template #blurUnreadSummariesTooltip>Blurs summary text on volumes or chapters that have no read progress (to avoid spoilers)</ng-template>
+                                            <span class="visually-hidden" id="settings-global-blurUnreadSummaries-help">Blurs summary text on volumes or chapters that have no read progress (to avoid spoilers)</span>
+                                        </div>
                                     </div>
 
                                     <div class="col-auto d-flex d-md-block justify-content-sm-center text-md-end mb-3">

--- a/UI/Web/src/app/user-settings/user-preferences/user-preferences.component.ts
+++ b/UI/Web/src/app/user-settings/user-preferences/user-preferences.component.ts
@@ -123,6 +123,7 @@ export class UserPreferencesComponent implements OnInit, OnDestroy {
 
       this.settingsForm.addControl('theme', new FormControl(this.user.preferences.theme, []));
       this.settingsForm.addControl('globalPageLayoutMode', new FormControl(this.user.preferences.globalPageLayoutMode, []));
+      this.settingsForm.addControl('blurUnreadSummaries', new FormControl(this.user.preferences.blurUnreadSummaries, []));
     });
 
     this.passwordChangeForm.addControl('password', new FormControl('', [Validators.required]));
@@ -169,6 +170,7 @@ export class UserPreferencesComponent implements OnInit, OnDestroy {
     this.settingsForm.get('theme')?.setValue(this.user.preferences.theme);
     this.settingsForm.get('bookReaderImmersiveMode')?.setValue(this.user.preferences.bookReaderImmersiveMode);
     this.settingsForm.get('globalPageLayoutMode')?.setValue(this.user.preferences.globalPageLayoutMode);
+    this.settingsForm.get('blurUnreadSummaries')?.setValue(this.user.preferences.blurUnreadSummaries);
   }
 
   resetPasswordForm() {
@@ -200,6 +202,7 @@ export class UserPreferencesComponent implements OnInit, OnDestroy {
       theme: modelSettings.theme,
       bookReaderImmersiveMode: modelSettings.bookReaderImmersiveMode,
       globalPageLayoutMode: parseInt(modelSettings.globalPageLayoutMode, 10),
+      blurUnreadSummaries: modelSettings.blurUnreadSummaries,
     };
 
     this.obserableHandles.push(this.accountService.updatePreferences(data).subscribe((updatedPrefs) => {


### PR DESCRIPTION
# Added
- Added: Admins can now change a library type after creation. There is a warning explaining that it's very likely series will be re-created and hence reading progress or bookmarks could be deleted. Proceed with caution.
- Added: Users can now enable a setting to blur summaries (mainly for list view) of volumes/chapters/books they haven't read yet. 

# Changed
- Changed: Changed some APIs for Tachiyomi to help with progress syncing edge cases
- Changed: When errors occur during scans, show the event widget icon in read

# Fixed
- Fixed: Fixed up swagger generation and ensure swagger copies files over on production builds (develop)
- Fixed: Fixed a bug where table of contents would no longer generate on some Epub 3's due to a change in the underlying epub reader we use (Fixes #1279)
- Fixed: Fixed a bug in the epub parsing where even if you had a series index and series group, but didn't have the series in the title, Kavita wouldn't group them properly.
- Fixed: Fixed a bug where refresh tokens were supposed to be granted, but weren't and hence a re-authentication was required.

