### PR TITLE
Nested Menus

### DIFF
--- a/UI/Web/package-lock.json
+++ b/UI/Web/package-lock.json
@@ -2637,9 +2637,9 @@
       }
     },
     "@angular/cdk": {
-      "version": "13.2.2",
-      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-13.2.2.tgz",
-      "integrity": "sha512-cT5DIaz+NI9IGb3X61Wh26+L6zdRcOXT1BP37iRbK2Qa2qM8/0VNeK6hrBBIblyoHKR/WUmRlS8XYf6mmArpZw==",
+      "version": "13.3.9",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-13.3.9.tgz",
+      "integrity": "sha512-XCuCbeuxWFyo3EYrgEYx7eHzwl76vaWcxtWXl00ka8d+WAOtMQ6Tf1D98ybYT5uwF9889fFpXAPw98mVnlo3MA==",
       "requires": {
         "parse5": "^5.0.0",
         "tslib": "^2.3.0"

--- a/UI/Web/src/app/_services/action-factory.service.ts
+++ b/UI/Web/src/app/_services/action-factory.service.ts
@@ -124,63 +124,31 @@ export class ActionFactoryService {
   }
 
   getLibraryActions(callback: (action: Action, library: Library) => void) {
-    const actions = this.libraryActions.map((a) => {
-      return { ...a };
-    });
-    actions.forEach((action) => (this.appyCallback(action, callback)));
-    return actions;
+		return this.applyCallbackToList(this.libraryActions, callback);
   }
 
   getSeriesActions(callback: (action: Action, series: Series) => void) {
-    const actions = this.seriesActions.map((a) => {
-      return { ...a };
-    });
-    actions.forEach((action) => (this.appyCallback(action, callback)));
-    return actions;
+		return this.applyCallbackToList(this.seriesActions, callback);
   }
 
   getVolumeActions(callback: (action: Action, volume: Volume) => void) {
-    const actions = this.volumeActions.map((a) => {
-      return { ...a };
-    });
-    actions.forEach((action) => (this.appyCallback(action, callback)));
-    return actions;
+		return this.applyCallbackToList(this.volumeActions, callback);
   }
 
   getChapterActions(callback: (action: Action, chapter: Chapter) => void) {
-    const actions = this.chapterActions.map((a) => {
-      return { ...a };
-    });
-    actions.forEach((action) => (this.appyCallback(action, callback)));
-    return actions;
+    return this.applyCallbackToList(this.chapterActions, callback);
   }
 
-  getCollectionTagActions(
-    callback: (action: Action, collectionTag: CollectionTag) => void
-  ) {
-    const actions = this.collectionTagActions.map((a) => {
-      return { ...a };
-    });
-    actions.forEach((action) => (this.appyCallback(action, callback)));
-    return actions;
+  getCollectionTagActions(callback: (action: Action, collectionTag: CollectionTag) => void) {
+		return this.applyCallbackToList(this.collectionTagActions, callback);
   }
 
-  getReadingListActions(
-    callback: (action: Action, readingList: ReadingList) => void
-  ) {
-    const actions = this.readingListActions.map((a) => {
-      return { ...a };
-    });
-    actions.forEach((action) => (this.appyCallback(action, callback)));
-    return actions;
+  getReadingListActions(callback: (action: Action, readingList: ReadingList) => void) {
+    return this.applyCallbackToList(this.readingListActions, callback);
   }
 
   getBookmarkActions(callback: (action: Action, series: Series) => void) {
-    const actions = this.bookmarkActions.map((a) => {
-      return { ...a };
-    });
-    actions.forEach((action) => (this.appyCallback(action, callback)));
-    return actions;
+    return this.applyCallbackToList(this.bookmarkActions, callback);
   }
 
   dummyCallback(action: Action, data: any) {}
@@ -191,23 +159,31 @@ export class ActionFactoryService {
         action: Action.Scan,
         title: 'Scan Library',
         callback: this.dummyCallback,
-        requiresAdmin: true,
-        children: []
+        requiresAdmin: false,
+        children: [],
       },
       {
-        action: Action.RefreshMetadata,
-        title: 'Refresh Covers',
+        action: Action.Others,
+        title: 'Others',
         callback: this.dummyCallback,
         requiresAdmin: true,
-        children: []
+        children: [
+          {
+            action: Action.RefreshMetadata,
+            title: 'Refresh Covers',
+            callback: this.dummyCallback,
+            requiresAdmin: true,
+            children: [],
+          },
+          {
+            action: Action.AnalyzeFiles,
+            title: 'Analyze Files',
+            callback: this.dummyCallback,
+            requiresAdmin: true,
+            children: [],
+          },
+        ],
       },
-      {
-        action: Action.AnalyzeFiles,
-        title: 'Analyze Files',
-        callback: this.dummyCallback,
-        requiresAdmin: true,
-        children: []
-      }
     ];
 
     this.collectionTagActions = [
@@ -216,8 +192,8 @@ export class ActionFactoryService {
         title: 'Edit',
         callback: this.dummyCallback,
         requiresAdmin: true,
-        children: []
-      }
+        children: [],
+      },
     ];
 
     this.seriesActions = [
@@ -226,14 +202,14 @@ export class ActionFactoryService {
         title: 'Mark as Read',
         callback: this.dummyCallback,
         requiresAdmin: false,
-        children: []
+        children: [],
       },
       {
         action: Action.MarkAsUnread,
         title: 'Mark as Unread',
         callback: this.dummyCallback,
         requiresAdmin: false,
-        children: []
+        children: [],
       },
       {
         action: Action.AddTo,
@@ -241,49 +217,49 @@ export class ActionFactoryService {
         callback: this.dummyCallback,
         requiresAdmin: false,
         children: [
-          {
+        	{
             action: Action.AddToWantToReadList,
             title: 'Add to Want To Read',
             callback: this.dummyCallback,
             requiresAdmin: false,
-            children: []
+            children: [],
           },
           {
             action: Action.RemoveFromWantToReadList,
             title: 'Remove from Want To Read',
             callback: this.dummyCallback,
             requiresAdmin: false,
-            children: []
+            children: [],
           },
           {
             action: Action.AddToReadingList,
             title: 'Add to Reading List',
             callback: this.dummyCallback,
             requiresAdmin: false,
-            children: []
+            children: [],
           },
           {
             action: Action.AddToCollection,
             title: 'Add to Collection',
             callback: this.dummyCallback,
             requiresAdmin: true,
-            children: []
-          }
+            children: [],
+          },
         ],
       },
       {
         action: Action.Scan,
         title: 'Scan Series',
         callback: this.dummyCallback,
-        requiresAdmin: true,
-        children: []
+        requiresAdmin: false,
+        children: [],
       },
       {
         action: Action.Edit,
         title: 'Edit',
         callback: this.dummyCallback,
         requiresAdmin: true,
-        children: []
+        children: [],
       },
       {
         action: Action.Others,
@@ -296,114 +272,131 @@ export class ActionFactoryService {
             title: 'Refresh Covers',
             callback: this.dummyCallback,
             requiresAdmin: true,
-            children: []
+            children: [],
           },
           {
             action: Action.AnalyzeFiles,
             title: 'Analyze Files',
             callback: this.dummyCallback,
             requiresAdmin: true,
-            children: []
+            children: [],
           },
           {
             action: Action.Delete,
             title: 'Delete',
             callback: this.dummyCallback,
             requiresAdmin: true,
-            children: []
-          }
-        ]
-      }
+            children: [],
+          },
+        ],
+      },
     ];
 
     this.volumeActions = [
       {
         action: Action.IncognitoRead,
-        title: '(Read Incognito)',
+        title: 'Read Incognito',
         callback: this.dummyCallback,
         requiresAdmin: false,
-        children: []
+        children: [],
       },
       {
         action: Action.MarkAsRead,
         title: 'Mark as Read',
         callback: this.dummyCallback,
         requiresAdmin: false,
-        children: []
+        children: [],
       },
       {
         action: Action.MarkAsUnread,
         title: 'Mark as Unread',
         callback: this.dummyCallback,
         requiresAdmin: false,
-        children: []
+        children: [],
       },
-      {
-        action: Action.AddToReadingList,
-        title: 'Add to Reading List',
-        callback: this.dummyCallback,
-        requiresAdmin: false,
-        children: []
-      },
+			{
+				action: Action.AddTo,
+				title: 'Add to',
+				callback: this.dummyCallback,
+				requiresAdmin: false,
+				children: [
+					{
+						action: Action.AddToReadingList,
+						title: 'Add to Reading List',
+						callback: this.dummyCallback,
+						requiresAdmin: false,
+						children: [],
+					}
+				]
+			},
       {
         action: Action.Edit,
         title: 'Details',
         callback: this.dummyCallback,
         requiresAdmin: false,
-        children: []
+        children: [],
       },
       {
         action: Action.Download,
         title: 'Download',
         callback: this.dummyCallback,
         requiresAdmin: false,
-        children: []
-      }
+        children: [],
+      },
     ];
 
     this.chapterActions = [
       {
         action: Action.IncognitoRead,
-        title: '(Read Incognito)',
+        title: 'Read Incognito',
         callback: this.dummyCallback,
         requiresAdmin: false,
-        children: []
+        children: [],
       },
       {
         action: Action.MarkAsRead,
         title: 'Mark as Read',
         callback: this.dummyCallback,
         requiresAdmin: false,
-        children: []
+        children: [],
       },
       {
         action: Action.MarkAsUnread,
         title: 'Mark as Unread',
         callback: this.dummyCallback,
         requiresAdmin: false,
-        children: []
+        children: [],
       },
-      {
-        action: Action.AddToReadingList,
-        title: 'Add to Reading List',
-        callback: this.dummyCallback,
-        requiresAdmin: false,
-        children: []
-      },
+			{
+				action: Action.AddTo,
+				title: 'Add to',
+				callback: this.dummyCallback,
+				requiresAdmin: false,
+				children: [
+					{
+						action: Action.AddToReadingList,
+						title: 'Add to Reading List',
+						callback: this.dummyCallback,
+						requiresAdmin: false,
+						children: [],
+					}
+				]
+			},
       {
         action: Action.Edit,
         title: 'Details',
         callback: this.dummyCallback,
         requiresAdmin: false,
-        children: []
+        children: [],
       },
+			// RBS will handle rendering this, so non-admins with download are appicable
       {
         action: Action.Download,
         title: 'Download',
         callback: this.dummyCallback,
         requiresAdmin: false,
-        children: []
-      }
+        children: [],
+      },
     ];
 
     this.readingListActions = [
@@ -412,14 +405,14 @@ export class ActionFactoryService {
         title: 'Edit',
         callback: this.dummyCallback,
         requiresAdmin: false,
-        children: []
+        children: [],
       },
       {
         action: Action.Delete,
         title: 'Delete',
         callback: this.dummyCallback,
         requiresAdmin: false,
-        children: []
+        children: [],
       },
     ];
 
@@ -429,32 +422,40 @@ export class ActionFactoryService {
         title: 'View Series',
         callback: this.dummyCallback,
         requiresAdmin: false,
-        children: []
+        children: [],
       },
       {
         action: Action.DownloadBookmark,
         title: 'Download',
         callback: this.dummyCallback,
         requiresAdmin: false,
-        children: []
+        children: [],
       },
       {
         action: Action.Delete,
         title: 'Clear',
         callback: this.dummyCallback,
         requiresAdmin: false,
-        children: []
+        children: [],
       },
     ];
   }
 
-  private appyCallback(action: ActionItem<any>, callback: (action: Action, data: any) => void) {
+  private applyCallback(action: ActionItem<any>, callback: (action: Action, data: any) => void) {
     action.callback = callback;
 
     if (action.children === null || action.children?.length === 0) return;
 
     action.children?.forEach((childAction) => {
-      this.appyCallback(childAction, callback);
+      this.applyCallback(childAction, callback);
     });
   }
+
+	private applyCallbackToList(list: Array<ActionItem<any>>, callback: (action: Action, data: any) => void): Array<ActionItem<any>> {
+		const actions = list.map((a) => {
+			return { ...a };
+		});
+		actions.forEach((action) => this.applyCallback(action, callback));
+		return actions;
+	}
 }

--- a/UI/Web/src/app/_services/action-factory.service.ts
+++ b/UI/Web/src/app/_services/action-factory.service.ts
@@ -9,7 +9,7 @@ import { AccountService } from './account.service';
 
 export enum Action {
   AddTo = -2,
-  MarkAs = -1,
+  Others = -1,
   /**
    * Mark entity as read
    */
@@ -85,7 +85,7 @@ export interface ActionItem<T> {
   action: Action;
   callback: (action: Action, data: T) => void;
   requiresAdmin: boolean;
-  children?: Array<ActionItem<T>>;
+  children: Array<ActionItem<T>>;
 }
 
 @Injectable({
@@ -120,102 +120,6 @@ export class ActionFactoryService {
       }
 
       this._resetActions();
-
-      if (this.isAdmin) {
-        this.collectionTagActions.push({
-          action: Action.Edit,
-          title: 'Edit',
-          callback: this.dummyCallback,
-          requiresAdmin: true,
-          children: []
-        });
-
-        this.seriesActions.push({
-          action: Action.Scan,
-          title: 'Scan Series',
-          callback: this.dummyCallback,
-          requiresAdmin: true,
-        });
-
-        this.seriesActions.push({
-          action: Action.RefreshMetadata,
-          title: 'Refresh Covers',
-          callback: this.dummyCallback,
-          requiresAdmin: true,
-        });
-
-        this.seriesActions.push({
-          action: Action.AnalyzeFiles,
-          title: 'Analyze Files',
-          callback: this.dummyCallback,
-          requiresAdmin: true,
-        });
-
-        this.seriesActions.push({
-          action: Action.Delete,
-          title: 'Delete',
-          callback: this.dummyCallback,
-          requiresAdmin: true,
-        });
-
-        this.seriesActions.find(a => a.action === Action.AddTo)?.children?.push({
-          action: Action.AddToCollection,
-          title: 'Add to Collection',
-          callback: this.dummyCallback,
-          requiresAdmin: true,
-        });
-
-        this.seriesActions.push({
-          action: Action.Edit,
-          title: 'Edit',
-          callback: this.dummyCallback,
-          requiresAdmin: true,
-        });
-
-        this.libraryActions.push({
-          action: Action.Scan,
-          title: 'Scan Library',
-          callback: this.dummyCallback,
-          requiresAdmin: true,
-        });
-
-        this.libraryActions.push({
-          action: Action.RefreshMetadata,
-          title: 'Refresh Covers',
-          callback: this.dummyCallback,
-          requiresAdmin: true,
-        });
-
-        this.libraryActions.push({
-          action: Action.AnalyzeFiles,
-          title: 'Analyze Files',
-          callback: this.dummyCallback,
-          requiresAdmin: true,
-        });
-
-        this.chapterActions.push({
-          action: Action.Edit,
-          title: 'Details',
-          callback: this.dummyCallback,
-          requiresAdmin: false,
-        });
-      }
-
-      if (this.hasDownloadRole || this.isAdmin) {
-        this.volumeActions.push({
-          action: Action.Download,
-          title: 'Download',
-          callback: this.dummyCallback,
-          requiresAdmin: false,
-        });
-
-        this.chapterActions.push({
-          action: Action.Download,
-          title: 'Download',
-          callback: this.dummyCallback,
-          requiresAdmin: false,
-        });
-      }
     });
   }
 
@@ -282,133 +186,224 @@ export class ActionFactoryService {
   dummyCallback(action: Action, data: any) {}
 
   _resetActions() {
-    this.libraryActions = [];
+    this.libraryActions = [
+      {
+        action: Action.Scan,
+        title: 'Scan Library',
+        callback: this.dummyCallback,
+        requiresAdmin: true,
+        children: []
+      },
+      {
+        action: Action.RefreshMetadata,
+        title: 'Refresh Covers',
+        callback: this.dummyCallback,
+        requiresAdmin: true,
+        children: []
+      },
+      {
+        action: Action.AnalyzeFiles,
+        title: 'Analyze Files',
+        callback: this.dummyCallback,
+        requiresAdmin: true,
+        children: []
+      }
+    ];
 
-    this.collectionTagActions = [];
+    this.collectionTagActions = [
+      {
+        action: Action.Edit,
+        title: 'Edit',
+        callback: this.dummyCallback,
+        requiresAdmin: true,
+        children: []
+      }
+    ];
 
     this.seriesActions = [
-      // {
-      //   action: Action.MarkAsRead,
-      //   title: 'Mark as Read',
-      //   callback: this.dummyCallback,
-      //   requiresAdmin: false
-      // },
-      // {
-      //   action: Action.MarkAsUnread,
-      //   title: 'Mark as Unread',
-      //   callback: this.dummyCallback,
-      //   requiresAdmin: false
-      // },
       {
         action: Action.MarkAsRead,
         title: 'Mark as Read',
         callback: this.dummyCallback,
-        requiresAdmin: false
+        requiresAdmin: false,
+        children: []
       },
       {
         action: Action.MarkAsUnread,
         title: 'Mark as Unread',
         callback: this.dummyCallback,
-        requiresAdmin: false
-      }, 
-      { action: Action.AddTo,
+        requiresAdmin: false,
+        children: []
+      },
+      {
+        action: Action.AddTo,
         title: 'Add to',
         callback: this.dummyCallback,
         requiresAdmin: false,
         children: [
           {
-            action: Action.AddToReadingList,
-            title: 'Add to Reading List',
-            callback: (action, data) => {console.log('Add to Reading List Works!')},
-            requiresAdmin: false,
-          },
-          {
             action: Action.AddToWantToReadList,
             title: 'Add to Want To Read',
-            callback: (action, data) => {console.log('Add to Want to Read List Works!')},
+            callback: this.dummyCallback,
             requiresAdmin: false,
             children: []
           },
+          {
+            action: Action.RemoveFromWantToReadList,
+            title: 'Remove from Want To Read',
+            callback: this.dummyCallback,
+            requiresAdmin: false,
+            children: []
+          },
+          {
+            action: Action.AddToReadingList,
+            title: 'Add to Reading List',
+            callback: this.dummyCallback,
+            requiresAdmin: false,
+            children: []
+          },
+          {
+            action: Action.AddToCollection,
+            title: 'Add to Collection',
+            callback: this.dummyCallback,
+            requiresAdmin: true,
+            children: []
+          }
         ],
       },
-      // {
-      //   action: Action.AddToReadingList,
-      //   title: 'Add to Reading List',
-      //   callback: this.dummyCallback,
-      //   requiresAdmin: false,
-      // },
-      // {
-      //   action: Action.AddToWantToReadList,
-      //   title: 'Add to Want To Read',
-      //   callback: this.dummyCallback,
-      //   requiresAdmin: false,
-      // },
       {
-        action: Action.RemoveFromWantToReadList,
-        title: 'Remove from Want To Read',
+        action: Action.Scan,
+        title: 'Scan Series',
+        callback: this.dummyCallback,
+        requiresAdmin: true,
+        children: []
+      },
+      {
+        action: Action.Edit,
+        title: 'Edit',
+        callback: this.dummyCallback,
+        requiresAdmin: true,
+        children: []
+      },
+      {
+        action: Action.Others,
+        title: 'Others',
         callback: this.dummyCallback,
         requiresAdmin: false,
-      },
+        children: [
+          {
+            action: Action.RefreshMetadata,
+            title: 'Refresh Covers',
+            callback: this.dummyCallback,
+            requiresAdmin: true,
+            children: []
+          },
+          {
+            action: Action.AnalyzeFiles,
+            title: 'Analyze Files',
+            callback: this.dummyCallback,
+            requiresAdmin: true,
+            children: []
+          },
+          {
+            action: Action.Delete,
+            title: 'Delete',
+            callback: this.dummyCallback,
+            requiresAdmin: true,
+            children: []
+          }
+        ]
+      }
     ];
 
     this.volumeActions = [
+      {
+        action: Action.IncognitoRead,
+        title: '(Read Incognito)',
+        callback: this.dummyCallback,
+        requiresAdmin: false,
+        children: []
+      },
       {
         action: Action.MarkAsRead,
         title: 'Mark as Read',
         callback: this.dummyCallback,
         requiresAdmin: false,
+        children: []
       },
       {
         action: Action.MarkAsUnread,
         title: 'Mark as Unread',
         callback: this.dummyCallback,
         requiresAdmin: false,
+        children: []
       },
       {
         action: Action.AddToReadingList,
         title: 'Add to Reading List',
         callback: this.dummyCallback,
         requiresAdmin: false,
-      },
-      {
-        action: Action.IncognitoRead,
-        title: 'Read Incognito',
-        callback: this.dummyCallback,
-        requiresAdmin: false,
+        children: []
       },
       {
         action: Action.Edit,
         title: 'Details',
         callback: this.dummyCallback,
         requiresAdmin: false,
+        children: []
       },
+      {
+        action: Action.Download,
+        title: 'Download',
+        callback: this.dummyCallback,
+        requiresAdmin: false,
+        children: []
+      }
     ];
 
     this.chapterActions = [
+      {
+        action: Action.IncognitoRead,
+        title: '(Read Incognito)',
+        callback: this.dummyCallback,
+        requiresAdmin: false,
+        children: []
+      },
       {
         action: Action.MarkAsRead,
         title: 'Mark as Read',
         callback: this.dummyCallback,
         requiresAdmin: false,
+        children: []
       },
       {
         action: Action.MarkAsUnread,
         title: 'Mark as Unread',
         callback: this.dummyCallback,
         requiresAdmin: false,
-      },
-      {
-        action: Action.IncognitoRead,
-        title: 'Read Incognito',
-        callback: this.dummyCallback,
-        requiresAdmin: false,
+        children: []
       },
       {
         action: Action.AddToReadingList,
         title: 'Add to Reading List',
         callback: this.dummyCallback,
         requiresAdmin: false,
+        children: []
       },
+      {
+        action: Action.Edit,
+        title: 'Details',
+        callback: this.dummyCallback,
+        requiresAdmin: false,
+        children: []
+      },
+      {
+        action: Action.Download,
+        title: 'Download',
+        callback: this.dummyCallback,
+        requiresAdmin: false,
+        children: []
+      }
     ];
 
     this.readingListActions = [
@@ -417,12 +412,14 @@ export class ActionFactoryService {
         title: 'Edit',
         callback: this.dummyCallback,
         requiresAdmin: false,
+        children: []
       },
       {
         action: Action.Delete,
         title: 'Delete',
         callback: this.dummyCallback,
         requiresAdmin: false,
+        children: []
       },
     ];
 
@@ -432,18 +429,21 @@ export class ActionFactoryService {
         title: 'View Series',
         callback: this.dummyCallback,
         requiresAdmin: false,
+        children: []
       },
       {
         action: Action.DownloadBookmark,
         title: 'Download',
         callback: this.dummyCallback,
         requiresAdmin: false,
+        children: []
       },
       {
         action: Action.Delete,
         title: 'Clear',
         callback: this.dummyCallback,
         requiresAdmin: false,
+        children: []
       },
     ];
   }

--- a/UI/Web/src/app/_services/action-factory.service.ts
+++ b/UI/Web/src/app/_services/action-factory.service.ts
@@ -127,6 +127,7 @@ export class ActionFactoryService {
           title: 'Edit',
           callback: this.dummyCallback,
           requiresAdmin: true,
+          children: []
         });
 
         this.seriesActions.push({
@@ -157,7 +158,7 @@ export class ActionFactoryService {
           requiresAdmin: true,
         });
 
-        this.seriesActions.push({
+        this.seriesActions.find(a => a.action === Action.AddTo)?.children?.push({
           action: Action.AddToCollection,
           title: 'Add to Collection',
           callback: this.dummyCallback,
@@ -222,7 +223,7 @@ export class ActionFactoryService {
     const actions = this.libraryActions.map((a) => {
       return { ...a };
     });
-    actions.forEach((action) => (action.callback = callback));
+    actions.forEach((action) => (this.appyCallback(action, callback)));
     return actions;
   }
 
@@ -230,7 +231,7 @@ export class ActionFactoryService {
     const actions = this.seriesActions.map((a) => {
       return { ...a };
     });
-    actions.forEach((action) => (action.callback = callback));
+    actions.forEach((action) => (this.appyCallback(action, callback)));
     return actions;
   }
 
@@ -238,7 +239,7 @@ export class ActionFactoryService {
     const actions = this.volumeActions.map((a) => {
       return { ...a };
     });
-    actions.forEach((action) => (action.callback = callback));
+    actions.forEach((action) => (this.appyCallback(action, callback)));
     return actions;
   }
 
@@ -246,7 +247,7 @@ export class ActionFactoryService {
     const actions = this.chapterActions.map((a) => {
       return { ...a };
     });
-    actions.forEach((action) => (action.callback = callback));
+    actions.forEach((action) => (this.appyCallback(action, callback)));
     return actions;
   }
 
@@ -256,7 +257,7 @@ export class ActionFactoryService {
     const actions = this.collectionTagActions.map((a) => {
       return { ...a };
     });
-    actions.forEach((action) => (action.callback = callback));
+    actions.forEach((action) => (this.appyCallback(action, callback)));
     return actions;
   }
 
@@ -266,7 +267,7 @@ export class ActionFactoryService {
     const actions = this.readingListActions.map((a) => {
       return { ...a };
     });
-    actions.forEach((action) => (action.callback = callback));
+    actions.forEach((action) => (this.appyCallback(action, callback)));
     return actions;
   }
 
@@ -274,7 +275,7 @@ export class ActionFactoryService {
     const actions = this.bookmarkActions.map((a) => {
       return { ...a };
     });
-    actions.forEach((action) => (action.callback = callback));
+    actions.forEach((action) => (this.appyCallback(action, callback)));
     return actions;
   }
 
@@ -286,6 +287,18 @@ export class ActionFactoryService {
     this.collectionTagActions = [];
 
     this.seriesActions = [
+      // {
+      //   action: Action.MarkAsRead,
+      //   title: 'Mark as Read',
+      //   callback: this.dummyCallback,
+      //   requiresAdmin: false
+      // },
+      // {
+      //   action: Action.MarkAsUnread,
+      //   title: 'Mark as Unread',
+      //   callback: this.dummyCallback,
+      //   requiresAdmin: false
+      // },
       {
         action: Action.MarkAsRead,
         title: 'Mark as Read',
@@ -314,14 +327,7 @@ export class ActionFactoryService {
             title: 'Add to Want To Read',
             callback: (action, data) => {console.log('Add to Want to Read List Works!')},
             requiresAdmin: false,
-            children: [
-              {
-                action: Action.AddToReadingList,
-                title: 'Add to Reading List',
-                callback: (action, data) => {console.log('Add to Reading List Works!')},
-                requiresAdmin: false,
-              },
-            ]
+            children: []
           },
         ],
       },
@@ -440,5 +446,15 @@ export class ActionFactoryService {
         requiresAdmin: false,
       },
     ];
+  }
+
+  private appyCallback(action: ActionItem<any>, callback: (action: Action, data: any) => void) {
+    action.callback = callback;
+
+    if (action.children === null || action.children?.length === 0) return;
+
+    action.children?.forEach((childAction) => {
+      this.appyCallback(childAction, callback);
+    });
   }
 }

--- a/UI/Web/src/app/_services/action-factory.service.ts
+++ b/UI/Web/src/app/_services/action-factory.service.ts
@@ -8,6 +8,8 @@ import { Volume } from '../_models/volume';
 import { AccountService } from './account.service';
 
 export enum Action {
+  AddTo = -2,
+  MarkAs = -1,
   /**
    * Mark entity as read
    */
@@ -83,13 +85,13 @@ export interface ActionItem<T> {
   action: Action;
   callback: (action: Action, data: T) => void;
   requiresAdmin: boolean;
+  children?: Array<ActionItem<T>>;
 }
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class ActionFactoryService {
-
   libraryActions: Array<ActionItem<Library>> = [];
 
   seriesActions: Array<ActionItem<Series>> = [];
@@ -108,7 +110,7 @@ export class ActionFactoryService {
   hasDownloadRole = false;
 
   constructor(private accountService: AccountService) {
-    this.accountService.currentUser$.subscribe(user => {
+    this.accountService.currentUser$.subscribe((user) => {
       if (user) {
         this.isAdmin = this.accountService.hasAdminRole(user);
         this.hasDownloadRole = this.accountService.hasDownloadRole(user);
@@ -124,77 +126,77 @@ export class ActionFactoryService {
           action: Action.Edit,
           title: 'Edit',
           callback: this.dummyCallback,
-          requiresAdmin: true
+          requiresAdmin: true,
         });
 
         this.seriesActions.push({
           action: Action.Scan,
           title: 'Scan Series',
           callback: this.dummyCallback,
-          requiresAdmin: true
+          requiresAdmin: true,
         });
 
         this.seriesActions.push({
           action: Action.RefreshMetadata,
           title: 'Refresh Covers',
           callback: this.dummyCallback,
-          requiresAdmin: true
+          requiresAdmin: true,
         });
 
         this.seriesActions.push({
           action: Action.AnalyzeFiles,
           title: 'Analyze Files',
           callback: this.dummyCallback,
-          requiresAdmin: true
+          requiresAdmin: true,
         });
 
         this.seriesActions.push({
           action: Action.Delete,
           title: 'Delete',
           callback: this.dummyCallback,
-          requiresAdmin: true
+          requiresAdmin: true,
         });
 
         this.seriesActions.push({
           action: Action.AddToCollection,
           title: 'Add to Collection',
           callback: this.dummyCallback,
-          requiresAdmin: true
+          requiresAdmin: true,
         });
 
         this.seriesActions.push({
           action: Action.Edit,
           title: 'Edit',
           callback: this.dummyCallback,
-          requiresAdmin: true
+          requiresAdmin: true,
         });
 
         this.libraryActions.push({
           action: Action.Scan,
           title: 'Scan Library',
           callback: this.dummyCallback,
-          requiresAdmin: true
+          requiresAdmin: true,
         });
 
         this.libraryActions.push({
           action: Action.RefreshMetadata,
           title: 'Refresh Covers',
           callback: this.dummyCallback,
-          requiresAdmin: true
+          requiresAdmin: true,
         });
 
         this.libraryActions.push({
           action: Action.AnalyzeFiles,
           title: 'Analyze Files',
           callback: this.dummyCallback,
-          requiresAdmin: true
+          requiresAdmin: true,
         });
-    
+
         this.chapterActions.push({
           action: Action.Edit,
           title: 'Details',
           callback: this.dummyCallback,
-          requiresAdmin: false
+          requiresAdmin: false,
         });
       }
 
@@ -203,58 +205,76 @@ export class ActionFactoryService {
           action: Action.Download,
           title: 'Download',
           callback: this.dummyCallback,
-          requiresAdmin: false
+          requiresAdmin: false,
         });
 
         this.chapterActions.push({
           action: Action.Download,
           title: 'Download',
           callback: this.dummyCallback,
-          requiresAdmin: false
+          requiresAdmin: false,
         });
       }
     });
   }
 
   getLibraryActions(callback: (action: Action, library: Library) => void) {
-    const actions = this.libraryActions.map(a => {return {...a}});
-    actions.forEach(action => action.callback = callback);
+    const actions = this.libraryActions.map((a) => {
+      return { ...a };
+    });
+    actions.forEach((action) => (action.callback = callback));
     return actions;
   }
 
   getSeriesActions(callback: (action: Action, series: Series) => void) {
-    const actions = this.seriesActions.map(a => {return {...a}});
-    actions.forEach(action => action.callback = callback);
+    const actions = this.seriesActions.map((a) => {
+      return { ...a };
+    });
+    actions.forEach((action) => (action.callback = callback));
     return actions;
   }
 
   getVolumeActions(callback: (action: Action, volume: Volume) => void) {
-    const actions = this.volumeActions.map(a => {return {...a}});
-    actions.forEach(action => action.callback = callback);
+    const actions = this.volumeActions.map((a) => {
+      return { ...a };
+    });
+    actions.forEach((action) => (action.callback = callback));
     return actions;
   }
 
   getChapterActions(callback: (action: Action, chapter: Chapter) => void) {
-    const actions = this.chapterActions.map(a => {return {...a}});
-    actions.forEach(action => action.callback = callback);
+    const actions = this.chapterActions.map((a) => {
+      return { ...a };
+    });
+    actions.forEach((action) => (action.callback = callback));
     return actions;
   }
 
-  getCollectionTagActions(callback: (action: Action, collectionTag: CollectionTag) => void) {
-    const actions = this.collectionTagActions.map(a => {return {...a}});
-    actions.forEach(action => action.callback = callback);
+  getCollectionTagActions(
+    callback: (action: Action, collectionTag: CollectionTag) => void
+  ) {
+    const actions = this.collectionTagActions.map((a) => {
+      return { ...a };
+    });
+    actions.forEach((action) => (action.callback = callback));
     return actions;
   }
 
-  getReadingListActions(callback: (action: Action, readingList: ReadingList) => void) {
-    const actions = this.readingListActions.map(a => {return {...a}});
-    actions.forEach(action => action.callback = callback);
+  getReadingListActions(
+    callback: (action: Action, readingList: ReadingList) => void
+  ) {
+    const actions = this.readingListActions.map((a) => {
+      return { ...a };
+    });
+    actions.forEach((action) => (action.callback = callback));
     return actions;
   }
 
   getBookmarkActions(callback: (action: Action, series: Series) => void) {
-    const actions = this.bookmarkActions.map(a => {return {...a}});
-    actions.forEach(action => action.callback = callback);
+    const actions = this.bookmarkActions.map((a) => {
+      return { ...a };
+    });
+    actions.forEach((action) => (action.callback = callback));
     return actions;
   }
 
@@ -264,7 +284,7 @@ export class ActionFactoryService {
     this.libraryActions = [];
 
     this.collectionTagActions = [];
-    
+
     this.seriesActions = [
       {
         action: Action.MarkAsRead,
@@ -278,24 +298,51 @@ export class ActionFactoryService {
         callback: this.dummyCallback,
         requiresAdmin: false
       }, 
-      {
-        action: Action.AddToReadingList,
-        title: 'Add to Reading List',
+      { action: Action.AddTo,
+        title: 'Add to',
         callback: this.dummyCallback,
-        requiresAdmin: false
+        requiresAdmin: false,
+        children: [
+          {
+            action: Action.AddToReadingList,
+            title: 'Add to Reading List',
+            callback: (action, data) => {console.log('Add to Reading List Works!')},
+            requiresAdmin: false,
+          },
+          {
+            action: Action.AddToWantToReadList,
+            title: 'Add to Want To Read',
+            callback: (action, data) => {console.log('Add to Want to Read List Works!')},
+            requiresAdmin: false,
+            children: [
+              {
+                action: Action.AddToReadingList,
+                title: 'Add to Reading List',
+                callback: (action, data) => {console.log('Add to Reading List Works!')},
+                requiresAdmin: false,
+              },
+            ]
+          },
+        ],
       },
-      {
-        action: Action.AddToWantToReadList,
-        title: 'Add to Want To Read',
-        callback: this.dummyCallback,
-        requiresAdmin: false
-      },
+      // {
+      //   action: Action.AddToReadingList,
+      //   title: 'Add to Reading List',
+      //   callback: this.dummyCallback,
+      //   requiresAdmin: false,
+      // },
+      // {
+      //   action: Action.AddToWantToReadList,
+      //   title: 'Add to Want To Read',
+      //   callback: this.dummyCallback,
+      //   requiresAdmin: false,
+      // },
       {
         action: Action.RemoveFromWantToReadList,
         title: 'Remove from Want To Read',
         callback: this.dummyCallback,
-        requiresAdmin: false
-      }
+        requiresAdmin: false,
+      },
     ];
 
     this.volumeActions = [
@@ -303,32 +350,32 @@ export class ActionFactoryService {
         action: Action.MarkAsRead,
         title: 'Mark as Read',
         callback: this.dummyCallback,
-          requiresAdmin: false
+        requiresAdmin: false,
       },
       {
         action: Action.MarkAsUnread,
         title: 'Mark as Unread',
         callback: this.dummyCallback,
-        requiresAdmin: false
+        requiresAdmin: false,
       },
       {
         action: Action.AddToReadingList,
         title: 'Add to Reading List',
         callback: this.dummyCallback,
-        requiresAdmin: false
+        requiresAdmin: false,
       },
       {
         action: Action.IncognitoRead,
         title: 'Read Incognito',
         callback: this.dummyCallback,
-        requiresAdmin: false
+        requiresAdmin: false,
       },
       {
         action: Action.Edit,
         title: 'Details',
         callback: this.dummyCallback,
-        requiresAdmin: false
-      }
+        requiresAdmin: false,
+      },
     ];
 
     this.chapterActions = [
@@ -336,25 +383,25 @@ export class ActionFactoryService {
         action: Action.MarkAsRead,
         title: 'Mark as Read',
         callback: this.dummyCallback,
-        requiresAdmin: false
+        requiresAdmin: false,
       },
       {
         action: Action.MarkAsUnread,
         title: 'Mark as Unread',
         callback: this.dummyCallback,
-        requiresAdmin: false
+        requiresAdmin: false,
       },
       {
         action: Action.IncognitoRead,
         title: 'Read Incognito',
         callback: this.dummyCallback,
-        requiresAdmin: false
+        requiresAdmin: false,
       },
       {
         action: Action.AddToReadingList,
         title: 'Add to Reading List',
         callback: this.dummyCallback,
-        requiresAdmin: false
+        requiresAdmin: false,
       },
     ];
 
@@ -363,13 +410,13 @@ export class ActionFactoryService {
         action: Action.Edit,
         title: 'Edit',
         callback: this.dummyCallback,
-        requiresAdmin: false
+        requiresAdmin: false,
       },
       {
         action: Action.Delete,
         title: 'Delete',
         callback: this.dummyCallback,
-        requiresAdmin: false
+        requiresAdmin: false,
       },
     ];
 
@@ -378,20 +425,20 @@ export class ActionFactoryService {
         action: Action.ViewSeries,
         title: 'View Series',
         callback: this.dummyCallback,
-        requiresAdmin: false
+        requiresAdmin: false,
       },
       {
         action: Action.DownloadBookmark,
         title: 'Download',
         callback: this.dummyCallback,
-        requiresAdmin: false
+        requiresAdmin: false,
       },
       {
         action: Action.Delete,
         title: 'Clear',
         callback: this.dummyCallback,
-        requiresAdmin: false
+        requiresAdmin: false,
       },
-    ]
+    ];
   }
 }

--- a/UI/Web/src/app/cards/card-detail-drawer/card-detail-drawer.component.ts
+++ b/UI/Web/src/app/cards/card-detail-drawer/card-detail-drawer.component.ts
@@ -130,7 +130,7 @@ export class CardDetailDrawerComponent implements OnInit, OnDestroy {
 
     this.chapterActions = this.actionFactoryService.getChapterActions(this.handleChapterActionCallback.bind(this))
                                 .filter(item => item.action !== Action.Edit);
-    this.chapterActions.push({title: 'Read', action: Action.Read, callback: this.handleChapterActionCallback.bind(this), requiresAdmin: false});    
+    this.chapterActions.push({title: 'Read', action: Action.Read, callback: this.handleChapterActionCallback.bind(this), requiresAdmin: false, children: []});    
 
     this.libraryService.getLibraryType(this.libraryId).subscribe(type => {
       this.libraryType = type;

--- a/UI/Web/src/app/cards/card-item/card-actionables/card-actionables.component.html
+++ b/UI/Web/src/app/cards/card-item/card-actionables/card-actionables.component.html
@@ -1,19 +1,25 @@
 <ng-container *ngIf="actions.length > 0">
     <div ngbDropdown container="body" class="d-inline-block">
-        <button [disabled]="disabled" class="btn {{btnClass}}" id="actions-{{labelBy}}" ngbDropdownToggle (click)="preventClick($event)"><i class="fa {{iconClass}}" aria-hidden="true"></i></button>
-      	<div ngbDropdownMenu attr.aria-labelledby="actions-{{labelBy}}">
-			<ng-container *ngTemplateOutlet="Submenu; context: { list: nonAdminActions }"></ng-container>
-      	</div>
+      <button [disabled]="disabled" class="btn {{btnClass}}" id="actions-{{labelBy}}" ngbDropdownToggle (click)="preventClick($event)"><i class="fa {{iconClass}}" aria-hidden="true"></i></button>
+      <div ngbDropdownMenu attr.aria-labelledby="actions-{{labelBy}}">
+			  <ng-container *ngTemplateOutlet="submenu; context: { list: nonAdminActions }"></ng-container>
+        <div class="dropdown-divider" *ngIf="nonAdminActions.length > 1 && adminActions.length > 1"></div>
+			  <ng-container *ngTemplateOutlet="submenu; context: { list: adminActions }"></ng-container>
+      </div>
     </div>
-	<ng-template #Submenu let-list="list">
+	<ng-template #submenu let-list="list">
 		<ng-container *ngFor="let action of list">
-			<button ngbDropdownItem *ngIf="action.children === undefined || action?.children?.length === 0" (click)="performAction($event, action)">{{action.title}}</button>
-			<div ngbDropdown *ngIf="action.children && action?.children?.length !== 0" placement="right">
-				<button id="actions-{{action.title}}" class="submenu-toggle" ngbDropdownToggle (click)="preventClick($event)">{{action.title}} <i class="fa-solid fa-play"></i></button>
-				<div ngbDropdownMenu attr.aria-labelledby="actions-{{action.title}}">
-				  <ng-container *ngTemplateOutlet="Submenu; context: { list: action.children }"></ng-container>
-				</div>
-			  </div>
+      <ng-container *ngIf="action.children === undefined || action?.children?.length === 0 else submenuDropdown">
+        <button ngbDropdownItem *ngIf="(action.requiresAdmin && isAdmin) || (action.title === 'Download' && canDownload)" (click)="performAction($event, action)">{{action.title}}</button>
+      </ng-container>
+      <ng-template #submenuDropdown>
+        <div ngbDropdown #subMenuHover="ngbDropdown" placement="right" (mouseenter)="$event.stopPropagation(); subMenuHover.toggle();" (mouseleave)="$event.stopPropagation(); subMenuHover.toggle();">
+          <button id="actions-{{action.title}}" class="submenu-toggle" ngbDropdownToggle>{{action.title}} &#8227;</button>
+          <div ngbDropdownMenu attr.aria-labelledby="actions-{{action.title}}">
+            <ng-container *ngTemplateOutlet="submenu; context: { list: action.children }"></ng-container>
+          </div>
+        </div>
+      </ng-template>
 		</ng-container>
 	</ng-template>
 </ng-container>

--- a/UI/Web/src/app/cards/card-item/card-actionables/card-actionables.component.html
+++ b/UI/Web/src/app/cards/card-item/card-actionables/card-actionables.component.html
@@ -1,11 +1,19 @@
 <ng-container *ngIf="actions.length > 0">
     <div ngbDropdown container="body" class="d-inline-block">
-      <button [disabled]="disabled" class="btn {{btnClass}}" id="actions-{{labelBy}}" ngbDropdownToggle (click)="preventClick($event)"><i class="fa {{iconClass}}" aria-hidden="true"></i></button>
-      <div ngbDropdownMenu attr.aria-labelledby="actions-{{labelBy}}">
-        <button ngbDropdownItem *ngFor="let action of nonAdminActions" (click)="performAction($event, action)">{{action.title}}</button>
-        <div class="dropdown-divider" *ngIf="nonAdminActions.length > 1 && adminActions.length > 1"></div>
-        <button ngbDropdownItem *ngFor="let action of adminActions" (click)="performAction($event, action)">{{action.title}}</button>
-      </div>
+        <button [disabled]="disabled" class="btn {{btnClass}}" id="actions-{{labelBy}}" ngbDropdownToggle (click)="preventClick($event)"><i class="fa {{iconClass}}" aria-hidden="true"></i></button>
+      	<div ngbDropdownMenu attr.aria-labelledby="actions-{{labelBy}}">
+			<ng-container *ngTemplateOutlet="Submenu; context: { list: nonAdminActions }"></ng-container>
+      	</div>
     </div>
-    <!-- IDEA: If we are not on desktop, then let's open a bottom drawer instead-->
+	<ng-template #Submenu let-list="list">
+		<ng-container *ngFor="let action of list">
+			<button ngbDropdownItem *ngIf="action.children === undefined || action?.children?.length === 0" (click)="performAction($event, action)">{{action.title}}</button>
+			<div ngbDropdown *ngIf="action.children && action?.children?.length !== 0" placement="right">
+				<button id="actions-{{action.title}}" class="submenu-toggle" ngbDropdownToggle (click)="preventClick($event)">{{action.title}} <i class="fa-solid fa-play"></i></button>
+				<div ngbDropdownMenu attr.aria-labelledby="actions-{{action.title}}">
+				  <ng-container *ngTemplateOutlet="Submenu; context: { list: action.children }"></ng-container>
+				</div>
+			  </div>
+		</ng-container>
+	</ng-template>
 </ng-container>

--- a/UI/Web/src/app/cards/card-item/card-actionables/card-actionables.component.html
+++ b/UI/Web/src/app/cards/card-item/card-actionables/card-actionables.component.html
@@ -8,11 +8,11 @@
 	<ng-template #submenu let-list="list">
 		<ng-container *ngFor="let action of list">
       <ng-container *ngIf="action.children === undefined || action?.children?.length === 0 else submenuDropdown">
-        <button ngbDropdownItem *ngIf="(action.requiresAdmin && isAdmin) || (action.title === 'Download' && (canDownload || isAdmin)) || (!action.requiresAdmin && action.title !== 'Download')" (click)="performAction($event, action)">{{action.title}}</button>
+        <button ngbDropdownItem *ngIf="willRenderAction(action)" (click)="performAction($event, action)">{{action.title}}</button>
       </ng-container>
       <ng-template #submenuDropdown>
-        <div ngbDropdown #subMenuHover="ngbDropdown" placement="right" (mouseover)="preventClick($event); subMenuHover.open();" (mouseleave)="preventClick($event); subMenuHover.close();">
-          <button id="actions-{{action.title}}" class="submenu-toggle" ngbDropdownToggle>{{action.title}} <i class="fa-solid fa-play submenu-icon"></i></button>
+        <div ngbDropdown #subMenuHover="ngbDropdown" placement="right" (mouseover)="preventClick($event); openSubmenu(action.title, subMenuHover)" (mouseleave)="preventClick($event)">
+          <button id="actions-{{action.title}}" class="submenu-toggle" ngbDropdownToggle>{{action.title}} <i class="fa-solid fa-angle-right submenu-icon"></i></button>
           <div ngbDropdownMenu attr.aria-labelledby="actions-{{action.title}}">
             <ng-container *ngTemplateOutlet="submenu; context: { list: action.children }"></ng-container>
           </div>

--- a/UI/Web/src/app/cards/card-item/card-actionables/card-actionables.component.html
+++ b/UI/Web/src/app/cards/card-item/card-actionables/card-actionables.component.html
@@ -8,7 +8,7 @@
 	<ng-template #submenu let-list="list">
 		<ng-container *ngFor="let action of list">
       <ng-container *ngIf="action.children === undefined || action?.children?.length === 0 else submenuDropdown">
-        <button ngbDropdownItem *ngIf="(action.requiresAdmin && isAdmin) || (action.title === 'Download' && canDownload) || (!action.requiresAdmin && action.title !== 'Download')" (click)="performAction($event, action)">{{action.title}}</button>
+        <button ngbDropdownItem *ngIf="(action.requiresAdmin && isAdmin) || (action.title === 'Download' && (canDownload || isAdmin)) || (!action.requiresAdmin && action.title !== 'Download')" (click)="performAction($event, action)">{{action.title}}</button>
       </ng-container>
       <ng-template #submenuDropdown>
         <div ngbDropdown #subMenuHover="ngbDropdown" placement="right" (mouseover)="preventClick($event); subMenuHover.open();" (mouseleave)="preventClick($event); subMenuHover.close();">

--- a/UI/Web/src/app/cards/card-item/card-actionables/card-actionables.component.html
+++ b/UI/Web/src/app/cards/card-item/card-actionables/card-actionables.component.html
@@ -2,20 +2,18 @@
     <div ngbDropdown container="body" class="d-inline-block">
       <button [disabled]="disabled" class="btn {{btnClass}}" id="actions-{{labelBy}}" ngbDropdownToggle (click)="preventClick($event)"><i class="fa {{iconClass}}" aria-hidden="true"></i></button>
       <div ngbDropdownMenu attr.aria-labelledby="actions-{{labelBy}}">
-			  <ng-container *ngTemplateOutlet="submenu; context: { list: nonAdminActions }"></ng-container>
-        <div class="dropdown-divider" *ngIf="nonAdminActions.length > 1 && adminActions.length > 1"></div>
-			  <ng-container *ngTemplateOutlet="submenu; context: { list: adminActions }"></ng-container>
+			  <ng-container *ngTemplateOutlet="submenu; context: { list: actions }"></ng-container>
       </div>
     </div>
 	<ng-template #submenu let-list="list">
 		<ng-container *ngFor="let action of list">
       <ng-container *ngIf="action.children === undefined || action?.children?.length === 0 else submenuDropdown">
-        <button ngbDropdownItem *ngIf="(action.requiresAdmin && isAdmin) || (action.title === 'Download' && canDownload)" (click)="performAction($event, action)">{{action.title}}</button>
+        <button ngbDropdownItem *ngIf="(action.requiresAdmin && isAdmin) || (action.title === 'Download' && canDownload) || (!action.requiresAdmin && action.title !== 'Download')" (click)="performAction($event, action)">{{action.title}}</button>
       </ng-container>
       <ng-template #submenuDropdown>
-        <div ngbDropdown #subMenuHover="ngbDropdown" placement="right" (mouseenter)="$event.stopPropagation(); subMenuHover.toggle();" (mouseleave)="$event.stopPropagation(); subMenuHover.toggle();">
-          <button id="actions-{{action.title}}" class="submenu-toggle" ngbDropdownToggle>{{action.title}} &#8227;</button>
-          <div ngbDropdownMenu attr.aria-labelledby="actions-{{action.title}}">
+        <div ngbDropdown #subMenuHover="ngbDropdown" placement="right" (mouseover)="preventClick($event); subMenuHover.open();" (mouseleave)="preventClick($event); subMenuHover.close();">
+          <button id="actions-{{action.title}}" class="submenu-toggle" ngbDropdownToggle>{{action.title}} <i class="fa-solid fa-play submenu-icon"></i></button>
+          <div ngbDropdownMenu class="submenu-menu" attr.aria-labelledby="actions-{{action.title}}">
             <ng-container *ngTemplateOutlet="submenu; context: { list: action.children }"></ng-container>
           </div>
         </div>

--- a/UI/Web/src/app/cards/card-item/card-actionables/card-actionables.component.html
+++ b/UI/Web/src/app/cards/card-item/card-actionables/card-actionables.component.html
@@ -13,7 +13,7 @@
       <ng-template #submenuDropdown>
         <div ngbDropdown #subMenuHover="ngbDropdown" placement="right" (mouseover)="preventClick($event); subMenuHover.open();" (mouseleave)="preventClick($event); subMenuHover.close();">
           <button id="actions-{{action.title}}" class="submenu-toggle" ngbDropdownToggle>{{action.title}} <i class="fa-solid fa-play submenu-icon"></i></button>
-          <div ngbDropdownMenu class="submenu-menu" attr.aria-labelledby="actions-{{action.title}}">
+          <div ngbDropdownMenu attr.aria-labelledby="actions-{{action.title}}">
             <ng-container *ngTemplateOutlet="submenu; context: { list: action.children }"></ng-container>
           </div>
         </div>

--- a/UI/Web/src/app/cards/card-item/card-actionables/card-actionables.component.scss
+++ b/UI/Web/src/app/cards/card-item/card-actionables/card-actionables.component.scss
@@ -11,10 +11,21 @@
     border: 0;
     color: var(--dropdown-item-text-color);
     background-color: var(--dropdown-item-bg-color);
+    &:hover {
+      color: var(--dropdown-item-text-color);
+      background-color: var(--dropdown-item-hover-bg-color);
+      cursor: pointer;
+    }
+    &:focus {
+      background-color: var(--dropdown-item-hover-bg-color);
+    }
 }
 
-.submenu-toggle:hover {
-    color: var(--dropdown-item-text-color);
-    background-color: var(--dropdown-item-hover-bg-color);
-    cursor: pointer;
+.submenu-icon {
+    float: right;
+    padding: var(--bs-dropdown-item-padding-y) 0;
+}
+
+.submenu-menu {
+  margin-left: -5px;
 }

--- a/UI/Web/src/app/cards/card-item/card-actionables/card-actionables.component.scss
+++ b/UI/Web/src/app/cards/card-item/card-actionables/card-actionables.component.scss
@@ -11,21 +11,20 @@
     border: 0;
     color: var(--dropdown-item-text-color);
     background-color: var(--dropdown-item-bg-color);
-    &:hover {
-      color: var(--dropdown-item-text-color);
-      background-color: var(--dropdown-item-hover-bg-color);
-      cursor: pointer;
-    }
-    &:focus {
-      background-color: var(--dropdown-item-hover-bg-color);
-    }
+}
+
+.submenu-toggle:hover {
+    color: var(--dropdown-item-text-color);
+    background-color: var(--dropdown-item-hover-bg-color);
+    cursor: pointer;
+}
+
+.submenu-toggle:focus {
+    color: var(--dropdown-item-text-color);
+    background-color: var(--dropdown-item-hover-bg-color);
 }
 
 .submenu-icon {
     float: right;
     padding: var(--bs-dropdown-item-padding-y) 0;
-}
-
-.submenu-menu {
-  margin-left: -5px;
 }

--- a/UI/Web/src/app/cards/card-item/card-actionables/card-actionables.component.scss
+++ b/UI/Web/src/app/cards/card-item/card-actionables/card-actionables.component.scss
@@ -1,3 +1,20 @@
 .dropdown-toggle:after {
     content: none !important;
 }
+
+.submenu-toggle {
+    display: block;
+    width: 100%;
+    padding: var(--bs-dropdown-item-padding-y) var(--bs-dropdown-item-padding-x);
+    font-weight: 400;
+    text-align: inherit;
+    border: 0;
+    color: var(--dropdown-item-text-color);
+    background-color: var(--dropdown-item-bg-color);
+}
+
+.submenu-toggle:hover {
+    color: var(--dropdown-item-text-color);
+    background-color: var(--dropdown-item-hover-bg-color);
+    cursor: pointer;
+}

--- a/UI/Web/src/app/cards/card-item/card-actionables/card-actionables.component.scss
+++ b/UI/Web/src/app/cards/card-item/card-actionables/card-actionables.component.scss
@@ -11,17 +11,15 @@
     border: 0;
     color: var(--dropdown-item-text-color);
     background-color: var(--dropdown-item-bg-color);
-}
-
-.submenu-toggle:hover {
-    color: var(--dropdown-item-text-color);
-    background-color: var(--dropdown-item-hover-bg-color);
-    cursor: pointer;
-}
-
-.submenu-toggle:focus {
-    color: var(--dropdown-item-text-color);
-    background-color: var(--dropdown-item-hover-bg-color);
+    &:hover {
+        color: var(--dropdown-item-text-color);
+        background-color: var(--dropdown-item-hover-bg-color);
+        cursor: pointer;
+    }
+    &:focus-visible {
+        color: var(--dropdown-item-text-color);
+        background-color: var(--dropdown-item-hover-bg-color);
+    }
 }
 
 .submenu-icon {

--- a/UI/Web/src/app/cards/card-item/card-actionables/card-actionables.component.ts
+++ b/UI/Web/src/app/cards/card-item/card-actionables/card-actionables.component.ts
@@ -1,7 +1,8 @@
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { NgbDropdown } from '@ng-bootstrap/ng-bootstrap';
 import { take } from 'rxjs';
 import { AccountService } from 'src/app/_services/account.service';
-import { ActionItem } from 'src/app/_services/action-factory.service';
+import { Action, ActionItem } from 'src/app/_services/action-factory.service';
 
 @Component({
   selector: 'app-card-actionables',
@@ -20,6 +21,7 @@ export class CardActionablesComponent implements OnInit {
 
   isAdmin: boolean = false;
   canDownload: boolean = false;
+  submenu: {[key: string]: NgbDropdown} = {};
 
   constructor(private readonly cdRef: ChangeDetectorRef, private accountService: AccountService) { }
 
@@ -44,6 +46,25 @@ export class CardActionablesComponent implements OnInit {
     if (typeof action.callback === 'function') {
       this.actionHandler.emit(action);
     }
+  }
+
+  willRenderAction(action: ActionItem<any>): boolean {
+    return (action.requiresAdmin && this.isAdmin) 
+        || (action.action === Action.Download && (this.canDownload || this.isAdmin))
+        || (!action.requiresAdmin && action.action !== Action.Download)
+  }
+
+  openSubmenu(actionTitle: string, subMenu: NgbDropdown) {
+    // We keep track when we open and when we get a request to open, if we have other keys, we close them and clear their keys
+    if (Object.keys(this.submenu).length > 0) {
+      const keys = Object.keys(this.submenu).filter(k => k !== actionTitle);
+      keys.forEach(key => {
+        this.submenu[key].close();
+        delete this.submenu[key];
+      });
+    }
+    this.submenu[actionTitle] = subMenu;
+    subMenu.open();
   }
 
 }

--- a/UI/Web/src/app/cards/card-item/card-actionables/card-actionables.component.ts
+++ b/UI/Web/src/app/cards/card-item/card-actionables/card-actionables.component.ts
@@ -30,9 +30,8 @@ export class CardActionablesComponent implements OnInit {
       if (!user) return;
       this.isAdmin = this.accountService.hasAdminRole(user);
       this.canDownload = this.accountService.hasDownloadRole(user);
+      this.cdRef.markForCheck();
     });
-
-    this.cdRef.markForCheck();
   }
 
   preventClick(event: any) {

--- a/UI/Web/src/app/cards/card-item/card-actionables/card-actionables.component.ts
+++ b/UI/Web/src/app/cards/card-item/card-actionables/card-actionables.component.ts
@@ -18,18 +18,12 @@ export class CardActionablesComponent implements OnInit {
   @Input() disabled: boolean = false;
   @Output() actionHandler = new EventEmitter<ActionItem<any>>();
 
-  adminActions: ActionItem<any>[] = [];
-  nonAdminActions: ActionItem<any>[] = [];
-
   isAdmin: boolean = false;
   canDownload: boolean = false;
 
   constructor(private readonly cdRef: ChangeDetectorRef, private accountService: AccountService) { }
 
   ngOnInit(): void {
-    this.nonAdminActions = this.actions.filter(item => !item.requiresAdmin);
-    this.adminActions = this.actions.filter(item => item.requiresAdmin);
-
     this.accountService.currentUser$.pipe(take(1)).subscribe((user) => {
       if (!user) return;
       this.isAdmin = this.accountService.hasAdminRole(user);
@@ -50,18 +44,6 @@ export class CardActionablesComponent implements OnInit {
     if (typeof action.callback === 'function') {
       this.actionHandler.emit(action);
     }
-  }
-
-  getNonAdminActions(actionsList: ActionItem<any>[]): ActionItem<any>[] {
-    return actionsList.filter(item => !item.requiresAdmin);
-  }
-
-  getAdminActions(actionsList: ActionItem<any>[]): ActionItem<any>[] {
-    return actionsList.filter(item => item.requiresAdmin);
-  }
-
-  getDivider(actionsList: ActionItem<any>[]): Boolean {
-    return actionsList.filter(item => !item.requiresAdmin).length > 0 && actionsList.filter(item => item.requiresAdmin).length > 0;
   }
 
 }

--- a/UI/Web/src/app/series-detail/series-detail.component.ts
+++ b/UI/Web/src/app/series-detail/series-detail.component.ts
@@ -482,7 +482,6 @@ export class SeriesDetailComponent implements OnInit, OnDestroy, AfterContentChe
 
       this.seriesActions = this.actionFactoryService.getSeriesActions(this.handleSeriesActionCallback.bind(this))
               .filter(action => action.action !== Action.Edit);
-      this.seriesActions.push({action: Action.Download, callback: this.seriesActions[0].callback, requiresAdmin: false, title: 'Download', children: []});
 
       this.volumeActions = this.actionFactoryService.getVolumeActions(this.handleVolumeActionCallback.bind(this));
       this.chapterActions = this.actionFactoryService.getChapterActions(this.handleChapterActionCallback.bind(this));

--- a/UI/Web/src/app/series-detail/series-detail.component.ts
+++ b/UI/Web/src/app/series-detail/series-detail.component.ts
@@ -482,7 +482,7 @@ export class SeriesDetailComponent implements OnInit, OnDestroy, AfterContentChe
 
       this.seriesActions = this.actionFactoryService.getSeriesActions(this.handleSeriesActionCallback.bind(this))
               .filter(action => action.action !== Action.Edit);
-      this.seriesActions.push({action: Action.Download, callback: this.seriesActions[0].callback, requiresAdmin: false, title: 'Download'});
+      this.seriesActions.push({action: Action.Download, callback: this.seriesActions[0].callback, requiresAdmin: false, title: 'Download', children: []});
 
       this.volumeActions = this.actionFactoryService.getVolumeActions(this.handleVolumeActionCallback.bind(this));
       this.chapterActions = this.actionFactoryService.getChapterActions(this.handleChapterActionCallback.bind(this));


### PR DESCRIPTION
# Changed
- Changed: Actionable menus are now able to have nested menus (Closes #1448)
![image](https://user-images.githubusercontent.com/735851/191861879-bf70d757-fded-44dc-be6e-6526abae8da4.png)
to 
![image](https://user-images.githubusercontent.com/735851/191861925-f494ba66-c2f8-4a79-aaec-4588e5ab1453.png)


# Developer
- Developer: Action Factory Service no longer handles attaching actions based on role. The Action Factory Service will generate all possible actions and the dropdown's actions will now be render conditionally based on role as required.
- Developer: Removed download action from the Series Detail dropdown menu as it feels redundant to have a download button next to the dropdown menu button.
- Developer: The layout of the dropdown menu, menu is no longer divided by non-admin actions and admin actions. Some actions are now grouped together into a submenu.