### PR TITLE
File Created Date

### DIFF
--- a/API/DTOs/MangaFileDto.cs
+++ b/API/DTOs/MangaFileDto.cs
@@ -1,4 +1,5 @@
-﻿using API.Entities.Enums;
+﻿using System;
+using API.Entities.Enums;
 
 namespace API.DTOs
 {
@@ -8,6 +9,7 @@ namespace API.DTOs
         public string FilePath { get; init; }
         public int Pages { get; init; }
         public MangaFormat Format { get; init; }
+        public DateTime Created { get; init; }
 
     }
 }

--- a/API/Data/Migrations/20220814134725_MangaFileCreatedDate.Designer.cs
+++ b/API/Data/Migrations/20220814134725_MangaFileCreatedDate.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using API.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace API.Data.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20220814134725_MangaFileCreatedDate")]
+    partial class MangaFileCreatedDate
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "6.0.7");

--- a/API/Data/Migrations/20220814134725_MangaFileCreatedDate.cs
+++ b/API/Data/Migrations/20220814134725_MangaFileCreatedDate.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace API.Data.Migrations
+{
+    public partial class MangaFileCreatedDate : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "Created",
+                table: "MangaFile",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Created",
+                table: "MangaFile");
+        }
+    }
+}

--- a/API/Entities/MangaFile.cs
+++ b/API/Entities/MangaFile.cs
@@ -2,13 +2,14 @@
 using System;
 using System.IO;
 using API.Entities.Enums;
+using API.Entities.Interfaces;
 
 namespace API.Entities
 {
     /// <summary>
     /// Represents a wrapper to the underlying file. This provides information around file, like number of pages, format, etc.
     /// </summary>
-    public class MangaFile
+    public class MangaFile : IEntityDate
     {
         public int Id { get; set; }
         /// <summary>
@@ -20,6 +21,9 @@ namespace API.Entities
         /// </summary>
         public int Pages { get; set; }
         public MangaFormat Format { get; set; }
+        /// <inheritdoc cref="IEntityDate.Created"/>
+        public DateTime Created { get; set; }
+
         /// <summary>
         /// Last time underlying file was modified
         /// </summary>

--- a/API/Program.cs
+++ b/API/Program.cs
@@ -105,6 +105,7 @@ namespace API
             string currentVersion = null;
             try
             {
+                if (!await context.ServerSetting.AnyAsync()) return "vUnknown";
                 currentVersion =
                     (await context.ServerSetting.SingleOrDefaultAsync(s =>
                         s.Key == ServerSettingKey.InstallVersion))?.Value;

--- a/API/Services/Tasks/SiteThemeService.cs
+++ b/API/Services/Tasks/SiteThemeService.cs
@@ -6,6 +6,7 @@ using API.Entities;
 using API.Entities.Enums.Theme;
 using API.SignalR;
 using Kavita.Common;
+using Microsoft.AspNetCore.Authorization;
 
 namespace API.Services.Tasks;
 
@@ -34,6 +35,7 @@ public class ThemeService : IThemeService
     /// </summary>
     /// <param name="themeId"></param>
     /// <returns></returns>
+    [AllowAnonymous]
     public async Task<string> GetContent(int themeId)
     {
         var theme = await _unitOfWork.SiteThemeRepository.GetThemeDto(themeId);

--- a/UI/Web/src/app/_models/manga-file.ts
+++ b/UI/Web/src/app/_models/manga-file.ts
@@ -5,4 +5,5 @@ export interface MangaFile {
     filePath: string;
     pages: number;
     format: MangaFormat;
+    created: string;
 }

--- a/UI/Web/src/app/cards/card-detail-drawer/card-detail-drawer.component.html
+++ b/UI/Web/src/app/cards/card-detail-drawer/card-detail-drawer.component.html
@@ -143,7 +143,15 @@
                                                 Pages: {{file.pages | number:''}}
                                             </div>
                                             <div class="col" *ngIf="data.hasOwnProperty('created')">
-                                                Added: {{(data.created | date: 'short') || '-'}}
+                                                Added: 
+                                                <!-- TODO: This data.created can be removed after v0.5.5 release -->
+                                                <ng-container *ngIf="file.created == '0001-01-01T00:00:00'; else fileDate">
+                                                    {{(data.created | date: 'short') || '-'}}
+                                                </ng-container>
+                                                <ng-template #fileDate>
+                                                    {{(file.created | date: 'short') || '-'}}
+                                                </ng-template>
+                                                
                                             </div>
                                         </div>
                                     </li>

--- a/UI/Web/src/app/cards/list-item/list-item.component.ts
+++ b/UI/Web/src/app/cards/list-item/list-item.component.ts
@@ -1,12 +1,11 @@
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
 import { ToastrService } from 'ngx-toastr';
-import { finalize, map, Observable, Subject, take, takeWhile, takeUntil } from 'rxjs';
+import { map, Observable, Subject, takeUntil } from 'rxjs';
 import { Download } from 'src/app/shared/_models/download';
 import { DownloadEvent, DownloadService } from 'src/app/shared/_services/download.service';
 import { UtilityService } from 'src/app/shared/_services/utility.service';
 import { Chapter } from 'src/app/_models/chapter';
 import { LibraryType } from 'src/app/_models/library';
-import { Series } from 'src/app/_models/series';
 import { RelationKind } from 'src/app/_models/series-detail/relation-kind';
 import { Volume } from 'src/app/_models/volume';
 import { Action, ActionItem } from 'src/app/_services/action-factory.service';

--- a/UI/Web/src/app/shared/read-more/read-more.component.ts
+++ b/UI/Web/src/app/shared/read-more/read-more.component.ts
@@ -30,10 +30,11 @@ export class ReadMoreComponent implements OnChanges {
     this.isCollapsed = !this.isCollapsed;
     this.determineView();
   }
+
   determineView() {
     if (!this.text || this.text.length <= this.maxLength) {
         this.currentText = this.text;
-        this.isCollapsed = false;
+        this.isCollapsed = true;
         this.hideToggle = true;
         return;
     }


### PR DESCRIPTION
# Fixed
- Fixed: Fixed a bug where UI was showing Chapter created date for files instead of file created. This fix introduced a new field so will not show for existing files.
- Fixed: Summaries wouldn't be blurred if they were less than 250 characters. (Fixes #1397 ) (these were not in last release)
- Fixed: Custom css themes wouldn't load after Hotfix (these were not in last release)
- Fixed: On fresh installs, check if the Server Settings table exists so we don't dump an error on startup (these were not in last release)

