### PR TITLE
Pre-Shakeout

### DIFF
--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -18,10 +18,9 @@ jobs:
             fetch-depth: 0
 
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v2
         with:
-          include-prerelease: True
-          dotnet-version: '6.0'
+            dotnet-version: 6.0.x
 
       - name: Install dependencies
         run: dotnet restore
@@ -47,10 +46,9 @@ jobs:
             fetch-depth: 0
 
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v2
         with:
-          include-prerelease: True
-          dotnet-version: '6.0'
+            dotnet-version: 6.0.x
 
       - name: Install dependencies
         run: dotnet restore
@@ -106,10 +104,9 @@ jobs:
           fetch-depth: 0
 
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v2
         with:
-            include-prerelease: True
-            dotnet-version: '6.0'
+            dotnet-version: 6.0.x
 
       - name: Install dependencies
         run: dotnet restore
@@ -118,10 +115,11 @@ jobs:
         run: dotnet build --configuration Release --no-restore
 
       - name: Bump versions
-        uses: ThomasEg/dotnet-bump-version@patch-1
+        uses: SiqiLu/dotnet-bump-version@2.0.0
         with:
           version_files: Kavita.Common/Kavita.Common.csproj
           github_token: ${{ secrets.REPO_GHA_PAT }}
+          version_mask: "0.0.0.1"
 
   develop:
     name: Build Nightly Docker if Develop push
@@ -193,10 +191,9 @@ jobs:
         run: echo "${{steps.get-version.outputs.assembly-version}}"
 
       - name: Compile dotnet app
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v2
         with:
-          include-prerelease: True
-          dotnet-version: '6.0'
+            dotnet-version: 6.0.x
       - run: ./monorepo-build.sh
 
       - name: Login to Docker Hub
@@ -307,10 +304,9 @@ jobs:
         id: parse-version
 
       - name: Compile dotnet app
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v2
         with:
-          include-prerelease: True
-          dotnet-version: '6.0'
+            dotnet-version: 6.0.x
       - run: ./monorepo-build.sh
 
       - name: Login to Docker Hub

--- a/API/Services/MetadataService.cs
+++ b/API/Services/MetadataService.cs
@@ -316,11 +316,8 @@ public class MetadataService : IMetadataService
 
         await RemoveAbandonedMetadataKeys();
 
-        if (_unitOfWork.HasChanges() && await _unitOfWork.CommitAsync())
-        {
-            await _eventHub.SendMessageAsync(MessageFactory.CoverUpdate, MessageFactory.CoverUpdateEvent(series.Id, MessageFactoryEntityTypes.Series), false);
-            await FlushEvents();
-        }
+        await _eventHub.SendMessageAsync(MessageFactory.CoverUpdate, MessageFactory.CoverUpdateEvent(series.Id, MessageFactoryEntityTypes.Series), false);
+        await FlushEvents();
 
         _logger.LogInformation("[MetadataService] Updated metadata for {SeriesName} in {ElapsedMilliseconds} milliseconds", series.Name, sw.ElapsedMilliseconds);
     }
@@ -328,6 +325,7 @@ public class MetadataService : IMetadataService
     private async Task FlushEvents()
     {
         // Send all events out now that entities are saved
+        _logger.LogDebug("Dispatching {Count} update events", _updateEvents.Count);
         foreach (var updateEvent in _updateEvents)
         {
             await _eventHub.SendMessageAsync(MessageFactory.CoverUpdate, updateEvent, false);

--- a/Kavita.Common/Kavita.Common.csproj
+++ b/Kavita.Common/Kavita.Common.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net6.0</TargetFramework>
         <Company>kavitareader.com</Company>
         <Product>Kavita</Product>
-        <AssemblyVersion>0.5.5.0</AssemblyVersion>
+        <AssemblyVersion>0.5.4.21</AssemblyVersion>
         <NeutralLanguage>en</NeutralLanguage>
     </PropertyGroup>
 

--- a/UI/Web/src/app/admin/manage-settings/manage-settings.component.ts
+++ b/UI/Web/src/app/admin/manage-settings/manage-settings.component.ts
@@ -89,7 +89,7 @@ export class ManageSettingsComponent implements OnInit {
     modalRef.componentInstance.startingFolder = existingDirectory || '';
     modalRef.componentInstance.helpUrl = '';
     modalRef.closed.subscribe((closeResult: DirectoryPickerResult) => {
-      if (closeResult.success) {
+      if (closeResult.success && closeResult.folderPath !== '') {
         this.settingsForm.get(formControl)?.setValue(closeResult.folderPath);
         this.settingsForm.markAsTouched();
       }

--- a/UI/Web/src/theme/components/_accordion.scss
+++ b/UI/Web/src/theme/components/_accordion.scss
@@ -21,6 +21,7 @@
     &:not(.collapsed) {
         color: var(--accordion-header-text-color); 
         background-color: var(--accordion-body-bg-color);
+        box-shadow: var(--accordion-body-box-shadow);
     }
 
     &.collapsed {

--- a/UI/Web/src/theme/components/_dropdown.scss
+++ b/UI/Web/src/theme/components/_dropdown.scss
@@ -14,7 +14,3 @@
         }
     }
 }
-
-.dropdown {
-    z-index: 1055 !important; // ngb v12 bug: https://github.com/ng-bootstrap/ng-bootstrap/issues/2686
-}

--- a/UI/Web/src/theme/themes/dark.scss
+++ b/UI/Web/src/theme/themes/dark.scss
@@ -162,6 +162,7 @@
     --accordion-button-focus-border-color: unset;
     --accordion-button-focus-box-shadow: unset;
     --accordion-active-body-bg-color: #292929;
+    --accordion-body-box-shadow: none;
 
     /* Breadcrumb */
     --breadcrumb-bg-color: #292d32;

--- a/UI/Web/src/theme/themes/light.scss
+++ b/UI/Web/src/theme/themes/light.scss
@@ -164,6 +164,7 @@
     --accordion-button-focus-border-color: unset;
     --accordion-button-focus-box-shadow: unset;
     --accordion-active-body-bg-color: #292929;
+    --accordion-body-box-shadow: none;
 
     /* Breadcrumb */
     --breadcrumb-bg-color: #292d32;


### PR DESCRIPTION
# Fixed
- Fixed: Fixed some z-index issues due to a bug on bootstrap finally being fixed. 
- Fixed: Fixed a bug where scan series, when generating new covers, wouldn't emit cover updates to the UI
- Fixed: Fixed an issue where opening directory picker to change bookmark directory and hitting Share without changing anything, would blank out the bookmark directory field. 
- Fixed: Summaries wouldn't be blurred if they were less than 250 characters. (Fixes #1397 )
- Fixed: Custom css themes wouldn't load after Hotfix
- Fixed: On fresh installs, check if the Server Settings table exists so we don't dump an error on startup
