### PR TITLE
Volume relative numbering

### DIFF
--- a/API/Services/SeriesService.cs
+++ b/API/Services/SeriesService.cs
@@ -485,8 +485,7 @@ public class SeriesService : ISeriesService
             if (v.Number == 0) return c;
             c.VolumeTitle = v.Name;
             return c;
-        })).ToList();
-
+        }).OrderBy(c => float.Parse(c.Number), new ChapterSortComparer()));
 
         foreach (var chapter in chapters)
         {
@@ -505,8 +504,7 @@ public class SeriesService : ISeriesService
         } else
         {
             retChapters = chapters
-                .Where(ShouldIncludeChapter)
-                .OrderBy(c => float.Parse(c.Number), new ChapterSortComparer());
+                .Where(ShouldIncludeChapter);
         }
 
         var storylineChapters = volumes

--- a/UI/Web/src/app/cards/card-item/card-item.component.html
+++ b/UI/Web/src/app/cards/card-item/card-item.component.html
@@ -44,6 +44,9 @@
             <i class="fa {{format | mangaFormatIcon}}" aria-hidden="true" *ngIf="format != MangaFormat.UNKNOWN" title="{{formatString}}"></i>
             <span class="visually-hidden">{{formatString}}</span>
           </ng-container>
+          <ng-container *ngIf="volumeTitle != ''">
+            {{volumeTitle}}
+          </ng-container>
           &nbsp;{{title}}
         </span>
         <span class="card-actions float-end">

--- a/UI/Web/src/app/cards/card-item/card-item.component.html
+++ b/UI/Web/src/app/cards/card-item/card-item.component.html
@@ -44,9 +44,6 @@
             <i class="fa {{format | mangaFormatIcon}}" aria-hidden="true" *ngIf="format != MangaFormat.UNKNOWN" title="{{formatString}}"></i>
             <span class="visually-hidden">{{formatString}}</span>
           </ng-container>
-          <ng-container *ngIf="volumeTitle != ''">
-            {{volumeTitle}}
-          </ng-container>
           &nbsp;{{title}}
         </span>
         <span class="card-actions float-end">

--- a/UI/Web/src/app/cards/card-item/card-item.component.ts
+++ b/UI/Web/src/app/cards/card-item/card-item.component.ts
@@ -100,6 +100,7 @@ export class CardItemComponent implements OnInit, OnDestroy {
    */
   format: MangaFormat = MangaFormat.UNKNOWN;
   chapterTitle: string = '';
+  volumeTitle: string = '';
 
   /**
    * This is the download we get from download service. 
@@ -159,6 +160,7 @@ export class CardItemComponent implements OnInit, OnDestroy {
 
     if (this.utilityService.isChapter(this.entity)) {
       this.chapterTitle = this.utilityService.asChapter(this.entity).titleName;
+      this.volumeTitle = this.utilityService.asChapter(this.entity).volumeTitle || '';
     } else if (this.utilityService.isVolume(this.entity)) {
       const vol = this.utilityService.asVolume(this.entity);
       if (vol.chapters !== undefined && vol.chapters.length > 0) {

--- a/UI/Web/src/app/cards/card-item/card-item.component.ts
+++ b/UI/Web/src/app/cards/card-item/card-item.component.ts
@@ -75,8 +75,8 @@ export class CardItemComponent implements OnInit, OnDestroy {
    */
   @Input() suppressArchiveWarning: boolean = false;
   /**
-    * The number of updates/items within the card. If less than 2, will not be shown.
-    */
+   * The number of updates/items within the card. If less than 2, will not be shown.
+   */
   @Input() count: number = 0;
   /**
    * Additional information to show on the overlay area. Will always render.
@@ -100,10 +100,10 @@ export class CardItemComponent implements OnInit, OnDestroy {
    */
   format: MangaFormat = MangaFormat.UNKNOWN;
   chapterTitle: string = '';
-  volumeTitle: string = '';
+  tooltipTitle: string = this.title;
 
   /**
-   * This is the download we get from download service. 
+   * This is the download we get from download service.
    */
   download$: Observable<DownloadEvent | null> | null = null;
 
@@ -118,13 +118,6 @@ export class CardItemComponent implements OnInit, OnDestroy {
   selectionInProgress: boolean = false;
 
   private user: User | undefined;
-
-  get tooltipTitle() {
-    if (this.chapterTitle === '' || this.chapterTitle === null)
-      return (this.volumeTitle + ' ' + this.title).trim();
-    return this.chapterTitle;
-  }
-
 
   get MangaFormat(): typeof MangaFormat {
     return MangaFormat;
@@ -161,7 +154,11 @@ export class CardItemComponent implements OnInit, OnDestroy {
 
     if (this.utilityService.isChapter(this.entity)) {
       this.chapterTitle = this.utilityService.asChapter(this.entity).titleName;
-      this.volumeTitle = this.utilityService.asChapter(this.entity).volumeTitle || '';
+      if (this.chapterTitle === '' || this.chapterTitle === null) {
+        this.tooltipTitle = (this.utilityService.asChapter(this.entity).volumeTitle + ' ' + this.title).trim();
+      } else {
+        this.tooltipTitle = this.chapterTitle;
+      }
     } else if (this.utilityService.isVolume(this.entity)) {
       const vol = this.utilityService.asVolume(this.entity);
       if (vol.chapters !== undefined && vol.chapters.length > 0) {

--- a/UI/Web/src/app/cards/card-item/card-item.component.ts
+++ b/UI/Web/src/app/cards/card-item/card-item.component.ts
@@ -120,7 +120,8 @@ export class CardItemComponent implements OnInit, OnDestroy {
   private user: User | undefined;
 
   get tooltipTitle() {
-    if (this.chapterTitle === '' || this.chapterTitle === null) return this.title;
+    if (this.chapterTitle === '' || this.chapterTitle === null)
+      return (this.volumeTitle + ' ' + this.title).trim();
     return this.chapterTitle;
   }
 

--- a/UI/Web/src/app/cards/card-item/card-item.component.ts
+++ b/UI/Web/src/app/cards/card-item/card-item.component.ts
@@ -99,7 +99,6 @@ export class CardItemComponent implements OnInit, OnDestroy {
    * Format of the entity (only applies to Series)
    */
   format: MangaFormat = MangaFormat.UNKNOWN;
-  chapterTitle: string = '';
   tooltipTitle: string = this.title;
 
   /**
@@ -153,19 +152,21 @@ export class CardItemComponent implements OnInit, OnDestroy {
     this.format = (this.entity as Series).format;
 
     if (this.utilityService.isChapter(this.entity)) {
-      this.chapterTitle = this.utilityService.asChapter(this.entity).titleName;
-      if (this.chapterTitle === '' || this.chapterTitle === null) {
+      const chapterTitle = this.utilityService.asChapter(this.entity).titleName;
+      if (chapterTitle === '' || chapterTitle === null) {
         this.tooltipTitle = (this.utilityService.asChapter(this.entity).volumeTitle + ' ' + this.title).trim();
       } else {
-        this.tooltipTitle = this.chapterTitle;
+        this.tooltipTitle = chapterTitle;
       }
     } else if (this.utilityService.isVolume(this.entity)) {
       const vol = this.utilityService.asVolume(this.entity);
       if (vol.chapters !== undefined && vol.chapters.length > 0) {
-        this.chapterTitle = vol.chapters[0].titleName;
+        this.tooltipTitle = vol.chapters[0].titleName;
+      }
+      if (this.tooltipTitle === '') {
+        this.tooltipTitle = vol.name;
       }
     }
-
     this.accountService.currentUser$.pipe(takeUntil(this.onDestroy)).subscribe(user => {
       this.user = user;
     });

--- a/UI/Web/src/app/series-detail/series-detail.component.ts
+++ b/UI/Web/src/app/series-detail/series-detail.component.ts
@@ -125,7 +125,7 @@ export class SeriesDetailComponent implements OnInit, OnDestroy, AfterContentChe
   /**
    * Track by function for Chapter to tell when to refresh card data
    */
-  trackByChapterIdentity = (index: number, item: Chapter) => `${item.title}_${item.number}_${item.pagesRead}`;
+  trackByChapterIdentity = (index: number, item: Chapter) => `${item.title}_${item.number}_${item.volumeId}_${item.pagesRead}`;
   trackByRelatedSeriesIdentiy = (index: number, item: RelatedSeris) => `${item.series.name}_${item.series.libraryId}_${item.series.pagesRead}_${item.relation}`;
   trackByStoryLineIdentity = (index: number, item: StoryLineItem) => {
     if (item.isChapter) {


### PR DESCRIPTION
# Added
- Added: Support series with a volume relative numbering by sorting them correctly in the `issues` tab. That should address this feature request: https://feats.kavitareader.com/posts/125/allow-sorting-of-issues-tab

# Changed
- Changed: Display the volume along with the issue number

# Fixed
- Fixed: Fixed the inconsistent display when scrolling in the issues tab when multiple issues share the same number
