### PR TITLE
Manga Reader Double Layout bugfixes

### DIFF
--- a/UI/Web/src/app/cards/list-item/list-item.component.html
+++ b/UI/Web/src/app/cards/list-item/list-item.component.html
@@ -1,6 +1,6 @@
 <div class="list-item-container d-flex flex-row g-0 mb-2 p-2">
     <div class="pe-2">
-        <app-image [imageUrl]="imageUrl" [height]="imageHeight" [width]="imageWidth"></app-image>
+        <app-image [imageUrl]="imageUrl" [height]="imageHeight" maxHeight="200px" [width]="imageWidth"></app-image>
         <div class="not-read-badge" *ngIf="pagesRead === 0 && totalPages > 0"></div>
         <span class="download" *ngIf="download$ | async as download">
             <app-circular-loader [currentValue]="download.progress"></app-circular-loader>

--- a/UI/Web/src/app/manga-reader/manga-reader.component.html
+++ b/UI/Web/src/app/manga-reader/manga-reader.component.html
@@ -162,7 +162,22 @@
 
                 <div class="row mb-2">
                     <div class="col-md-6 col-sm-12">
-                        <label for="layout-mode" class="form-label">Layout Mode</label>
+                        <label for="layout-mode" class="form-label">Layout Mode</label>&nbsp;
+                        <div class="split fa fa-image">
+                            <ng-container [ngSwitch]="layoutMode">
+                                <ng-container *ngSwitchCase="LayoutMode.Single">
+                                    <div class="fa fa-image"></div>
+                                </ng-container>
+                                <ng-container *ngSwitchCase="LayoutMode.Double">
+                                    <div class="fa fa-image">
+                                        <div class="{{LayoutModeIconClass}}"></div> 
+                                    </div>
+                                    <div class="fa fa-image"></div>
+                                </ng-container>
+                                <ng-container *ngSwitchCase="LayoutMode.DoubleReversed"></ng-container>
+                                <!-- <div class="{{LayoutModeIconClass}}"></div> -->
+                            </ng-container>
+                        </div>
                         <select class="form-control" id="page-fitting" formControlName="layoutMode">
                             <option [value]="opt.value" *ngFor="let opt of layoutModes">{{opt.text}}</option>
                         </select>

--- a/UI/Web/src/app/manga-reader/manga-reader.component.html
+++ b/UI/Web/src/app/manga-reader/manga-reader.component.html
@@ -63,13 +63,17 @@
             <div class="image-container {{getFittingOptionClass()}}" [ngClass]="{'d-none': renderWithCanvas, 'center-double': ShouldRenderDoublePage,
                     'fit-to-width-double-offset' : FittingOption === FITTING_OPTION.WIDTH && ShouldRenderDoublePage,
                     'fit-to-height-double-offset': FittingOption === FITTING_OPTION.HEIGHT && ShouldRenderDoublePage,
-                    'original-double-offset' : FittingOption === FITTING_OPTION.ORIGINAL && ShouldRenderDoublePage,
-                    'reverse': ShouldRenderReverseDouble}">
+                    'original-double-offset' : FittingOption === FITTING_OPTION.ORIGINAL && ShouldRenderDoublePage}"> <!-- ,
+                        'reverse': ShouldRenderReverseDouble -->
                 <img #image [src]="canvasImage.src" id="image-1"
                     class="{{getFittingOptionClass()}} {{readerMode === ReaderMode.LeftRight || readerMode === ReaderMode.UpDown ? '' : 'd-none'}} {{showClickOverlay ? 'blur' : ''}}">
 
-                <ng-container *ngIf="(ShouldRenderDoublePage || ShouldRenderReverseDouble) && (this.pageNum <= maxPages - 1 && this.pageNum > 0)">
+                <!-- TODO: Refactor: 1) isLastPage and isCoverImage should be used rather than hardcoded logic-->
+                <!-- <ng-container *ngIf="(ShouldRenderDoublePage || ShouldRenderReverseDouble) && (this.pageNum <= maxPages - 1 && !isCoverImage())">
                     <img [src]="canvasImage2.src" id="image-2"  class="image-2 {{getFittingOptionClass()}} {{readerMode === ReaderMode.LeftRight || readerMode === ReaderMode.UpDown ? '' : 'd-none'}} {{showClickOverlay ? 'blur' : ''}} {{ShouldRenderReverseDouble ? 'reverse' : ''}}">
+                </ng-container> -->
+                <ng-container *ngIf="(this.canvasImage2.src !== '') && (this.pageNum <= maxPages - 1 && !isCoverImage())">
+                    <img [src]="canvasImage2.src" id="image-2"  class="image-2 {{getFittingOptionClass()}} {{readerMode === ReaderMode.LeftRight || readerMode === ReaderMode.UpDown ? '' : 'd-none'}} {{showClickOverlay ? 'blur' : ''}}"> <!--  {{ShouldRenderReverseDouble ? 'reverse' : ''}} -->
                 </ng-container>
             </div>
 

--- a/UI/Web/src/app/manga-reader/manga-reader.component.html
+++ b/UI/Web/src/app/manga-reader/manga-reader.component.html
@@ -13,6 +13,9 @@
                 </div>
             </div>
 
+            {{readerService.imageUrlToPageNum(this.canvasImage.src)}}
+            {{readerService.imageUrlToPageNum(this.canvasImage2.src)}}
+
             <div style="margin-left: auto; padding-right: 3%;">
                 <button class="btn btn-icon btn-small" title="Shortcuts" (click)="openShortcutModal()">
                     <i class="fa-regular fa-rectangle-list" aria-hidden="true"></i>
@@ -72,8 +75,9 @@
                 <!-- <ng-container *ngIf="(ShouldRenderDoublePage || ShouldRenderReverseDouble) && (this.pageNum <= maxPages - 1 && !isCoverImage())">
                     <img [src]="canvasImage2.src" id="image-2"  class="image-2 {{getFittingOptionClass()}} {{readerMode === ReaderMode.LeftRight || readerMode === ReaderMode.UpDown ? '' : 'd-none'}} {{showClickOverlay ? 'blur' : ''}} {{ShouldRenderReverseDouble ? 'reverse' : ''}}">
                 </ng-container> -->
+
                 <ng-container *ngIf="(this.canvasImage2.src !== '') && (this.pageNum <= maxPages - 1 && !isCoverImage())">
-                    <img [src]="canvasImage2.src" id="image-2"  class="image-2 {{getFittingOptionClass()}} {{readerMode === ReaderMode.LeftRight || readerMode === ReaderMode.UpDown ? '' : 'd-none'}} {{showClickOverlay ? 'blur' : ''}}"> <!--  {{ShouldRenderReverseDouble ? 'reverse' : ''}} -->
+                    <img [src]="canvasImage2.src" id="image-2" class="image-2 {{getFittingOptionClass()}} {{readerMode === ReaderMode.LeftRight || readerMode === ReaderMode.UpDown ? '' : 'd-none'}} {{showClickOverlay ? 'blur' : ''}}"> <!--  {{ShouldRenderReverseDouble ? 'reverse' : ''}} -->
                 </ng-container>
             </div>
 

--- a/UI/Web/src/app/manga-reader/manga-reader.component.html
+++ b/UI/Web/src/app/manga-reader/manga-reader.component.html
@@ -66,17 +66,11 @@
             <div class="image-container {{getFittingOptionClass()}}" [ngClass]="{'d-none': renderWithCanvas, 'center-double': ShouldRenderDoublePage,
                     'fit-to-width-double-offset' : FittingOption === FITTING_OPTION.WIDTH && ShouldRenderDoublePage,
                     'fit-to-height-double-offset': FittingOption === FITTING_OPTION.HEIGHT && ShouldRenderDoublePage,
-                    'original-double-offset' : FittingOption === FITTING_OPTION.ORIGINAL && ShouldRenderDoublePage}"> <!-- ,
-                        'reverse': ShouldRenderReverseDouble -->
+                    'original-double-offset' : FittingOption === FITTING_OPTION.ORIGINAL && ShouldRenderDoublePage}">
                 <img #image [src]="canvasImage.src" id="image-1"
                     class="{{getFittingOptionClass()}} {{readerMode === ReaderMode.LeftRight || readerMode === ReaderMode.UpDown ? '' : 'd-none'}} {{showClickOverlay ? 'blur' : ''}}">
 
-                <!-- TODO: Refactor: 1) isLastPage and isCoverImage should be used rather than hardcoded logic-->
-                <!-- <ng-container *ngIf="(ShouldRenderDoublePage || ShouldRenderReverseDouble) && (this.pageNum <= maxPages - 1 && !isCoverImage())">
-                    <img [src]="canvasImage2.src" id="image-2"  class="image-2 {{getFittingOptionClass()}} {{readerMode === ReaderMode.LeftRight || readerMode === ReaderMode.UpDown ? '' : 'd-none'}} {{showClickOverlay ? 'blur' : ''}} {{ShouldRenderReverseDouble ? 'reverse' : ''}}">
-                </ng-container> -->
-
-                <ng-container *ngIf="(this.canvasImage2.src !== '') && (this.pageNum <= maxPages - 1 && !isCoverImage())">
+                <ng-container *ngIf="(this.canvasImage2.src !== '') && (readerService.imageUrlToPageNum(canvasImage2.src) <= maxPages - 1 && !isCoverImage())">
                     <img [src]="canvasImage2.src" id="image-2" class="image-2 {{getFittingOptionClass()}} {{readerMode === ReaderMode.LeftRight || readerMode === ReaderMode.UpDown ? '' : 'd-none'}} {{showClickOverlay ? 'blur' : ''}}"> <!--  {{ShouldRenderReverseDouble ? 'reverse' : ''}} -->
                 </ng-container>
             </div>

--- a/UI/Web/src/app/manga-reader/manga-reader.component.html
+++ b/UI/Web/src/app/manga-reader/manga-reader.component.html
@@ -163,21 +163,41 @@
                 <div class="row mb-2">
                     <div class="col-md-6 col-sm-12">
                         <label for="layout-mode" class="form-label">Layout Mode</label>&nbsp;
-                        <div class="split fa fa-image">
                             <ng-container [ngSwitch]="layoutMode">
                                 <ng-container *ngSwitchCase="LayoutMode.Single">
-                                    <div class="fa fa-image"></div>
+                                    <div class="split-double">
+                                        <span class="fa-stack fa-1x">
+                                            <i class="fa-regular fa-square-full fa-stack-2x"></i>
+                                            <i class="fa fa-image fa-stack-1x"></i>
+                                          </span>
+                                    </div>
                                 </ng-container>
                                 <ng-container *ngSwitchCase="LayoutMode.Double">
-                                    <div class="fa fa-image">
-                                        <div class="{{LayoutModeIconClass}}"></div> 
+                                    <div class="split-double">
+                                        <span class="fa-stack fa-1x">
+                                            <i class="fa-regular fa-square-full fa-stack-2x"></i>
+                                            <i class="fab fa-1 fa-stack-1x"></i>
+                                          </span>
+                                          <span class="fa-stack fa right">
+                                            <i class="fa-regular fa-square-full fa-stack-2x"></i>
+                                            <i class="fab fa-2 fa-stack-1x"></i>
+                                          </span>
                                     </div>
-                                    <div class="fa fa-image"></div>
                                 </ng-container>
-                                <ng-container *ngSwitchCase="LayoutMode.DoubleReversed"></ng-container>
+                                <ng-container *ngSwitchCase="LayoutMode.DoubleReversed">
+                                    <div class="split-double">
+                                        <span class="fa-stack fa-1x">
+                                            <i class="fa-regular fa-square-full fa-stack-2x"></i>
+                                            <i class="fab fa-2 fa-stack-1x"></i>
+                                          </span>
+                                          <span class="fa-stack fa right">
+                                            <i class="fa-regular fa-square-full fa-stack-2x"></i>
+                                            <i class="fab fa-1 fa-stack-1x"></i>
+                                          </span>
+                                    </div>                                   
+                                </ng-container>
                                 <!-- <div class="{{LayoutModeIconClass}}"></div> -->
                             </ng-container>
-                        </div>
                         <select class="form-control" id="page-fitting" formControlName="layoutMode">
                             <option [value]="opt.value" *ngFor="let opt of layoutModes">{{opt.text}}</option>
                         </select>

--- a/UI/Web/src/app/manga-reader/manga-reader.component.scss
+++ b/UI/Web/src/app/manga-reader/manga-reader.component.scss
@@ -172,6 +172,7 @@ img {
     overflow: hidden;
     border: 2px solid #ccc;
     vertical-align: sub;
+    display: inline-block;
 
     &::before {
         margin-left: 30%;
@@ -201,7 +202,17 @@ img {
     // For layout only
 
   }
-  
+
+  .split-double {
+    height: 20px;
+    display: inline-block;
+    font-size: .7em;
+
+    .right {
+      left: -7px;
+    }
+  }
+
   ::ng-deep {
     .custom-slider .ngx-slider .ngx-slider-bar {
       background: #e9ffe2;

--- a/UI/Web/src/app/manga-reader/manga-reader.component.scss
+++ b/UI/Web/src/app/manga-reader/manga-reader.component.scss
@@ -197,6 +197,9 @@ img {
     .none {
         background-color: rgba(255, 255, 255, 0.5);
     }
+
+    // For layout only
+
   }
   
   ::ng-deep {

--- a/UI/Web/src/app/manga-reader/manga-reader.component.scss
+++ b/UI/Web/src/app/manga-reader/manga-reader.component.scss
@@ -57,9 +57,14 @@ img {
   }
 
   &.reverse {
-    flex-direction: row-reverse;
     overflow: unset;
-    justify-content: flex-end;
+    display: flex;
+    align-content: center;
+    justify-content: center;
+
+    img {
+      margin: unset;
+    }
   }
   
   #image-2 {

--- a/UI/Web/src/app/manga-reader/manga-reader.component.ts
+++ b/UI/Web/src/app/manga-reader/manga-reader.component.ts
@@ -372,6 +372,17 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
     return 'right-side';
   }
 
+  get LayoutModeIconClass() {
+    switch (this.layoutMode) {
+      case LayoutMode.Single:
+        return 'none';
+      case LayoutMode.Double:
+        return 'double';
+      case LayoutMode.DoubleReversed:
+        return 'double-reversed';
+    }
+  }
+
   get ReaderModeIcon() {
     switch(this.readerMode) {
       case ReaderMode.LeftRight:

--- a/UI/Web/src/app/manga-reader/manga-reader.component.ts
+++ b/UI/Web/src/app/manga-reader/manga-reader.component.ts
@@ -37,16 +37,6 @@ const ANIMATION_SPEED = 200;
 const OVERLAY_AUTO_CLOSE_TIME = 3000;
 const CLICK_OVERLAY_TIMEOUT = 3000;
 
-interface PageInfo {
-  /**
-   * The page number 
-   */
-  pageNumber: number;
-  /**
-   * If It's a wide image or not
-   */
-  isWide: boolean;
-}
 
 
 @Component({
@@ -311,11 +301,6 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
    * This is here as absolute layout requires us to calculate a negative right property for the right pagination when there is overflow. This is calculated on scroll.
    */
   rightPaginationOffset = 0;
-
-  /**
-   * As we load images from the backend, keep track of some information about them to make it easy to for the double layout renderers.
-   */
-  pageDimensionHistory: {[keyof: number]: PageInfo}= {};
 
   getPageUrl = (pageNum: number) => {
     if (this.bookmarkMode) return this.readerService.getBookmarkPageUrl(this.seriesId, this.user.apiKey, pageNum);
@@ -1329,7 +1314,6 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
         return;
       }
       if (offsetIndex < this.maxPages - 1) {
-        item.onload = () => this.calculatePageInfo(item);
         item.src = this.getPageUrl(offsetIndex);
         index += 1;
       }
@@ -1338,12 +1322,6 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
     //console.log('cachedImages: ', this.cachedImages.arr.map(img => this.readerService.imageUrlToPageNum(img.src) + ': ' + img.complete));
   }
 
-  calculatePageInfo(image: HTMLImageElement) {
-    const page = this.readerService.imageUrlToPageNum(image.src);
-    if (page < 0) return;
-    image.onload = null;
-    //if (!this.pageDimensionHistory.hasOwnProperty(page)) this.pageDimensionHistory[page] = {pageNumber: page, isWide: this.isWideImage(image)};
-  }
 
   loadPage() {
     this.isLoading = true;
@@ -1351,7 +1329,6 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
     this.canvasImageAheadBy2.src = '';
 
     this.isLoose = (this.pageAmount === 1 ? true : false);
-    this.canvasImage.onload = () => this.calculatePageInfo(this.canvasImage);
     this.canvasImage.src = this.getPageUrl(this.pageNum);
 
     if (this.layoutMode !== LayoutMode.Single) {
@@ -1364,13 +1341,7 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       if (this.pageNum - 2 >= 0) {
         this.canvasImageBehindBy2.src = this.getPageUrl(this.pageNum - 2 || 0);
       }      
-      
-
-      this.canvasImagePrev.onload = () => this.calculatePageInfo(this.canvasImagePrev);
-      this.canvasImageNext.onload = () => this.calculatePageInfo(this.canvasImageNext);
-      this.canvasImageAheadBy2.onload = () => this.calculatePageInfo(this.canvasImageAheadBy2);
-
-
+    
       if (this.ShouldRenderDoublePage || this.ShouldRenderReverseDouble) {
         if (this.layoutMode === LayoutMode.Double) {
           this.canvasImage2.src = this.canvasImageNext.src;

--- a/UI/Web/src/app/manga-reader/manga-reader.component.ts
+++ b/UI/Web/src/app/manga-reader/manga-reader.component.ts
@@ -1342,7 +1342,7 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
     const page = this.readerService.imageUrlToPageNum(image.src);
     if (page < 0) return;
     image.onload = null;
-    if (!this.pageDimensionHistory.hasOwnProperty(page)) this.pageDimensionHistory[page] = {pageNumber: page, isWide: this.isWideImage(image)};
+    //if (!this.pageDimensionHistory.hasOwnProperty(page)) this.pageDimensionHistory[page] = {pageNumber: page, isWide: this.isWideImage(image)};
   }
 
   loadPage() {

--- a/UI/Web/src/app/manga-reader/manga-reader.component.ts
+++ b/UI/Web/src/app/manga-reader/manga-reader.component.ts
@@ -1010,10 +1010,10 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
 
     const notInSplit = this.currentImageSplitPart !== (this.isSplitLeftToRight() ? SPLIT_PAGE_PART.LEFT_PART : SPLIT_PAGE_PART.RIGHT_PART);
 
-    console.log('Current, Next: ', this.readerService.imageUrlToPageNum(this.canvasImage.src), ',', this.readerService.imageUrlToPageNum(this.canvasImageNext.src));
-      console.log('Is canvasImage wide: ', this.isWideImage(this.canvasImage));
-      console.log('Is canvasImage next wide: ', this.isWideImage(this.canvasImageNext));
-      console.log('PRev: ', this.readerService.imageUrlToPageNum(this.canvasImagePrev.src));
+    // console.log('Current, Next: ', this.readerService.imageUrlToPageNum(this.canvasImage.src), ',', this.readerService.imageUrlToPageNum(this.canvasImageNext.src));
+    // console.log('Is canvasImage wide: ', this.isWideImage(this.canvasImage));
+    // console.log('Is canvasImage next wide: ', this.isWideImage(this.canvasImageNext));
+    // console.log('PRev: ', this.readerService.imageUrlToPageNum(this.canvasImagePrev.src));
 
 
     let pageAmount = 1;
@@ -1070,10 +1070,10 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
     let pageAmount = 1;
     if (this.layoutMode === LayoutMode.Double) {
       // Current is current and next is current + 1 (current is the page we are paging from)
-      console.log('Current, Next: ', this.readerService.imageUrlToPageNum(this.canvasImage.src), ',', this.readerService.imageUrlToPageNum(this.canvasImageNext.src));
-      console.log('Is canvasImage wide: ', this.isWideImage(this.canvasImage));
-      console.log('Is canvasImage next wide: ', this.isWideImage(this.canvasImageNext));
-      console.log('PRev: ', this.readerService.imageUrlToPageNum(this.canvasImagePrev.src)); // Prev is actually currentPage - 1 on double
+      // console.log('Current, Next: ', this.readerService.imageUrlToPageNum(this.canvasImage.src), ',', this.readerService.imageUrlToPageNum(this.canvasImageNext.src));
+      // console.log('Is canvasImage wide: ', this.isWideImage(this.canvasImage));
+      // console.log('Is canvasImage next wide: ', this.isWideImage(this.canvasImageNext));
+      // console.log('PRev: ', this.readerService.imageUrlToPageNum(this.canvasImagePrev.src)); // Prev is actually currentPage - 1 on double
 
       pageAmount = (
         !this.isCoverImage() &&
@@ -1081,13 +1081,11 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
         ? 2 : 1);
     }
     if (this.layoutMode === LayoutMode.DoubleReversed) {
-      //?! BUG: This can sometimes skip images if current image is wide and prev is not. 
-
       // Current is current - 1 and next is current -2 (current is the page we are paging from)
-      console.log('Current, Next: ', this.readerService.imageUrlToPageNum(this.canvasImage.src), ',', this.readerService.imageUrlToPageNum(this.canvasImageNext.src));
-      console.log('Is canvasImage wide: ', this.isWideImage(this.canvasImage));
-      console.log('Is canvasImage next wide: ', this.isWideImage(this.canvasImageNext));
-      console.log('PRev: ', this.readerService.imageUrlToPageNum(this.canvasImagePrev.src)); // Prev is actually currentPage + 1 on double reversed
+      // console.log('Current, Next: ', this.readerService.imageUrlToPageNum(this.canvasImage.src), ',', this.readerService.imageUrlToPageNum(this.canvasImageNext.src));
+      // console.log('Is canvasImage wide: ', this.isWideImage(this.canvasImage));
+      // console.log('Is canvasImage next wide: ', this.isWideImage(this.canvasImageNext));
+      // console.log('PRev: ', this.readerService.imageUrlToPageNum(this.canvasImagePrev.src)); // Prev is actually currentPage + 1 on double reversed
       pageAmount = (
         !this.isCoverImage() &&
         !this.isCoverImage(this.pageNum - 1) &&
@@ -1095,8 +1093,6 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
         !this.isWideImage(this.canvasImageNext)
         ? 2 : 1);
     }
-
-    console.log('Page amount: ', pageAmount);
 
     if ((this.pageNum - 1 < 0 && notInSplit) || this.isLoading) {
       if (this.isLoading) { return; }
@@ -1291,6 +1287,7 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       elem.onload = () => {
         return elem.width > elem.height;
       }
+      if (elem.src === '') return false;
     }
     const element = elem || this.canvasImage;
     return element.width > element.height;
@@ -1351,24 +1348,23 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
   loadPage() {
     this.isLoading = true;
     this.canvasImage2.src = '';
+    this.canvasImageAheadBy2.src = '';
+
     this.isLoose = (this.pageAmount === 1 ? true : false);
     this.canvasImage.onload = () => this.calculatePageInfo(this.canvasImage);
     this.canvasImage.src = this.getPageUrl(this.pageNum);
 
     if (this.layoutMode !== LayoutMode.Single) {
-      const isDouble = this.layoutMode !== LayoutMode.DoubleReversed;
-
-      // If double, prev = pageNumb - 1, if reversed, prev = pageNum + 1
-      this.canvasImagePrev.src = this.getPageUrl(this.pageNum + (isDouble ? - 1 : + 1)); 
-      // If double, next = pageNumb + 1, if reversed, next = pageNum - 1
-      this.canvasImageNext.src = this.getPageUrl(this.pageNum + (isDouble ? + 1 : - 1));
-
-      // Joe's overrides to try to streamline the logic
-      this.canvasImageNext.src = this.getPageUrl(this.pageNum + 1);
+      this.canvasImageNext.src = this.getPageUrl(this.pageNum + 1); // This needs to be capped at maxPages !this.isLastImage()
       this.canvasImagePrev.src = this.getPageUrl(this.pageNum - 1);
 
-      this.canvasImageAheadBy2.src = this.getPageUrl(this.pageNum + 2);
-      this.canvasImageBehindBy2.src = this.getPageUrl(this.pageNum - 2 || 0);
+      if (this.pageNum + 2 < this.maxPages - 1) {
+        this.canvasImageAheadBy2.src = this.getPageUrl(this.pageNum + 2);
+      }
+      if (this.pageNum - 2 >= 0) {
+        this.canvasImageBehindBy2.src = this.getPageUrl(this.pageNum - 2 || 0);
+      }      
+      
 
       this.canvasImagePrev.onload = () => this.calculatePageInfo(this.canvasImagePrev);
       this.canvasImageNext.onload = () => this.calculatePageInfo(this.canvasImageNext);
@@ -1383,15 +1379,15 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
         }
       }
 
-      console.log('======================================================');
-      console.log('Page History: ', this.pageDimensionHistory);
-      console.log('Current Page: ', this.pageNum);
-      console.log('CanvasImage page: ', this.readerService.imageUrlToPageNum(this.canvasImage.src));
-      console.log('CanvasImage2 page: ', this.readerService.imageUrlToPageNum(this.canvasImage2.src));
-      console.log('Canvas Image Next:', this.readerService.imageUrlToPageNum(this.canvasImageNext.src));
-      console.log('Canvas Image Next Ahead by 2:', this.readerService.imageUrlToPageNum(this.canvasImageAheadBy2.src));
-      console.log('Canvas Image Prev:', this.readerService.imageUrlToPageNum(this.canvasImagePrev.src));
-      console.log('======================================================');
+      // console.log('======================================================');
+      // console.log('Page History: ', this.pageDimensionHistory);
+      // console.log('Current Page: ', this.pageNum);
+      // console.log('CanvasImage page: ', this.readerService.imageUrlToPageNum(this.canvasImage.src));
+      // console.log('CanvasImage2 page: ', this.readerService.imageUrlToPageNum(this.canvasImage2.src));
+      // console.log('Canvas Image Next:', this.readerService.imageUrlToPageNum(this.canvasImageNext.src));
+      // console.log('Canvas Image Next Ahead by 2:', this.readerService.imageUrlToPageNum(this.canvasImageAheadBy2.src));
+      // console.log('Canvas Image Prev:', this.readerService.imageUrlToPageNum(this.canvasImagePrev.src));
+      // console.log('======================================================');
     }
     this.renderPage();
     this.prefetch();

--- a/UI/Web/src/app/series-detail/series-detail.component.html
+++ b/UI/Web/src/app/series-detail/series-detail.component.html
@@ -57,7 +57,7 @@
 <div [ngStyle]="{'height': ScrollingBlockHeight}" class="main-container container-fluid pt-2" *ngIf="series !== undefined" #scrollingBlock>
     <div class="row mb-3 info-container">
         <div class="col-md-2 col-xs-4 col-sm-6 d-none d-sm-block">
-            <app-image maxWidth="300px" [imageUrl]="seriesImage"></app-image>
+            <app-image maxWidth="300px" maxHeight="400px" [imageUrl]="seriesImage"></app-image>
             <!-- NOTE: We can put continue point here as Vol X Ch Y or just Ch Y or Book Z ?-->
         </div>
         <div class="col-md-10 col-xs-8 col-sm-6 mt-2">


### PR DESCRIPTION
# Changed
- Changed: Added a dynamic icon to help users understand the new layout mode in manga menu
- Changed: Enforce max heights on series detail pages to avoid skewing when users have webtoon covers

# Fixed
- Fixed: Fixed up a bug where occasionally on double (manga) paging backwards could skip a page. (develop)
- Fixed: Fixed a bug on double where last page could get duplicated. (develop)
