### PR TITLE
Folder Watching

### DIFF
--- a/API.Tests/Parser/ParserTest.cs
+++ b/API.Tests/Parser/ParserTest.cs
@@ -223,7 +223,7 @@ namespace API.Tests.Parser
         [InlineData("/manga/1/1/1", "/manga/1/1/1")]
         [InlineData("/manga/1/1/1.jpg", "/manga/1/1/1.jpg")]
         [InlineData(@"/manga/1/1\1.jpg", @"/manga/1/1/1.jpg")]
-        [InlineData("/manga/1/1//1", "/manga/1/1//1")]
+        [InlineData("/manga/1/1//1", "/manga/1/1/1")]
         [InlineData("/manga/1\\1\\1", "/manga/1/1/1")]
         [InlineData("C:/manga/1\\1\\1.jpg", "C:/manga/1/1/1.jpg")]
         public void NormalizePathTest(string inputPath, string expected)

--- a/API.Tests/Services/DirectoryServiceTests.cs
+++ b/API.Tests/Services/DirectoryServiceTests.cs
@@ -677,6 +677,7 @@ namespace API.Tests.Services
         [InlineData(new [] {"C:/Manga/"}, new [] {"C:/Manga/Love Hina/Vol. 01.cbz"}, "C:/Manga/Love Hina")]
         [InlineData(new [] {"C:/Manga/Dir 1/", "c://Manga/Dir 2/"}, new [] {"C:/Manga/Dir 1/Love Hina/Vol. 01.cbz"}, "C:/Manga/Dir 1/Love Hina")]
         [InlineData(new [] {"C:/Manga/Dir 1/", "c://Manga/"}, new [] {"D:/Manga/Love Hina/Vol. 01.cbz", "D:/Manga/Vol. 01.cbz"}, "")]
+        [InlineData(new [] {"C:/Manga/"}, new [] {"C:/Manga//Love Hina/Vol. 01.cbz"}, "C:/Manga/Love Hina")]
         public void FindHighestDirectoriesFromFilesTest(string[] rootDirectories, string[] files, string expectedDirectory)
         {
             var fileSystem = new MockFileSystem();

--- a/API/DTOs/ScanFolderDto.cs
+++ b/API/DTOs/ScanFolderDto.cs
@@ -1,0 +1,17 @@
+﻿namespace API.DTOs;
+
+/// <summary>
+/// DTO for requesting a folder to be scanned
+/// </summary>
+public class ScanFolderDto
+{
+    /// <summary>
+    /// Api key for a user with Admin permissions
+    /// </summary>
+    public string ApiKey { get; set; }
+    /// <summary>
+    /// Folder Path to Scan
+    /// </summary>
+    /// <remarks>JSON cannot accept /, so you may need to use // escaping on paths</remarks>
+    public string FolderPath { get; set; }
+}

--- a/API/DTOs/Settings/ServerSettingDTO.cs
+++ b/API/DTOs/Settings/ServerSettingDTO.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using API.Services;
+﻿using API.Services;
 
 namespace API.DTOs.Settings
 {
@@ -43,7 +42,9 @@ namespace API.DTOs.Settings
         /// Represents a unique Id to this Kavita installation. Only used in Stats to identify unique installs.
         /// </summary>
         public string InstallId { get; set; }
-
+        /// <summary>
+        /// If the server should save bookmarks as WebP encoding
+        /// </summary>
         public bool ConvertBookmarkToWebP { get; set; }
         /// <summary>
         /// If the Swagger UI Should be exposed. Does not require authentication, but does require a JWT.
@@ -55,5 +56,9 @@ namespace API.DTOs.Settings
         /// </summary>
         /// <remarks>Value should be between 1 and 30</remarks>
         public int TotalBackups { get; set; } = 30;
+        /// <summary>
+        /// If Kavita should watch the library folders and process changes
+        /// </summary>
+        public bool EnableFolderWatching { get; set; } = true;
     }
 }

--- a/API/Data/Seed.cs
+++ b/API/Data/Seed.cs
@@ -103,6 +103,7 @@ namespace API.Data
                 new() {Key = ServerSettingKey.ConvertBookmarkToWebP, Value = "false"},
                 new() {Key = ServerSettingKey.EnableSwaggerUi, Value = "false"},
                 new() {Key = ServerSettingKey.TotalBackups, Value = "30"},
+                new() {Key = ServerSettingKey.EnableFolderWatching, Value = "true"},
             }.ToArray());
 
             foreach (var defaultSetting in DefaultSettings)

--- a/API/Entities/Enums/ServerSettingKey.cs
+++ b/API/Entities/Enums/ServerSettingKey.cs
@@ -91,5 +91,10 @@ namespace API.Entities.Enums
         /// </summary>
         [Description("TotalBackups")]
         TotalBackups = 16,
+        /// <summary>
+        /// If Kavita should watch the library folders and process changes
+        /// </summary>
+        [Description("EnableFolderWatching")]
+        EnableFolderWatching = 17,
     }
 }

--- a/API/Helpers/Converters/ServerSettingConverter.cs
+++ b/API/Helpers/Converters/ServerSettingConverter.cs
@@ -60,6 +60,9 @@ namespace API.Helpers.Converters
                     case ServerSettingKey.InstallId:
                         destination.InstallId = row.Value;
                         break;
+                    case ServerSettingKey.EnableFolderWatching:
+                        destination.EnableFolderWatching = bool.Parse(row.Value);
+                        break;
                 }
             }
 

--- a/API/Parser/Parser.cs
+++ b/API/Parser/Parser.cs
@@ -1074,7 +1074,8 @@ namespace API.Parser
         /// <returns></returns>
         public static string NormalizePath(string path)
         {
-            return path.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            return path.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+                .Replace(@"//", Path.AltDirectorySeparatorChar + string.Empty);
         }
 
         /// <summary>

--- a/API/Services/DirectoryService.cs
+++ b/API/Services/DirectoryService.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
@@ -560,7 +560,7 @@ namespace API.Services
        {
             try
             {
-                return Parser.Parser.NormalizePath(Directory.GetParent(fileOrFolder).FullName);
+                return Parser.Parser.NormalizePath(Directory.GetParent(fileOrFolder)?.FullName);
             }
             catch (Exception)
             {

--- a/API/Services/DirectoryService.cs
+++ b/API/Services/DirectoryService.cs
@@ -511,7 +511,7 @@ namespace API.Services
                    var fullPath = Path.Join(folder, parts.Last());
                    if (!dirs.ContainsKey(fullPath))
                    {
-                       dirs.Add(fullPath, string.Empty);
+                       dirs.Add(Parser.Parser.NormalizePath(fullPath), string.Empty);
                    }
                }
            }

--- a/API/Services/TaskScheduler.cs
+++ b/API/Services/TaskScheduler.cs
@@ -19,6 +19,7 @@ public interface ITaskScheduler
     Task ScheduleTasks();
     Task ScheduleStatsTasks();
     void ScheduleUpdaterTasks();
+    void ScanFolder(string folderPath);
     void ScanLibrary(int libraryId, bool force = false);
     void CleanupChapters(int[] chapterIds);
     void RefreshMetadata(int libraryId, bool forceUpdate = true);
@@ -161,6 +162,12 @@ public class TaskScheduler : ITaskScheduler
         // Schedule update check between noon and 6pm local time
         RecurringJob.AddOrUpdate("check-updates", () => CheckForUpdate(), Cron.Daily(Rnd.Next(12, 18)), TimeZoneInfo.Local);
     }
+
+    public void ScanFolder(string folderPath)
+    {
+        _scannerService.ScanFolder(Parser.Parser.NormalizePath(folderPath));
+    }
+
     #endregion
 
     public void ScanLibraries()

--- a/API/Services/Tasks/Scanner/LibraryWatcher.cs
+++ b/API/Services/Tasks/Scanner/LibraryWatcher.cs
@@ -144,7 +144,9 @@ public class LibraryWatcher : ILibraryWatcher
     private void OnDeleted(object sender, FileSystemEventArgs e) {
         Console.WriteLine($"Deleted: {e.FullPath}, {e.Name}");
 
-        ProcessChange(e.FullPath, !_directoryService.FileSystem.File.Exists(e.Name));
+        // On deletion, we need another type of check. We need to check if e.Name has an extension or not
+        // NOTE: File deletion will trigger a folder change event, so this might not be needed
+        ProcessChange(e.FullPath, string.IsNullOrEmpty(_directoryService.FileSystem.Path.GetExtension(e.Name)));
     }
 
 

--- a/API/Services/Tasks/Scanner/LibraryWatcher.cs
+++ b/API/Services/Tasks/Scanner/LibraryWatcher.cs
@@ -138,12 +138,13 @@ public class LibraryWatcher : ILibraryWatcher
     private void OnCreated(object sender, FileSystemEventArgs e)
     {
         Console.WriteLine($"Created: {e.FullPath}, {e.Name}");
-        ProcessChange(e.FullPath);
+        ProcessChange(e.FullPath, !_directoryService.FileSystem.File.Exists(e.Name));
     }
 
     private void OnDeleted(object sender, FileSystemEventArgs e) {
         Console.WriteLine($"Deleted: {e.FullPath}, {e.Name}");
-        ProcessChange(e.FullPath);
+
+        ProcessChange(e.FullPath, !_directoryService.FileSystem.File.Exists(e.Name));
     }
 
 
@@ -153,12 +154,18 @@ public class LibraryWatcher : ILibraryWatcher
         Console.WriteLine($"Renamed:");
         Console.WriteLine($"    Old: {e.OldFullPath}");
         Console.WriteLine($"    New: {e.FullPath}");
-        ProcessChange(e.FullPath);
+        ProcessChange(e.FullPath, _directoryService.FileSystem.Directory.Exists(e.FullPath));
     }
 
-    private void ProcessChange(string filePath)
+    /// <summary>
+    /// Processes the file or folder change.
+    /// </summary>
+    /// <param name="filePath">File or folder that changed</param>
+    /// <param name="isDirectoryChange">If the change is on a directory and not a file</param>
+    private void ProcessChange(string filePath, bool isDirectoryChange = false)
     {
-        if (!new Regex(Parser.Parser.SupportedExtensions).IsMatch(new FileInfo(filePath).Extension)) return;
+        // We need to check if directory or not
+        if (!isDirectoryChange &&  !new Regex(Parser.Parser.SupportedExtensions).IsMatch(new FileInfo(filePath).Extension)) return;
         // Don't do anything if a Library or ScanSeries in progress
         if (TaskScheduler.RunningAnyTasksByMethod(new[] {"MetadataService", "ScannerService"}))
         {

--- a/API/Services/Tasks/Scanner/LibraryWatcher.cs
+++ b/API/Services/Tasks/Scanner/LibraryWatcher.cs
@@ -169,11 +169,12 @@ public class LibraryWatcher : ILibraryWatcher
         // We need to check if directory or not
         if (!isDirectoryChange &&  !new Regex(Parser.Parser.SupportedExtensions).IsMatch(new FileInfo(filePath).Extension)) return;
         // Don't do anything if a Library or ScanSeries in progress
-        if (TaskScheduler.RunningAnyTasksByMethod(new[] {"MetadataService", "ScannerService"}))
-        {
-            _logger.LogDebug("Suppressing Change due to scan being inprogress");
-            return;
-        }
+        // if (TaskScheduler.RunningAnyTasksByMethod(new[] {"MetadataService", "ScannerService"}))
+        // {
+        //     // NOTE: I'm not sure we need this to be honest. Now with the speed of the new loop and the queue, we should just put in queue for processing
+        //     _logger.LogDebug("Suppressing Change due to scan being inprogress");
+        //     return;
+        // }
 
 
         var parentDirectory = _directoryService.GetParentDirectoryName(filePath);

--- a/API/Services/Tasks/Scanner/LibraryWatcher.cs
+++ b/API/Services/Tasks/Scanner/LibraryWatcher.cs
@@ -22,6 +22,11 @@ public interface ILibraryWatcher
     /// Stop watching all folders
     /// </summary>
     void StopWatching();
+    /// <summary>
+    /// Essentially stops then starts watching. Useful if there is a change in folders or libraries
+    /// </summary>
+    /// <returns></returns>
+    Task RestartWatching();
 }
 
 internal class FolderScanQueueable
@@ -126,6 +131,12 @@ public class LibraryWatcher : ILibraryWatcher
             fileSystemWatcher.Dispose();
         }
         _watcherDictionary.Clear();
+    }
+
+    public async Task RestartWatching()
+    {
+        StopWatching();
+        await StartWatching();
     }
 
     private void OnChanged(object sender, FileSystemEventArgs e)

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -100,8 +100,6 @@ public class ScannerService : IScannerService
     [Queue(TaskScheduler.ScanQueue)]
     public async Task ScanFolder(string folder)
     {
-        // NOTE: I might want to move a lot of this code to the LibraryWatcher or something and just pack libraryId and seriesId
-        // Validate if we are scanning a new series (that belongs to a library) or an existing series
         var seriesId = await _unitOfWork.SeriesRepository.GetSeriesIdByFolder(folder);
         if (seriesId > 0)
         {

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -109,6 +109,7 @@ public class ScannerService : IScannerService
             return;
         }
 
+        // This is basically rework of what's already done in Library Watcher but is needed if invoked via API
         var parentDirectory = _directoryService.GetParentDirectoryName(folder);
         if (string.IsNullOrEmpty(parentDirectory)) return; // This should never happen as it's calculated before enqueing
 

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -455,6 +455,8 @@ public class ScannerService : IScannerService
                 Format = parsedFiles.First().Format
             };
 
+            // NOTE: Could we check if there are multiple found series (different series) and process each one? 
+
             if (skippedScan)
             {
                 seenSeries.AddRange(parsedFiles.Select(pf => new ParsedSeries()

--- a/UI/Web/src/app/admin/_models/server-settings.ts
+++ b/UI/Web/src/app/admin/_models/server-settings.ts
@@ -12,4 +12,5 @@ export interface ServerSettings {
     convertBookmarkToWebP: boolean;
     enableSwaggerUi: boolean;
     totalBackups: number;
+    enableFolderWatching: boolean;
 }

--- a/UI/Web/src/app/admin/manage-settings/manage-settings.component.html
+++ b/UI/Web/src/app/admin/manage-settings/manage-settings.component.html
@@ -83,6 +83,15 @@
                 <label for="opds" class="form-check-label">Enable OPDS</label>
             </div>
         </div>
+
+        <div class="mb-3">
+            <label for="folder-watching" class="form-label" aria-describedby="folder-watching-info">Folder Watching</label>
+            <p class="accent" id="folder-watching-info">Allows Kavita to monitor Library Folders to detect changes and invoke scanning on those changes. This allows content to be updated without manually invoking scans or waiting for nightly scans.</p>
+            <div class="form-check form-switch">
+                <input id="folder-watching" type="checkbox" class="form-check-input" formControlName="enableFolderWatching" role="switch">
+                <label for="folder-watching" class="form-check-label">Enable Folder Watching</label>
+            </div>
+        </div>
     
         <div class="col-auto d-flex d-md-block justify-content-sm-center text-md-end">
             <button type="button" class="flex-fill btn btn-secondary me-2" (click)="resetToDefaults()">Reset to Default</button>

--- a/UI/Web/src/app/admin/manage-settings/manage-settings.component.ts
+++ b/UI/Web/src/app/admin/manage-settings/manage-settings.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { UntypedFormGroup, UntypedFormControl, Validators } from '@angular/forms';
+import { FormGroup, Validators, FormControl } from '@angular/forms';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { ToastrService } from 'ngx-toastr';
 import { take } from 'rxjs/operators';
@@ -16,7 +16,7 @@ import { ServerSettings } from '../_models/server-settings';
 export class ManageSettingsComponent implements OnInit {
 
   serverSettings!: ServerSettings;
-  settingsForm: UntypedFormGroup = new UntypedFormGroup({});
+  settingsForm: FormGroup = new FormGroup({});
   taskFrequencies: Array<string> = [];
   logLevels: Array<string> = [];
 
@@ -32,18 +32,19 @@ export class ManageSettingsComponent implements OnInit {
     });
     this.settingsService.getServerSettings().pipe(take(1)).subscribe((settings: ServerSettings) => {
       this.serverSettings = settings;
-      this.settingsForm.addControl('cacheDirectory', new UntypedFormControl(this.serverSettings.cacheDirectory, [Validators.required]));
-      this.settingsForm.addControl('bookmarksDirectory', new UntypedFormControl(this.serverSettings.bookmarksDirectory, [Validators.required]));
-      this.settingsForm.addControl('taskScan', new UntypedFormControl(this.serverSettings.taskScan, [Validators.required]));
-      this.settingsForm.addControl('taskBackup', new UntypedFormControl(this.serverSettings.taskBackup, [Validators.required]));
-      this.settingsForm.addControl('port', new UntypedFormControl(this.serverSettings.port, [Validators.required]));
-      this.settingsForm.addControl('loggingLevel', new UntypedFormControl(this.serverSettings.loggingLevel, [Validators.required]));
-      this.settingsForm.addControl('allowStatCollection', new UntypedFormControl(this.serverSettings.allowStatCollection, [Validators.required]));
-      this.settingsForm.addControl('enableOpds', new UntypedFormControl(this.serverSettings.enableOpds, [Validators.required]));
-      this.settingsForm.addControl('baseUrl', new UntypedFormControl(this.serverSettings.baseUrl, [Validators.required]));
-      this.settingsForm.addControl('emailServiceUrl', new UntypedFormControl(this.serverSettings.emailServiceUrl, [Validators.required]));
-      this.settingsForm.addControl('enableSwaggerUi', new UntypedFormControl(this.serverSettings.enableSwaggerUi, [Validators.required]));
-      this.settingsForm.addControl('totalBackups', new UntypedFormControl(this.serverSettings.totalBackups, [Validators.required, Validators.min(1), Validators.max(30)]));
+      this.settingsForm.addControl('cacheDirectory', new FormControl(this.serverSettings.cacheDirectory, [Validators.required]));
+      this.settingsForm.addControl('bookmarksDirectory', new FormControl(this.serverSettings.bookmarksDirectory, [Validators.required]));
+      this.settingsForm.addControl('taskScan', new FormControl(this.serverSettings.taskScan, [Validators.required]));
+      this.settingsForm.addControl('taskBackup', new FormControl(this.serverSettings.taskBackup, [Validators.required]));
+      this.settingsForm.addControl('port', new FormControl(this.serverSettings.port, [Validators.required]));
+      this.settingsForm.addControl('loggingLevel', new FormControl(this.serverSettings.loggingLevel, [Validators.required]));
+      this.settingsForm.addControl('allowStatCollection', new FormControl(this.serverSettings.allowStatCollection, [Validators.required]));
+      this.settingsForm.addControl('enableOpds', new FormControl(this.serverSettings.enableOpds, [Validators.required]));
+      this.settingsForm.addControl('baseUrl', new FormControl(this.serverSettings.baseUrl, [Validators.required]));
+      this.settingsForm.addControl('emailServiceUrl', new FormControl(this.serverSettings.emailServiceUrl, [Validators.required]));
+      this.settingsForm.addControl('enableSwaggerUi', new FormControl(this.serverSettings.enableSwaggerUi, [Validators.required]));
+      this.settingsForm.addControl('totalBackups', new FormControl(this.serverSettings.totalBackups, [Validators.required, Validators.min(1), Validators.max(30)]));
+      this.settingsForm.addControl('enableFolderWatching', new FormControl(this.serverSettings.enableFolderWatching, [Validators.required]));
     });
   }
 
@@ -60,6 +61,7 @@ export class ManageSettingsComponent implements OnInit {
     this.settingsForm.get('emailServiceUrl')?.setValue(this.serverSettings.emailServiceUrl);
     this.settingsForm.get('enableSwaggerUi')?.setValue(this.serverSettings.enableSwaggerUi);
     this.settingsForm.get('totalBackups')?.setValue(this.serverSettings.totalBackups);
+    this.settingsForm.get('enableFolderWatching')?.setValue(this.serverSettings.enableFolderWatching);
     this.settingsForm.markAsPristine();
   }
 


### PR DESCRIPTION
# Added
- Added: Kavita now comes out of the box with Folder Watching for libraries. This means that when any sort of event occurs, like new files, file/folder renames, deletions, etc, Kavita will queue a task to scan those changes into the system. By default, tasks will only be processed every 10 mins. This is currently set for a trial period and may change before final release. 
- Added: Kavita now comes with a new API for library/scan-folder and takes the API key (with admin permissions) and a folder path. 

Closes #1304 