### PR TITLE
Tachiyomi + Fixes

### DIFF
--- a/API.Tests/Parser/BookParserTests.cs
+++ b/API.Tests/Parser/BookParserTests.cs
@@ -7,6 +7,7 @@ namespace API.Tests.Parser
         [Theory]
         [InlineData("Gifting The Wonderful World With Blessings! - 3 Side Stories [yuNS][Unknown]", "Gifting The Wonderful World With Blessings!")]
         [InlineData("BBC Focus 00 The Science of Happiness 2nd Edition (2018)", "BBC Focus 00 The Science of Happiness 2nd Edition")]
+        [InlineData("Faust - Volume 01 [Del Rey][Scans_Compressed]", "Faust")]
         public void ParseSeriesTest(string filename, string expected)
         {
             Assert.Equal(expected, API.Parser.Parser.ParseSeries(filename));
@@ -14,6 +15,7 @@ namespace API.Tests.Parser
 
         [Theory]
         [InlineData("Harrison, Kim - Dates from Hell - Hollows Vol 2.5.epub", "2.5")]
+        [InlineData("Faust - Volume 01 [Del Rey][Scans_Compressed]", "1")]
         public void ParseVolumeTest(string filename, string expected)
         {
             Assert.Equal(expected, API.Parser.Parser.ParseVolume(filename));

--- a/API/Controllers/TachiyomiController.cs
+++ b/API/Controllers/TachiyomiController.cs
@@ -49,9 +49,8 @@ public class TachiyomiController : BaseApiController
         // If prevChapterId is -1, this means either nothing is read or everything is read.
         if (prevChapterId == -1)
         {
-            var userWithProgress = await _unitOfWork.UserRepository.GetUserByIdAsync(userId, AppUserIncludes.Progress);
-            var userHasProgress =
-                userWithProgress.Progresses.Any(x => x.SeriesId == seriesId);
+            var series = await _unitOfWork.SeriesRepository.GetSeriesDtoByIdAsync(seriesId, userId);
+            var userHasProgress = series.PagesRead == 0 || series.PagesRead < series.Pages;
 
             // If the user doesn't have progress, then return null, which the extension will catch as 204 (no content) and report nothing as read
             if (!userHasProgress) return null;
@@ -75,7 +74,8 @@ public class TachiyomiController : BaseApiController
         // There is progress, we now need to figure out the highest volume or chapter and return that.
         var prevChapter = await _unitOfWork.ChapterRepository.GetChapterDtoAsync(prevChapterId);
         var volumeWithProgress = await _unitOfWork.VolumeRepository.GetVolumeDtoAsync(prevChapter.VolumeId, userId);
-        if (volumeWithProgress.Number != 0)
+        // We only encode for single-file volumes
+        if (volumeWithProgress.Number != 0 && volumeWithProgress.Chapters.Count == 1)
         {
             // The progress is on a volume, encode it as a fake chapterDTO
             return Ok(new ChapterDto()

--- a/API/Parser/DefaultParser.cs
+++ b/API/Parser/DefaultParser.cs
@@ -52,9 +52,9 @@ public class DefaultParser : IDefaultParser
         {
             ret = new ParserInfo()
             {
-                Chapters = type == LibraryType.Manga ? Parser.ParseChapter(fileName) : Parser.ParseComicChapter(fileName),
-                Series = type == LibraryType.Manga ? Parser.ParseSeries(fileName) : Parser.ParseComicSeries(fileName),
-                Volumes = type == LibraryType.Manga ? Parser.ParseVolume(fileName) : Parser.ParseComicVolume(fileName),
+                Chapters = type == LibraryType.Comic ? Parser.ParseComicChapter(fileName) : Parser.ParseChapter(fileName),
+                Series = type == LibraryType.Comic ? Parser.ParseComicSeries(fileName) : Parser.ParseSeries(fileName),
+                Volumes = type == LibraryType.Comic ? Parser.ParseComicVolume(fileName) : Parser.ParseVolume(fileName),
                 Filename = Path.GetFileName(filePath),
                 Format = Parser.ParseFormat(filePath),
                 Title = Path.GetFileNameWithoutExtension(fileName),

--- a/API/Services/Tasks/Scanner/LibraryWatcher.cs
+++ b/API/Services/Tasks/Scanner/LibraryWatcher.cs
@@ -200,7 +200,7 @@ public class LibraryWatcher : ILibraryWatcher
         };
         if (!_scanQueue.Contains(queueItem, _folderScanQueueableComparer))
         {
-            _logger.LogDebug("[LibraryWatcher] Queuing job for {Folder}", fullPath);
+            _logger.LogDebug("[LibraryWatcher] Queuing job for {Folder} at {TimeStamp}", fullPath, DateTime.Now);
             _scanQueue.Enqueue(queueItem);
         }
 
@@ -221,12 +221,12 @@ public class LibraryWatcher : ILibraryWatcher
                 _logger.LogDebug("[LibraryWatcher] Scheduling ScanSeriesFolder for {Folder}", item.FolderPath);
                 BackgroundJob.Enqueue(() => _scannerService.ScanFolder(item.FolderPath));
                 _scanQueue.Dequeue();
-                i++;
             }
             else
             {
-                break;
+                i++;
             }
+
         }
 
         if (_scanQueue.Count > 0)

--- a/API/Services/Tasks/Scanner/ProcessSeries.cs
+++ b/API/Services/Tasks/Scanner/ProcessSeries.cs
@@ -170,7 +170,7 @@ public class ProcessSeries : IProcessSeries
 
                     await _eventHub.SendMessageAsync(MessageFactory.Error,
                         MessageFactory.ErrorEvent($"There was an issue writing to the DB for Series {series}",
-                            string.Empty));
+                            ex.Message));
                 }
             }
         }

--- a/API/Services/Tasks/Scanner/ProcessSeries.cs
+++ b/API/Services/Tasks/Scanner/ProcessSeries.cs
@@ -157,18 +157,21 @@ public class ProcessSeries : IProcessSeries
             series.LastFolderScanned = DateTime.Now;
             _unitOfWork.SeriesRepository.Attach(series);
 
-            try
+            if (_unitOfWork.HasChanges())
             {
-                await _unitOfWork.CommitAsync();
-            }
-            catch (Exception ex)
-            {
-                await _unitOfWork.RollbackAsync();
-                _logger.LogCritical(ex, "[ScannerService] There was an issue writing to the for series {@SeriesName}", series);
+                try
+                {
+                    await _unitOfWork.CommitAsync();
+                }
+                catch (Exception ex)
+                {
+                    await _unitOfWork.RollbackAsync();
+                    _logger.LogCritical(ex, "[ScannerService] There was an issue writing to the for series {@SeriesName}", series);
 
-                await _eventHub.SendMessageAsync(MessageFactory.Error,
-                    MessageFactory.ErrorEvent($"There was an issue writing to the DB for Series {series}",
-                        string.Empty));
+                    await _eventHub.SendMessageAsync(MessageFactory.Error,
+                        MessageFactory.ErrorEvent($"There was an issue writing to the DB for Series {series}",
+                            string.Empty));
+                }
             }
         }
         catch (Exception ex)

--- a/UI/Web/src/app/collections/collection-detail/collection-detail.component.html
+++ b/UI/Web/src/app/collections/collection-detail/collection-detail.component.html
@@ -29,6 +29,7 @@
         [filterSettings]="filterSettings"
         [filterOpen]="filterOpen"
         [parentScroll]="scrollingBlock"
+        [trackByIdentity]="trackByIdentity"
         [jumpBarKeys]="jumpbarKeys"
         (applyFilter)="updateFilter($event)">
         <ng-template #cardItem let-item let-position="idx">

--- a/UI/Web/src/app/collections/collection-detail/collection-detail.component.ts
+++ b/UI/Web/src/app/collections/collection-detail/collection-detail.component.ts
@@ -53,6 +53,7 @@ export class CollectionDetailComponent implements OnInit, OnDestroy, AfterConten
   jumpbarKeys: Array<JumpKey> = [];
 
   filterOpen: EventEmitter<boolean> = new EventEmitter();
+  trackByIdentity = (index: number, item: Series) => `${item.name}_${item.localizedName}_${item.pagesRead}`;
  
 
   private onDestory: Subject<void> = new Subject<void>();

--- a/UI/Web/src/theme/components/_modal.scss
+++ b/UI/Web/src/theme/components/_modal.scss
@@ -1,7 +1,3 @@
-.modal {
-    z-index: 1056; // ngb v12 bug: https://github.com/ng-bootstrap/ng-bootstrap/issues/2686
-}
-
 .modal-content {
     background-color: var(--bs-body-bg);
     color: var(--body-text-color);


### PR DESCRIPTION
# Changed
- Changed: When parsing non-epubs in Book library, use Manga parsing instead of Comic, to better support Light Novels (Closes #1478 )

# Fixed
- Fixed: Fixed a bug with stacked modals not showing overlay (Fixes #1469 )
- Fixed: Fixed repeating images on collection detail (again) (Fixes #1464 )
- Fixed: Fixed up some logic in the folder watching which wasn't processing all of the queue (develop)
- Fixed: API changes to support some changes in Tachiyomi around progress syncing

