### PR TITLE
More Stat collection

### DIFF
--- a/API/DTOs/Stats/ServerInfoDto.cs
+++ b/API/DTOs/Stats/ServerInfoDto.cs
@@ -2,49 +2,122 @@
 
 namespace API.DTOs.Stats
 {
+    /// <summary>
+    /// Represents information about a Kavita Installation
+    /// </summary>
     public class ServerInfoDto
     {
+        /// <summary>
+        /// Unique Id that represents a unique install
+        /// </summary>
         public string InstallId { get; set; }
         public string Os { get; set; }
+        /// <summary>
+        /// If the Kavita install is using Docker
+        /// </summary>
         public bool IsDocker { get; set; }
+        /// <summary>
+        /// Version of .NET instance is running
+        /// </summary>
         public string DotnetVersion { get; set; }
+        /// <summary>
+        /// Version of Kavita
+        /// </summary>
         public string KavitaVersion { get; set; }
+        /// <summary>
+        /// Number of Cores on the instance
+        /// </summary>
         public int NumOfCores { get; set; }
+        /// <summary>
+        /// The number of libraries on the instance
+        /// </summary>
         public int NumberOfLibraries { get; set; }
+        /// <summary>
+        /// Does any user have bookmarks
+        /// </summary>
         public bool HasBookmarks { get; set; }
         /// <summary>
         /// The site theme the install is using
         /// </summary>
+        /// <remarks>Introduced in v0.5.2</remarks>
         public string ActiveSiteTheme { get; set; }
-
         /// <summary>
         /// The reading mode the main user has as a preference
         /// </summary>
+        /// <remarks>Introduced in v0.5.2</remarks>
         public ReaderMode MangaReaderMode { get; set; }
 
         /// <summary>
         /// Number of users on the install
         /// </summary>
+        /// <remarks>Introduced in v0.5.2</remarks>
         public int NumberOfUsers { get; set; }
 
         /// <summary>
         /// Number of collections on the install
         /// </summary>
+        /// <remarks>Introduced in v0.5.2</remarks>
         public int NumberOfCollections { get; set; }
-
         /// <summary>
         /// Number of reading lists on the install (Sum of all users)
         /// </summary>
+        /// <remarks>Introduced in v0.5.2</remarks>
         public int NumberOfReadingLists { get; set; }
-
         /// <summary>
         /// Is OPDS enabled
         /// </summary>
+        /// <remarks>Introduced in v0.5.2</remarks>
         public bool OPDSEnabled { get; set; }
-
         /// <summary>
         /// Total number of files in the instance
         /// </summary>
+        /// <remarks>Introduced in v0.5.2</remarks>
         public int TotalFiles { get; set; }
+        /// <summary>
+        /// Total number of Genres in the instance
+        /// </summary>
+        /// <remarks>Introduced in v0.5.4</remarks>
+        public int TotalGenres { get; set; }
+        /// <summary>
+        /// Total number of People in the instance
+        /// </summary>
+        /// <remarks>Introduced in v0.5.4</remarks>
+        public int TotalPeople { get; set; }
+        /// <summary>
+        /// Is this instance storing bookmarks as WebP
+        /// </summary>
+        /// <remarks>Introduced in v0.5.4</remarks>
+        public bool StoreBookmarksAsWebP { get; set; }
+        /// <summary>
+        /// Number of users on this instance using Card Layout
+        /// </summary>
+        /// <remarks>Introduced in v0.5.4</remarks>
+        public int UsersOnCardLayout { get; set; }
+        /// <summary>
+        /// Number of users on this instance using List Layout
+        /// </summary>
+        /// <remarks>Introduced in v0.5.4</remarks>
+        public int UsersOnListLayout { get; set; }
+        /// <summary>
+        /// Max number of Series for any library on the instance
+        /// </summary>
+        /// <remarks>Introduced in v0.5.4</remarks>
+        public int MaxSeriesInALibrary { get; set; }
+        /// <summary>
+        /// Max number of Volumes for any library on the instance
+        /// </summary>
+        /// <remarks>Introduced in v0.5.4</remarks>
+        public int MaxVolumesInASeries { get; set; }
+        /// <summary>
+        /// Max number of Chapters for any library on the instance
+        /// </summary>
+        /// <remarks>Introduced in v0.5.4</remarks>
+        public int MaxChaptersInASeries { get; set; }
+        /// <summary>
+        /// Does this instance have relationships setup between series
+        /// </summary>
+        /// <remarks>Introduced in v0.5.4</remarks>
+        public bool UsingSeriesRelationships { get; set; }
+
     }
 }

--- a/API/Data/Repositories/GenreRepository.cs
+++ b/API/Data/Repositories/GenreRepository.cs
@@ -18,6 +18,7 @@ public interface IGenreRepository
     Task<IList<GenreTagDto>> GetAllGenreDtosAsync();
     Task RemoveAllGenreNoLongerAssociated(bool removeExternal = false);
     Task<IList<GenreTagDto>> GetAllGenreDtosForLibrariesAsync(IList<int> libraryIds);
+    Task<int> GetCountAsync();
 }
 
 public class GenreRepository : IGenreRepository
@@ -70,6 +71,11 @@ public class GenreRepository : IGenreRepository
             .OrderBy(p => p.Title)
             .ProjectTo<GenreTagDto>(_mapper.ConfigurationProvider)
             .ToListAsync();
+    }
+
+    public async Task<int> GetCountAsync()
+    {
+        return await _context.Genre.CountAsync();
     }
 
     public async Task<IList<Genre>> GetAllGenresAsync()

--- a/API/Data/Repositories/PersonRepository.cs
+++ b/API/Data/Repositories/PersonRepository.cs
@@ -16,6 +16,7 @@ public interface IPersonRepository
     Task<IList<Person>> GetAllPeople();
     Task RemoveAllPeopleNoLongerAssociated(bool removeExternal = false);
     Task<IList<PersonDto>> GetAllPeopleDtosForLibrariesAsync(List<int> libraryIds);
+    Task<int> GetCountAsync();
 }
 
 public class PersonRepository : IPersonRepository
@@ -70,6 +71,11 @@ public class PersonRepository : IPersonRepository
             .AsNoTracking()
             .ProjectTo<PersonDto>(_mapper.ConfigurationProvider)
             .ToListAsync();
+    }
+
+    public async Task<int> GetCountAsync()
+    {
+        return await _context.Person.CountAsync();
     }
 
 

--- a/API/Data/Repositories/UserRepository.cs
+++ b/API/Data/Repositories/UserRepository.cs
@@ -57,6 +57,7 @@ public interface IUserRepository
 
     Task<IEnumerable<AppUserPreferences>> GetAllPreferencesByThemeAsync(int themeId);
     Task<bool> HasAccessToLibrary(int libraryId, int userId);
+    Task<IEnumerable<AppUser>> GetAllUsersAsync(AppUserIncludes includeFlags);
 }
 
 public class UserRepository : IUserRepository
@@ -244,6 +245,12 @@ public class UserRepository : IUserRepository
         return await _context.Library
             .Include(l => l.AppUsers)
             .AnyAsync(library => library.AppUsers.Any(user => user.Id == userId));
+    }
+
+    public async Task<IEnumerable<AppUser>> GetAllUsersAsync(AppUserIncludes includeFlags)
+    {
+        var query = AddIncludesToQuery(_context.Users.AsQueryable(), includeFlags);
+        return await query.ToListAsync();
     }
 
     public async Task<IEnumerable<AppUser>> GetAdminUsersAsync()

--- a/API/Services/Tasks/Metadata/WordCountAnalyzerService.cs
+++ b/API/Services/Tasks/Metadata/WordCountAnalyzerService.cs
@@ -18,7 +18,7 @@ namespace API.Services.Tasks.Metadata;
 public interface IWordCountAnalyzerService
 {
     [DisableConcurrentExecution(timeoutInSeconds: 60 * 60 * 60)]
-    [AutomaticRetry(Attempts = 0, OnAttemptsExceeded = AttemptsExceededAction.Delete)]
+    [AutomaticRetry(Attempts = 2, OnAttemptsExceeded = AttemptsExceededAction.Delete)]
     Task ScanLibrary(int libraryId, bool forceUpdate = false);
     Task ScanSeries(int libraryId, int seriesId, bool forceUpdate = true);
 }
@@ -46,7 +46,7 @@ public class WordCountAnalyzerService : IWordCountAnalyzerService
 
 
     [DisableConcurrentExecution(timeoutInSeconds: 60 * 60 * 60)]
-    [AutomaticRetry(Attempts = 0, OnAttemptsExceeded = AttemptsExceededAction.Delete)]
+    [AutomaticRetry(Attempts = 2, OnAttemptsExceeded = AttemptsExceededAction.Delete)]
     public async Task ScanLibrary(int libraryId, bool forceUpdate = false)
     {
         var sw = Stopwatch.StartNew();

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -191,6 +191,7 @@ public class ScannerService : IScannerService
         await CleanupDbEntities();
         BackgroundJob.Enqueue(() => _cacheService.CleanupChapters(chapterIds));
         BackgroundJob.Enqueue(() => _metadataService.RefreshMetadataForSeries(libraryId, series.Id, false));
+        BackgroundJob.Enqueue(() => _wordCountAnalyzerService.ScanSeries(libraryId, series.Id, false));
     }
 
     private static void RemoveParsedInfosNotForSeries(Dictionary<ParsedSeries, List<ParserInfo>> parsedSeries, Series series)


### PR DESCRIPTION
# Added
- Added: Added new stats to help see how many features are being used from v0.5.3 and to prepare for upcoming performance release (v0.5.5). In addition, some of the new functionality (virtual scrolling) have new stats to ensure we are seeing how it performs on the user base rather than just the beta testers. New fields: Total Genres, Total People, If storing bookmarks as WebP, Users on Cards layout, Users on List Layout, Max number of Series in a Library, Max Volumes in a Series, Max Chapters in a Series, and if any series relationships are present.

# Changed
- Changed: Always queue up a file analysis on series scan (develop)
