### PR TITLE
Lots of Bugfixes

### DIFF
--- a/API/API.csproj
+++ b/API/API.csproj
@@ -40,7 +40,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
-    <PackageReference Include="Docnet.Core" Version="2.4.0-alpha.4" />
+    <PackageReference Include="Docnet.Core" Version="2.4.0-alpha.2" />
     <PackageReference Include="ExCSS" Version="4.1.0" />
     <PackageReference Include="Flurl" Version="3.0.6" />
     <PackageReference Include="Flurl.Http" Version="3.2.4" />

--- a/API/Controllers/CollectionController.cs
+++ b/API/Controllers/CollectionController.cs
@@ -99,6 +99,7 @@ namespace API.Controllers
         /// </summary>
         /// <param name="dto"></param>
         /// <returns></returns>
+        [Authorize(Policy = "RequireAdminRole")]
         [HttpPost("update-for-series")]
         public async Task<ActionResult> AddToMultipleSeries(CollectionTagBulkAddDto dto)
         {

--- a/API/Controllers/ImageController.cs
+++ b/API/Controllers/ImageController.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using API.Data;
 using API.Entities.Enums;
+using API.Extensions;
 using API.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -16,7 +17,6 @@ namespace API.Controllers
     {
         private readonly IUnitOfWork _unitOfWork;
         private readonly IDirectoryService _directoryService;
-        private const int ImageCacheSeconds = 1 * 60;
 
         /// <inheritdoc />
         public ImageController(IUnitOfWork unitOfWork, IDirectoryService directoryService)
@@ -31,7 +31,7 @@ namespace API.Controllers
         /// <param name="chapterId"></param>
         /// <returns></returns>
         [HttpGet("chapter-cover")]
-        [ResponseCache(Duration = ImageCacheSeconds, Location = ResponseCacheLocation.Client, NoStore = false)]
+        [ResponseCache(CacheProfileName = "Images")]
         public async Task<ActionResult> GetChapterCoverImage(int chapterId)
         {
             var path = Path.Join(_directoryService.CoverImageDirectory, await _unitOfWork.ChapterRepository.GetChapterCoverImageAsync(chapterId));
@@ -47,7 +47,7 @@ namespace API.Controllers
         /// <param name="volumeId"></param>
         /// <returns></returns>
         [HttpGet("volume-cover")]
-        [ResponseCache(Duration = ImageCacheSeconds, Location = ResponseCacheLocation.Client, NoStore = false)]
+        [ResponseCache(CacheProfileName = "Images")]
         public async Task<ActionResult> GetVolumeCoverImage(int volumeId)
         {
             var path = Path.Join(_directoryService.CoverImageDirectory, await _unitOfWork.VolumeRepository.GetVolumeCoverImageAsync(volumeId));
@@ -62,13 +62,15 @@ namespace API.Controllers
         /// </summary>
         /// <param name="seriesId">Id of Series</param>
         /// <returns></returns>
-        [ResponseCache(Duration = ImageCacheSeconds, Location = ResponseCacheLocation.Client, NoStore = false)]
+        [ResponseCache(CacheProfileName = "Images")]
         [HttpGet("series-cover")]
         public async Task<ActionResult> GetSeriesCoverImage(int seriesId)
         {
             var path = Path.Join(_directoryService.CoverImageDirectory, await _unitOfWork.SeriesRepository.GetSeriesCoverImageAsync(seriesId));
             if (string.IsNullOrEmpty(path) || !_directoryService.FileSystem.File.Exists(path)) return BadRequest($"No cover image");
             var format = _directoryService.FileSystem.Path.GetExtension(path).Replace(".", "");
+
+            Response.AddCacheHeader(path);
 
             return PhysicalFile(path, "image/" + format, _directoryService.FileSystem.Path.GetFileName(path));
         }
@@ -79,7 +81,7 @@ namespace API.Controllers
         /// <param name="collectionTagId"></param>
         /// <returns></returns>
         [HttpGet("collection-cover")]
-        [ResponseCache(Duration = ImageCacheSeconds, Location = ResponseCacheLocation.Client, NoStore = false)]
+        [ResponseCache(CacheProfileName = "Images")]
         public async Task<ActionResult> GetCollectionCoverImage(int collectionTagId)
         {
             var path = Path.Join(_directoryService.CoverImageDirectory, await _unitOfWork.CollectionTagRepository.GetCoverImageAsync(collectionTagId));
@@ -95,7 +97,7 @@ namespace API.Controllers
         /// <param name="readingListId"></param>
         /// <returns></returns>
         [HttpGet("readinglist-cover")]
-        [ResponseCache(Duration = ImageCacheSeconds, Location = ResponseCacheLocation.Client, NoStore = false)]
+        [ResponseCache(CacheProfileName = "Images")]
         public async Task<ActionResult> GetReadingListCoverImage(int readingListId)
         {
             var path = Path.Join(_directoryService.CoverImageDirectory, await _unitOfWork.ReadingListRepository.GetCoverImageAsync(readingListId));
@@ -114,7 +116,7 @@ namespace API.Controllers
         /// <param name="apiKey">API Key for user. Needed to authenticate request</param>
         /// <returns></returns>
         [HttpGet("bookmark")]
-        [ResponseCache(Duration = ImageCacheSeconds, Location = ResponseCacheLocation.Client, NoStore = false)]
+        [ResponseCache(CacheProfileName = "Images")]
         public async Task<ActionResult> GetBookmarkImage(int chapterId, int pageNum, string apiKey)
         {
             var userId = await _unitOfWork.UserRepository.GetUserIdByApiKeyAsync(apiKey);
@@ -136,7 +138,7 @@ namespace API.Controllers
         /// <returns></returns>
         [Authorize(Policy="RequireAdminRole")]
         [HttpGet("cover-upload")]
-        [ResponseCache(Duration = ImageCacheSeconds, Location = ResponseCacheLocation.Client, NoStore = false)]
+        [ResponseCache(CacheProfileName = "Images")]
         public ActionResult GetCoverUploadImage(string filename)
         {
             if (filename.Contains("..")) return BadRequest("Invalid Filename");

--- a/API/Controllers/ImageController.cs
+++ b/API/Controllers/ImageController.cs
@@ -134,7 +134,7 @@ namespace API.Controllers
         /// </summary>
         /// <param name="filename">Filename of file. This is used with upload/upload-by-url</param>
         /// <returns></returns>
-        [AllowAnonymous]
+        [Authorize(Policy="RequireAdminRole")]
         [HttpGet("cover-upload")]
         [ResponseCache(Duration = ImageCacheSeconds, Location = ResponseCacheLocation.Client, NoStore = false)]
         public ActionResult GetCoverUploadImage(string filename)

--- a/API/Controllers/PluginController.cs
+++ b/API/Controllers/PluginController.cs
@@ -2,6 +2,7 @@
 using API.Data;
 using API.DTOs;
 using API.Services;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 
@@ -26,6 +27,7 @@ namespace API.Controllers
         /// <param name="apiKey"></param>
         /// <param name="pluginName">Name of the Plugin</param>
         /// <returns></returns>
+        [AllowAnonymous]
         [HttpPost("authenticate")]
         public async Task<ActionResult<UserDto>> Authenticate(string apiKey, string pluginName)
         {

--- a/API/Controllers/ReaderController.cs
+++ b/API/Controllers/ReaderController.cs
@@ -47,7 +47,7 @@ namespace API.Controllers
         /// <param name="chapterId"></param>
         /// <returns></returns>
         [HttpGet("pdf")]
-        [ResponseCache(Duration = 60 * 10, Location = ResponseCacheLocation.Client, NoStore = false)]
+        [ResponseCache(CacheProfileName = "Hour")]
         public async Task<ActionResult> GetPdf(int chapterId)
         {
             var chapter = await _cacheService.Ensure(chapterId);
@@ -79,7 +79,7 @@ namespace API.Controllers
         /// <param name="page"></param>
         /// <returns></returns>
         [HttpGet("image")]
-        [ResponseCache(Duration = 60 * 10, Location = ResponseCacheLocation.Client, NoStore = false)]
+        [ResponseCache(CacheProfileName = "Hour")]
         [AllowAnonymous]
         public async Task<ActionResult> GetImage(int chapterId, int page)
         {
@@ -111,7 +111,7 @@ namespace API.Controllers
         /// <remarks>We must use api key as bookmarks could be leaked to other users via the API</remarks>
         /// <returns></returns>
         [HttpGet("bookmark-image")]
-        [ResponseCache(Duration = 60 * 10, Location = ResponseCacheLocation.Client, NoStore = false)]
+        [ResponseCache(CacheProfileName = "Hour")]
         [AllowAnonymous]
         public async Task<ActionResult> GetBookmarkImage(int seriesId, string apiKey, int page)
         {

--- a/API/Controllers/ReaderController.cs
+++ b/API/Controllers/ReaderController.cs
@@ -11,7 +11,6 @@ using API.Entities;
 using API.Entities.Enums;
 using API.Extensions;
 using API.Services;
-using API.SignalR;
 using Hangfire;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -113,6 +112,7 @@ namespace API.Controllers
         /// <returns></returns>
         [HttpGet("bookmark-image")]
         [ResponseCache(Duration = 60 * 10, Location = ResponseCacheLocation.Client, NoStore = false)]
+        [AllowAnonymous]
         public async Task<ActionResult> GetBookmarkImage(int seriesId, string apiKey, int page)
         {
             if (page < 0) page = 0;

--- a/API/Controllers/ReadingListController.cs
+++ b/API/Controllers/ReadingListController.cs
@@ -508,6 +508,7 @@ namespace API.Controllers
         private async Task<bool> AddChaptersToReadingList(int seriesId, IList<int> chapterIds,
             ReadingList readingList)
         {
+            // TODO: Move to ReadingListService and Unit Test
             readingList.Items ??= new List<ReadingListItem>();
             var lastOrder = 0;
             if (readingList.Items.Any())

--- a/API/DTOs/Account/ResetPasswordDto.cs
+++ b/API/DTOs/Account/ResetPasswordDto.cs
@@ -4,10 +4,20 @@ namespace API.DTOs.Account
 {
     public class ResetPasswordDto
     {
+        /// <summary>
+        /// The Username of the User
+        /// </summary>
         [Required]
         public string UserName { get; init; }
+        /// <summary>
+        /// The new password
+        /// </summary>
         [Required]
         [StringLength(32, MinimumLength = 6)]
         public string Password { get; init; }
+        /// <summary>
+        /// The old, existing password. If an admin is performing the change, this is not required. Otherwise, it is.
+        /// </summary>
+        public string OldPassword { get; init; }
     }
 }

--- a/API/DTOs/Reader/BulkRemoveBookmarkForSeriesDto.cs
+++ b/API/DTOs/Reader/BulkRemoveBookmarkForSeriesDto.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace API.DTOs.Reader
+{
+    public class BulkRemoveBookmarkForSeriesDto
+    {
+        public ICollection<int> SeriesIds { get; init; }
+    }
+}

--- a/API/Extensions/HttpExtensions.cs
+++ b/API/Extensions/HttpExtensions.cs
@@ -39,5 +39,23 @@ namespace API.Extensions
             response.Headers.Add(HeaderNames.ETag, string.Concat(sha1.ComputeHash(content).Select(x => x.ToString("X2"))));
             response.Headers.CacheControl =  $"private,max-age=100";
         }
+
+        /// <summary>
+        /// Calculates SHA256 hash for a cover image filename and sets as ETag. Ensures Cache-Control: private header is added.
+        /// </summary>
+        /// <param name="response"></param>
+        /// <param name="filename"></param>
+        /// <param name="maxAge">Maximum amount of seconds to set for Cache-Control</param>
+        public static void AddCacheHeader(this HttpResponse response, string filename, int maxAge = 10)
+        {
+            if (filename is not {Length: > 0}) return;
+            var hashContent = filename + File.GetLastWriteTimeUtc(filename);
+            using var sha1 = SHA256.Create();
+            response.Headers.Add("ETag", string.Concat(sha1.ComputeHash(Encoding.UTF8.GetBytes(hashContent)).Select(x => x.ToString("X2"))));
+            if (maxAge != 10)
+            {
+                response.Headers.CacheControl =  $"max-age={maxAge}";
+            }
+        }
     }
 }

--- a/API/Helpers/Filters/ETagFromFilename.cs
+++ b/API/Helpers/Filters/ETagFromFilename.cs
@@ -1,0 +1,234 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Net.Http.Headers;
+using Newtonsoft.Json;
+
+namespace API.Helpers.Filters;
+
+// NOTE: I'm leaving this in, but I don't think it's needed. Will validate in next release.
+
+//[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false)]
+// public class ETagFromFilename : ActionFilterAttribute, IAsyncActionFilter
+// {
+//     public override async Task OnActionExecutionAsync(ActionExecutingContext executingContext,
+//         ActionExecutionDelegate next)
+//     {
+//         var request = executingContext.HttpContext.Request;
+//
+//         var executedContext = await next();
+//         var response = executedContext.HttpContext.Response;
+//
+//         // Computing ETags for Response Caching on GET requests
+//         if (request.Method == HttpMethod.Get.Method && response.StatusCode == (int) HttpStatusCode.OK)
+//         {
+//             ValidateETagForResponseCaching(executedContext);
+//         }
+//     }
+//
+//     private void ValidateETagForResponseCaching(ActionExecutedContext executedContext)
+//     {
+//         if (executedContext.Result == null)
+//         {
+//             return;
+//         }
+//
+//         var request = executedContext.HttpContext.Request;
+//         var response = executedContext.HttpContext.Response;
+//
+//         var objectResult = executedContext.Result as ObjectResult;
+//         if (objectResult == null) return;
+//         var result = (PhysicalFileResult) objectResult.Value;
+//
+//         // generate ETag from LastModified property
+//         //var etag = GenerateEtagFromFilename(result.);
+//
+//         // generates ETag from the entire response Content
+//         //var etag = GenerateEtagFromResponseBodyWithHash(result);
+//
+//         if (request.Headers.ContainsKey(HeaderNames.IfNoneMatch))
+//         {
+//             // fetch etag from the incoming request header
+//             var incomingEtag = request.Headers[HeaderNames.IfNoneMatch].ToString();
+//
+//             // if both the etags are equal
+//             // raise a 304 Not Modified Response
+//             if (incomingEtag.Equals(etag))
+//             {
+//                 executedContext.Result = new StatusCodeResult((int) HttpStatusCode.NotModified);
+//             }
+//         }
+//
+//         // add ETag response header
+//         response.Headers.Add(HeaderNames.ETag, new[] {etag});
+//     }
+//
+     // private static string GenerateEtagFromFilename(HttpResponse response, string filename, int maxAge = 10)
+     // {
+     //     if (filename is not {Length: > 0}) return string.Empty;
+     //     var hashContent = filename + File.GetLastWriteTimeUtc(filename);
+     //     using var sha1 = SHA256.Create();
+     //     return string.Concat(sha1.ComputeHash(Encoding.UTF8.GetBytes(hashContent)).Select(x => x.ToString("X2")));
+     // }
+// }
+
+[AttributeUsage(AttributeTargets.Method)]
+public class ETagFilter : Attribute, IActionFilter
+{
+    private readonly int[] _statusCodes;
+
+    public ETagFilter(params int[] statusCodes)
+    {
+        _statusCodes = statusCodes;
+        if (statusCodes.Length == 0) _statusCodes = new[] { 200 };
+    }
+
+    public void OnActionExecuting(ActionExecutingContext context)
+    {
+    }
+
+    public void OnActionExecuted(ActionExecutedContext context)
+    {
+        if (context.HttpContext.Request.Method != "GET" || context.HttpContext.Request.Method != "HEAD") return;
+        if (!_statusCodes.Contains(context.HttpContext.Response.StatusCode)) return;
+
+        var etag = string.Empty;;
+        //I just serialize the result to JSON, could do something less costly
+        if (context.Result is PhysicalFileResult)
+        {
+            // Do a cheap LastWriteTime etag gen
+            if (context.Result is PhysicalFileResult fileResult)
+            {
+                etag = ETagGenerator.GenerateEtagFromFilename(fileResult.FileName);
+                context.HttpContext.Response.Headers.LastModified = File.GetLastWriteTimeUtc(fileResult.FileName).ToLongDateString();
+            }
+        }
+
+        if (string.IsNullOrEmpty(etag))
+        {
+            var content = JsonConvert.SerializeObject(context.Result);
+            etag = ETagGenerator.GetETag(context.HttpContext.Request.Path.ToString(), Encoding.UTF8.GetBytes(content));
+        }
+
+
+        if (context.HttpContext.Request.Headers.IfNoneMatch.ToString() == etag)
+        {
+            context.Result = new StatusCodeResult(304);
+        }
+
+        //context.HttpContext.Response.Headers.ETag = etag;
+    }
+
+
+}
+
+// Helper class that generates the etag from a key (route) and content (response)
+public static class ETagGenerator
+{
+    public static string GetETag(string key, byte[] contentBytes)
+    {
+        var keyBytes = Encoding.UTF8.GetBytes(key);
+        var combinedBytes = Combine(keyBytes, contentBytes);
+
+        return GenerateETag(combinedBytes);
+    }
+
+    private static string GenerateETag(byte[] data)
+    {
+        using var md5 = MD5.Create();
+        var hash = md5.ComputeHash(data);
+        var hex = BitConverter.ToString(hash);
+        return hex.Replace("-", "");
+    }
+
+    private static byte[] Combine(byte[] a, byte[] b)
+    {
+        var c = new byte[a.Length + b.Length];
+        Buffer.BlockCopy(a, 0, c, 0, a.Length);
+        Buffer.BlockCopy(b, 0, c, a.Length, b.Length);
+        return c;
+    }
+
+    public static string GenerateEtagFromFilename(string filename)
+    {
+        if (filename is not {Length: > 0}) return string.Empty;
+        var hashContent = filename + File.GetLastWriteTimeUtc(filename);
+        using var md5 = MD5.Create();
+        return string.Concat(md5.ComputeHash(Encoding.UTF8.GetBytes(hashContent)).Select(x => x.ToString("X2")));
+    }
+}
+
+// /// <summary>
+// /// Enables HTTP Response CacheControl management with ETag values.
+// /// </summary>
+// public class ClientCacheWithEtagAttribute : ActionFilterAttribute
+// {
+//     private readonly TimeSpan _clientCache;
+//
+//     private readonly HttpMethod[] _supportedRequestMethods = {
+//         HttpMethod.Get,
+//         HttpMethod.Head
+//     };
+//
+//     /// <summary>
+//     /// Default constructor
+//     /// </summary>
+//     /// <param name="clientCacheInSeconds">Indicates for how long the client should cache the response. The value is in seconds</param>
+//     public ClientCacheWithEtagAttribute(int clientCacheInSeconds)
+//     {
+//         _clientCache = TimeSpan.FromSeconds(clientCacheInSeconds);
+//     }
+//
+//     public override async Task OnActionExecutionAsync(ActionExecutingContext executingContext, ActionExecutionDelegate next)
+//     {
+//
+//         if (executingContext.Response?.Content == null)
+//         {
+//             return;
+//         }
+//
+//         var body = await executingContext.Response.Content.ReadAsStringAsync();
+//         if (body == null)
+//         {
+//             return;
+//         }
+//
+//         var computedEntityTag = GetETag(Encoding.UTF8.GetBytes(body));
+//
+//         if (actionExecutedContext.Request.Headers.IfNoneMatch.Any()
+//             && actionExecutedContext.Request.Headers.IfNoneMatch.First().Tag.Trim('"').Equals(computedEntityTag, StringComparison.InvariantCultureIgnoreCase))
+//         {
+//             actionExecutedContext.Response.StatusCode = HttpStatusCode.NotModified;
+//             actionExecutedContext.Response.Content = null;
+//         }
+//
+//         var cacheControlHeader = new CacheControlHeaderValue
+//         {
+//             Private = true,
+//             MaxAge = _clientCache
+//         };
+//
+//         actionExecutedContext.Response.Headers.ETag = new EntityTagHeaderValue($"\"{computedEntityTag}\"", false);
+//         actionExecutedContext.Response.Headers.CacheControl = cacheControlHeader;
+//     }
+//
+//     private static string GetETag(byte[] contentBytes)
+//     {
+//         using (var md5 = MD5.Create())
+//         {
+//             var hash = md5.ComputeHash(contentBytes);
+//             string hex = BitConverter.ToString(hash);
+//             return hex.Replace("-", "");
+//         }
+//     }
+// }
+

--- a/API/Services/DirectoryService.cs
+++ b/API/Services/DirectoryService.cs
@@ -90,6 +90,11 @@ namespace API.Services
            SiteThemeDirectory = FileSystem.Path.Join(FileSystem.Directory.GetCurrentDirectory(), "config", "themes");
 
            ExistOrCreate(SiteThemeDirectory);
+           ExistOrCreate(CoverImageDirectory);
+           ExistOrCreate(CacheDirectory);
+           ExistOrCreate(LogDirectory);
+           ExistOrCreate(TempDirectory);
+           ExistOrCreate(BookmarkDirectory);
        }
 
        /// <summary>

--- a/API/Services/MetadataService.cs
+++ b/API/Services/MetadataService.cs
@@ -158,7 +158,7 @@ public class MetadataService : IMetadataService
     /// </summary>
     /// <param name="series"></param>
     /// <param name="forceUpdate"></param>
-    private async Task ProcessSeriesMetadataUpdate(Series series, bool forceUpdate)
+    private async Task ProcessSeriesCoverGen(Series series, bool forceUpdate)
     {
         _logger.LogDebug("[MetadataService] Processing series {SeriesName}", series.OriginalName);
         try
@@ -250,7 +250,7 @@ public class MetadataService : IMetadataService
 
                 try
                 {
-                    await ProcessSeriesMetadataUpdate(series, forceUpdate);
+                    await ProcessSeriesCoverGen(series, forceUpdate);
                 }
                 catch (Exception ex)
                 {
@@ -303,7 +303,7 @@ public class MetadataService : IMetadataService
         await _eventHub.SendMessageAsync(MessageFactory.NotificationProgress,
             MessageFactory.CoverUpdateProgressEvent(libraryId, 0F, ProgressEventType.Started, series.Name));
 
-        await ProcessSeriesMetadataUpdate(series, forceUpdate);
+        await ProcessSeriesCoverGen(series, forceUpdate);
 
 
         if (_unitOfWork.HasChanges())

--- a/API/Startup.cs
+++ b/API/Startup.cs
@@ -25,6 +25,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.Extensions.Configuration;
@@ -52,7 +53,23 @@ namespace API
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddApplicationServices(_config, _env);
-            services.AddControllers();
+            services.AddControllers(options =>
+            {
+                options.CacheProfiles.Add("Images",
+                    new CacheProfile()
+                    {
+                        Duration = 60,
+                        Location = ResponseCacheLocation.None,
+                        NoStore = false
+                    });
+                options.CacheProfiles.Add("Hour",
+                    new CacheProfile()
+                    {
+                        Duration = 60 * 10,
+                        Location = ResponseCacheLocation.None,
+                        NoStore = false
+                    });
+            });
             services.Configure<ForwardedHeadersOptions>(options =>
             {
                 options.ForwardedHeaders = ForwardedHeaders.All;

--- a/API/Startup.cs
+++ b/API/Startup.cs
@@ -252,6 +252,12 @@ namespace API
                 context.Response.Headers[Microsoft.Net.Http.Headers.HeaderNames.Vary] =
                     new[] { "Accept-Encoding" };
 
+                // Don't let the site be iframed outside the same origin (clickjacking)
+                context.Response.Headers.XFrameOptions = "SAMEORIGIN";
+
+                // Setup CSP to ensure we load assets only from these origins
+                context.Response.Headers.Add("Content-Security-Policy", "default-src 'self' frame-ancestors 'none';");
+
                 await next();
             });
 

--- a/UI/Web/src/app/_services/account.service.ts
+++ b/UI/Web/src/app/_services/account.service.ts
@@ -168,8 +168,8 @@ export class AccountService implements OnDestroy {
     return this.httpClient.post(this.baseUrl + 'account/confirm-password-reset', model);
   }
 
-  resetPassword(username: string, password: string) {
-    return this.httpClient.post(this.baseUrl + 'account/reset-password', {username, password}, {responseType: 'json' as 'text'});
+  resetPassword(username: string, password: string, oldPassword: string) {
+    return this.httpClient.post(this.baseUrl + 'account/reset-password', {username, password, oldPassword}, {responseType: 'json' as 'text'});
   }
 
   update(model: {email: string, roles: Array<string>, libraries: Array<number>, userId: number}) {

--- a/UI/Web/src/app/_services/reader.service.ts
+++ b/UI/Web/src/app/_services/reader.service.ts
@@ -67,7 +67,10 @@ export class ReaderService {
   }
 
   clearBookmarks(seriesId: number) {
-    return this.httpClient.post(this.baseUrl + 'reader/remove-bookmarks', {seriesId});
+    return this.httpClient.post(this.baseUrl + 'reader/remove-bookmarks', {seriesId}, {responseType: 'text' as 'json'});
+  }
+  clearMultipleBookmarks(seriesIds: Array<number>) {
+    return this.httpClient.post(this.baseUrl + 'reader/bulk-remove-bookmarks', {seriesIds}, {responseType: 'text' as 'json'});
   }
 
   /**

--- a/UI/Web/src/app/admin/_modals/reset-password-modal/reset-password-modal.component.ts
+++ b/UI/Web/src/app/admin/_modals/reset-password-modal/reset-password-modal.component.ts
@@ -1,9 +1,8 @@
 import { Component, Input, OnInit } from '@angular/core';
-import { UntypedFormGroup, UntypedFormControl, Validators } from '@angular/forms';
+import { FormGroup, FormControl, Validators } from '@angular/forms';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { Member } from 'src/app/_models/member';
 import { AccountService } from 'src/app/_services/account.service';
-import { MemberService } from 'src/app/_services/member.service';
 
 @Component({
   selector: 'app-reset-password-modal',
@@ -14,8 +13,8 @@ export class ResetPasswordModalComponent implements OnInit {
 
   @Input() member!: Member;
   errorMessage = '';
-  resetPasswordForm: UntypedFormGroup = new UntypedFormGroup({
-    password: new UntypedFormControl('', [Validators.required]),
+  resetPasswordForm: FormGroup = new FormGroup({
+    password: new FormControl('', [Validators.required]),
   });
 
   constructor(public modal: NgbActiveModal, private accountService: AccountService) { }
@@ -24,7 +23,7 @@ export class ResetPasswordModalComponent implements OnInit {
   }
 
   save() {
-    this.accountService.resetPassword(this.member.username, this.resetPasswordForm.value.password).subscribe(() => {
+    this.accountService.resetPassword(this.member.username, this.resetPasswordForm.value.password,'').subscribe(() => {
       this.modal.close();
     });
   }

--- a/UI/Web/src/app/bookmark/bookmarks/bookmarks.component.ts
+++ b/UI/Web/src/app/bookmark/bookmarks/bookmarks.component.ts
@@ -1,7 +1,7 @@
-import { Component, HostListener, OnDestroy, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, HostListener, OnDestroy, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { ToastrService } from 'ngx-toastr';
-import { take, takeWhile, finalize, Subject, forkJoin } from 'rxjs';
+import { take, Subject } from 'rxjs';
 import { BulkSelectionService } from 'src/app/cards/bulk-selection.service';
 import { ConfirmService } from 'src/app/shared/confirm.service';
 import { DownloadService } from 'src/app/shared/_services/download.service';
@@ -16,7 +16,8 @@ import { SeriesService } from 'src/app/_services/series.service';
 @Component({
   selector: 'app-bookmarks',
   templateUrl: './bookmarks.component.html',
-  styleUrls: ['./bookmarks.component.scss']
+  styleUrls: ['./bookmarks.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class BookmarksComponent implements OnInit, OnDestroy {
 
@@ -36,7 +37,7 @@ export class BookmarksComponent implements OnInit, OnDestroy {
     private downloadService: DownloadService, private toastr: ToastrService,
     private confirmService: ConfirmService, public bulkSelectionService: BulkSelectionService, 
     public imageService: ImageService, private actionFactoryService: ActionFactoryService,
-    private router: Router) { }
+    private router: Router, private readonly cdRef: ChangeDetectorRef) { }
 
   ngOnInit(): void {
     this.loadBookmarks();
@@ -96,12 +97,12 @@ export class BookmarksComponent implements OnInit, OnDestroy {
         if (!await this.confirmService.confirm('Are you sure you want to clear all bookmarks for multiple series? This cannot be undone.')) {
           break;
         }
-        
-        forkJoin(seriesIds.map(id => this.readerService.clearBookmarks(id))).subscribe(() => {
+
+        this.readerService.clearMultipleBookmarks(seriesIds).subscribe(() => {
           this.toastr.success('Bookmarks have been removed');
           this.bulkSelectionService.deselectAll();
           this.loadBookmarks();
-        })
+        });
         break;
       default:
         break;
@@ -110,6 +111,7 @@ export class BookmarksComponent implements OnInit, OnDestroy {
 
   loadBookmarks() {
     this.loadingBookmarks = true;
+    this.cdRef.markForCheck();
     this.readerService.getAllBookmarks().pipe(take(1)).subscribe(bookmarks => {
       this.bookmarks = bookmarks;
       this.seriesIds = {};
@@ -127,7 +129,9 @@ export class BookmarksComponent implements OnInit, OnDestroy {
       this.seriesService.getAllSeriesByIds(ids).subscribe(series => {
         this.series = series;
         this.loadingBookmarks = false;
+        this.cdRef.markForCheck();
       });
+      this.cdRef.markForCheck();
     });
   }
 
@@ -141,6 +145,7 @@ export class BookmarksComponent implements OnInit, OnDestroy {
     }
 
     this.clearingSeries[series.id] = true;
+    this.cdRef.markForCheck();
     this.readerService.clearBookmarks(series.id).subscribe(() => {
       const index = this.series.indexOf(series);
       if (index > -1) {
@@ -148,6 +153,7 @@ export class BookmarksComponent implements OnInit, OnDestroy {
       }
       this.clearingSeries[series.id] = false;
       this.toastr.success(series.name + '\'s bookmarks have been removed');
+      this.cdRef.markForCheck();
     });
   }
 
@@ -157,18 +163,13 @@ export class BookmarksComponent implements OnInit, OnDestroy {
 
   downloadBookmarks(series: Series) {
     this.downloadingSeries[series.id] = true;
+    this.cdRef.markForCheck();
     this.downloadService.download('bookmark', this.bookmarks.filter(bmk => bmk.seriesId === series.id), (d) => {
       if (!d) {
         this.downloadingSeries[series.id] = false;
+        this.cdRef.markForCheck();
       }
     });
-    // this.downloadService.downloadBookmarks(this.bookmarks.filter(bmk => bmk.seriesId === series.id)).pipe(
-    //   takeWhile(val => {
-    //     return val.state != 'DONE';
-    //   }),
-    //   finalize(() => {
-    //     this.downloadingSeries[series.id] = false;
-    //   })).subscribe(() => {/* No Operation */});
   }
 
 }

--- a/UI/Web/src/app/cards/_modals/edit-series-modal/edit-series-modal.component.scss
+++ b/UI/Web/src/app/cards/_modals/edit-series-modal/edit-series-modal.component.scss
@@ -1,5 +1,5 @@
 .scrollable-modal {
-    max-height: calc(var(--vh) * 100 - 198px); // 600px
+    max-height: calc(var(--vh) * 100 - 198px);
     overflow: auto;
 }
 

--- a/UI/Web/src/app/cards/_modals/edit-series-modal/edit-series-modal.component.ts
+++ b/UI/Web/src/app/cards/_modals/edit-series-modal/edit-series-modal.component.ts
@@ -417,7 +417,7 @@ export class EditSeriesModalComponent implements OnInit, OnDestroy {
   }
 
   close() {
-    this.modal.close({success: false, series: undefined});
+    this.modal.close({success: false, series: undefined, coverImageUpdate: this.coverImageReset});
   }
 
   fetchCollectionTags(filter: string = '') {
@@ -458,7 +458,7 @@ export class EditSeriesModalComponent implements OnInit, OnDestroy {
     this.saveNestedComponents.emit();
 
     forkJoin(apis).subscribe(results => {
-      this.modal.close({success: true, series: model, coverImageUpdate: selectedIndex > 0});
+      this.modal.close({success: true, series: model, coverImageUpdate: selectedIndex > 0 || this.coverImageReset});
     });
   }
 

--- a/UI/Web/src/app/cards/card-detail-layout/card-detail-layout.component.ts
+++ b/UI/Web/src/app/cards/card-detail-layout/card-detail-layout.component.ts
@@ -151,7 +151,7 @@ export class CardDetailLayoutComponent implements OnInit, OnDestroy, OnChanges, 
       targetIndex += this.jumpBarKeys[i].size;
     }
 
-    this.virtualScroller.scrollToIndex(targetIndex, true, 800, 1000);
+    this.virtualScroller.scrollToIndex(targetIndex, true, 0, 1000);
     this.jumpbarService.saveResumeKey(this.header, jumpKey.key);
     this.changeDetectionRef.markForCheck();
     return;

--- a/UI/Web/src/app/cards/series-card/series-card.component.ts
+++ b/UI/Web/src/app/cards/series-card/series-card.component.ts
@@ -100,6 +100,9 @@ export class SeriesCardComponent implements OnInit, OnChanges, OnDestroy {
       case Action.AddToWantToReadList:
         this.actionService.addMultipleSeriesToWantToReadList([series.id]);
         break;
+      case Action.RemoveFromWantToReadList:
+        this.actionService.removeMultipleSeriesFromWantToReadList([series.id]);
+        break;
       case(Action.AddToCollection):
         this.actionService.addMultipleSeriesToCollectionTag([series]);
         break;

--- a/UI/Web/src/app/library-detail/library-detail.component.html
+++ b/UI/Web/src/app/library-detail/library-detail.component.html
@@ -41,6 +41,6 @@
     </div>
 </app-side-nav-companion-bar>
 <app-bulk-operations [actionCallback]="bulkActionCallback"></app-bulk-operations>
-<div [ngbNavOutlet]="nav" class="mt-3"></div>
+<div [ngbNavOutlet]="nav"></div>
 
 

--- a/UI/Web/src/app/reading-list/_modals/add-to-list-modal/add-to-list-modal.component.html
+++ b/UI/Web/src/app/reading-list/_modals/add-to-list-modal/add-to-list-modal.component.html
@@ -6,7 +6,7 @@
     </button>
 </div>
 <form style="width: 100%" [formGroup]="listForm">
-<div class="modal-body">
+<div class="modal-body scrollable-modal">
     <div class="mb-3" *ngIf="lists.length >= 5">
         <label for="filter" class="form-label">Filter</label>
         <div class="input-group">

--- a/UI/Web/src/app/reading-list/_modals/add-to-list-modal/add-to-list-modal.component.scss
+++ b/UI/Web/src/app/reading-list/_modals/add-to-list-modal/add-to-list-modal.component.scss
@@ -2,3 +2,8 @@
 .clickable:hover, .clickable:focus {
     background-color: var(--primary-color);
 }
+
+.list-group {
+    overflow: auto;
+    max-height: 350px;
+}

--- a/UI/Web/src/app/reading-list/_modals/add-to-list-modal/add-to-list-modal.component.scss
+++ b/UI/Web/src/app/reading-list/_modals/add-to-list-modal/add-to-list-modal.component.scss
@@ -3,7 +3,7 @@
     background-color: var(--primary-color);
 }
 
-.list-group {
+.scrollable-modal {
+    max-height: calc(var(--vh) * 100 - 198px);
     overflow: auto;
-    max-height: 350px;
 }

--- a/UI/Web/src/app/reading-list/reading-list-item/reading-list-item.component.ts
+++ b/UI/Web/src/app/reading-list/reading-list-item/reading-list-item.component.ts
@@ -50,7 +50,9 @@ export class ReadingListItemComponent implements OnInit {
       chapterNum = this.utilityService.cleanSpecialTitle(item.chapterNumber);
     }
 
-    this.title = this.utilityService.formatChapterName(this.libraryTypes[item.libraryId], true, true) + chapterNum;
+    if (this.title === '') {
+      this.title = this.utilityService.formatChapterName(this.libraryTypes[item.libraryId], true, true) + chapterNum;
+    }
     this.cdRef.markForCheck();
   }
 

--- a/UI/Web/src/app/reading-list/reading-lists/reading-lists.component.html
+++ b/UI/Web/src/app/reading-list/reading-lists/reading-lists.component.html
@@ -9,6 +9,7 @@
     [isLoading]="loadingLists"
     [items]="lists"
     [pagination]="pagination"
+    [jumpBarKeys]="jumpbarKeys"
     [filteringDisabled]="true"
     >
     <ng-template #cardItem let-item let-position="idx">

--- a/UI/Web/src/app/reading-list/reading-lists/reading-lists.component.ts
+++ b/UI/Web/src/app/reading-list/reading-lists/reading-lists.component.ts
@@ -2,6 +2,8 @@ import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit } from '@
 import { Router } from '@angular/router';
 import { ToastrService } from 'ngx-toastr';
 import { take } from 'rxjs/operators';
+import { UtilityService } from 'src/app/shared/_services/utility.service';
+import { JumpKey } from 'src/app/_models/jumpbar/jump-key';
 import { PaginatedResult, Pagination } from 'src/app/_models/pagination';
 import { ReadingList } from 'src/app/_models/reading-list';
 import { AccountService } from 'src/app/_services/account.service';
@@ -22,10 +24,11 @@ export class ReadingListsComponent implements OnInit {
   loadingLists = false;
   pagination!: Pagination;
   isAdmin: boolean = false;
+  jumpbarKeys: Array<JumpKey> = [];
 
   constructor(private readingListService: ReadingListService, public imageService: ImageService, private actionFactoryService: ActionFactoryService,
     private accountService: AccountService, private toastr: ToastrService, private router: Router, private actionService: ActionService,
-   private readonly cdRef: ChangeDetectorRef) { }
+    private utilityService: UtilityService, private readonly cdRef: ChangeDetectorRef) { }
 
   ngOnInit(): void {
     this.accountService.currentUser$.pipe(take(1)).subscribe(user => {
@@ -81,6 +84,7 @@ export class ReadingListsComponent implements OnInit {
     this.readingListService.getReadingLists(true).pipe(take(1)).subscribe((readingLists: PaginatedResult<ReadingList[]>) => {
       this.lists = readingLists.result;
       this.pagination = readingLists.pagination;
+      this.jumpbarKeys = this.utilityService.getJumpKeys(readingLists.result, (rl: ReadingList) => rl.title);
       this.loadingLists = false;
       window.scrollTo(0, 0);
       this.cdRef.markForCheck();

--- a/UI/Web/src/app/registration/reset-password/reset-password.component.ts
+++ b/UI/Web/src/app/registration/reset-password/reset-password.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { UntypedFormGroup, UntypedFormControl, Validators } from '@angular/forms';
+import { Validators, FormGroup, FormControl } from '@angular/forms';
 import { Router } from '@angular/router';
 import { ToastrService } from 'ngx-toastr';
 import { AccountService } from 'src/app/_services/account.service';
@@ -12,8 +12,8 @@ import { AccountService } from 'src/app/_services/account.service';
 })
 export class ResetPasswordComponent {
 
-  registerForm: UntypedFormGroup = new UntypedFormGroup({
-    email: new UntypedFormControl('', [Validators.required, Validators.email]),
+  registerForm: FormGroup = new FormGroup({
+    email: new FormControl('', [Validators.required, Validators.email]),
   });
 
   constructor(private router: Router, private accountService: AccountService, 

--- a/UI/Web/src/app/series-detail/series-detail.component.ts
+++ b/UI/Web/src/app/series-detail/series-detail.component.ts
@@ -1,10 +1,10 @@
-import { Component, ElementRef, HostListener, OnDestroy, OnInit, ViewChild, Inject, ChangeDetectionStrategy, ChangeDetectorRef, AfterContentChecked, AfterViewInit } from '@angular/core';
+import { Component, ElementRef, HostListener, OnDestroy, OnInit, ViewChild, Inject, ChangeDetectionStrategy, ChangeDetectorRef, AfterContentChecked } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 import { ActivatedRoute, Router } from '@angular/router';
 import { NgbModal, NgbNavChangeEvent, NgbOffcanvas } from '@ng-bootstrap/ng-bootstrap';
 import { ToastrService } from 'ngx-toastr';
 import { forkJoin, Subject, tap } from 'rxjs';
-import { filter, finalize, switchMap, take, takeUntil, takeWhile } from 'rxjs/operators';
+import { take, takeUntil } from 'rxjs/operators';
 import { BulkSelectionService } from '../cards/bulk-selection.service';
 import { EditSeriesModalComponent } from '../cards/_modals/edit-series-modal/edit-series-modal.component';
 import { ConfirmConfig } from '../shared/confirm-dialog/_models/confirm-config';
@@ -39,7 +39,6 @@ import { FormGroup, UntypedFormControl, UntypedFormGroup } from '@angular/forms'
 import { PageLayoutMode } from '../_models/page-layout-mode';
 import { DOCUMENT } from '@angular/common';
 import { User } from '../_models/user';
-import { Download } from '../shared/_models/download';
 import { ScrollService } from '../_services/scroll.service';
 
 interface RelatedSeris {
@@ -696,6 +695,10 @@ export class SeriesDetailComponent implements OnInit, OnDestroy, AfterContentChe
         });
         
         this.loadSeries(this.seriesId);
+      }
+
+      if (closeResult.coverImageUpdate) {
+        this.toastr.info('It can take up to a minute for your browser to refresh the image. Until then, the old image may be shown on some pages.');
       }
     });
   }

--- a/UI/Web/src/app/shared/_services/utility.service.ts
+++ b/UI/Web/src/app/shared/_services/utility.service.ts
@@ -208,7 +208,7 @@ export class UtilityService {
     const keys: {[key: string]: number} = {};
     data.forEach(obj => {
       let ch = keySelector(obj).charAt(0);
-      if (/\d|\#|!|%|@|\(|\)|\^|\*/g.test(ch)) {
+      if (/\d|\#|!|%|@|\(|\)|\^|\.|_|\*/g.test(ch)) {
         ch = '#';
       }
       if (!keys.hasOwnProperty(ch)) {

--- a/UI/Web/src/app/user-settings/user-preferences/user-preferences.component.html
+++ b/UI/Web/src/app/user-settings/user-preferences/user-preferences.component.html
@@ -283,8 +283,18 @@
                     </div>
                     <form [formGroup]="passwordChangeForm">
                         <div class="mb-3">
+                            <label for="oldpass" class="form-label">Current Password</label>
+                            <input class="form-control custom-input" type="password" id="oldpass" formControlName="oldPassword">
+                            <div id="inviteForm-validations" class="invalid-feedback" *ngIf="passwordChangeForm.dirty || passwordChangeForm.touched">
+                                <div *ngIf="passwordChangeForm.get('oldPassword')?.errors?.required">
+                                    This field is required
+                                </div>
+                            </div>
+                        </div>
+                        
+                        <div class="mb-3">
                             <label for="new-password">New Password</label>
-                            <input class="form-control" type="password" id="new-password" formControlName="password" required>
+                            <input class="form-control" type="password" id="new-password" formControlName="password">
                             <div id="password-validations" class="invalid-feedback" *ngIf="passwordChangeForm.dirty || passwordChangeForm.touched">
                                 <div *ngIf="password?.errors?.required">
                                     This field is required
@@ -293,7 +303,7 @@
                         </div>
                         <div class="mb-3">
                             <label for="confirm-password">Confirm Password</label>
-                            <input class="form-control" type="password" id="confirm-password" formControlName="confirmPassword" aria-describedby="password-validations" required>
+                            <input class="form-control" type="password" id="confirm-password" formControlName="confirmPassword" aria-describedby="password-validations">
                             <div id="password-validations" class="invalid-feedback" *ngIf="passwordChangeForm.dirty || passwordChangeForm.touched">
                                 <div *ngIf="!passwordsMatch">
                                     Passwords must match

--- a/UI/Web/src/app/user-settings/user-preferences/user-preferences.component.ts
+++ b/UI/Web/src/app/user-settings/user-preferences/user-preferences.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnDestroy, OnInit } from '@angular/core';
-import { UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { ToastrService } from 'ngx-toastr';
 import { map, shareReplay, take, takeUntil } from 'rxjs/operators';
 import { Title } from '@angular/platform-browser';
@@ -36,8 +36,8 @@ export class UserPreferencesComponent implements OnInit, OnDestroy {
   bookColorThemes = bookColorThemes;
   pageLayoutModes = pageLayoutModes;
 
-  settingsForm: UntypedFormGroup = new UntypedFormGroup({});
-  passwordChangeForm: UntypedFormGroup = new UntypedFormGroup({});
+  settingsForm: FormGroup = new FormGroup({});
+  passwordChangeForm: FormGroup = new FormGroup({});
   user: User | undefined = undefined;
   hasChangePasswordAbility: Observable<boolean> = of(false);
 
@@ -112,32 +112,36 @@ export class UserPreferencesComponent implements OnInit, OnDestroy {
         this.user.preferences.bookReaderFontFamily = 'default';
       }
 
-      this.settingsForm.addControl('readingDirection', new UntypedFormControl(this.user.preferences.readingDirection, []));
-      this.settingsForm.addControl('scalingOption', new UntypedFormControl(this.user.preferences.scalingOption, []));
-      this.settingsForm.addControl('pageSplitOption', new UntypedFormControl(this.user.preferences.pageSplitOption, []));
-      this.settingsForm.addControl('autoCloseMenu', new UntypedFormControl(this.user.preferences.autoCloseMenu, []));
-      this.settingsForm.addControl('showScreenHints', new UntypedFormControl(this.user.preferences.showScreenHints, []));
-      this.settingsForm.addControl('readerMode', new UntypedFormControl(this.user.preferences.readerMode, []));
-      this.settingsForm.addControl('layoutMode', new UntypedFormControl(this.user.preferences.layoutMode, []));
-      this.settingsForm.addControl('bookReaderFontFamily', new UntypedFormControl(this.user.preferences.bookReaderFontFamily, []));
-      this.settingsForm.addControl('bookReaderFontSize', new UntypedFormControl(this.user.preferences.bookReaderFontSize, []));
-      this.settingsForm.addControl('bookReaderLineSpacing', new UntypedFormControl(this.user.preferences.bookReaderLineSpacing, []));
-      this.settingsForm.addControl('bookReaderMargin', new UntypedFormControl(this.user.preferences.bookReaderMargin, []));
-      this.settingsForm.addControl('bookReaderReadingDirection', new UntypedFormControl(this.user.preferences.bookReaderReadingDirection, []));
-      this.settingsForm.addControl('bookReaderTapToPaginate', new UntypedFormControl(!!this.user.preferences.bookReaderTapToPaginate, []));
-      this.settingsForm.addControl('bookReaderLayoutMode', new UntypedFormControl(this.user.preferences.bookReaderLayoutMode || BookPageLayoutMode.Default, []));
-      this.settingsForm.addControl('bookReaderThemeName', new UntypedFormControl(this.user?.preferences.bookReaderThemeName || bookColorThemes[0].name, []));
-      this.settingsForm.addControl('bookReaderImmersiveMode', new UntypedFormControl(this.user?.preferences.bookReaderImmersiveMode, []));
+      this.settingsForm.addControl('readingDirection', new FormControl(this.user.preferences.readingDirection, []));
+      this.settingsForm.addControl('scalingOption', new FormControl(this.user.preferences.scalingOption, []));
+      this.settingsForm.addControl('pageSplitOption', new FormControl(this.user.preferences.pageSplitOption, []));
+      this.settingsForm.addControl('autoCloseMenu', new FormControl(this.user.preferences.autoCloseMenu, []));
+      this.settingsForm.addControl('showScreenHints', new FormControl(this.user.preferences.showScreenHints, []));
+      this.settingsForm.addControl('readerMode', new FormControl(this.user.preferences.readerMode, []));
+      this.settingsForm.addControl('layoutMode', new FormControl(this.user.preferences.layoutMode, []));
+      this.settingsForm.addControl('bookReaderFontFamily', new FormControl(this.user.preferences.bookReaderFontFamily, []));
+      this.settingsForm.addControl('bookReaderFontSize', new FormControl(this.user.preferences.bookReaderFontSize, []));
+      this.settingsForm.addControl('bookReaderLineSpacing', new FormControl(this.user.preferences.bookReaderLineSpacing, []));
+      this.settingsForm.addControl('bookReaderMargin', new FormControl(this.user.preferences.bookReaderMargin, []));
+      this.settingsForm.addControl('bookReaderReadingDirection', new FormControl(this.user.preferences.bookReaderReadingDirection, []));
+      this.settingsForm.addControl('bookReaderTapToPaginate', new FormControl(!!this.user.preferences.bookReaderTapToPaginate, []));
+      this.settingsForm.addControl('bookReaderLayoutMode', new FormControl(this.user.preferences.bookReaderLayoutMode || BookPageLayoutMode.Default, []));
+      this.settingsForm.addControl('bookReaderThemeName', new FormControl(this.user?.preferences.bookReaderThemeName || bookColorThemes[0].name, []));
+      this.settingsForm.addControl('bookReaderImmersiveMode', new FormControl(this.user?.preferences.bookReaderImmersiveMode, []));
 
-      this.settingsForm.addControl('theme', new UntypedFormControl(this.user.preferences.theme, []));
-      this.settingsForm.addControl('globalPageLayoutMode', new UntypedFormControl(this.user.preferences.globalPageLayoutMode, []));
-      this.settingsForm.addControl('blurUnreadSummaries', new UntypedFormControl(this.user.preferences.blurUnreadSummaries, []));
-      this.settingsForm.addControl('promptForDownloadSize', new UntypedFormControl(this.user.preferences.promptForDownloadSize, []));
+      this.settingsForm.addControl('theme', new FormControl(this.user.preferences.theme, []));
+      this.settingsForm.addControl('globalPageLayoutMode', new FormControl(this.user.preferences.globalPageLayoutMode, []));
+      this.settingsForm.addControl('blurUnreadSummaries', new FormControl(this.user.preferences.blurUnreadSummaries, []));
+      this.settingsForm.addControl('promptForDownloadSize', new FormControl(this.user.preferences.promptForDownloadSize, []));
+
       this.cdRef.markForCheck();
     });
 
-    this.passwordChangeForm.addControl('password', new UntypedFormControl('', [Validators.required]));
-    this.passwordChangeForm.addControl('confirmPassword', new UntypedFormControl('', [Validators.required]));
+    this.passwordChangeForm.addControl('password', new FormControl('', [Validators.required]));
+    this.passwordChangeForm.addControl('confirmPassword', new FormControl('', [Validators.required]));
+    this.passwordChangeForm.addControl('oldPassword', new FormControl('', [Validators.required]));
+
+    
 
     this.observableHandles.push(this.passwordChangeForm.valueChanges.subscribe(() => {
       const values = this.passwordChangeForm.value;
@@ -189,6 +193,7 @@ export class UserPreferencesComponent implements OnInit, OnDestroy {
   resetPasswordForm() {
     this.passwordChangeForm.get('password')?.setValue('');
     this.passwordChangeForm.get('confirmPassword')?.setValue('');
+    this.passwordChangeForm.get('oldPassword')?.setValue('');
     this.resetPasswordErrors = [];
     this.cdRef.markForCheck();
   }
@@ -235,7 +240,7 @@ export class UserPreferencesComponent implements OnInit, OnDestroy {
 
     const model = this.passwordChangeForm.value;
     this.resetPasswordErrors = [];
-    this.observableHandles.push(this.accountService.resetPassword(this.user?.username, model.confirmPassword).subscribe(() => {
+    this.observableHandles.push(this.accountService.resetPassword(this.user?.username, model.confirmPassword, model.oldPassword).subscribe(() => {
       this.toastr.success('Password has been updated');
       this.resetPasswordForm();
     }, err => {

--- a/UI/Web/src/app/want-to-read/want-to-read/want-to-read.component.html
+++ b/UI/Web/src/app/want-to-read/want-to-read/want-to-read.component.html
@@ -17,8 +17,8 @@
         [pagination]="seriesPagination"
         [filterSettings]="filterSettings"
         [filterOpen]="filterOpen"
-        [parentScroll]="scrollingBlock"
         [jumpBarKeys]="jumpbarKeys"
+        [trackByIdentity]="trackByIdentity"
         (applyFilter)="updateFilter($event)">
         <ng-template #cardItem let-item let-position="idx">
             <app-series-card [data]="item" [libraryId]="item.libraryId" (reload)="loadPage()"

--- a/UI/Web/src/app/want-to-read/want-to-read/want-to-read.component.scss
+++ b/UI/Web/src/app/want-to-read/want-to-read/want-to-read.component.scss
@@ -1,0 +1,13 @@
+.virtual-scroller, virtual-scroller {
+    width: 100%;
+    height: calc(100vh - 85px);
+    max-height: calc(var(--vh)*100 - 170px);
+  }
+  
+  // This is responsible for ensuring we scroll down and only tabs and companion bar is visible
+  .main-container {
+    // Height set dynamically by  get ScrollingBlockHeight()
+    overflow-y: auto;
+    position: relative;
+    overscroll-behavior-y: none;
+  }

--- a/UI/Web/src/app/want-to-read/want-to-read/want-to-read.component.ts
+++ b/UI/Web/src/app/want-to-read/want-to-read/want-to-read.component.ts
@@ -2,7 +2,7 @@ import { DOCUMENT } from '@angular/common';
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, EventEmitter, HostListener, Inject, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 import { Router, ActivatedRoute } from '@angular/router';
-import { Subject, take, pipe, debounceTime, takeUntil } from 'rxjs';
+import { Subject, take, debounceTime, takeUntil } from 'rxjs';
 import { BulkSelectionService } from 'src/app/cards/bulk-selection.service';
 import { FilterSettings } from 'src/app/metadata-filter/filter-settings';
 import { FilterUtilitiesService } from 'src/app/shared/_services/filter-utilities.service';
@@ -45,6 +45,7 @@ export class WantToReadComponent implements OnInit, OnDestroy {
  
 
   private onDestory: Subject<void> = new Subject<void>();
+  trackByIdentity = (index: number, item: Series) => `${item.name}_${item.localizedName}_${item.pagesRead}`;
 
   bulkActionCallback = (action: Action, data: any) => {
     const selectedSeriesIndexies = this.bulkSelectionService.getSelectedCardsForSource('series');
@@ -55,7 +56,6 @@ export class WantToReadComponent implements OnInit, OnDestroy {
         this.actionService.removeMultipleSeriesFromWantToReadList(selectedSeries.map(s => s.id), () => {
           this.bulkSelectionService.deselectAll();
           this.loadPage();
-          this.cdRef.markForCheck();
         });
         break;
     }

--- a/build.sh
+++ b/build.sh
@@ -27,12 +27,12 @@ ProgressEnd()
 
 UpdateVersionNumber()
 {
-  # TODO: Enhance this to increment version number in KavitaCommon.csproj
+  # TODO: Read from KavitaCommon and update in Info.plist
     if [ "$KAVITAVERSION" != "" ]; then
         echo "Updating Version Info"
         sed -i'' -e "s/<AssemblyVersion>[0-9.*]\+<\/AssemblyVersion>/<AssemblyVersion>$KAVITAVERSION<\/AssemblyVersion>/g" src/Directory.Build.props
         sed -i'' -e "s/<AssemblyConfiguration>[\$()A-Za-z-]\+<\/AssemblyConfiguration>/<AssemblyConfiguration>${BUILD_SOURCEBRANCHNAME}<\/AssemblyConfiguration>/g" src/Directory.Build.props
-#        sed -i'' -e "s/<string>10.0.0.0<\/string>/<string>$KAVITAVERSION<\/string>/g" macOS/Kavita.app/Contents/Info.plist
+        sed -i'' -e "s/<string>10.0.0.0<\/string>/<string>$KAVITAVERSION<\/string>/g" macOS/Kavita.app/Contents/Info.plist
     fi
 }
 
@@ -87,8 +87,8 @@ Package()
     echo dotnet publish -c Release --self-contained --runtime $runtime -o "$lOutputFolder" --framework $framework
     dotnet publish -c Release --self-contained --runtime $runtime -o "$lOutputFolder" --framework $framework
 
-    echo "Recopying wwwroot due to bug"
-    cp -R ./wwwroot/* $lOutputFolder/wwwroot
+    #echo "Recopying wwwroot due to bug"
+    #cp -R ./wwwroot/* $lOutputFolder/wwwroot
 
     echo "Copying Install information"
     cp ../INSTALL.txt "$lOutputFolder"/README.txt
@@ -105,7 +105,9 @@ Package()
     fi
 
     echo "Copying appsettings.json"
-    cp config/appsettings.Development.json $lOutputFolder/config/appsettings.json
+    cp config/appsettings.json $lOutputFolder/config/appsettings.json
+    echo "Removing appsettings.Development.json"
+    rm $lOutputFolder/config/appsettings.Development.json
 
     echo "Creating tar"
     cd ../$outputFolder/"$runtime"/
@@ -117,8 +119,6 @@ Package()
 
 }
 
-
-#UpdateVersionNumber
 
 RID="$1"
 


### PR DESCRIPTION
# Added
- Added: Added Jump bar to reading list page

# Changed
- Changed: Downgraded Docnet to 2.4.0-alpha2 which is the version with our patches that enable pdfs to work on ARMx64 (Fixes #1393)
- Changed: Updated all but one API in collection control to admin only policy
- Changed: Updated some headers on Kavita to tighten security
- Changed: Tightened up cover upload to restrict more APIs to the admin
- Changed: Resetting your own password now requires you to pass your current password (if already authenticated). Admins can still change passwords for the user without this restriction.
- Changed: Removed an additional copy in the build script and changed a copy to use appsettings.json from build rather than development.json

# Fixed
- Fixed: Fixed a regression from hotfix where bookmarks were not able to load due to a missing [AllowAnonymous]
- Fixed: Fixed a bug where some config folders wouldn't be created on first load (Fixes #1408 )
- Fixed: Fixed a regression which broke Plugins (and Tachiyomi) from authenticating
- Fixed: Fixed up the caching for images when doing the cover reset flow. Chrome-based browsers do not respect cache-control headers and require a hard refresh for new cover images to show. (develop)
- Fixed: Fixed a bug where clicking on a Jump key wouldn't go exactly to the selected letter (Fixes #1404 )
- Fixed: Fixed a bug where . wasn't being included in # JumpKey
- Fixed: Fixed a bug where the add to reading list modal would overflow and make create button hidden
- Fixed: Remove from Want to Read wasn't working (Fixes #1424 )
- Fixed: Fixed some inconsistencies with clearing multiple series of bookmarks in one go by building a dedicated api (Fixes #1403 )
- Fixed: Fixed a bad naming case for reading list items where it was just a volume (Fixes #1396)
- Fixed: Fixed a bug where there could be duplicate scrollbars on pages with virtual scroller (Fixes #1401 )