### PR TITLE
Release Testing Day 3

### DIFF
--- a/API/Controllers/TachiyomiController.cs
+++ b/API/Controllers/TachiyomiController.cs
@@ -50,7 +50,7 @@ public class TachiyomiController : BaseApiController
         if (prevChapterId == -1)
         {
             var series = await _unitOfWork.SeriesRepository.GetSeriesDtoByIdAsync(seriesId, userId);
-            var userHasProgress = series.PagesRead == 0 || series.PagesRead < series.Pages;
+            var userHasProgress = series.PagesRead != 0 && series.PagesRead < series.Pages;
 
             // If the user doesn't have progress, then return null, which the extension will catch as 204 (no content) and report nothing as read
             if (!userHasProgress) return null;

--- a/API/Controllers/ThemeController.cs
+++ b/API/Controllers/ThemeController.cs
@@ -51,6 +51,7 @@ public class ThemeController : BaseApiController
     /// Returns css content to the UI. UI is expected to escape the content
     /// </summary>
     /// <returns></returns>
+    [AllowAnonymous]
     [HttpGet("download-content")]
     public async Task<ActionResult<string>> GetThemeContent(int themeId)
     {

--- a/API/Data/Repositories/SeriesRepository.cs
+++ b/API/Data/Repositories/SeriesRepository.cs
@@ -122,7 +122,7 @@ public interface ISeriesRepository
     Task<Series> GetSeriesByFolderPath(string folder);
     Task<Series> GetFullSeriesByName(string series, int libraryId);
     Task<Series> GetFullSeriesByAnyName(string seriesName, string localizedName, int libraryId, MangaFormat format, bool withFullIncludes = true);
-    Task RemoveSeriesNotInList(IList<ParsedSeries> seenSeries, int libraryId);
+    Task<List<Series>> RemoveSeriesNotInList(IList<ParsedSeries> seenSeries, int libraryId);
     Task<IDictionary<string, IList<SeriesModified>>> GetFolderPathMap(int libraryId);
 }
 
@@ -1273,9 +1273,9 @@ public class SeriesRepository : ISeriesRepository
     /// </summary>
     /// <param name="seenSeries"></param>
     /// <param name="libraryId"></param>
-    public async Task RemoveSeriesNotInList(IList<ParsedSeries> seenSeries, int libraryId)
+    public async Task<List<Series>> RemoveSeriesNotInList(IList<ParsedSeries> seenSeries, int libraryId)
     {
-        if (seenSeries.Count == 0) return;
+        if (seenSeries.Count == 0) return new List<Series>();
         var ids = new List<int>();
         foreach (var parsedSeries in seenSeries)
         {
@@ -1288,7 +1288,6 @@ public class SeriesRepository : ISeriesRepository
             {
                 ids.Add(series);
             }
-
         }
 
         var seriesToRemove = await _context.Series
@@ -1297,6 +1296,8 @@ public class SeriesRepository : ISeriesRepository
             .ToListAsync();
 
         _context.Series.RemoveRange(seriesToRemove);
+
+        return seriesToRemove;
     }
 
     public async Task<PagedList<SeriesDto>> GetHighlyRated(int userId, int libraryId, UserParams userParams)

--- a/API/Data/Repositories/SeriesRepository.cs
+++ b/API/Data/Repositories/SeriesRepository.cs
@@ -230,6 +230,7 @@ public class SeriesRepository : ISeriesRepository
     {
         return await _context.Series
             .Where(s => s.Id == seriesId)
+            .Include(s => s.Relations)
             .Include(s => s.Metadata)
             .ThenInclude(m => m.People)
             .Include(s => s.Metadata)

--- a/API/Services/MetadataService.cs
+++ b/API/Services/MetadataService.cs
@@ -36,8 +36,8 @@ public interface IMetadataService
     /// <param name="libraryId"></param>
     /// <param name="seriesId"></param>
     /// <param name="forceUpdate">Overrides any cache logic and forces execution</param>
-    Task GenerateCoversForSeries(int libraryId, int seriesId, bool forceUpdate = true);
 
+    Task GenerateCoversForSeries(int libraryId, int seriesId, bool forceUpdate = true);
     Task GenerateCoversForSeries(Series series, bool forceUpdate = false);
     Task RemoveAbandonedMetadataKeys();
 }

--- a/API/Services/Tasks/Scanner/ProcessSeries.cs
+++ b/API/Services/Tasks/Scanner/ProcessSeries.cs
@@ -182,7 +182,7 @@ public class ProcessSeries : IProcessSeries
         if (seriesAdded)
         {
             await _eventHub.SendMessageAsync(MessageFactory.SeriesAdded,
-                MessageFactory.SeriesAddedEvent(series.Id, series.Name, series.LibraryId));
+                MessageFactory.SeriesAddedEvent(series.Id, series.Name, series.LibraryId), false);
         }
 
         _logger.LogInformation("[ScannerService] Finished series update on {SeriesName} in {Milliseconds} ms", seriesName, scanWatch.ElapsedMilliseconds);

--- a/API/Services/Tasks/Scanner/ProcessSeries.cs
+++ b/API/Services/Tasks/Scanner/ProcessSeries.cs
@@ -171,7 +171,16 @@ public class ProcessSeries : IProcessSeries
                     await _eventHub.SendMessageAsync(MessageFactory.Error,
                         MessageFactory.ErrorEvent($"There was an issue writing to the DB for Series {series}",
                             ex.Message));
+                    return;
                 }
+
+                if (seriesAdded)
+                {
+                    await _eventHub.SendMessageAsync(MessageFactory.SeriesAdded,
+                        MessageFactory.SeriesAddedEvent(series.Id, series.Name, series.LibraryId), false);
+                }
+
+                _logger.LogInformation("[ScannerService] Finished series update on {SeriesName} in {Milliseconds} ms", seriesName, scanWatch.ElapsedMilliseconds);
             }
         }
         catch (Exception ex)
@@ -179,13 +188,7 @@ public class ProcessSeries : IProcessSeries
             _logger.LogError(ex, "[ScannerService] There was an exception updating series for {SeriesName}", series.Name);
         }
 
-        if (seriesAdded)
-        {
-            await _eventHub.SendMessageAsync(MessageFactory.SeriesAdded,
-                MessageFactory.SeriesAddedEvent(series.Id, series.Name, series.LibraryId), false);
-        }
-
-        _logger.LogInformation("[ScannerService] Finished series update on {SeriesName} in {Milliseconds} ms", seriesName, scanWatch.ElapsedMilliseconds);
+        await _metadataService.GenerateCoversForSeries(series, false);
         EnqueuePostSeriesProcessTasks(series.LibraryId, series.Id);
     }
 
@@ -213,7 +216,7 @@ public class ProcessSeries : IProcessSeries
 
     public void EnqueuePostSeriesProcessTasks(int libraryId, int seriesId, bool forceUpdate = false)
     {
-        BackgroundJob.Enqueue(() => _metadataService.GenerateCoversForSeries(libraryId, seriesId, forceUpdate));
+        //BackgroundJob.Enqueue(() => _metadataService.GenerateCoversForSeries(libraryId, seriesId, forceUpdate));
         BackgroundJob.Enqueue(() => _wordCountAnalyzerService.ScanSeries(libraryId, seriesId, forceUpdate));
     }
 

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -480,9 +480,18 @@ public class ScannerService : IScannerService
         _unitOfWork.LibraryRepository.Update(library);
         if (await _unitOfWork.CommitAsync())
         {
-            _logger.LogInformation(
-                "[ScannerService] Finished scan of {TotalFiles} files and {ParsedSeriesCount} series in {ElapsedScanTime} milliseconds for {LibraryName}",
-                totalFiles, seenSeries.Count, sw.ElapsedMilliseconds, library.Name);
+            if (totalFiles == 0)
+            {
+                _logger.LogInformation(
+                    "[ScannerService] Finished library scan of {ParsedSeriesCount} series in {ElapsedScanTime} milliseconds for {LibraryName}. There were no changes",
+                    totalFiles, seenSeries.Count, sw.ElapsedMilliseconds, library.Name);
+            }
+            else
+            {
+                _logger.LogInformation(
+                    "[ScannerService] Finished library scan of {TotalFiles} files and {ParsedSeriesCount} series in {ElapsedScanTime} milliseconds for {LibraryName}",
+                    totalFiles, seenSeries.Count, sw.ElapsedMilliseconds, library.Name);
+            }
         }
         else
         {

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -205,7 +205,7 @@ public class ScannerService : IScannerService
         var scanElapsedTime = await ScanFiles(library, new []{folderPath}, false, TrackFiles, true);
         _logger.LogInformation("ScanFiles for {Series} took {Time}", series.Name, scanElapsedTime);
 
-        await Task.WhenAll(processTasks);
+        //await Task.WhenAll(processTasks);
 
         await _eventHub.SendMessageAsync(MessageFactory.NotificationProgress, MessageFactory.LibraryScanProgressEvent(library.Name, ProgressEventType.Ended, series.Name));
 

--- a/API/Startup.cs
+++ b/API/Startup.cs
@@ -156,7 +156,7 @@ namespace API
             services.AddHangfire(configuration => configuration
                 .UseSimpleAssemblyNameTypeSerializer()
                 .UseRecommendedSerializerSettings()
-                .UseSQLiteStorage());
+                .UseMemoryStorage()); // UseSQLiteStorage - SQLite has some issues around resuming jobs when aborted
 
             // Add the processing server as IHostedService
             services.AddHangfireServer(options =>

--- a/UI/Web/src/app/dashboard/dashboard.component.ts
+++ b/UI/Web/src/app/dashboard/dashboard.component.ts
@@ -57,7 +57,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
           this.seriesService.getSeries(seriesAddedEvent.seriesId).subscribe(series => {
             this.recentlyAddedSeries.unshift(series);
-            this.cdRef.markForCheck();
+            this.cdRef.detectChanges();
           });
         } else if (res.event === EVENTS.SeriesRemoved) {
           const seriesRemovedEvent = res.payload as SeriesRemovedEvent;

--- a/UI/Web/src/app/manga-reader/manga-reader.component.html
+++ b/UI/Web/src/app/manga-reader/manga-reader.component.html
@@ -218,7 +218,7 @@
                 </div>
                 <div class="row mb-2">
                     <div class="col-md-6 col-sm-12">
-                        <label for="darkness" class="form-label range-label">Darkess</label>
+                        <label for="darkness" class="form-label range-label">Brightness</label>
                         <input type="range" class="form-range" id="darkness" 
                                 min="10" max="100" step="1" formControlName="darkness">
                         <span class="range-text">{{generalSettingsForm.get('darkness')?.value + '%'}}</span>

--- a/UI/Web/src/app/sidenav/side-nav/side-nav.component.html
+++ b/UI/Web/src/app/sidenav/side-nav/side-nav.component.html
@@ -12,7 +12,7 @@
         <app-side-nav-item icon="fa-list" title="Collections" link="/collections/"></app-side-nav-item>
         <app-side-nav-item icon="fa-list-ol" title="Reading Lists" link="/lists/"></app-side-nav-item>
         <app-side-nav-item icon="fa-bookmark" title="Bookmarks" link="/bookmarks/"></app-side-nav-item>
-        <app-side-nav-item icon="fa-regular fa-rectangle-list" title="All Series" link="/all-series/"></app-side-nav-item>
+        <app-side-nav-item icon="fa-regular fa-rectangle-list" title="All Series" link="/all-series/" *ngIf="libraries.length > 0"></app-side-nav-item>
         <div class="mb-2 mt-3 ms-2 me-2" *ngIf="libraries.length > 10 && !(navService?.sideNavCollapsed$ | async)">
             <label for="filter" class="form-label visually-hidden">Filter</label>
             <div class="form-group">

--- a/UI/Web/src/app/user-settings/theme-manager/theme-manager.component.html
+++ b/UI/Web/src/app/user-settings/theme-manager/theme-manager.component.html
@@ -20,7 +20,7 @@
                   <h5 class="card-title">{{theme.name | sentenceCase}}</h5>
                   <h6 class="card-subtitle mb-2 text-muted">{{theme.provider | siteThemeProvider}}</h6>
                   <button class="btn btn-secondary me-2" [disabled]="theme.isDefault" *ngIf="isAdmin" (click)="updateDefault(theme)">Set Default</button>
-                  <button class="btn btn-primary" (click)="applyTheme(theme)" [disabled]="currentTheme.id === theme.id">{{currentTheme.id === theme.id ? 'Applied' : 'Apply'}}</button>
+                  <button class="btn btn-primary" (click)="applyTheme(theme)" [disabled]="currentTheme?.id === theme.id">{{currentTheme?.id === theme.id ? 'Applied' : 'Apply'}}</button>
                 </div>
               </div>
         </ng-container>

--- a/UI/Web/src/app/user-settings/theme-manager/theme-manager.component.ts
+++ b/UI/Web/src/app/user-settings/theme-manager/theme-manager.component.ts
@@ -14,7 +14,7 @@ import { AccountService } from 'src/app/_services/account.service';
 })
 export class ThemeManagerComponent implements OnInit, OnDestroy {
 
-  currentTheme!: SiteTheme;
+  currentTheme: SiteTheme | undefined;
   isAdmin: boolean = false;
   user: User | undefined;
 


### PR DESCRIPTION
# Changed
- Changed: Changed how messaging for logs when a library scan occurred but no files actually processed
- Changed: When a theme that is set for a user, gets removed from Kavita, inform the user to refresh.
- Changed: Manga reader Darkness control is now called Brightness
- Changed: Removed SQLite for Hangfire due to some bugs occurring with it. It will be added back in the future. (develop)

# Fixed
- Fixed: Downloading theme files was previously not allowed by non-authenticated users due to some changes in the Hotfix
- Fixed: Hide the All Series side nav item if there are no libraries exposed to the user
- Fixed: Fixed a page read check for Tachiyomi progress syncing
- Fixed: Home Dashboard wasn't refreshing and responding to SeriesAdded and SeriesRemoved events (develop)
- Fixed: Fixed some bugs where not all covers would generate on first scan (develop)
