### PR TITLE
Configure Animation Module

### DIFF
--- a/UI/Web/src/app/app.module.ts
+++ b/UI/Web/src/app/app.module.ts
@@ -14,10 +14,8 @@ import { SidenavModule } from './sidenav/sidenav.module';
 import { NavModule } from './nav/nav.module';
 
 
-// Disable Animations for older iOS devices (f.animate is not defined).
-const disableAnimations =
-  !('animate' in document.documentElement)
-  || (navigator && /iPhone OS (8|9|10|11|12|13)_/.test(navigator.userAgent));
+// Disable Web Animations if the user's browser (such as iOS 12.5.5) does not support this.
+const disableAnimations = !('animate' in document.documentElement);
 
 
 @NgModule({

--- a/UI/Web/src/app/app.module.ts
+++ b/UI/Web/src/app/app.module.ts
@@ -14,6 +14,10 @@ import { SidenavModule } from './sidenav/sidenav.module';
 import { NavModule } from './nav/nav.module';
 
 
+// Disable Animations for older iOS devices (f.animate is not defined).
+const disableAnimations =
+  !('animate' in document.documentElement)
+  || (navigator && /iPhone OS (8|9|10|11|12|13)_/.test(navigator.userAgent));
 
 
 @NgModule({
@@ -24,7 +28,7 @@ import { NavModule } from './nav/nav.module';
         HttpClientModule,
         BrowserModule,
         AppRoutingModule,
-        BrowserAnimationsModule,
+        BrowserAnimationsModule.withConfig({ disableAnimations }),
         SidenavModule,
         NavModule,
         ToastrModule.forRoot({

--- a/UI/Web/src/app/app.module.ts
+++ b/UI/Web/src/app/app.module.ts
@@ -16,7 +16,7 @@ import { NavModule } from './nav/nav.module';
 
 // Disable Web Animations if the user's browser (such as iOS 12.5.5) does not support this.
 const disableAnimations = !('animate' in document.documentElement);
-
+if (disableAnimations) console.error("Web Animations have been disabled as your current browser does not support this.");
 
 @NgModule({
     declarations: [


### PR DESCRIPTION
Configure the Animation Module of Angular to disable animation on older iOS devices (<14) where it causes animate not defined errors.

# Changed
- Changed: Disable Angular Animations for older iOS (<14) devices to allow the readers to still function (Fixes #1516 )