### PR TITLE
Misc Polish and Fixes

### DIFF
--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -123,7 +123,7 @@ jobs:
 
   develop:
     name: Build Nightly Docker if Develop push
-    needs: [ build, test, version ]
+    needs: [ build, version ]
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
     steps:
@@ -232,7 +232,7 @@ jobs:
 
   stable:
     name: Build Stable Docker if Main push
-    needs: [ build, test ]
+    needs: [ build ]
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     steps:

--- a/API.Tests/Services/CleanupServiceTests.cs
+++ b/API.Tests/Services/CleanupServiceTests.cs
@@ -38,6 +38,7 @@ public class CleanupServiceTests
     private const string CacheDirectory = "C:/kavita/config/cache/";
     private const string CoverImageDirectory = "C:/kavita/config/covers/";
     private const string BackupDirectory = "C:/kavita/config/backups/";
+    private const string LogDirectory = "C:/kavita/config/logs/";
     private const string BookmarkDirectory = "C:/kavita/config/bookmarks/";
 
 
@@ -83,6 +84,9 @@ public class CleanupServiceTests
 
         setting = await _context.ServerSetting.Where(s => s.Key == ServerSettingKey.BookmarkDirectory).SingleAsync();
         setting.Value = BookmarkDirectory;
+
+        setting = await _context.ServerSetting.Where(s => s.Key == ServerSettingKey.TotalLogs).SingleAsync();
+        setting.Value = "10";
 
         _context.ServerSetting.Update(setting);
 
@@ -408,6 +412,59 @@ public class CleanupServiceTests
             ds);
         await cleanupService.CleanupBackups();
         Assert.True(filesystem.File.Exists($"{BackupDirectory}randomfile.zip"));
+    }
+
+    #endregion
+
+    #region CleanupLogs
+
+    [Fact]
+    public async Task CleanupLogs_LeaveOneFile_SinceAllAreExpired()
+    {
+        var filesystem = CreateFileSystem();
+        foreach (var i in Enumerable.Range(1, 10))
+        {
+            var day = API.Services.Tasks.Scanner.Parser.Parser.PadZeros($"{i}");
+            filesystem.AddFile($"{LogDirectory}kavita202009{day}.log", new MockFileData("")
+            {
+                CreationTime = DateTimeOffset.Now.Subtract(TimeSpan.FromDays(31))
+            });
+        }
+
+        var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), filesystem);
+        var cleanupService = new CleanupService(_logger, _unitOfWork, _messageHub,
+            ds);
+        await cleanupService.CleanupLogs();
+        Assert.Single(ds.GetFiles(LogDirectory, searchOption: SearchOption.AllDirectories));
+    }
+
+    [Fact]
+    public async Task CleanupLogs_LeaveLestExpired()
+    {
+        var filesystem = CreateFileSystem();
+        foreach (var i in Enumerable.Range(1, 9))
+        {
+            var day = API.Services.Tasks.Scanner.Parser.Parser.PadZeros($"{i}");
+            filesystem.AddFile($"{LogDirectory}kavita202009{day}.log", new MockFileData("")
+            {
+                CreationTime = DateTimeOffset.Now.Subtract(TimeSpan.FromDays(31 - i))
+            });
+        }
+        filesystem.AddFile($"{LogDirectory}kavita20200910.log", new MockFileData("")
+        {
+            CreationTime = DateTimeOffset.Now.Subtract(TimeSpan.FromDays(31 - 10))
+        });
+        filesystem.AddFile($"{LogDirectory}kavita20200911.log", new MockFileData("")
+        {
+            CreationTime = DateTimeOffset.Now.Subtract(TimeSpan.FromDays(31 - 11))
+        });
+
+
+        var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), filesystem);
+        var cleanupService = new CleanupService(_logger, _unitOfWork, _messageHub,
+            ds);
+        await cleanupService.CleanupLogs();
+        Assert.True(filesystem.File.Exists($"{LogDirectory}kavita20200911.log"));
     }
 
     #endregion

--- a/API.Tests/Services/ReaderServiceTests.cs
+++ b/API.Tests/Services/ReaderServiceTests.cs
@@ -896,6 +896,60 @@ public class ReaderServiceTests
     }
 
     [Fact]
+    public async Task GetPrevChapterIdAsync_ShouldGetPrevVolume_2()
+    {
+        await ResetDb();
+
+        _context.Series.Add(new Series()
+        {
+            Name = "Test",
+            Library = new Library() {
+                Name = "Test LIb",
+                Type = LibraryType.Manga,
+            },
+            Volumes = new List<Volume>()
+            {
+                EntityFactory.CreateVolume("0", new List<Chapter>()
+                {
+                    EntityFactory.CreateChapter("40", false, new List<MangaFile>(), 1),
+                    EntityFactory.CreateChapter("50", false, new List<MangaFile>(), 1),
+                    EntityFactory.CreateChapter("60", false, new List<MangaFile>(), 1),
+                    EntityFactory.CreateChapter("Some Special Title", true, new List<MangaFile>(), 1),
+                }),
+                EntityFactory.CreateVolume("1997", new List<Chapter>()
+                {
+                    EntityFactory.CreateChapter("1", false, new List<MangaFile>(), 1),
+                }),
+                EntityFactory.CreateVolume("2001", new List<Chapter>()
+                {
+                    EntityFactory.CreateChapter("21", false, new List<MangaFile>(), 1),
+                }),
+                EntityFactory.CreateVolume("2005", new List<Chapter>()
+                {
+                    EntityFactory.CreateChapter("31", false, new List<MangaFile>(), 1),
+                }),
+            }
+        });
+
+
+       _context.AppUser.Add(new AppUser()
+        {
+            UserName = "majora2007"
+        });
+
+        await _context.SaveChangesAsync();
+
+        var readerService = new ReaderService(_unitOfWork, Substitute.For<ILogger<ReaderService>>(), Substitute.For<IEventHub>());
+
+        // prevChapter should be id from ch.21 from volume 2001
+        var prevChapter = await readerService.GetPrevChapterIdAsync(1, 4, 7, 1);
+
+        var actualChapter = await _unitOfWork.ChapterRepository.GetChapterAsync(prevChapter);
+        Assert.NotNull(actualChapter);
+        Assert.Equal("21", actualChapter.Range);
+    }
+
+    [Fact]
     public async Task GetPrevChapterIdAsync_ShouldRollIntoPrevVolume()
     {
         await ResetDb();

--- a/API.Tests/Services/SeriesServiceTests.cs
+++ b/API.Tests/Services/SeriesServiceTests.cs
@@ -85,19 +85,19 @@ public class SeriesServiceTests
 
         _context.ServerSetting.Update(setting);
 
-        var lib = new Library()
-        {
-            Name = "Manga", Folders = new List<FolderPath>() {new FolderPath() {Path = "C:/data/"}}
-        };
-
-        _context.AppUser.Add(new AppUser()
-        {
-            UserName = "majora2007",
-            Libraries = new List<Library>()
-            {
-                lib
-            }
-        });
+        // var lib = new Library()
+        // {
+        //     Name = "Manga", Folders = new List<FolderPath>() {new FolderPath() {Path = "C:/data/"}}
+        // };
+        //
+        // _context.AppUser.Add(new AppUser()
+        // {
+        //     UserName = "majora2007",
+        //     Libraries = new List<Library>()
+        //     {
+        //         lib
+        //     }
+        // });
 
         return await _context.SaveChangesAsync() > 0;
     }
@@ -109,6 +109,7 @@ public class SeriesServiceTests
         _context.Genre.RemoveRange(_context.Genre.ToList());
         _context.CollectionTag.RemoveRange(_context.CollectionTag.ToList());
         _context.Person.RemoveRange(_context.Person.ToList());
+        _context.Library.RemoveRange(_context.Library.ToList());
 
         await _context.SaveChangesAsync();
     }
@@ -135,32 +136,44 @@ public class SeriesServiceTests
     {
         await ResetDb();
 
-        _context.Series.Add(new Series()
+        _context.Library.Add(new Library()
         {
-            Name = "Test",
-            Library = new Library() {
-                Name = "Test LIb",
-                Type = LibraryType.Manga,
-            },
-            Volumes = new List<Volume>()
+            AppUsers = new List<AppUser>()
             {
-                EntityFactory.CreateVolume("0", new List<Chapter>()
+                new AppUser()
                 {
-                    EntityFactory.CreateChapter("Omake", true, new List<MangaFile>()),
-                    EntityFactory.CreateChapter("Something SP02", true, new List<MangaFile>()),
-                }),
-                EntityFactory.CreateVolume("2", new List<Chapter>()
+                    UserName = "majora2007"
+                }
+            },
+            Name = "Test LIb",
+            Type = LibraryType.Book,
+            Series = new List<Series>()
+            {
+                new Series()
                 {
-                    EntityFactory.CreateChapter("21", false, new List<MangaFile>()),
-                    EntityFactory.CreateChapter("22", false, new List<MangaFile>()),
-                }),
-                EntityFactory.CreateVolume("3", new List<Chapter>()
-                {
-                    EntityFactory.CreateChapter("31", false, new List<MangaFile>()),
-                    EntityFactory.CreateChapter("32", false, new List<MangaFile>()),
-                }),
+                    Name = "Test",
+                    Volumes = new List<Volume>()
+                    {
+                        EntityFactory.CreateVolume("0", new List<Chapter>()
+                        {
+                            EntityFactory.CreateChapter("Omake", true, new List<MangaFile>()),
+                            EntityFactory.CreateChapter("Something SP02", true, new List<MangaFile>()),
+                        }),
+                        EntityFactory.CreateVolume("2", new List<Chapter>()
+                        {
+                            EntityFactory.CreateChapter("21", false, new List<MangaFile>()),
+                            EntityFactory.CreateChapter("22", false, new List<MangaFile>()),
+                        }),
+                        EntityFactory.CreateVolume("3", new List<Chapter>()
+                        {
+                            EntityFactory.CreateChapter("31", false, new List<MangaFile>()),
+                            EntityFactory.CreateChapter("32", false, new List<MangaFile>()),
+                        }),
+                    }
+                }
             }
         });
+
 
         await _context.SaveChangesAsync();
 
@@ -177,30 +190,41 @@ public class SeriesServiceTests
     {
         await ResetDb();
 
-        _context.Series.Add(new Series()
+        _context.Library.Add(new Library()
         {
-            Name = "Test",
-            Library = new Library() {
-                Name = "Test LIb",
-                Type = LibraryType.Manga,
-            },
-            Volumes = new List<Volume>()
+            AppUsers = new List<AppUser>()
             {
-                EntityFactory.CreateVolume("0", new List<Chapter>()
+                new AppUser()
                 {
-                    EntityFactory.CreateChapter("1", false, new List<MangaFile>()),
-                    EntityFactory.CreateChapter("2", false, new List<MangaFile>()),
-                }),
-                EntityFactory.CreateVolume("2", new List<Chapter>()
+                    UserName = "majora2007"
+                }
+            },
+            Name = "Test LIb",
+            Type = LibraryType.Manga,
+            Series = new List<Series>()
+            {
+                new Series()
                 {
-                    EntityFactory.CreateChapter("21", false, new List<MangaFile>()),
-                    EntityFactory.CreateChapter("22", false, new List<MangaFile>()),
-                }),
-                EntityFactory.CreateVolume("3", new List<Chapter>()
-                {
-                    EntityFactory.CreateChapter("31", false, new List<MangaFile>()),
-                    EntityFactory.CreateChapter("32", false, new List<MangaFile>()),
-                }),
+                    Name = "Test",
+                    Volumes = new List<Volume>()
+                    {
+                        EntityFactory.CreateVolume("0", new List<Chapter>()
+                        {
+                            EntityFactory.CreateChapter("1", false, new List<MangaFile>()),
+                            EntityFactory.CreateChapter("2", false, new List<MangaFile>()),
+                        }),
+                        EntityFactory.CreateVolume("2", new List<Chapter>()
+                        {
+                            EntityFactory.CreateChapter("21", false, new List<MangaFile>()),
+                            EntityFactory.CreateChapter("22", false, new List<MangaFile>()),
+                        }),
+                        EntityFactory.CreateVolume("3", new List<Chapter>()
+                        {
+                            EntityFactory.CreateChapter("31", false, new List<MangaFile>()),
+                            EntityFactory.CreateChapter("32", false, new List<MangaFile>()),
+                        }),
+                    }
+                }
             }
         });
 
@@ -220,28 +244,39 @@ public class SeriesServiceTests
     {
         await ResetDb();
 
-        _context.Series.Add(new Series()
+        _context.Library.Add(new Library()
         {
-            Name = "Test",
-            Library = new Library() {
-                Name = "Test LIb",
-                Type = LibraryType.Manga,
-            },
-            Volumes = new List<Volume>()
+            AppUsers = new List<AppUser>()
             {
-                EntityFactory.CreateVolume("0", new List<Chapter>()
+                new AppUser()
                 {
-                    EntityFactory.CreateChapter("1", false, new List<MangaFile>()),
-                    EntityFactory.CreateChapter("2", false, new List<MangaFile>()),
-                }),
-                EntityFactory.CreateVolume("2", new List<Chapter>()
+                    UserName = "majora2007"
+                }
+            },
+            Name = "Test LIb",
+            Type = LibraryType.Manga,
+            Series = new List<Series>()
+            {
+                new Series()
                 {
-                    EntityFactory.CreateChapter("0", false, new List<MangaFile>()),
-                }),
-                EntityFactory.CreateVolume("3", new List<Chapter>()
-                {
-                    EntityFactory.CreateChapter("31", false, new List<MangaFile>()),
-                }),
+                    Name = "Test",
+                    Volumes = new List<Volume>()
+                    {
+                        EntityFactory.CreateVolume("0", new List<Chapter>()
+                        {
+                            EntityFactory.CreateChapter("1", false, new List<MangaFile>()),
+                            EntityFactory.CreateChapter("2", false, new List<MangaFile>()),
+                        }),
+                        EntityFactory.CreateVolume("2", new List<Chapter>()
+                        {
+                            EntityFactory.CreateChapter("0", false, new List<MangaFile>()),
+                        }),
+                        EntityFactory.CreateVolume("3", new List<Chapter>()
+                        {
+                            EntityFactory.CreateChapter("31", false, new List<MangaFile>()),
+                        }),
+                    }
+                }
             }
         });
 
@@ -261,28 +296,39 @@ public class SeriesServiceTests
     {
         await ResetDb();
 
-        _context.Series.Add(new Series()
+        _context.Library.Add(new Library()
         {
-            Name = "Test",
-            Library = new Library() {
-                Name = "Test LIb",
-                Type = LibraryType.Manga,
-            },
-            Volumes = new List<Volume>()
+            AppUsers = new List<AppUser>()
             {
-                EntityFactory.CreateVolume("0", new List<Chapter>()
+                new AppUser()
                 {
-                    EntityFactory.CreateChapter("1", false, new List<MangaFile>()),
-                    EntityFactory.CreateChapter("2", false, new List<MangaFile>()),
-                }),
-                EntityFactory.CreateVolume("2", new List<Chapter>()
+                    UserName = "majora2007"
+                }
+            },
+            Name = "Test LIb",
+            Type = LibraryType.Manga,
+            Series = new List<Series>()
+            {
+                new Series()
                 {
-                    EntityFactory.CreateChapter("0", false, new List<MangaFile>()),
-                }),
-                EntityFactory.CreateVolume("3", new List<Chapter>()
-                {
-                    EntityFactory.CreateChapter("31", false, new List<MangaFile>()),
-                }),
+                    Name = "Test",
+                    Volumes = new List<Volume>()
+                    {
+                        EntityFactory.CreateVolume("0", new List<Chapter>()
+                        {
+                            EntityFactory.CreateChapter("1", false, new List<MangaFile>()),
+                            EntityFactory.CreateChapter("2", false, new List<MangaFile>()),
+                        }),
+                        EntityFactory.CreateVolume("2", new List<Chapter>()
+                        {
+                            EntityFactory.CreateChapter("0", false, new List<MangaFile>()),
+                        }),
+                        EntityFactory.CreateVolume("3", new List<Chapter>()
+                        {
+                            EntityFactory.CreateChapter("31", false, new List<MangaFile>()),
+                        }),
+                    }
+                }
             }
         });
 
@@ -305,25 +351,37 @@ public class SeriesServiceTests
     {
         await ResetDb();
 
-        _context.Series.Add(new Series()
+        _context.Library.Add(new Library()
         {
-            Name = "Test",
-            Library = new Library() {
-                Name = "Test LIb",
-                Type = LibraryType.Book,
-            },
-            Volumes = new List<Volume>()
+            AppUsers = new List<AppUser>()
             {
-                EntityFactory.CreateVolume("2", new List<Chapter>()
+                new AppUser()
                 {
-                    EntityFactory.CreateChapter("0", false, new List<MangaFile>()),
-                }),
-                EntityFactory.CreateVolume("3", new List<Chapter>()
+                    UserName = "majora2007"
+                }
+            },
+            Name = "Test LIb",
+            Type = LibraryType.Book,
+            Series = new List<Series>()
+            {
+                new Series()
                 {
-                    EntityFactory.CreateChapter("0", false, new List<MangaFile>()),
-                }),
+                    Name = "Test",
+                    Volumes = new List<Volume>()
+                    {
+                        EntityFactory.CreateVolume("2", new List<Chapter>()
+                        {
+                            EntityFactory.CreateChapter("0", false, new List<MangaFile>()),
+                        }),
+                        EntityFactory.CreateVolume("3", new List<Chapter>()
+                        {
+                            EntityFactory.CreateChapter("0", false, new List<MangaFile>()),
+                        }),
+                    }
+                }
             }
         });
+
 
         await _context.SaveChangesAsync();
 
@@ -339,25 +397,38 @@ public class SeriesServiceTests
     {
         await ResetDb();
 
-        _context.Series.Add(new Series()
+        _context.Library.Add(new Library()
         {
-            Name = "Test",
-            Library = new Library() {
-                Name = "Test LIb",
-                Type = LibraryType.Book,
-            },
-            Volumes = new List<Volume>()
+            AppUsers = new List<AppUser>()
             {
-                EntityFactory.CreateVolume("0", new List<Chapter>()
+                new AppUser()
                 {
-                    EntityFactory.CreateChapter("Ano Orokamono ni mo Kyakkou wo! - Volume 1.epub", true, new List<MangaFile>()),
-                }),
-                EntityFactory.CreateVolume("2", new List<Chapter>()
+                    UserName = "majora2007"
+                }
+            },
+            Name = "Test LIb",
+            Type = LibraryType.Book,
+            Series = new List<Series>()
+            {
+                new Series()
                 {
-                    EntityFactory.CreateChapter("Ano Orokamono ni mo Kyakkou wo! - Volume 2.epub", false, new List<MangaFile>()),
-                }),
+                    Name = "Test",
+                    Volumes = new List<Volume>()
+                    {
+                        EntityFactory.CreateVolume("0", new List<Chapter>()
+                        {
+                            EntityFactory.CreateChapter("Ano Orokamono ni mo Kyakkou wo! - Volume 1.epub", true, new List<MangaFile>()),
+                        }),
+                        EntityFactory.CreateVolume("2", new List<Chapter>()
+                        {
+                            EntityFactory.CreateChapter("Ano Orokamono ni mo Kyakkou wo! - Volume 2.epub", false, new List<MangaFile>()),
+                        }),
+                    }
+                }
             }
         });
+
+
 
         await _context.SaveChangesAsync();
 
@@ -379,36 +450,48 @@ public class SeriesServiceTests
     {
         await ResetDb();
 
-        _context.Series.Add(new Series()
+        _context.Library.Add(new Library()
         {
-            Name = "Test",
-            Library = new Library() {
-                Name = "Test LIb",
-                Type = LibraryType.Book,
-            },
-            Volumes = new List<Volume>()
+            AppUsers = new List<AppUser>()
             {
-                EntityFactory.CreateVolume("2", new List<Chapter>()
+                new AppUser()
                 {
-                    EntityFactory.CreateChapter("0", false, new List<MangaFile>()),
-                }),
-                EntityFactory.CreateVolume("1.2", new List<Chapter>()
+                    UserName = "majora2007"
+                }
+            },
+            Name = "Test LIb",
+            Type = LibraryType.Manga,
+            Series = new List<Series>()
+            {
+                new Series()
                 {
-                    EntityFactory.CreateChapter("0", false, new List<MangaFile>()),
-                }),
-                EntityFactory.CreateVolume("1", new List<Chapter>()
-                {
-                    EntityFactory.CreateChapter("0", false, new List<MangaFile>()),
-                }),
+                    Name = "Test",
+                    Volumes = new List<Volume>()
+                    {
+                        EntityFactory.CreateVolume("2", new List<Chapter>()
+                        {
+                            EntityFactory.CreateChapter("0", false, new List<MangaFile>()),
+                        }),
+                        EntityFactory.CreateVolume("1.2", new List<Chapter>()
+                        {
+                            EntityFactory.CreateChapter("0", false, new List<MangaFile>()),
+                        }),
+                        EntityFactory.CreateVolume("1", new List<Chapter>()
+                        {
+                            EntityFactory.CreateChapter("0", false, new List<MangaFile>()),
+                        }),
+                    }
+                }
             }
         });
+
 
         await _context.SaveChangesAsync();
 
         var detail = await _seriesService.GetSeriesDetail(1, 1);
-        Assert.Equal("1", detail.Volumes.ElementAt(0).Name);
-        Assert.Equal("1.2", detail.Volumes.ElementAt(1).Name);
-        Assert.Equal("2", detail.Volumes.ElementAt(2).Name);
+        Assert.Equal("Volume 1", detail.Volumes.ElementAt(0).Name);
+        Assert.Equal("Volume 1.2", detail.Volumes.ElementAt(1).Name);
+        Assert.Equal("Volume 2", detail.Volumes.ElementAt(2).Name);
     }
 
 
@@ -422,27 +505,33 @@ public class SeriesServiceTests
     {
         await ResetDb();
 
-        _context.Series.Add(new Series()
+        _context.Library.Add(new Library()
         {
-            Name = "Test",
-            Library = new Library() {
-                Name = "Test LIb",
-                Type = LibraryType.Manga,
-            },
-            Volumes = new List<Volume>()
+            AppUsers = new List<AppUser>()
             {
-                new Volume()
+                new AppUser()
                 {
-                    Chapters = new List<Chapter>()
+                    UserName = "majora2007"
+                }
+            },
+            Name = "Test LIb",
+            Type = LibraryType.Manga,
+            Series = new List<Series>()
+            {
+                new Series()
+                {
+                    Name = "Test",
+                    Volumes = new List<Volume>()
                     {
-                        new Chapter()
+                        EntityFactory.CreateVolume("1", new List<Chapter>()
                         {
-                            Pages = 1
-                        }
+                            EntityFactory.CreateChapter("1", false, new List<MangaFile>(), 1),
+                        }),
                     }
                 }
             }
         });
+
 
         await _context.SaveChangesAsync();
 
@@ -470,23 +559,28 @@ public class SeriesServiceTests
     {
         await ResetDb();
 
-        _context.Series.Add(new Series()
+        _context.Library.Add(new Library()
         {
-            Name = "Test",
-            Library = new Library() {
-                Name = "Test LIb",
-                Type = LibraryType.Manga,
-            },
-            Volumes = new List<Volume>()
+            AppUsers = new List<AppUser>()
             {
-                new Volume()
+                new AppUser()
                 {
-                    Chapters = new List<Chapter>()
+                    UserName = "majora2007"
+                }
+            },
+            Name = "Test LIb",
+            Type = LibraryType.Manga,
+            Series = new List<Series>()
+            {
+                new Series()
+                {
+                    Name = "Test",
+                    Volumes = new List<Volume>()
                     {
-                        new Chapter()
+                        EntityFactory.CreateVolume("1", new List<Chapter>()
                         {
-                            Pages = 1
-                        }
+                            EntityFactory.CreateChapter("1", false, new List<MangaFile>(), 1),
+                        }),
                     }
                 }
             }
@@ -536,23 +630,28 @@ public class SeriesServiceTests
     {
         await ResetDb();
 
-        _context.Series.Add(new Series()
+        _context.Library.Add(new Library()
         {
-            Name = "Test",
-            Library = new Library() {
-                Name = "Test LIb",
-                Type = LibraryType.Manga,
-            },
-            Volumes = new List<Volume>()
+            AppUsers = new List<AppUser>()
             {
-                new Volume()
+                new AppUser()
                 {
-                    Chapters = new List<Chapter>()
+                    UserName = "majora2007"
+                }
+            },
+            Name = "Test LIb",
+            Type = LibraryType.Manga,
+            Series = new List<Series>()
+            {
+                new Series()
+                {
+                    Name = "Test",
+                    Volumes = new List<Volume>()
                     {
-                        new Chapter()
+                        EntityFactory.CreateVolume("1", new List<Chapter>()
                         {
-                            Pages = 1
-                        }
+                            EntityFactory.CreateChapter("1", false, new List<MangaFile>(), 1),
+                        }),
                     }
                 }
             }
@@ -583,23 +682,28 @@ public class SeriesServiceTests
     {
         await ResetDb();
 
-        _context.Series.Add(new Series()
+        _context.Library.Add(new Library()
         {
-            Name = "Test",
-            Library = new Library() {
-                Name = "Test LIb",
-                Type = LibraryType.Manga,
-            },
-            Volumes = new List<Volume>()
+            AppUsers = new List<AppUser>()
             {
-                new Volume()
+                new AppUser()
                 {
-                    Chapters = new List<Chapter>()
+                    UserName = "majora2007"
+                }
+            },
+            Name = "Test LIb",
+            Type = LibraryType.Manga,
+            Series = new List<Series>()
+            {
+                new Series()
+                {
+                    Name = "Test",
+                    Volumes = new List<Volume>()
                     {
-                        new Chapter()
+                        EntityFactory.CreateVolume("1", new List<Chapter>()
                         {
-                            Pages = 1
-                        }
+                            EntityFactory.CreateChapter("1", false, new List<MangaFile>(), 1),
+                        }),
                     }
                 }
             }
@@ -625,18 +729,6 @@ public class SeriesServiceTests
     #endregion
 
     #region UpdateSeriesMetadata
-
-    private void SetupUpdateSeriesMetadataDb()
-    {
-        _context.Series.Add(new Series()
-        {
-            Name = "Test",
-            Library = new Library() {
-                Name = "Test LIb",
-                Type = LibraryType.Book,
-            }
-        });
-    }
 
     [Fact]
     public async Task UpdateSeriesMetadata_ShouldCreateEmptyMetadata_IfDoesntExist()

--- a/API/Controllers/HealthController.cs
+++ b/API/Controllers/HealthController.cs
@@ -9,7 +9,7 @@ namespace API.Controllers;
 public class HealthController : BaseApiController
 {
 
-    [HttpGet()]
+    [HttpGet]
     public ActionResult GetHealth()
     {
         return Ok("Ok");

--- a/API/Controllers/SettingsController.cs
+++ b/API/Controllers/SettingsController.cs
@@ -223,6 +223,16 @@ public class SettingsController : BaseApiController
                 _unitOfWork.SettingsRepository.Update(setting);
             }
 
+            if (setting.Key == ServerSettingKey.TotalLogs && updateSettingsDto.TotalLogs + string.Empty != setting.Value)
+            {
+                if (updateSettingsDto.TotalLogs > 30 || updateSettingsDto.TotalLogs < 1)
+                {
+                    return BadRequest("Total Logs must be between 1 and 30");
+                }
+                setting.Value = updateSettingsDto.TotalLogs + string.Empty;
+                _unitOfWork.SettingsRepository.Update(setting);
+            }
+
             if (setting.Key == ServerSettingKey.EmailServiceUrl && updateSettingsDto.EmailServiceUrl + string.Empty != setting.Value)
             {
                 setting.Value = string.IsNullOrEmpty(updateSettingsDto.EmailServiceUrl) ? EmailService.DefaultApiUrl : updateSettingsDto.EmailServiceUrl;

--- a/API/DTOs/Settings/ServerSettingDTO.cs
+++ b/API/DTOs/Settings/ServerSettingDTO.cs
@@ -1,4 +1,5 @@
-﻿using API.Services;
+﻿using System.ComponentModel.DataAnnotations;
+using API.Services;
 
 namespace API.DTOs.Settings;
 
@@ -50,7 +51,6 @@ public class ServerSettingDto
     /// If the Swagger UI Should be exposed. Does not require authentication, but does require a JWT.
     /// </summary>
     public bool EnableSwaggerUi { get; set; }
-
     /// <summary>
     /// The amount of Backups before cleanup
     /// </summary>
@@ -60,4 +60,9 @@ public class ServerSettingDto
     /// If Kavita should watch the library folders and process changes
     /// </summary>
     public bool EnableFolderWatching { get; set; } = true;
+    /// <summary>
+    /// Total number of days worth of logs to keep at a given time.
+    /// </summary>
+    /// <remarks>Value should be between 1 and 30</remarks>
+    public int TotalLogs { get; set; }
 }

--- a/API/DTOs/Stats/FileFormatDto.cs
+++ b/API/DTOs/Stats/FileFormatDto.cs
@@ -1,0 +1,15 @@
+﻿using API.Entities.Enums;
+
+namespace API.DTOs.Stats;
+
+public class FileFormatDto
+{
+    /// <summary>
+    /// The extension with the ., in lowercase
+    /// </summary>
+    public string Extension { get; set; }
+    /// <summary>
+    /// Format of extension
+    /// </summary>
+    public MangaFormat Format { get; set; }
+}

--- a/API/DTOs/Stats/ServerInfoDto.cs
+++ b/API/DTOs/Stats/ServerInfoDto.cs
@@ -1,4 +1,6 @@
-﻿using API.Entities.Enums;
+﻿using System.Collections.Generic;
+using API.Entities.Enums;
+using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace API.DTOs.Stats;
 
@@ -118,4 +120,24 @@ public class ServerInfoDto
     /// </summary>
     /// <remarks>Introduced in v0.5.4</remarks>
     public bool UsingSeriesRelationships { get; set; }
+    /// <summary>
+    /// A list of background colors set on the instance
+    /// </summary>
+    /// <remarks>Introduced in v0.6.0</remarks>
+    public IEnumerable<string> MangaReaderBackgroundColors { get; set; }
+    /// <summary>
+    /// A list of Page Split defaults being used on the instance
+    /// </summary>
+    /// <remarks>Introduced in v0.6.0</remarks>
+    public IEnumerable<PageSplitOption> MangaReaderPageSplittingModes { get; set; }
+    /// <summary>
+    /// A list of Layout Mode defaults being used on the instance
+    /// </summary>
+    /// <remarks>Introduced in v0.6.0</remarks>
+    public IEnumerable<LayoutMode> MangaReaderLayoutModes { get; set; }
+    /// <summary>
+    /// A list of file formats existing in the instance
+    /// </summary>
+    /// <remarks>Introduced in v0.6.0</remarks>
+    public IEnumerable<FileFormatDto> FileFormats { get; set; }
 }

--- a/API/Data/Repositories/LibraryRepository.cs
+++ b/API/Data/Repositories/LibraryRepository.cs
@@ -38,6 +38,7 @@ public interface ILibraryRepository
     Task<IEnumerable<Library>> GetLibrariesAsync(LibraryIncludes includes = LibraryIncludes.None);
     Task<bool> DeleteLibrary(int libraryId);
     Task<IEnumerable<Library>> GetLibrariesForUserIdAsync(int userId);
+    Task<IEnumerable<int>> GetLibraryIdsForUserIdAsync(int userId);
     Task<LibraryType> GetLibraryTypeAsync(int libraryId);
     Task<IEnumerable<Library>> GetLibraryForIdsAsync(IEnumerable<int> libraryIds, LibraryIncludes includes = LibraryIncludes.None);
     Task<int> GetTotalFiles();
@@ -111,12 +112,25 @@ public class LibraryRepository : ILibraryRepository
         return await _context.SaveChangesAsync() > 0;
     }
 
+    /// <summary>
+    /// This does not track
+    /// </summary>
+    /// <param name="userId"></param>
+    /// <returns></returns>
     public async Task<IEnumerable<Library>> GetLibrariesForUserIdAsync(int userId)
     {
         return await _context.Library
             .Include(l => l.AppUsers)
             .Where(l => l.AppUsers.Select(ap => ap.Id).Contains(userId))
             .AsNoTracking()
+            .ToListAsync();
+    }
+
+    public async Task<IEnumerable<int>> GetLibraryIdsForUserIdAsync(int userId)
+    {
+        return await _context.Library
+            .Where(l => l.AppUsers.Select(ap => ap.Id).Contains(userId))
+            .Select(l => l.Id)
             .ToListAsync();
     }
 

--- a/API/Data/Seed.cs
+++ b/API/Data/Seed.cs
@@ -103,6 +103,7 @@ public static class Seed
             new() {Key = ServerSettingKey.ConvertBookmarkToWebP, Value = "false"},
             new() {Key = ServerSettingKey.EnableSwaggerUi, Value = "false"},
             new() {Key = ServerSettingKey.TotalBackups, Value = "30"},
+            new() {Key = ServerSettingKey.TotalLogs, Value = "30"},
             new() {Key = ServerSettingKey.EnableFolderWatching, Value = "false"},
         }.ToArray());
 

--- a/API/Entities/Enums/ServerSettingKey.cs
+++ b/API/Entities/Enums/ServerSettingKey.cs
@@ -96,4 +96,9 @@ public enum ServerSettingKey
     /// </summary>
     [Description("EnableFolderWatching")]
     EnableFolderWatching = 17,
+    /// <summary>
+    /// Total number of days worth of logs to keep
+    /// </summary>
+    [Description("TotalLogs")]
+    TotalLogs = 18,
 }

--- a/API/Helpers/Converters/ServerSettingConverter.cs
+++ b/API/Helpers/Converters/ServerSettingConverter.cs
@@ -63,6 +63,9 @@ public class ServerSettingConverter : ITypeConverter<IEnumerable<ServerSetting>,
                 case ServerSettingKey.EnableFolderWatching:
                     destination.EnableFolderWatching = bool.Parse(row.Value);
                     break;
+                case ServerSettingKey.TotalLogs:
+                    destination.TotalLogs = int.Parse(row.Value);
+                    break;
             }
         }
 

--- a/API/Logging/LogLevelOptions.cs
+++ b/API/Logging/LogLevelOptions.cs
@@ -60,26 +60,31 @@ public static class LogLevelOptions
         {
             case "Debug":
                 LogLevelSwitch.MinimumLevel = LogEventLevel.Debug;
+                MicrosoftLogLevelSwitch.MinimumLevel = LogEventLevel.Information;
                 MicrosoftHostingLifetimeLogLevelSwitch.MinimumLevel = LogEventLevel.Debug;
                 AspNetCoreLogLevelSwitch.MinimumLevel = LogEventLevel.Debug;
                 break;
             case "Information":
                 LogLevelSwitch.MinimumLevel = LogEventLevel.Error;
+                MicrosoftLogLevelSwitch.MinimumLevel = LogEventLevel.Error;
                 MicrosoftHostingLifetimeLogLevelSwitch.MinimumLevel = LogEventLevel.Error;
                 AspNetCoreLogLevelSwitch.MinimumLevel = LogEventLevel.Error;
                 break;
             case "Trace":
                 LogLevelSwitch.MinimumLevel = LogEventLevel.Verbose;
+                MicrosoftLogLevelSwitch.MinimumLevel = LogEventLevel.Information;
                 MicrosoftHostingLifetimeLogLevelSwitch.MinimumLevel = LogEventLevel.Debug;
                 AspNetCoreLogLevelSwitch.MinimumLevel = LogEventLevel.Debug;
                 break;
             case "Warning":
                 LogLevelSwitch.MinimumLevel = LogEventLevel.Warning;
+                MicrosoftLogLevelSwitch.MinimumLevel = LogEventLevel.Error;
                 MicrosoftHostingLifetimeLogLevelSwitch.MinimumLevel = LogEventLevel.Error;
                 AspNetCoreLogLevelSwitch.MinimumLevel = LogEventLevel.Error;
                 break;
             case "Critical":
                 LogLevelSwitch.MinimumLevel = LogEventLevel.Fatal;
+                MicrosoftLogLevelSwitch.MinimumLevel = LogEventLevel.Error;
                 MicrosoftHostingLifetimeLogLevelSwitch.MinimumLevel = LogEventLevel.Error;
                 AspNetCoreLogLevelSwitch.MinimumLevel = LogEventLevel.Error;
                 break;

--- a/API/Logging/LogLevelOptions.cs
+++ b/API/Logging/LogLevelOptions.cs
@@ -51,7 +51,7 @@ public static class LogLevelOptions
             .WriteTo.File(LogFile,
                 shared: true,
                 rollingInterval: RollingInterval.Day,
-                outputTemplate: "[{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} {CorrelationId} {Level}] {Message:lj}{NewLine}{Exception}");
+                outputTemplate: "[{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} {CorrelationId}] [{Level}] {Message:lj}{NewLine}{Exception}");
     }
 
     public static void SwitchLogLevel(string level)

--- a/API/Services/ArchiveService.cs
+++ b/API/Services/ArchiveService.cs
@@ -332,7 +332,7 @@ public class ArchiveService : IArchiveService
     {
         var filenameWithoutExtension = Path.GetFileNameWithoutExtension(name).ToLower();
         return !Tasks.Scanner.Parser.Parser.HasBlacklistedFolderInPath(fullName)
-               && fullName.Equals(ComicInfoFilename)
+               && (fullName.Equals(ComicInfoFilename) || (string.IsNullOrEmpty(fullName) && name.Equals(ComicInfoFilename)))
                && !filenameWithoutExtension.StartsWith(Tasks.Scanner.Parser.Parser.MacOsMetadataFileStartsWith);
     }
 

--- a/API/Services/ReaderService.cs
+++ b/API/Services/ReaderService.cs
@@ -389,6 +389,15 @@ public class ReaderService : IReaderService
             if (chapterId > 0) return chapterId;
         }
 
+        var maxDiff = 0;
+        for (var i = 0; i < volumes.Count - 1; i++)
+        {
+            var diff = volumes[i].Number - volumes[i + 1].Number;
+            if (diff > maxDiff)
+            {
+                maxDiff = diff;
+            }
+        }
         foreach (var volume in volumes)
         {
             if (volume.Number == currentVolume.Number)

--- a/API/Services/SeriesService.cs
+++ b/API/Services/SeriesService.cs
@@ -13,6 +13,7 @@ using API.Entities;
 using API.Entities.Enums;
 using API.Helpers;
 using API.SignalR;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 
 namespace API.Services;
@@ -462,6 +463,9 @@ public class SeriesService : ISeriesService
     public async Task<SeriesDetailDto> GetSeriesDetail(int seriesId, int userId)
     {
         var series = await _unitOfWork.SeriesRepository.GetSeriesDtoByIdAsync(seriesId, userId);
+        var libraryIds = (await _unitOfWork.LibraryRepository.GetLibraryIdsForUserIdAsync(userId));
+        if (!libraryIds.Contains(series.LibraryId))
+            throw new UnauthorizedAccessException("User does not have access to the library this series belongs to");
 
         var libraryType = await _unitOfWork.LibraryRepository.GetLibraryTypeAsync(series.LibraryId);
         var volumes = (await _unitOfWork.VolumeRepository.GetVolumesDtoAsync(seriesId, userId))

--- a/API/Services/Tasks/Scanner/ProcessSeries.cs
+++ b/API/Services/Tasks/Scanner/ProcessSeries.cs
@@ -116,7 +116,7 @@ public class ProcessSeries : IProcessSeries
         {
             _logger.LogInformation("[ScannerService] Processing series {SeriesName}", series.OriginalName);
 
-            // parsedInfos[0] is not the first volume or chapter. We need to find it. Using a ComicInfo check
+            // parsedInfos[0] is not the first volume or chapter. We need to find it using a ComicInfo check (as it uses firstParsedInfo for series sort)
             var firstParsedInfo = parsedInfos.FirstOrDefault(p => p.ComicInfo != null, parsedInfos[0]);
 
             UpdateVolumes(series, parsedInfos);

--- a/API/Services/Tasks/Scanner/ProcessSeries.cs
+++ b/API/Services/Tasks/Scanner/ProcessSeries.cs
@@ -116,7 +116,8 @@ public class ProcessSeries : IProcessSeries
         {
             _logger.LogInformation("[ScannerService] Processing series {SeriesName}", series.OriginalName);
 
-            var firstParsedInfo = parsedInfos[0];
+            // parsedInfos[0] is not the first volume or chapter. We need to find it. Using a ComicInfo check
+            var firstParsedInfo = parsedInfos.FirstOrDefault(p => p.ComicInfo != null, parsedInfos[0]);
 
             UpdateVolumes(series, parsedInfos);
             series.Pages = series.Volumes.Sum(v => v.Pages);
@@ -482,7 +483,7 @@ public class ProcessSeries : IProcessSeries
                 var file = volume.Chapters.FirstOrDefault()?.Files?.FirstOrDefault()?.FilePath ?? string.Empty;
                 if (!string.IsNullOrEmpty(file) && _directoryService.FileSystem.File.Exists(file))
                 {
-                    _logger.LogError(
+                    _logger.LogInformation(
                         "[ScannerService] Volume cleanup code was trying to remove a volume with a file still existing on disk. File: {File}",
                         file);
                 }

--- a/API/Services/Tasks/Scanner/ProcessSeries.cs
+++ b/API/Services/Tasks/Scanner/ProcessSeries.cs
@@ -479,7 +479,7 @@ public class ProcessSeries : IProcessSeries
             var deletedVolumes = series.Volumes.Except(nonDeletedVolumes);
             foreach (var volume in deletedVolumes)
             {
-                var file = volume.Chapters.FirstOrDefault()?.Files?.FirstOrDefault()?.FilePath ?? "";
+                var file = volume.Chapters.FirstOrDefault()?.Files?.FirstOrDefault()?.FilePath ?? string.Empty;
                 if (!string.IsNullOrEmpty(file) && _directoryService.FileSystem.File.Exists(file))
                 {
                     _logger.LogError(

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -458,7 +458,7 @@ public class ScannerService : IScannerService
         }
 
 
-        var scanElapsedTime = await ScanFiles(library, libraryFolderPaths, shouldUseLibraryScan, TrackFiles);
+        var scanElapsedTime = await ScanFiles(library, libraryFolderPaths, shouldUseLibraryScan, TrackFiles, forceUpdate);
 
 
         await Task.WhenAll(processTasks);

--- a/API/Services/Tasks/StatsService.cs
+++ b/API/Services/Tasks/StatsService.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Runtime.InteropServices;
@@ -21,13 +23,14 @@ public interface IStatsService
 {
     Task Send();
     Task<ServerInfoDto> GetServerInfo();
+    Task SendCancellation();
 }
 public class StatsService : IStatsService
 {
     private readonly ILogger<StatsService> _logger;
     private readonly IUnitOfWork _unitOfWork;
     private readonly DataContext _context;
-    private const string ApiUrl = "https://stats.kavitareader.com";
+    private const string ApiUrl = "http://localhost:5001"; // "https://stats.kavitareader.com"
 
     public StatsService(ILogger<StatsService> logger, IUnitOfWork unitOfWork, DataContext context)
     {
@@ -127,6 +130,10 @@ public class StatsService : IStatsService
             MaxSeriesInALibrary = await MaxSeriesInAnyLibrary(),
             MaxVolumesInASeries = await MaxVolumesInASeries(),
             MaxChaptersInASeries = await MaxChaptersInASeries(),
+            MangaReaderBackgroundColors = await AllMangaReaderBackgroundColors(),
+            MangaReaderPageSplittingModes = await AllMangaReaderPageSplitting(),
+            MangaReaderLayoutModes = await AllMangaReaderLayoutModes(),
+            FileFormats = AllFormats(),
         };
 
         var usersWithPref = (await _unitOfWork.UserRepository.GetAllUsersAsync(AppUserIncludes.UserPreferences)).ToList();
@@ -147,6 +154,39 @@ public class StatsService : IStatsService
         }
 
         return serverInfo;
+    }
+
+    public async Task SendCancellation()
+    {
+        _logger.LogInformation("Informing KavitaStats that this instance is no longer sending stats");
+        var installId = (await _unitOfWork.SettingsRepository.GetSettingsDtoAsync()).InstallId;
+
+        var responseContent = string.Empty;
+
+        try
+        {
+            var response = await (ApiUrl + "/api/v2/stats/opt-out?installId=" + installId)
+                .WithHeader("Accept", "application/json")
+                .WithHeader("User-Agent", "Kavita")
+                .WithHeader("x-api-key", "MsnvA2DfQqxSK5jh")
+                .WithHeader("x-kavita-version", BuildInfo.Version)
+                .WithHeader("Content-Type", "application/json")
+                .WithTimeout(TimeSpan.FromSeconds(30))
+                .PostAsync();
+
+            if (response.StatusCode != StatusCodes.Status200OK)
+            {
+                _logger.LogError("KavitaStats did not respond successfully. {Content}", response);
+            }
+        }
+        catch (HttpRequestException e)
+        {
+            _logger.LogError(e, "KavitaStats did not respond successfully. {Response}", responseContent);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "An error happened during the request to KavitaStats");
+        }
     }
 
     private Task<bool> GetIfUsingSeriesRelationship()
@@ -189,5 +229,36 @@ public class StatsService : IStatsService
                 .Where(v => v.Number == 0)
                 .SelectMany(v => v.Chapters)
                 .Count());
+    }
+
+    private async Task<IEnumerable<string>> AllMangaReaderBackgroundColors()
+    {
+        return await _context.AppUserPreferences.Select(p => p.BackgroundColor).Distinct().ToListAsync();
+    }
+
+    private async Task<IEnumerable<PageSplitOption>> AllMangaReaderPageSplitting()
+    {
+        return await _context.AppUserPreferences.Select(p => p.PageSplitOption).Distinct().ToListAsync();
+    }
+
+    private async Task<IEnumerable<LayoutMode>> AllMangaReaderLayoutModes()
+    {
+        return await _context.AppUserPreferences.Select(p => p.LayoutMode).Distinct().ToListAsync();
+    }
+
+    private IEnumerable<FileFormatDto> AllFormats()
+    {
+        var results =  _context.MangaFile
+            .AsNoTracking()
+            .AsEnumerable()
+            .Select(m => new FileFormatDto()
+            {
+                Format = m.Format,
+                Extension = Path.GetExtension(m.FilePath)?.ToLowerInvariant()
+            })
+            .DistinctBy(f => f.Extension)
+            .ToList();
+
+        return results;
     }
 }

--- a/API/Services/Tasks/StatsService.cs
+++ b/API/Services/Tasks/StatsService.cs
@@ -30,7 +30,7 @@ public class StatsService : IStatsService
     private readonly ILogger<StatsService> _logger;
     private readonly IUnitOfWork _unitOfWork;
     private readonly DataContext _context;
-    private const string ApiUrl = "http://localhost:5001"; // "https://stats.kavitareader.com"
+    private const string ApiUrl = "https://stats.kavitareader.com";
 
     public StatsService(ILogger<StatsService> logger, IUnitOfWork unitOfWork, DataContext context)
     {

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ EXPOSE 5000
 
 WORKDIR /kavita
 
-HEALTHCHECK --interval=30s --timeout=15s --start-period=30s --retries=3 CMD curl --fail http://localhost:5000 || exit 1
+HEALTHCHECK --interval=30s --timeout=15s --start-period=30s --retries=3 CMD curl --fail http://localhost:5000/api/health || exit 1
 
 ENTRYPOINT [ "/bin/bash" ]
 CMD ["/entrypoint.sh"]

--- a/Kavita.Common/Configuration.cs
+++ b/Kavita.Common/Configuration.cs
@@ -11,12 +11,6 @@ public static class Configuration
 {
     public static readonly string AppSettingsFilename = Path.Join("config", GetAppSettingFilename());
 
-    public static string Branch
-    {
-        get => GetBranch(GetAppSettingFilename());
-        set => SetBranch(GetAppSettingFilename(), value);
-    }
-
     public static int Port
     {
         get => GetPort(GetAppSettingFilename());
@@ -146,42 +140,4 @@ public static class Configuration
     }
 
     #endregion
-
-    private static string GetBranch(string filePath)
-    {
-        const string defaultBranch = "main";
-
-        try
-        {
-            var json = File.ReadAllText(filePath);
-            var jsonObj = JsonSerializer.Deserialize<dynamic>(json);
-            const string key = "Branch";
-
-            if (jsonObj.TryGetProperty(key, out JsonElement tokenElement))
-            {
-                return tokenElement.GetString();
-            }
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine("Error reading app settings: " + ex.Message);
-        }
-
-        return defaultBranch;
-    }
-
-    private static void SetBranch(string filePath, string updatedBranch)
-    {
-        try
-        {
-            var currentBranch = GetBranch(filePath);
-            var json = File.ReadAllText(filePath)
-                .Replace("\"Branch\": " + currentBranch, "\"Branch\": " + updatedBranch);
-            File.WriteAllText(filePath, json);
-        }
-        catch (Exception)
-        {
-            /* Swallow Exception */
-        }
-    }
 }

--- a/UI/Web/src/app/admin/_models/server-settings.ts
+++ b/UI/Web/src/app/admin/_models/server-settings.ts
@@ -12,5 +12,6 @@ export interface ServerSettings {
     convertBookmarkToWebP: boolean;
     enableSwaggerUi: boolean;
     totalBackups: number;
+    totalLogs: number;
     enableFolderWatching: boolean;
 }

--- a/UI/Web/src/app/admin/manage-settings/manage-settings.component.html
+++ b/UI/Web/src/app/admin/manage-settings/manage-settings.component.html
@@ -21,14 +21,14 @@
         </div>
 
         <div class="row g-0 mb-2">
-            <div class="col-md-4 col-sm-12 pe-2">
+            <div class="col-md-3 col-sm-12 pe-2">
                 <label for="settings-port" class="form-label">Port</label>&nbsp;<i class="fa fa-info-circle" placement="right" [ngbTooltip]="portTooltip" role="button" tabindex="0"></i>
                 <ng-template #portTooltip>Port the server listens on. This is fixed if you are running on Docker. Requires restart to take effect.</ng-template>
                 <span class="visually-hidden" id="settings-port-help">Port the server listens on. This is fixed if you are running on Docker. Requires restart to take effect.</span>
                 <input id="settings-port" aria-describedby="settings-port-help" class="form-control" formControlName="port" type="number" step="1" min="1" onkeypress="return event.charCode >= 48 && event.charCode <= 57">
             </div>
 
-            <div class="col-md-4 col-sm-12 pe-2">
+            <div class="col-md-3 col-sm-12 pe-2">
                 <label for="backup-tasks" class="form-label">Days of Backups</label>&nbsp;<i class="fa fa-info-circle" placement="right" [ngbTooltip]="backupTasksTooltip" role="button" tabindex="0"></i>
                 <ng-template #backupTasksTooltip>The number of backups to maintain. Default is 30, minumum is 1, maximum is 30.</ng-template>
                 <span class="visually-hidden" id="backup-tasks-help">The number of backups to maintain. Default is 30, minumum is 1, maximum is 30.</span>
@@ -45,8 +45,26 @@
                     </p>
                 </ng-container>
             </div>
+
+            <div class="col-md-3 col-sm-12 pe-2">
+                <label for="log-tasks" class="form-label">Days of Logs</label>&nbsp;<i class="fa fa-info-circle" placement="right" [ngbTooltip]="logTasksTooltip" role="button" tabindex="0"></i>
+                <ng-template #logTasksTooltip>The number of logs to maintain. Default is 30, minumum is 1, maximum is 30.</ng-template>
+                <span class="visually-hidden" id="log-tasks-help">The number of backups to maintain. Default is 30, minumum is 1, maximum is 30.</span>
+                <input id="log-tasks" aria-describedby="log-tasks-help" class="form-control" formControlName="totalLogs" type="number" step="1" min="1" max="30" onkeypress="return event.charCode >= 48 && event.charCode <= 57">
+                <ng-container *ngIf="settingsForm.get('totalLogs')?.errors as errors">
+                    <p class="invalid-feedback" *ngIf="errors.min">
+                        You must have at least 1 log
+                    </p>
+                    <p class="invalid-feedback" *ngIf="errors.max">
+                        You cannot have more than {{errors.max.max}} logs
+                    </p>
+                    <p class="invalid-feedback" *ngIf="errors.required">
+                        This field is required
+                    </p>
+                </ng-container>
+            </div>
     
-            <div class="col-md-4 col-sm-12">
+            <div class="col-md-3 col-sm-12">
                 <label for="logging-level-port" class="form-label">Logging Level</label>&nbsp;<i class="fa fa-info-circle" placement="right" [ngbTooltip]="loggingLevelTooltip" role="button" tabindex="0"></i>
                 <ng-template #loggingLevelTooltip>Use debug to help identify issues. Debug can eat up a lot of disk space.</ng-template>
                 <span class="visually-hidden" id="logging-level-port-help">Port the server listens on.</span>

--- a/UI/Web/src/app/admin/manage-settings/manage-settings.component.ts
+++ b/UI/Web/src/app/admin/manage-settings/manage-settings.component.ts
@@ -49,6 +49,7 @@ export class ManageSettingsComponent implements OnInit {
       this.settingsForm.addControl('emailServiceUrl', new FormControl(this.serverSettings.emailServiceUrl, [Validators.required]));
       this.settingsForm.addControl('enableSwaggerUi', new FormControl(this.serverSettings.enableSwaggerUi, [Validators.required]));
       this.settingsForm.addControl('totalBackups', new FormControl(this.serverSettings.totalBackups, [Validators.required, Validators.min(1), Validators.max(30)]));
+      this.settingsForm.addControl('totalLogs', new FormControl(this.serverSettings.totalLogs, [Validators.required, Validators.min(1), Validators.max(30)]));
       this.settingsForm.addControl('enableFolderWatching', new FormControl(this.serverSettings.enableFolderWatching, [Validators.required]));
       this.settingsForm.addControl('convertBookmarkToWebP', new FormControl(this.serverSettings.convertBookmarkToWebP, []));
     });
@@ -67,6 +68,7 @@ export class ManageSettingsComponent implements OnInit {
     this.settingsForm.get('emailServiceUrl')?.setValue(this.serverSettings.emailServiceUrl);
     this.settingsForm.get('enableSwaggerUi')?.setValue(this.serverSettings.enableSwaggerUi);
     this.settingsForm.get('totalBackups')?.setValue(this.serverSettings.totalBackups);
+    this.settingsForm.get('totalLogs')?.setValue(this.serverSettings.totalLogs);
     this.settingsForm.get('enableFolderWatching')?.setValue(this.serverSettings.enableFolderWatching);
     this.settingsForm.get('convertBookmarkToWebP')?.setValue(this.serverSettings.convertBookmarkToWebP);
     this.settingsForm.markAsPristine();

--- a/UI/Web/src/app/series-detail/series-detail.component.ts
+++ b/UI/Web/src/app/series-detail/series-detail.component.ts
@@ -3,7 +3,7 @@ import { Title } from '@angular/platform-browser';
 import { ActivatedRoute, Router } from '@angular/router';
 import { NgbModal, NgbNavChangeEvent, NgbOffcanvas } from '@ng-bootstrap/ng-bootstrap';
 import { ToastrService } from 'ngx-toastr';
-import { forkJoin, Subject } from 'rxjs';
+import { catchError, forkJoin, of, Subject } from 'rxjs';
 import { take, takeUntil } from 'rxjs/operators';
 import { BulkSelectionService } from '../cards/bulk-selection.service';
 import { EditSeriesModalComponent } from '../cards/_modals/edit-series-modal/edit-series-modal.component';
@@ -511,7 +511,11 @@ export class SeriesDetailComponent implements OnInit, OnDestroy, AfterContentChe
         }
       });
 
-      this.seriesService.getSeriesDetail(this.seriesId).subscribe(detail => {
+      this.seriesService.getSeriesDetail(this.seriesId).pipe(catchError(err => {
+        this.router.navigateByUrl('/libraries');
+        return of(null);
+      })).subscribe(detail => {
+        if (detail == null) return;
         this.hasSpecials = detail.specials.length > 0;
         this.specials = detail.specials;
 

--- a/UI/Web/src/app/user-settings/user-preferences/user-preferences.component.ts
+++ b/UI/Web/src/app/user-settings/user-preferences/user-preferences.component.ts
@@ -210,7 +210,7 @@ export class UserPreferencesComponent implements OnInit, OnDestroy {
       readerMode: parseInt(modelSettings.readerMode, 10),
       layoutMode: parseInt(modelSettings.layoutMode, 10),
       showScreenHints: modelSettings.showScreenHints,
-      backgroundColor: modelSettings.backgroundColor,
+      backgroundColor: this.user.preferences.backgroundColor,
       bookReaderFontFamily: modelSettings.bookReaderFontFamily,
       bookReaderLineSpacing: modelSettings.bookReaderLineSpacing,
       bookReaderFontSize: modelSettings.bookReaderFontSize,

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,24 +3,7 @@
 if [ ! -f "/kavita/config/appsettings.json" ]; then
     echo "Kavita configuration file does not exist, creating..."
     echo '{
-  "ConnectionStrings": {
-    "DefaultConnection": "Data source=config//kavita.db"
-  },
   "TokenKey": "super secret unguessable key",
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft": "Information",
-      "Microsoft.Hosting.Lifetime": "Error",
-      "Hangfire": "Information",
-      "Microsoft.AspNetCore.Hosting.Internal.WebHost": "Information"
-    },
-    "File": {
-      "Path": "config//logs/kavita.log",
-      "Append": "True",
-      "FileSizeLimitBytes": 26214400,
-      "MaxRollingFiles": 2
-    }
   },
   "Port": 5000
 }' >> /kavita/config/appsettings.json


### PR DESCRIPTION
# Added
- Added: Added a new setting to manage how many log files exists in terms of days, since Kavita uses splitting on days now.
- Added: Added new stats for tracking to help with some of the reader feature utilization for some upcoming redesign/polish work (Closes #1522 )

# Changed
- Changed: Moved LibraryWatcher (folder watching) to utilize a queue for calculating the change events to ensure the watcher doesn't get overwhelmed on large moves.
- Changed: Tweaked the log levels and template (develop)
- Changed: Changed the build pipeline to remove a redundant build step 

# Fixed
- Fixed: Fixed a security vulnerability (https://huntr.dev/bounties/8a3e652f-d6bf-436e-877e-0eaf5c69ef95/). This will be disclosed in Stable release changelog.
- Fixed: Fixed a bug where ComicInfo wouldn't be found at root level (develop)
- Fixed: Fixed a bug where scanner could select the wrong first file when a series is first imported and has ComicInfo.
- Fixed: Fixed a bug where Manga Reader background color wasn't actually sending to the backend from UI
- Fixed: Fixed a bug where volumes that had larger than 1 difference wouldn't properly return next/prev chapter (for continuous reader) (Fixes #1540 )
