### PR TITLE
Release Testing Day 1

### DIFF
--- a/API/Controllers/ReaderController.cs
+++ b/API/Controllers/ReaderController.cs
@@ -11,6 +11,7 @@ using API.Entities;
 using API.Entities.Enums;
 using API.Extensions;
 using API.Services;
+using API.Services.Tasks;
 using Hangfire;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;

--- a/API/DTOs/Reader/BookmarkDto.cs
+++ b/API/DTOs/Reader/BookmarkDto.cs
@@ -1,11 +1,17 @@
-﻿namespace API.DTOs.Reader
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace API.DTOs.Reader
 {
     public class BookmarkDto
     {
         public int Id { get; set; }
+        [Required]
         public int Page { get; set; }
+        [Required]
         public int VolumeId { get; set; }
+        [Required]
         public int SeriesId { get; set; }
+        [Required]
         public int ChapterId { get; set; }
     }
 }

--- a/API/Services/MetadataService.cs
+++ b/API/Services/MetadataService.cs
@@ -44,6 +44,7 @@ public interface IMetadataService
 
 public class MetadataService : IMetadataService
 {
+    public const string Name = "MetadataService";
     private readonly IUnitOfWork _unitOfWork;
     private readonly ILogger<MetadataService> _logger;
     private readonly IEventHub _eventHub;

--- a/API/Services/Tasks/CleanupService.cs
+++ b/API/Services/Tasks/CleanupService.cs
@@ -127,16 +127,18 @@ namespace API.Services.Tasks
         }
 
         /// <summary>
-        /// Removes all files and directories in the cache directory
+        /// Removes all files and directories in the cache and temp directory
         /// </summary>
         public void CleanupCacheDirectory()
         {
             _logger.LogInformation("Performing cleanup of Cache directory");
             _directoryService.ExistOrCreate(_directoryService.CacheDirectory);
+            _directoryService.ExistOrCreate(_directoryService.TempDirectory);
 
             try
             {
                 _directoryService.ClearDirectory(_directoryService.CacheDirectory);
+                _directoryService.ClearDirectory(_directoryService.TempDirectory);
             }
             catch (Exception ex)
             {

--- a/API/Services/Tasks/CleanupService.cs
+++ b/API/Services/Tasks/CleanupService.cs
@@ -20,6 +20,7 @@ namespace API.Services.Tasks
         Task DeleteChapterCoverImages();
         Task DeleteTagCoverImages();
         Task CleanupBackups();
+        void CleanupTemp();
     }
     /// <summary>
     /// Cleans up after operations on reoccurring basis
@@ -176,6 +177,23 @@ namespace API.Services.Tasks
                 _directoryService.DeleteFiles(expiredBackups.Select(f => f.FullName));
             }
             _logger.LogInformation("Finished cleanup of Database backups at {Time}", DateTime.Now);
+        }
+
+        public void CleanupTemp()
+        {
+            _logger.LogInformation("Performing cleanup of Temp directory");
+            _directoryService.ExistOrCreate(_directoryService.TempDirectory);
+
+            try
+            {
+                _directoryService.ClearDirectory(_directoryService.TempDirectory);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "There was an issue deleting one or more folders/files during cleanup");
+            }
+
+            _logger.LogInformation("Temp directory purged");
         }
     }
 }

--- a/API/Services/Tasks/Scanner/ParseScannedFiles.cs
+++ b/API/Services/Tasks/Scanner/ParseScannedFiles.cs
@@ -289,12 +289,19 @@ namespace API.Services.Tasks.Scanner
             await _eventHub.SendMessageAsync(MessageFactory.NotificationProgress, MessageFactory.FileScanProgressEvent("File Scan Done", libraryName, ProgressEventType.Ended));
         }
 
+        /// <summary>
+        /// Checks against all folder paths on file if the last scanned is >= the directory's last write down to the second
+        /// </summary>
+        /// <param name="seriesPaths"></param>
+        /// <param name="normalizedFolder"></param>
+        /// <param name="forceCheck"></param>
+        /// <returns></returns>
         private bool HasSeriesFolderNotChangedSinceLastScan(IDictionary<string, IList<SeriesModified>> seriesPaths, string normalizedFolder, bool forceCheck = false)
         {
             if (forceCheck) return false;
 
-            return seriesPaths.ContainsKey(normalizedFolder) && seriesPaths[normalizedFolder].All(f => f.LastScanned.Truncate(TimeSpan.TicksPerMinute) >=
-                _directoryService.GetLastWriteTime(normalizedFolder).Truncate(TimeSpan.TicksPerMinute));
+            return seriesPaths.ContainsKey(normalizedFolder) && seriesPaths[normalizedFolder].All(f => f.LastScanned.Truncate(TimeSpan.TicksPerSecond) >=
+                _directoryService.GetLastWriteTime(normalizedFolder).Truncate(TimeSpan.TicksPerSecond));
         }
 
         /// <summary>

--- a/API/Services/Tasks/Scanner/ProcessSeries.cs
+++ b/API/Services/Tasks/Scanner/ProcessSeries.cs
@@ -375,6 +375,13 @@ public class ProcessSeries : IProcessSeries
             }
         }
 
+        var genres = chapters.SelectMany(c => c.Genres).ToList();
+        GenreHelper.KeepOnlySameGenreBetweenLists(series.Metadata.Genres.ToList(), genres, genre =>
+        {
+            if (series.Metadata.GenresLocked) return;
+            series.Metadata.Genres.Remove(genre);
+        });
+
         // NOTE: The issue here is that people is just from chapter, but series metadata might already have some people on it
         // I might be able to filter out people that are in locked fields?
         var people = chapters.SelectMany(c => c.People).ToList();

--- a/API/Startup.cs
+++ b/API/Startup.cs
@@ -273,13 +273,14 @@ namespace API
 
             app.Use(async (context, next) =>
             {
-                context.Response.GetTypedHeaders().CacheControl =
-                    new Microsoft.Net.Http.Headers.CacheControlHeaderValue()
-                    {
-                        Public = false,
-                        MaxAge = TimeSpan.FromSeconds(10),
-                    };
-                context.Response.Headers[Microsoft.Net.Http.Headers.HeaderNames.Vary] =
+                // Note: I removed this as I caught Chrome caching api responses when it shouldn't have
+                // context.Response.GetTypedHeaders().CacheControl =
+                //     new CacheControlHeaderValue()
+                //     {
+                //         Public = false,
+                //         MaxAge = TimeSpan.FromSeconds(10),
+                //     };
+                context.Response.Headers[HeaderNames.Vary] =
                     new[] { "Accept-Encoding" };
 
                 // Don't let the site be iframed outside the same origin (clickjacking)

--- a/UI/Web/src/app/cards/edit-series-relation/edit-series-relation.component.html
+++ b/UI/Web/src/app/cards/edit-series-relation/edit-series-relation.component.html
@@ -12,7 +12,7 @@
     <form>
         <div class="row g-0 mb-3" *ngFor="let relation of relations; let idx = index; let isLast = last;">
             <div class="col-sm-12 col-md-7">
-                <app-typeahead (selectedData)="updateSeries($event, relation)" [settings]="relation.typeaheadSettings" id="relation--{{idx}}">
+                <app-typeahead (selectedData)="updateSeries($event, relation)" [settings]="relation.typeaheadSettings" id="relation--{{idx}}" [focus]="focusTypeahead">
                     <ng-template #badgeItem let-item let-position="idx">
                         {{item.name}} ({{libraryNames[item.libraryId]}})
                     </ng-template>

--- a/UI/Web/src/app/cards/edit-series-relation/edit-series-relation.component.ts
+++ b/UI/Web/src/app/cards/edit-series-relation/edit-series-relation.component.ts
@@ -100,14 +100,8 @@ export class EditSeriesRelationComponent implements OnInit, OnDestroy {
 
     // Focus on the new typeahead
     setTimeout(() => {
-      //const typeahead = this.relations.map(item => item.typeaheadSettings).filter(setting => setting.id === `relation--${this.relations.length - 1}`);
-      //const typeahead = document.querySelector(`#relation--${this.relations.length - 1} .typeahead-input`) as HTMLInputElement;
-      //console.log('typeahead: ', typeahead);
       this.focusTypeahead.emit(`relation--${this.relations.length - 1}`);
-      
-      //if (typeahead) typeahead.focus();
     }, 10);
-
   }
 
   removeRelation(index: number) {
@@ -171,7 +165,7 @@ export class EditSeriesRelationComponent implements OnInit, OnDestroy {
     const alternativeVersions = this.relations.filter(item => (parseInt(item.formControl.value, 10) as RelationKind) === RelationKind.AlternativeVersion && item.series !== undefined).map(item => item.series!.id);
     const doujinshis = this.relations.filter(item => (parseInt(item.formControl.value, 10) as RelationKind) === RelationKind.Doujinshi && item.series !== undefined).map(item => item.series!.id);
     
-    // TODO: We can actually emit this onto an observable and in main parent, use mergeMap into the forkJoin
+    // NOTE: We can actually emit this onto an observable and in main parent, use mergeMap into the forkJoin
     this.seriesService.updateRelationships(this.series.id, adaptations, characters, contains, others, prequels, sequels, sideStories, spinOffs, alternativeSettings, alternativeVersions, doujinshis).subscribe(() => {});
     
   }

--- a/UI/Web/src/app/reading-list/reading-list-item/reading-list-item.component.ts
+++ b/UI/Web/src/app/reading-list/reading-list-item/reading-list-item.component.ts
@@ -42,7 +42,12 @@ export class ReadingListItemComponent implements OnInit {
     }
 
     if (item.seriesFormat === MangaFormat.EPUB) {
-      this.title = 'Volume ' + this.utilityService.cleanSpecialTitle(item.chapterNumber);
+      const specialTitle = this.utilityService.cleanSpecialTitle(item.chapterNumber);
+      if (specialTitle === '0') {
+        this.title = 'Volume ' + this.utilityService.cleanSpecialTitle(item.volumeNumber);
+      } else {
+        this.title = 'Volume ' + specialTitle;
+      }
     }
 
     let chapterNum = item.chapterNumber;

--- a/UI/Web/src/app/series-detail/series-detail.component.ts
+++ b/UI/Web/src/app/series-detail/series-detail.component.ts
@@ -504,6 +504,9 @@ export class SeriesDetailComponent implements OnInit, OnDestroy, AfterContentChe
         if (this.relations.length > 0) {
           this.hasRelations = true;
           this.changeDetectionRef.markForCheck();
+        } else {
+          this.hasRelations = false;
+          this.changeDetectionRef.markForCheck();
         }
       });
 

--- a/UI/Web/src/app/typeahead/typeahead.component.ts
+++ b/UI/Web/src/app/typeahead/typeahead.component.ts
@@ -168,6 +168,10 @@ export class TypeaheadComponent implements OnInit, OnDestroy {
    * If disabled, a user will not be able to interact with the typeahead
    */
   @Input() disabled: boolean = false;
+  /**
+   * When triggered, will focus the input if the passed string matches the id
+   */
+  @Input() focus: EventEmitter<string> | undefined;
   @Output() selectedData = new EventEmitter<any[] | any>();
   @Output() newItemAdded = new EventEmitter<any[] | any>();
   @Output() onUnlock = new EventEmitter<void>();
@@ -202,6 +206,13 @@ export class TypeaheadComponent implements OnInit, OnDestroy {
       this.clearSelections(resetToEmpty);
       this.init();
     });
+
+    if (this.focus) {
+      this.focus.pipe(takeUntil(this.onDestroy)).subscribe((id: string) => {
+        if (this.settings.id !== id) return;
+        this.onInputFocus();
+      });
+    }
 
     this.init();
   }


### PR DESCRIPTION
# Changed
- Changed: Tweaked the code which checks if a modification occurred to check check at the second level, rather than minute. 
- Changed: Clear cache will now clear temp directory as well, to clear out bookmark and downloads. 
- Changed: When a library is in progress and a user tries to delete the library, tell them to wait before we let them

# Fixed
- Fixed: Fixed a bug where typeahead wouldn't automatically show results on relationship screen without an additional click
- Fixed: Fixed an issue where Chrome was caching api responses when it shouldn't had, thus causing some apis to return invalid data after a modification
- Fixed: Genres weren't being removed from a series after they got removed from comicinfo in the underlying chapters
- Fixed: Fixed a bug where all epubs with a volume would show as Volume 0 in reading lists

