### PR TITLE
Add Cypress e2e testing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,4 @@
 # How to Contribute #
-
 We're always looking for people to help make Kavita even better, there are a number of ways to contribute.
 
 ## Documentation ##
@@ -8,34 +7,33 @@ Setup guides, FAQ, the more information we have on the [wiki](https://wiki.kavit
 ## Development ##
 
 ### Tools required ###
-- Visual Studio 2019 or higher (https://www.visualstudio.com/vs/).  The community version is free and works fine. [Download it here](https://www.visualstudio.com/downloads/).
-- Rider (optional to Visual Studio) (https://www.jetbrains.com/rider/)  
-- HTML/Javascript editor of choice (VS Code/Sublime Text/Webstorm/Atom/etc)
+- [Visual Studio 2019](https://www.visualstudio.com/vs/) or higher. The community version is free and works fine. [Download it here](https://www.visualstudio.com/downloads/).
+- [Rider](https://www.jetbrains.com/rider/) (alternative to Visual Studio)   
+- HTML/Javascript editor of choice ([VS Code](https://code.visualstudio.com/)/[Sublime Text](https://www.sublimetext.com/)/Webstorm/[Atom](https://atom.io/)/etc)
 - [Git](https://git-scm.com/downloads)
 - [NodeJS](https://nodejs.org/en/download/) (Node 14.X.X or higher)
-- .NET 5.0+ 
+- [.NET 5.0+](https://dotnet.microsoft.com/en-us/download) 
 
 ### Getting started ###
-
 1. Fork Kavita
 2. Clone the repository into your development machine. [*info*](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository-from-github)
 3. Install the required Node Packages
-    - cd Kavita/UI/Web
+    - `cd Kavita/UI/Web`
     - `npm install`
     - `npm install -g @angular/cli`
 4. Start angular server `ng serve`
-5. Build the project in Visual Studio/Rider, Setting startup project to `API`
+5. Build the project in Visual Studio/Rider, setting the startup project to `API`
 6. Debug the project in Visual Studio/Rider
 7. Open http://localhost:4200
 8. (Deployment only) Run build.sh and pass the Runtime Identifier for your OS or just build.sh for all supported RIDs.
 
 
 ### Contributing Code ###
-- If you're adding a new, already requested feature, please comment on [Github Issues](https://github.com/Kareadita/Kavita/issues "Github Issues") so work is not duplicated (If you want to add something not already on there, please talk to us first)
+- If you're adding a new, already requested feature, please comment on [GitHub Issues](https://github.com/Kareadita/Kavita/issues "GitHub Issues") so work is not duplicated (If you want to add something not already on there, please talk to us first)
 - Rebase from Kavita's develop branch, don't merge
 - Make meaningful commits, or squash them
-- Feel free to make a pull request before work is complete, this will let us see where its at and make comments/suggest improvements
-- Reach out to us on the discord if you have any questions
+- Feel free to make a pull request before work is complete, this will let us see where it's at and make comments/suggest improvements
+- Reach out to us on the [Discord](https://discord.gg/b52wT37kt7) server if you have any questions
 - Add tests (unit/integration)
 - Commit with *nix line endings for consistency (We checkout Windows and commit *nix)
 - One feature/bug fix per pull request to keep things clean and easy to understand
@@ -46,7 +44,7 @@ Setup guides, FAQ, the more information we have on the [wiki](https://wiki.kavit
 - Only make pull requests to develop, never main, if you make a PR to main we'll comment on it and close it
 - You're probably going to get some comments or questions from us, they will be to ensure consistency and maintainability
 - We'll try to respond to pull requests as soon as possible, if its been a day or two, please reach out to us, we may have missed it
-- Each PR should come from its own [feature branch](http://martinfowler.com/bliki/FeatureBranch.html) not develop in your fork, it should have a meaningful branch name (what is being added/fixed)
+- Each PR should come from its own [feature branch](http://martinfowler.com/bliki/FeatureBranch.html), not the `develop` branch in your fork, and should have a meaningful branch name (what is being added/fixed)
     - new-feature (Good)
     - fix-bug (Good)
     - patch (Bad)
@@ -54,10 +52,18 @@ Setup guides, FAQ, the more information we have on the [wiki](https://wiki.kavit
     - feature/parser-enhancements (Great)
     - bugfix/book-issues (Great)
 
+### Testing ###
+We use [Cypress](https://www.cypress.io/) for end-to-end testing before each release
+- Make sure the API is running in Visual Studio/Rider before continuing
+- To open the Cypress GUI, run `ng e2e`, then go to `Start E2E Testing > Specs`. The specs can be found in `Kavita\UI\Web\cypress\e2e`
+- To run all specs in order from the command line, run `ng run kavita-webui:cypress-run --browser firefox`
+  - If you don't have Firefox installed, substitute `--browser firefox` with `--browser edge` or `--browser chrome`
+- To run a specific spec from the command line, run `ng run kavita-webui:cypress-run --browser firefox --spec "cypress\e2e\SPEC_FILE"`
+
 ### Swagger API ###
 If you just want to play with Swagger, you can just
-- cd Kavita/API
-- dotnet run -c Debug
+- `cd Kavita/API`
+- `dotnet run -c Debug`
 - Go to http://localhost:5000/swagger/index.html
 
 If you have any questions about any of this, please let us know.

--- a/UI/Web/.gitignore
+++ b/UI/Web/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 test-results/
 playwright-report/
+cypress/screenshots
+cypress/videos

--- a/UI/Web/angular.json
+++ b/UI/Web/angular.json
@@ -129,7 +129,7 @@
             "tsConfig": [
               "tsconfig.app.json",
               "tsconfig.spec.json",
-              "e2e/tsconfig.json"
+              "cypress/tsconfig.json"
             ],
             "exclude": [
               "**/node_modules/**"
@@ -137,15 +137,34 @@
           }
         },
         "e2e": {
-          "builder": "@angular-devkit/build-angular:protractor",
+          "builder": "@cypress/schematic:cypress",
           "options": {
-            "protractorConfig": "e2e/protractor.conf.js",
+            "devServerTarget": "kavita-webui:serve",
+            "watch": true,
+            "headless": false
+          },
+          "configurations": {
+            "production": {
+              "devServerTarget": "kavita-webui:serve:production"
+            }
+          }
+        },
+        "cypress-run": {
+          "builder": "@cypress/schematic:cypress",
+          "options": {
             "devServerTarget": "kavita-webui:serve"
           },
           "configurations": {
             "production": {
               "devServerTarget": "kavita-webui:serve:production"
             }
+          }
+        },
+        "cypress-open": {
+          "builder": "@cypress/schematic:cypress",
+          "options": {
+            "watch": true,
+            "headless": false
           }
         }
       }

--- a/UI/Web/cypress.config.ts
+++ b/UI/Web/cypress.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "cypress";
+
+export default defineConfig({
+  e2e: {
+    baseUrl: 'http://localhost:4200/',
+    setupNodeEvents(on, config) {
+      // implement node event listeners here
+    },
+  },
+});

--- a/UI/Web/cypress/e2e/1. New User.cy.ts
+++ b/UI/Web/cypress/e2e/1. New User.cy.ts
@@ -1,0 +1,30 @@
+/// <reference types="Cypress" />
+
+describe('First time server regestration', () => {
+
+  const username = "Cypress"
+  const email = "asdasdasdasd@easdasd.com"
+  const password = "test123test123"
+
+  it('access the server', () => {
+    cy.visit('/')
+    cy.contains('Kavita')
+  })
+
+  it('register', () => {
+    cy.visit('/registration/register')
+
+    cy.get('#username').type(username)
+    cy.get('#email').type(email)
+    cy.get('#password').type(password)
+    cy.get('.btn').click()
+  })
+
+  it('log in', () => {
+    cy.visit('/login')
+
+    cy.get('#username').type(username)
+    cy.get('#password').type(password)
+    cy.get('.btn').click()
+  })
+})

--- a/UI/Web/cypress/e2e/2. Admin - Libraries.cy.ts
+++ b/UI/Web/cypress/e2e/2. Admin - Libraries.cy.ts
@@ -1,0 +1,116 @@
+describe('Existing User.cy', () => {
+
+
+  //TODO - Figure out paths that work for more than just my machine
+  const librarypath = "F:\\Library\\.KavitaTesting\\WantToRead"
+  const emptylibrarypath = "F:\\Library\\.KavitaTesting\\KeepEmpty"
+  const libraryname = "Books"
+
+  //beforeEach(()=>{
+  //})
+
+
+  it('log in', () => {
+    const username = "Cypress"
+    const email = "asdasdasdasd@easdasd.com"
+    const password = "test123test123"
+
+    cy.visit('/login')
+    cy.get('#username').type(username)
+    cy.get('#password').type(password)
+    cy.get('.btn').click()
+  })
+
+
+  // Validate scan fails if library is an empty folder
+  it('error message if a library is empty', () => {
+    cy.get('.not-xs-only > .dark-exempt').click()
+    cy.contains('Libraries').click()
+    cy.contains('Add Library').click()
+
+    cy.get('#library-name').type('Empty')
+    cy.get('#library-type').select('Book')
+    cy.get('.modal-body > h4 > .btn').click()
+
+    cy.get('#typeahead-focus').type(emptylibrarypath) // This gives a harmless "Invalid Path" error
+    cy.get('.component-host-scrollable > .modal-footer > .btn-primary').contains("Share").click({force: true})
+    cy.get('.modal-footer > .btn-primary').contains("Save").click({force: true})
+
+    // Wait 15 seconds to give the message time to appear
+    cy.wait(15000)
+    cy.get('app-nav-events-toggle > .btn').click()
+    cy.contains("Some of the root folders for the library")
+  })
+
+
+  //Delete a library
+  it('delete a library', () => {
+    cy.get('.not-xs-only > .dark-exempt').click()
+    cy.contains('Libraries').click()
+    cy.get('.btn-danger').click()
+    cy.get('.modal-footer').contains('Confirm').click()
+
+    //Sometimes you need to click off and back it seems. Should probably be fixed
+    cy.contains('Users').click()
+    cy.contains('Libraries').click()
+
+    // Validate the "no library" message shows
+    cy.get('.list-group-item').contains('There are no libraries')
+  })
+
+
+  // Create a new library
+  it('create a library', () => {
+
+    cy.get('.not-xs-only > .dark-exempt').click()
+    cy.contains('Libraries').click()
+    cy.contains('Add Library').click()
+
+    cy.get('#library-name').type('Books')
+    cy.get('#library-type').select('Book')
+    cy.get('.modal-body > h4 > .btn').click()
+
+    cy.get('#typeahead-focus').type(librarypath) // This causes a "Invalid Path" Kavita error, but it's safe to ignore
+    cy.get('.component-host-scrollable > .modal-footer > .btn-primary').contains("Share").click({force: true})
+    cy.get('.modal-footer > .btn-primary').contains("Save").click({force: true})
+
+    //TODO - should check for the library name on this page and the sidebar
+
+  })
+
+
+  // Validate that a new library scans
+  it('Validate that a new library scans', () => {
+    cy.wait(1000)
+    cy.get('.ng-trigger').contains("A scan has")
+    cy.wait(7000) // Seven seconds for 3 Books should be enough
+    cy.get('.side-nav-item').contains('Books').click()
+    cy.get('.subtitle-with-actionables').contains('3 Series')
+  })
+
+
+  //Scan a library
+  it('Scan a library', () => {
+    cy.get('.not-xs-only > .dark-exempt').click()
+    cy.contains('Libraries').click()
+    cy.get('h4 > .float-end > .btn-secondary').click()
+
+    cy.wait(1000)
+    cy.get('.ng-trigger').contains("A scan has")
+  })
+
+
+/*
+  //Validate last scanned updates
+  it('Validate last scanned library updates', () => {
+
+  })
+
+  //Edit library folders and validate scan happens
+  it('Edit library folders and validate scan happens', () => {
+
+  })
+
+*/
+
+})

--- a/UI/Web/cypress/e2e/3. Want to Read.cy.ts
+++ b/UI/Web/cypress/e2e/3. Want to Read.cy.ts
@@ -1,0 +1,99 @@
+describe('User flows for Want to Read', () => {
+
+  const username = "Cypress"
+  const password = "test123test123"
+
+  const bookname = 'Britannica' // Doesn't need to be the full title
+
+  it('log in', () => {
+    const username = "Cypress"
+    const email = "asdasdasdasd@easdasd.com"
+    const password = "test123test123"
+
+    cy.visit('/login')
+    cy.get('#username').type(username)
+    cy.get('#password').type(password)
+    cy.get('.btn').click()
+  })
+
+  function GoToWantToRead () {
+    cy.get('[icon="fa-star"] > .side-nav-item').click()
+  }
+
+  function OpenSeriesPageActionMenu () {
+    cy.get('.side-nav-item').contains('Books').click()
+    cy.get('#jumpbar-index--0 > app-series-card > app-card-item > .card > .card-body').click()
+    cy.get('.d-sm-block > .card-actions > app-card-actionables > .d-inline-block').click()
+  }
+
+
+  ///*
+  //Add from Series Detail
+  it('Add to Want to Read from series detail', () => {
+    OpenSeriesPageActionMenu()
+    cy.get('[data-popper-placement="bottom-start"] > .dropdown-menu > :nth-child(4)').click() // Add to Want to Read
+    GoToWantToRead()
+    cy.get('.card-body').contains(bookname)
+  })
+
+  //Remove from Series Detail
+  it('Remove Want to Read from series detail', () => {
+    OpenSeriesPageActionMenu()
+    cy.get('[data-popper-placement="bottom-start"] > .dropdown-menu > :nth-child(5)').click() // Remove from Want to Read
+    GoToWantToRead()
+    cy.get('.main-container').contains("There are no items")
+  })
+
+
+  //Ability to add 1 series from library
+  it('Add 1 Series from Library', () => {
+    cy.get('.side-nav-item').contains('Books').click()
+
+    cy.get('#jumpbar-index--0 > app-series-card > app-card-item > .card > .card-body').within(() => {
+      cy.get('.fa').eq(1).click()
+    })
+
+    cy.get('[data-popper-placement="top-start"] > .dropdown-menu').contains('Add to Want').click()
+    GoToWantToRead()
+    cy.get('.card-body').contains(bookname)
+
+  })
+
+
+  //Ability to remove 1 series from library
+  it('Remove 1 Series from Library', () => {
+    cy.get('.side-nav-item').contains('Books').click()
+
+    cy.get('#jumpbar-index--0 > app-series-card > app-card-item > .card > .card-body').within(() => {
+      cy.get('.fa').eq(1).click()
+    })
+
+    cy.get('[data-popper-placement="top-start"] > .dropdown-menu').contains('Remove from Want').click()
+    GoToWantToRead()
+    cy.get('.main-container').contains("There are no items")
+
+  })
+  //*/
+  /*
+  //Ability to add muliple series from library
+  it('Add muliple series from library', () => {
+    cy.get('.side-nav-item').contains('Books').click()
+
+    // The bulk selection checkbox is very elusive
+    //cy.get('#jumpbar-index--1 > app-series-card.ng-star-inserted').invoke('show');
+
+  })
+  */
+
+})
+
+//Ability to add 1 series from library            - Done
+//Ability to remove 1 series from library         - Done
+
+//Ability to add muliple series from library      - WIP
+//Ability to remove multiple series from library  -
+
+//Add from Series Detail                          - Done
+//Remove from Series Detail                       - Done
+
+//Remove from Want To Read                        -

--- a/UI/Web/cypress/fixtures/example.json
+++ b/UI/Web/cypress/fixtures/example.json
@@ -1,0 +1,5 @@
+{
+  "name": "Using fixtures to represent data",
+  "email": "hello@cypress.io",
+  "body": "Fixtures are a great way to mock data for responses to routes"
+}

--- a/UI/Web/cypress/support/commands.ts
+++ b/UI/Web/cypress/support/commands.ts
@@ -1,0 +1,37 @@
+/// <reference types="cypress" />
+// ***********************************************
+// This example commands.ts shows you how to
+// create various custom commands and overwrite
+// existing commands.
+//
+// For more comprehensive examples of custom
+// commands please read more here:
+// https://on.cypress.io/custom-commands
+// ***********************************************
+//
+//
+// -- This is a parent command --
+// Cypress.Commands.add('login', (email, password) => { ... })
+//
+//
+// -- This is a child command --
+// Cypress.Commands.add('drag', { prevSubject: 'element'}, (subject, options) => { ... })
+//
+//
+// -- This is a dual command --
+// Cypress.Commands.add('dismiss', { prevSubject: 'optional'}, (subject, options) => { ... })
+//
+//
+// -- This will overwrite an existing command --
+// Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
+//
+// declare global {
+//   namespace Cypress {
+//     interface Chainable {
+//       login(email: string, password: string): Chainable<void>
+//       drag(subject: string, options?: Partial<TypeOptions>): Chainable<Element>
+//       dismiss(subject: string, options?: Partial<TypeOptions>): Chainable<Element>
+//       visit(originalFn: CommandOriginalFn, url: string, options: Partial<VisitOptions>): Chainable<Element>
+//     }
+//   }
+// }

--- a/UI/Web/cypress/support/e2e.ts
+++ b/UI/Web/cypress/support/e2e.ts
@@ -1,0 +1,20 @@
+// ***********************************************************
+// This example support/e2e.ts is processed and
+// loaded automatically before your test files.
+//
+// This is a great place to put global configuration and
+// behavior that modifies Cypress.
+//
+// You can change the location of this file or turn off
+// automatically serving support files with the
+// 'supportFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/configuration
+// ***********************************************************
+
+// Import commands.js using ES2015 syntax:
+import './commands'
+
+// Alternatively you can use CommonJS syntax:
+// require('./commands')

--- a/UI/Web/package.json
+++ b/UI/Web/package.json
@@ -11,7 +11,9 @@
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "lint": "ng lint",
-    "e2e": "ng e2e"
+    "e2e": "ng e2e",
+    "cypress:open": "cypress open",
+    "cypress:run": "cypress run"
   },
   "private": true,
   "dependencies": {
@@ -54,6 +56,7 @@
     "@angular-devkit/build-angular": "^14.1.1",
     "@angular/cli": "^14.1.1",
     "@angular/compiler-cli": "^14.1.1",
+    "@cypress/schematic": "^2.0.3",
     "@playwright/test": "^1.23.2",
     "@types/jest": "^27.4.0",
     "@types/node": "^17.0.17",
@@ -65,7 +68,8 @@
     "protractor": "~7.0.0",
     "ts-node": "~10.5.0",
     "tslint": "^6.1.3",
-    "typescript": "~4.7.4"
+    "typescript": "~4.7.4",
+    "cypress": "latest"
   },
   "jest": {
     "preset": "jest-preset-angular",


### PR DESCRIPTION
# Added
- Added: End-to-end testing using Cypress (Closes #1038)

To run a test from the Cypress GUI, run `ng e2e`, then go to `Start E2E Testing > Specs` and run each spec in order

To run all specs from the CLI, run `ng run kavita-webui:cypress-run --browser firefox`. Edge and Chrome are also supported if they are installed on your system. If you don't have Firefox installed, alter the command to a different browser. The config will need to be cleared between each CLI run for now.