### PR TITLE
Typeahead Fixes 

### DIFF
--- a/UI/Web/src/app/typeahead/typeahead.component.ts
+++ b/UI/Web/src/app/typeahead/typeahead.component.ts
@@ -5,7 +5,6 @@ import { UntypedFormControl, UntypedFormGroup } from '@angular/forms';
 import { Observable, of, ReplaySubject, Subject } from 'rxjs';
 import { auditTime, distinctUntilChanged, filter, map, shareReplay, switchMap, take, takeUntil, tap } from 'rxjs/operators';
 import { KEY_CODES } from '../shared/_services/utility.service';
-import { ToggleService } from '../_services/toggle.service';
 import { SelectionCompareFn, TypeaheadSettings } from './typeahead-settings';
 
 /**
@@ -256,6 +255,7 @@ export class TypeaheadComponent implements OnInit, OnDestroy {
         tap((filteredOptions) => {
           this.isLoadingOptions = false;
           this.focusedIndex = 0;
+          this.cdRef.markForCheck();
           setTimeout(() => {
             this.updateShowAddItem(filteredOptions);
             this.updateHighlight();


### PR DESCRIPTION
# Fixed
- Fixed: Fixed a bug where typeahead wasn't opening after an initial query
- Fixed: Fixed a bug where typeahead was clearing out multiple tags (selections) when typing (Fixes #1439 )
