### PR TITLE
SQLite Hangfire 

### DIFF
--- a/API/API.csproj
+++ b/API/API.csproj
@@ -54,6 +54,7 @@
     <PackageReference Include="Hangfire.AspNetCore" Version="1.7.30" />
     <PackageReference Include="Hangfire.MaximumConcurrentExecutions" Version="1.1.0" />
     <PackageReference Include="Hangfire.MemoryStorage.Core" Version="1.4.0" />
+    <PackageReference Include="Hangfire.Storage.SQLite" Version="0.3.2" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.43" />
     <PackageReference Include="MarkdownDeep.NET.Core" Version="1.5.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.7" />

--- a/API/Services/Tasks/Scanner/LibraryWatcher.cs
+++ b/API/Services/Tasks/Scanner/LibraryWatcher.cs
@@ -115,6 +115,7 @@ public class LibraryWatcher : ILibraryWatcher
             .SelectMany(l => l.Folders)
             .Distinct()
             .Select(Parser.Parser.NormalizePath)
+            .Where(_directoryService.Exists)
             .ToList();
         foreach (var libraryFolder in _libraryFolders)
         {

--- a/API/Startup.cs
+++ b/API/Startup.cs
@@ -17,6 +17,7 @@ using API.Services.Tasks;
 using API.SignalR;
 using Hangfire;
 using Hangfire.MemoryStorage;
+using Hangfire.Storage.SQLite;
 using Kavita.Common;
 using Kavita.Common.EnvironmentInfo;
 using Microsoft.AspNetCore.Builder;
@@ -155,7 +156,7 @@ namespace API
             services.AddHangfire(configuration => configuration
                 .UseSimpleAssemblyNameTypeSerializer()
                 .UseRecommendedSerializerSettings()
-                .UseMemoryStorage());
+                .UseSQLiteStorage());
 
             // Add the processing server as IHostedService
             services.AddHangfireServer(options =>

--- a/UI/Web/src/app/admin/_modals/directory-picker/directory-picker.component.html
+++ b/UI/Web/src/app/admin/_modals/directory-picker/directory-picker.component.html
@@ -57,7 +57,7 @@
     </table>
 </div>
 <div class="modal-footer">
-    <a class="btn btn-icon" *ngIf="helpUrl.length > 0" href="{{helpUrl}}" target="_blank">Help</a>
+    <a class="btn btn-icon" *ngIf="helpUrl.length > 0" href="{{helpUrl}}" target="_blank" rel="noopener noreferrer">Help</a>
     <button type="button" class="btn btn-secondary" (click)="close()">Cancel</button>
     <button type="button" class="btn btn-primary" (click)="share()">Share</button>
 </div>

--- a/UI/Web/src/app/admin/invite-user/invite-user.component.html
+++ b/UI/Web/src/app/admin/invite-user/invite-user.component.html
@@ -6,7 +6,7 @@
 </div>
 <div class="modal-body">
     <p>
-        Invite a user to your server. Enter their email in and we will send them an email to create an account. If you do not want to use our email service, you can <a href="https://wiki.kavitareader.com/en/guides/misc/email" target="_blank" rel="noopener noreferrer">host your own</a> 
+        Invite a user to your server. Enter their email in and we will send them an email to create an account. If you do not want to use our email service, you can <a href="https://wiki.kavitareader.com/en/guides/misc/email" rel="noopener noreferrer" target="_blank" rel="noopener noreferrer">host your own</a> 
         email service or use a fake email (Forgot User will not work). A link will be presented regardless and can be used to setup the email account manually.
     </p>
 
@@ -39,7 +39,7 @@
         <p>You can use the following link below to setup the account for your user or use the copy button. You may need to log out before using the link to register a new user.
             If your server is externally accessible, an email will have been sent to the user and the links can be used by them to finish setting up their account.
         </p>
-        <a class="email-link" href="{{emailLink}}" target="_blank">Setup user's account</a>
+        <a class="email-link" href="{{emailLink}}" target="_blank" rel="noopener noreferrer">Setup user's account</a>
         <app-api-key title="Invite Url" tooltipText="Copy this and paste in a new tab. You may need to log out." [showRefresh]="false" [transform]="makeLink"></app-api-key>
     </ng-container>
 

--- a/UI/Web/src/app/admin/manage-email-settings/manage-email-settings.component.html
+++ b/UI/Web/src/app/admin/manage-email-settings/manage-email-settings.component.html
@@ -2,7 +2,7 @@
     <form [formGroup]="settingsForm" *ngIf="serverSettings !== undefined">
         <h4>Email Services (SMTP)</h4>
         <p>Kavita comes out of the box with an email service to power flows like invite user, forgot password, etc. Emails sent via our service are deleted immediately. You can use your own
-            email service. Set the url of the email service and use the Test button to ensure it works. At any time you can reset to ours. There is no way to disable emails although you are not required to use a 
+            email service, by setting up <a href="https://github.com/Kareadita/KavitaEmail" target="_blank" rel="noopener noreferrer">Kavita Email</a> service. Set the url of the email service and use the Test button to ensure it works. At any time you can reset to ours. There is no way to disable emails although you are not required to use a 
             valid email address for users. Confirmation links will always be saved to logs. Emails will not be sent if you are not accessing Kavita via a publically reachable url.
         </p>
         <div class="mb-3">

--- a/UI/Web/src/app/admin/manage-email-settings/manage-email-settings.component.html
+++ b/UI/Web/src/app/admin/manage-email-settings/manage-email-settings.component.html
@@ -2,8 +2,8 @@
     <form [formGroup]="settingsForm" *ngIf="serverSettings !== undefined">
         <h4>Email Services (SMTP)</h4>
         <p>Kavita comes out of the box with an email service to power flows like invite user, forgot password, etc. Emails sent via our service are deleted immediately. You can use your own
-            email service, by setting up <a href="https://github.com/Kareadita/KavitaEmail" target="_blank" rel="noopener noreferrer">Kavita Email</a> service. Set the url of the email service and use the Test button to ensure it works. At any time you can reset to ours. There is no way to disable emails although you are not required to use a 
-            valid email address for users. Confirmation links will always be saved to logs. Emails will not be sent if you are not accessing Kavita via a publically reachable url.
+            email service, by setting up <a href="https://github.com/Kareadita/KavitaEmail" target="_blank" rel="noopener noreferrer">Kavita Email</a> service. Set the url of the email service and use the Test button to ensure it works. At any time you can reset to the default. There is no way to disable emails although you are not required to use a 
+            valid email address for users. Confirmation links will always be saved to logs and presented in the UI. Emails will not be sent if you are not accessing Kavita via a publically reachable url.
         </p>
         <div class="mb-3">
             <label for="settings-emailservice" class="form-label">Email Service Url</label>&nbsp;<i class="fa fa-info-circle" placement="right" [ngbTooltip]="emailServiceTooltip" role="button" tabindex="0"></i>

--- a/UI/Web/src/app/admin/manage-settings/manage-settings.component.html
+++ b/UI/Web/src/app/admin/manage-settings/manage-settings.component.html
@@ -58,7 +58,7 @@
 
         <div class="mb-3">
             <label for="stat-collection"  class="form-label" aria-describedby="collection-info">Allow Anonymous Usage Collection</label>
-            <p class="accent" id="collection-info">Send anonymous usage data to Kavita's servers. This includes information on certain features used, number of files, OS version, kavita install version, cpu and memory. We will use this information to prioritize features, bug fixes, and preformance tuning. Requires restart to take effect. See <a href="https://wiki.kavitareader.com/en/faq" target="_blank" referrerpolicy="no-refer">wiki</a> for what is collected.</p>
+            <p class="accent" id="collection-info">Send anonymous usage data to Kavita's servers. This includes information on certain features used, number of files, OS version, kavita install version, cpu and memory. We will use this information to prioritize features, bug fixes, and preformance tuning. Requires restart to take effect. See <a href="https://wiki.kavitareader.com/en/faq" rel="noopener noreferrer" target="_blank" referrerpolicy="no-refer">wiki</a> for what is collected.</p>
             <div class="form-check form-switch">
                 <input id="stat-collection" type="checkbox" aria-label="Stat Collection" class="form-check-input" formControlName="allowStatCollection" role="switch">
                 <label for="stat-collection" class="form-check-label">Send Data</label>

--- a/UI/Web/src/app/admin/manage-system/manage-system.component.html
+++ b/UI/Web/src/app/admin/manage-system/manage-system.component.html
@@ -16,26 +16,26 @@
     <div>
         <div class="row">
             <div class="col-4">Home page:</div> 
-            <div class="col"><a href="https://www.kavitareader.com" target="_blank">kavitareader.com</a></div>
+            <div class="col"><a href="https://www.kavitareader.com" target="_blank" rel="noopener noreferrer">kavitareader.com</a></div>
         </div>
         <div class="row">
             <div class="col-4">Wiki:</div> 
-            <div class="col"><a href="https://wiki.kavitareader.com" target="_blank">wiki.kavitareader.com</a></div>
+            <div class="col"><a href="https://wiki.kavitareader.com" target="_blank" rel="noopener noreferrer">wiki.kavitareader.com</a></div>
         </div>
         <div class="row">
             <div class="col-4">Discord:</div> 
-            <div class="col"><a href="https://discord.gg/b52wT37kt7" target="_blank">discord.gg/b52wT37kt7</a></div>
+            <div class="col"><a href="https://discord.gg/b52wT37kt7" target="_blank" rel="noopener noreferrer">discord.gg/b52wT37kt7</a></div>
         </div>
         <div class="row">
             <div class="col-4">Donations:</div> 
-            <div class="col"><a href="https://opencollective.com/kavita" target="_blank">opencollective.com/kavita</a></div>
+            <div class="col"><a href="https://opencollective.com/kavita" target="_blank" rel="noopener noreferrer">opencollective.com/kavita</a></div>
         </div>
         <div class="row">
             <div class="col-4">Source:</div> 
-            <div class="col"><a href="https://github.com/Kareadita/Kavita" target="_blank">github.com/Kareadita/Kavita</a></div>
+            <div class="col"><a href="https://github.com/Kareadita/Kavita" target="_blank" rel="noopener noreferrer">github.com/Kareadita/Kavita</a></div>
         </div>
         <div class="row">
             <div class="col-4">Feature Requests:</div> 
-            <div class="col"><a href="https://feats.kavitareader.com" target="_blank">https://feats.kavitareader.com</a><br/>
+            <div class="col"><a href="https://feats.kavitareader.com" target="_blank" rel="noopener noreferrer">https://feats.kavitareader.com</a><br/>
         </div>      
 </div>

--- a/UI/Web/src/app/admin/manage-users/manage-users.component.ts
+++ b/UI/Web/src/app/admin/manage-users/manage-users.component.ts
@@ -133,7 +133,7 @@ export class ManageUsersComponent implements OnInit, OnDestroy {
           return;
         }
         await this.confirmService.alert(
-          'Please click this link to confirm your email. You must confirm to be able to login. You may need to log out of the current account before clicking. <br/> <a href="' + email + '" target="_blank">' + email + '</a>');
+          'Please click this link to confirm your email. You must confirm to be able to login. You may need to log out of the current account before clicking. <br/> <a href="' + email + '" target="_blank" rel="noopener noreferrer">' + email + '</a>');
 
       });
     });

--- a/UI/Web/src/app/announcements/changelog/changelog.component.html
+++ b/UI/Web/src/app/announcements/changelog/changelog.component.html
@@ -13,8 +13,8 @@
           <pre class="card-text update-body">
             <app-read-more [text]="update.updateBody" [maxLength]="500"></app-read-more>
           </pre>
-          <a *ngIf="!update.isDocker && update.updateVersion === update.currentVersion" href="{{update.updateUrl}}" class="btn disabled btn-{{indx === 0 ? 'primary' : 'secondary'}} float-end" target="_blank">Installed</a>
-          <a *ngIf="!update.isDocker && update.updateVersion !== update.currentVersion" href="{{update.updateUrl}}" class="btn btn-{{indx === 0 ? 'primary' : 'secondary'}} float-end" target="_blank">Download</a>
+          <a *ngIf="!update.isDocker && update.updateVersion === update.currentVersion" href="{{update.updateUrl}}" class="btn disabled btn-{{indx === 0 ? 'primary' : 'secondary'}} float-end" target="_blank" rel="noopener noreferrer">Installed</a>
+          <a *ngIf="!update.isDocker && update.updateVersion !== update.currentVersion" href="{{update.updateUrl}}" class="btn btn-{{indx === 0 ? 'primary' : 'secondary'}} float-end" target="_blank" rel="noopener noreferrer">Download</a>
         </div>
       </div>
   </ng-container>

--- a/UI/Web/src/app/bookmark/bookmarks/bookmarks.component.html
+++ b/UI/Web/src/app/bookmark/bookmarks/bookmarks.component.html
@@ -21,6 +21,6 @@
     </ng-template>
 
     <ng-template #noData>
-        There are no bookmarks. Try creating <a href="https://wiki.kavitareader.com/en/guides/get-started-using-your-library/bookmarks" target="_blank">one&nbsp;<i class="fa fa-external-link-alt" aria-hidden="true"></i></a>.
+        There are no bookmarks. Try creating <a href="https://wiki.kavitareader.com/en/guides/get-started-using-your-library/bookmarks" rel="noopener noreferrer" target="_blank">one&nbsp;<i class="fa fa-external-link-alt" aria-hidden="true"></i></a>.
     </ng-template>
 </app-card-detail-layout>

--- a/UI/Web/src/app/cards/edit-series-relation/edit-series-relation.component.html
+++ b/UI/Web/src/app/cards/edit-series-relation/edit-series-relation.component.html
@@ -1,7 +1,7 @@
 <div class="container-fluid">
 
     <p>
-        Not sure what relationship to add? See our <a href="https://wiki.kavitareader.com/en/guides/get-started-using-your-library/series-relationships" target="_blank" referrerpolicy="no-refer">wiki for hints</a>.
+        Not sure what relationship to add? See our <a href="https://wiki.kavitareader.com/en/guides/get-started-using-your-library/series-relationships" target="_blank" rel="noopener noreferrer" referrerpolicy="no-refer">wiki for hints</a>.
     </p>
 
     <div class="row g-0" *ngIf="relations.length > 0">

--- a/UI/Web/src/app/collections/all-collections/all-collections.component.html
+++ b/UI/Web/src/app/collections/all-collections/all-collections.component.html
@@ -16,6 +16,6 @@
         </ng-template>
 
         <ng-template #noData>
-            There are no collections. Try creating <a href="https://wiki.kavitareader.com/en/guides/get-started-using-your-library/collections" target="_blank">one&nbsp;<i class="fa fa-external-link-alt" aria-hidden="true"></i></a>.
+            There are no collections. Try creating <a href="https://wiki.kavitareader.com/en/guides/get-started-using-your-library/collections" rel="noopener noreferrer" target="_blank">one&nbsp;<i class="fa fa-external-link-alt" aria-hidden="true"></i></a>.
         </ng-template>
 </app-card-detail-layout>

--- a/UI/Web/src/app/reading-list/reading-lists/reading-lists.component.html
+++ b/UI/Web/src/app/reading-list/reading-lists/reading-lists.component.html
@@ -19,6 +19,6 @@
     </ng-template>
 
     <ng-template #noData>
-        There are no reading lists. Try creating <a href="https://wiki.kavitareader.com/en/guides/get-started-using-your-library#reading-list" target="_blank">one&nbsp;<i class="fa fa-external-link-alt" aria-hidden="true"></i></a>.
+        There are no reading lists. Try creating <a href="https://wiki.kavitareader.com/en/guides/get-started-using-your-library#reading-list" rel="noopener noreferrer" target="_blank">one&nbsp;<i class="fa fa-external-link-alt" aria-hidden="true"></i></a>.
     </ng-template>
 </app-card-detail-layout>

--- a/UI/Web/src/app/shared/update-notification/update-notification-modal.component.html
+++ b/UI/Web/src/app/shared/update-notification/update-notification-modal.component.html
@@ -11,5 +11,5 @@
 
 <div class="modal-footer">
     <button type="button" class="btn {{updateData.isDocker ? 'btn-primary' : 'btn-secondary'}}" (click)="close()">Close</button>
-    <a *ngIf="!updateData.isDocker" href="{{updateData.updateUrl}}" class="btn btn-primary" target="_blank" (click)="close()">Download</a>
+    <a *ngIf="!updateData.isDocker" href="{{updateData.updateUrl}}" class="btn btn-primary" target="_blank" rel="noopener noreferrer" (click)="close()">Download</a>
 </div>


### PR DESCRIPTION
# Added
- Added: We now use SQLite for Hangfire data storage. This will allow Tasks screen to show last run times between runs.

# Changed
- Changed: Updated all links that point to external sites to use noopener noreferrer
- Changed: When watching folders, make sure they exist (develop)
- Changed: Updated the Email Service wording to point to the Github for the external email service
