### PR TITLE
Create Users Manually (Email still required)

### DIFF
--- a/API/Data/Migrations/20220717145254_UserConfirmationLink.Designer.cs
+++ b/API/Data/Migrations/20220717145254_UserConfirmationLink.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using API.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace API.Data.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20220717145254_UserConfirmationLink")]
+    partial class UserConfirmationLink
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "6.0.7");

--- a/API/Data/Migrations/20220717145254_UserConfirmationLink.cs
+++ b/API/Data/Migrations/20220717145254_UserConfirmationLink.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace API.Data.Migrations
+{
+    public partial class UserConfirmationLink : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ConfirmationToken",
+                table: "AspNetUsers",
+                type: "TEXT",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ConfirmationToken",
+                table: "AspNetUsers");
+        }
+    }
+}

--- a/API/Entities/AppUser.cs
+++ b/API/Entities/AppUser.cs
@@ -25,6 +25,10 @@ namespace API.Entities
         /// An API Key to interact with external services, like OPDS
         /// </summary>
         public string ApiKey { get; set; }
+        /// <summary>
+        /// The confirmation token for the user (invite). This will be set to null after the user confirms.
+        /// </summary>
+        public string ConfirmationToken { get; set; }
 
 
         /// <inheritdoc />

--- a/API/Middleware/ExceptionMiddleware.cs
+++ b/API/Middleware/ExceptionMiddleware.cs
@@ -35,9 +35,9 @@ namespace API.Middleware
                 context.Response.ContentType = "application/json";
                 context.Response.StatusCode = (int) HttpStatusCode.InternalServerError;
 
-                var response = _env.IsDevelopment()
-                    ? new ApiException(context.Response.StatusCode, ex.Message, ex.StackTrace)
-                    : new ApiException(context.Response.StatusCode, "Internal Server Error", ex.StackTrace);
+                var errorMessage = string.IsNullOrEmpty(ex.Message) ? "Internal Server Error" : ex.Message;
+
+                var response = new ApiException(context.Response.StatusCode, errorMessage, ex.StackTrace);
 
                 var options = new JsonSerializerOptions
                 {

--- a/UI/Web/src/app/_interceptors/error.interceptor.ts
+++ b/UI/Web/src/app/_interceptors/error.interceptor.ts
@@ -85,9 +85,9 @@ export class ErrorInterceptor implements HttpInterceptor {
           this.toastr.error('There was an issue downloading this file or you do not have permissions', error.status);         
           return; 
         }
-        this.toastr.error(error.error, error.status);
+        this.toastr.error(error.error, error.status + ' Error');
       } else {
-        this.toastr.error(error.statusText === 'OK' ? error.error : error.statusText, error.status);
+        this.toastr.error(error.statusText === 'OK' ? error.error : error.statusText, error.status + ' Error');
       }
     }
   }

--- a/UI/Web/src/app/_services/account.service.ts
+++ b/UI/Web/src/app/_services/account.service.ts
@@ -147,6 +147,15 @@ export class AccountService implements OnDestroy {
     return this.httpClient.post<User>(this.baseUrl + 'account/confirm-email', model);
   }
 
+  /**
+   * Given a user id, returns a full url for setting up the user account
+   * @param userId 
+   * @returns 
+   */
+  getInviteUrl(userId: number, withBaseUrl: boolean = true) {
+    return this.httpClient.get<string>(this.baseUrl + 'account/invite-url?userId=' + userId + '&withBaseUrl=' + withBaseUrl, {responseType: 'text' as 'json'});
+  }
+
   getDecodedToken(token: string) {
     return JSON.parse(atob(token.split('.')[1]));
   }

--- a/UI/Web/src/app/admin/manage-users/manage-users.component.html
+++ b/UI/Web/src/app/admin/manage-users/manage-users.component.html
@@ -13,7 +13,8 @@
                         <span id="member-name--{{idx}}">{{invite.username | titlecase}} </span>
                         <div class="float-end">
                             <button class="btn btn-danger btn-sm me-2" (click)="deleteUser(invite)">Cancel</button>
-                            <button class="btn btn-secondary btn-sm" (click)="resendEmail(invite)">Resend</button>
+                            <button class="btn btn-secondary btn-sm me-2" (click)="resendEmail(invite)">Resend</button>
+                            <button class="btn btn-secondary btn-sm" (click)="setup(invite)">Setup</button>
                         </div>
                     </h4>
 

--- a/UI/Web/src/app/admin/manage-users/manage-users.component.ts
+++ b/UI/Web/src/app/admin/manage-users/manage-users.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
-import { take } from 'rxjs/operators';
+import { catchError, take } from 'rxjs/operators';
 import { MemberService } from 'src/app/_services/member.service';
 import { Member } from 'src/app/_models/member';
 import { User } from 'src/app/_models/user';
@@ -13,6 +13,7 @@ import { MessageHubService } from 'src/app/_services/message-hub.service';
 import { InviteUserComponent } from '../invite-user/invite-user.component';
 import { EditUserComponent } from '../edit-user/edit-user.component';
 import { ServerService } from 'src/app/_services/server.service';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-manage-users',
@@ -34,7 +35,8 @@ export class ManageUsersComponent implements OnInit, OnDestroy {
               private toastr: ToastrService,
               private confirmService: ConfirmService,
               public messageHub: MessageHubService,
-              private serverService: ServerService) {
+              private serverService: ServerService,
+              private router: Router) {
     this.accountService.currentUser$.pipe(take(1)).subscribe((user) => {
       if (user) {
         this.loggedInUsername = user.username;
@@ -122,7 +124,6 @@ export class ManageUsersComponent implements OnInit, OnDestroy {
   }
 
   resendEmail(member: Member) {
-
     this.serverService.isServerAccessible().subscribe(canAccess => {
       this.accountService.resendConfirmationEmail(member.id).subscribe(async (email) => {
         if (canAccess) {
@@ -134,7 +135,15 @@ export class ManageUsersComponent implements OnInit, OnDestroy {
 
       });
     });
-    
+  }
+
+  setup(member: Member) {
+    this.accountService.getInviteUrl(member.id, false).subscribe(url => {
+      console.log('Url: ', url);
+      if (url) {
+        this.router.navigateByUrl(url);
+      }
+    });
   }
 
   updatePassword(member: Member) {


### PR DESCRIPTION
# Added
- Added: Added the ability to manually setup users without having to worry about the invite url during invite flow or doing it right at invite time. Now a Setup button will appear next to all Pending invites and at any time can be pressed to manually complete the account setup. Note: This does not work with pending invites created before this update. Please re-create them to get the new functionality. 

# Changed
- Changed: Exception middleware will now send the original error message to the UI rather than a generic "Internal Server Error".
- Changed: Error toasts now have Error in the title along with the status code