### PR TITLE
Misc Polish

### DIFF
--- a/API.Tests/Services/BookmarkServiceTests.cs
+++ b/API.Tests/Services/BookmarkServiceTests.cs
@@ -536,7 +536,7 @@ public class BookmarkServiceTests
 
 
         var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), filesystem);
-        Assert.Equal(1, ds.GetFiles(BookmarkDirectory, searchOption:SearchOption.AllDirectories).Count());
+        Assert.Single(ds.GetFiles(BookmarkDirectory, searchOption:SearchOption.AllDirectories));
         Assert.NotNull(await _unitOfWork.UserRepository.GetBookmarkAsync(1));
     }
 

--- a/API.Tests/Services/BookmarkServiceTests.cs
+++ b/API.Tests/Services/BookmarkServiceTests.cs
@@ -410,7 +410,7 @@ public class BookmarkServiceTests
     #region Misc
 
     [Fact]
-    public async Task ShouldNotDeleteBookmarkOnChapterDeletion()
+    public async Task ShouldNotDeleteBookmark_OnChapterDeletion()
     {
         var filesystem = CreateFileSystem();
         filesystem.AddFile($"{CacheDirectory}1/0001.jpg", new MockFileData("123"));
@@ -462,8 +462,6 @@ public class BookmarkServiceTests
 
 
         var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), filesystem);
-        var bookmarkService = Create(ds);
-        var user = await _unitOfWork.UserRepository.GetUserByIdAsync(1, AppUserIncludes.Bookmarks);
 
         var vol = await _unitOfWork.VolumeRepository.GetVolumeAsync(1);
         vol.Chapters = new List<Chapter>();
@@ -471,6 +469,73 @@ public class BookmarkServiceTests
         await _unitOfWork.CommitAsync();
 
 
+        Assert.Equal(1, ds.GetFiles(BookmarkDirectory, searchOption:SearchOption.AllDirectories).Count());
+        Assert.NotNull(await _unitOfWork.UserRepository.GetBookmarkAsync(1));
+    }
+
+
+    [Fact]
+    public async Task ShouldNotDeleteBookmark_OnVolumeDeletion()
+    {
+        var filesystem = CreateFileSystem();
+        filesystem.AddFile($"{CacheDirectory}1/0001.jpg", new MockFileData("123"));
+        filesystem.AddFile($"{BookmarkDirectory}1/1/0001.jpg", new MockFileData("123"));
+
+        // Delete all Series to reset state
+        await ResetDB();
+        var series = new Series()
+        {
+            Name = "Test",
+            Library = new Library()
+            {
+                Name = "Test LIb",
+                Type = LibraryType.Manga,
+            },
+            Volumes = new List<Volume>()
+            {
+                new Volume()
+                {
+                    Chapters = new List<Chapter>()
+                    {
+                        new Chapter()
+                        {
+
+                        }
+                    }
+                }
+            }
+        };
+
+        _context.Series.Add(series);
+
+
+        _context.AppUser.Add(new AppUser()
+        {
+            UserName = "Joe",
+            Bookmarks = new List<AppUserBookmark>()
+            {
+                new AppUserBookmark()
+                {
+                    Page = 1,
+                    ChapterId = 1,
+                    FileName = $"1/1/0001.jpg",
+                    SeriesId = 1,
+                    VolumeId = 1
+                }
+            }
+        });
+
+        await _context.SaveChangesAsync();
+
+        var user = await _unitOfWork.UserRepository.GetUserByIdAsync(1, AppUserIncludes.Bookmarks);
+        Assert.NotEmpty(user.Bookmarks);
+
+        series.Volumes = new List<Volume>();
+        _unitOfWork.SeriesRepository.Update(series);
+        await _unitOfWork.CommitAsync();
+
+
+        var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), filesystem);
         Assert.Equal(1, ds.GetFiles(BookmarkDirectory, searchOption:SearchOption.AllDirectories).Count());
         Assert.NotNull(await _unitOfWork.UserRepository.GetBookmarkAsync(1));
     }

--- a/API.Tests/Services/ParseScannedFilesTests.cs
+++ b/API.Tests/Services/ParseScannedFilesTests.cs
@@ -53,7 +53,7 @@ internal class MockReadingItemService : IReadingItemService
 
     public void Extract(string fileFilePath, string targetDirectory, MangaFormat format, int imageCount = 1)
     {
-        throw new System.NotImplementedException();
+        throw new NotImplementedException();
     }
 
     public ParserInfo Parse(string path, string rootPath, LibraryType type)
@@ -245,11 +245,11 @@ public class ParseScannedFilesTests
 
         var parsedSeries = new Dictionary<ParsedSeries, IList<ParserInfo>>();
 
-        void TrackFiles(Tuple<bool, IList<ParserInfo>> parsedInfo)
+        Task TrackFiles(Tuple<bool, IList<ParserInfo>> parsedInfo)
         {
             var skippedScan = parsedInfo.Item1;
             var parsedFiles = parsedInfo.Item2;
-            if (parsedFiles.Count == 0) return;
+            if (parsedFiles.Count == 0) return Task.CompletedTask;
 
             var foundParsedSeries = new ParsedSeries()
             {
@@ -259,6 +259,7 @@ public class ParseScannedFilesTests
             };
 
             parsedSeries.Add(foundParsedSeries, parsedFiles);
+            return Task.CompletedTask;
         }
 
 

--- a/API/Controllers/LibraryController.cs
+++ b/API/Controllers/LibraryController.cs
@@ -213,9 +213,11 @@ public class LibraryController : BaseApiController
     {
         var userId = await _unitOfWork.UserRepository.GetUserIdByApiKeyAsync(dto.ApiKey);
         var user = await _unitOfWork.UserRepository.GetUserByIdAsync(userId);
+
         // Validate user has Admin privileges
         var isAdmin = await _unitOfWork.UserRepository.IsUserAdminAsync(user);
         if (!isAdmin) return BadRequest("API key must belong to an admin");
+
         if (dto.FolderPath.Contains("..")) return BadRequest("Invalid Path");
 
         dto.FolderPath = Services.Tasks.Scanner.Parser.Parser.NormalizePath(dto.FolderPath);

--- a/API/Entities/AppUserBookmark.cs
+++ b/API/Entities/AppUserBookmark.cs
@@ -11,8 +11,8 @@ public class AppUserBookmark : IEntityDate
 {
     public int Id { get; set; }
     public int Page { get; set; }
-    public int VolumeId { get; set; }
     public int SeriesId { get; set; }
+    public int VolumeId { get; set; }
     public int ChapterId { get; set; }
 
     /// <summary>

--- a/API/Logging/LogLevelOptions.cs
+++ b/API/Logging/LogLevelOptions.cs
@@ -40,7 +40,7 @@ public static class LogLevelOptions
 
     public static LoggerConfiguration CreateConfig(LoggerConfiguration configuration)
     {
-        const string outputTemplate = "[{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} {CorrelationId} {ThreadId}] [{Level}] {SourceContext} {Message:lj}{NewLine}{Exception}";
+        const string outputTemplate = "[Kavita] [{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} {CorrelationId} {ThreadId}] [{Level}] {SourceContext} {Message:lj}{NewLine}{Exception}";
         return configuration
             .MinimumLevel
             .ControlledBy(LogLevelSwitch)

--- a/API/Services/TaskScheduler.cs
+++ b/API/Services/TaskScheduler.cs
@@ -158,7 +158,13 @@ public class TaskScheduler : ITaskScheduler
 
     public void ScanSiteThemes()
     {
-        _logger.LogInformation("Starting Site Theme scan");
+        if (HasAlreadyEnqueuedTask("ThemeService", "Scan", new object[] { }, ScanQueue))
+        {
+            _logger.LogInformation("A Theme Scan is already running");
+            return;
+        }
+
+        _logger.LogInformation("Enqueueing Site Theme scan");
         BackgroundJob.Enqueue(() => _themeService.Scan());
     }
 

--- a/API/Services/TaskScheduler.cs
+++ b/API/Services/TaskScheduler.cs
@@ -158,7 +158,7 @@ public class TaskScheduler : ITaskScheduler
 
     public void ScanSiteThemes()
     {
-        if (HasAlreadyEnqueuedTask("ThemeService", "Scan", new object[] { }, ScanQueue))
+        if (HasAlreadyEnqueuedTask("ThemeService", "Scan", Array.Empty<object>(), ScanQueue))
         {
             _logger.LogInformation("A Theme Scan is already running");
             return;

--- a/API/Services/Tasks/Scanner/ParseScannedFiles.cs
+++ b/API/Services/Tasks/Scanner/ParseScannedFiles.cs
@@ -223,7 +223,7 @@ public class ParseScannedFiles
     /// <returns></returns>
     public async Task ScanLibrariesForSeries(LibraryType libraryType,
         IEnumerable<string> folders, string libraryName, bool isLibraryScan,
-        IDictionary<string, IList<SeriesModified>> seriesPaths, Action<Tuple<bool, IList<ParserInfo>>> processSeriesInfos, bool forceCheck = false)
+        IDictionary<string, IList<SeriesModified>> seriesPaths, Func<Tuple<bool, IList<ParserInfo>>, Task> processSeriesInfos, bool forceCheck = false)
     {
 
         await _eventHub.SendMessageAsync(MessageFactory.NotificationProgress, MessageFactory.FileScanProgressEvent("File Scan Starting", libraryName, ProgressEventType.Started));
@@ -242,7 +242,7 @@ public class ParseScannedFiles
                             Series = fp.SeriesName,
                             Format = fp.Format,
                         }).ToList();
-                        processSeriesInfos.Invoke(new Tuple<bool, IList<ParserInfo>>(true, parsedInfos));
+                        await processSeriesInfos.Invoke(new Tuple<bool, IList<ParserInfo>>(true, parsedInfos));
                         _logger.LogDebug("Skipped File Scan for {Folder} as it hasn't changed since last scan", folder);
                         return;
                     }
@@ -280,7 +280,7 @@ public class ParseScannedFiles
                     {
                         if (scannedSeries[series].Count > 0 && processSeriesInfos != null)
                         {
-                            processSeriesInfos.Invoke(new Tuple<bool, IList<ParserInfo>>(false, scannedSeries[series]));
+                            await processSeriesInfos.Invoke(new Tuple<bool, IList<ParserInfo>>(false, scannedSeries[series]));
                         }
                     }
                 }, forceCheck);

--- a/API/Services/Tasks/Scanner/ProcessSeries.cs
+++ b/API/Services/Tasks/Scanner/ProcessSeries.cs
@@ -49,10 +49,6 @@ public class ProcessSeries : IProcessSeries
     private volatile IList<Person> _people;
     private volatile IList<Tag> _tags;
 
-    private static readonly SemaphoreSlim _saveChangesLock = new SemaphoreSlim(initialCount: 1);
-
-
-
     public ProcessSeries(IUnitOfWork unitOfWork, ILogger<ProcessSeries> logger, IEventHub eventHub,
         IDirectoryService directoryService, ICacheHelper cacheHelper, IReadingItemService readingItemService,
         IFileService fileService, IMetadataService metadataService, IWordCountAnalyzerService wordCountAnalyzerService)
@@ -165,7 +161,6 @@ public class ProcessSeries : IProcessSeries
             {
                 try
                 {
-                    await _saveChangesLock.WaitAsync();
                     await _unitOfWork.CommitAsync();
                 }
                 catch (Exception ex)
@@ -179,10 +174,6 @@ public class ProcessSeries : IProcessSeries
                         MessageFactory.ErrorEvent($"There was an issue writing to the DB for Series {series}",
                             ex.Message));
                     return;
-                }
-                finally
-                {
-                    _saveChangesLock.Release();
                 }
 
                 if (seriesAdded)

--- a/API/Services/Tasks/Scanner/ProcessSeries.cs
+++ b/API/Services/Tasks/Scanner/ProcessSeries.cs
@@ -235,7 +235,7 @@ public class ProcessSeries : IProcessSeries
         var chapters = series.Volumes.SelectMany(volume => volume.Chapters).ToList();
 
         // Update Metadata based on Chapter metadata
-        series.Metadata.ReleaseYear = chapters.Min(c => c.ReleaseDate.Year);
+        series.Metadata.ReleaseYear = chapters.Select(v => v.ReleaseDate.Year).Where(y => y >= 1000).Min();
 
         if (series.Metadata.ReleaseYear < 1000)
         {
@@ -440,6 +440,7 @@ public class ProcessSeries : IProcessSeries
         _logger.LogDebug("[ScannerService] Updating {DistinctVolumes} volumes on {SeriesName}", distinctVolumes.Count, series.Name);
         foreach (var volumeNumber in distinctVolumes)
         {
+            _logger.LogDebug("[ScannerService] Looking up volume for {volumeNumber}", volumeNumber);
             var volume = series.Volumes.SingleOrDefault(s => s.Name == volumeNumber);
             if (volume == null)
             {

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -187,8 +187,6 @@ public class ScannerService : IScannerService
         }
 
         var parsedSeries = new Dictionary<ParsedSeries, IList<ParserInfo>>();
-        var processTasks = new List<Task>();
-
 
         await _eventHub.SendMessageAsync(MessageFactory.NotificationProgress, MessageFactory.LibraryScanProgressEvent(library.Name, ProgressEventType.Started, series.Name));
 
@@ -210,7 +208,6 @@ public class ScannerService : IScannerService
                 return;
             }
 
-            //processTasks.Add(_processSeries.ProcessSeriesAsync(parsedFiles, library));
             await _processSeries.ProcessSeriesAsync(parsedFiles, library);
             parsedSeries.Add(foundParsedSeries, parsedFiles);
         }
@@ -465,7 +462,6 @@ public class ScannerService : IScannerService
 
 
             seenSeries.Add(foundParsedSeries);
-            //processTasks.Add();
             await _processSeries.ProcessSeriesAsync(parsedFiles, library);
         }
 

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -181,7 +181,7 @@ public class ScannerService : IScannerService
         await _eventHub.SendMessageAsync(MessageFactory.NotificationProgress, MessageFactory.LibraryScanProgressEvent(library.Name, ProgressEventType.Started, series.Name));
 
         await _processSeries.Prime();
-        void TrackFiles(Tuple<bool, IList<ParserInfo>> parsedInfo)
+        async Task TrackFiles(Tuple<bool, IList<ParserInfo>> parsedInfo)
         {
             var parsedFiles = parsedInfo.Item2;
             if (parsedFiles.Count == 0) return;
@@ -198,7 +198,8 @@ public class ScannerService : IScannerService
                 return;
             }
 
-            processTasks.Add(_processSeries.ProcessSeriesAsync(parsedFiles, library));
+            //processTasks.Add(_processSeries.ProcessSeriesAsync(parsedFiles, library));
+            await _processSeries.ProcessSeriesAsync(parsedFiles, library);
             parsedSeries.Add(foundParsedSeries, parsedFiles);
         }
 
@@ -424,7 +425,7 @@ public class ScannerService : IScannerService
 
         await _processSeries.Prime();
         var processTasks = new List<Task>();
-        void TrackFiles(Tuple<bool, IList<ParserInfo>> parsedInfo)
+        async Task TrackFiles(Tuple<bool, IList<ParserInfo>> parsedInfo)
         {
             var skippedScan = parsedInfo.Item1;
             var parsedFiles = parsedInfo.Item2;
@@ -452,7 +453,8 @@ public class ScannerService : IScannerService
 
 
             seenSeries.Add(foundParsedSeries);
-            processTasks.Add(_processSeries.ProcessSeriesAsync(parsedFiles, library));
+            //processTasks.Add();
+            await _processSeries.ProcessSeriesAsync(parsedFiles, library);
         }
 
 
@@ -512,7 +514,7 @@ public class ScannerService : IScannerService
     }
 
     private async Task<long> ScanFiles(Library library, IEnumerable<string> dirs,
-        bool isLibraryScan, Action<Tuple<bool, IList<ParserInfo>>> processSeriesInfos = null, bool forceChecks = false)
+        bool isLibraryScan, Func<Tuple<bool, IList<ParserInfo>>, Task> processSeriesInfos = null, bool forceChecks = false)
     {
         var scanner = new ParseScannedFiles(_logger, _directoryService, _readingItemService, _eventHub);
         var scanWatch = Stopwatch.StartNew();

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -102,6 +102,12 @@ public class ScannerService : IScannerService
         var seriesId = await _unitOfWork.SeriesRepository.GetSeriesIdByFolder(folder);
         if (seriesId > 0)
         {
+            if (TaskScheduler.HasAlreadyEnqueuedTask(Name, "ScanSeries",
+                    new object[] {seriesId, true}))
+            {
+                _logger.LogInformation("[ScannerService] Scan folder invoked for {Folder} but a task is already queued for this series. Dropping request", folder);
+                return;
+            }
             BackgroundJob.Enqueue(() => ScanSeries(seriesId, true));
             return;
         }
@@ -119,6 +125,12 @@ public class ScannerService : IScannerService
         var library = libraries.FirstOrDefault(l => l.Folders.Select(Scanner.Parser.Parser.NormalizePath).Contains(libraryFolder));
         if (library != null)
         {
+            if (TaskScheduler.HasAlreadyEnqueuedTask(Name, "ScanLibrary",
+                    new object[] {library.Id, false}))
+            {
+                _logger.LogInformation("[ScannerService] Scan folder invoked for {Folder} but a task is already queued for this library. Dropping request", folder);
+                return;
+            }
             BackgroundJob.Enqueue(() => ScanLibrary(library.Id, false));
         }
     }

--- a/UI/Web/src/app/_services/action-factory.service.ts
+++ b/UI/Web/src/app/_services/action-factory.service.ts
@@ -543,12 +543,28 @@ export class ActionFactoryService {
     });
   }
 
-	private applyCallbackToList(list: Array<ActionItem<any>>, callback: (action: ActionItem<any>, data: any) => void): Array<ActionItem<any>> {
+	public applyCallbackToList(list: Array<ActionItem<any>>, callback: (action: ActionItem<any>, data: any) => void): Array<ActionItem<any>> {
 		const actions = list.map((a) => {
 			return { ...a };
 		});
 		actions.forEach((action) => this.applyCallback(action, callback));
 		return actions;
 	}
+
+  // Checks the whole tree for the action and returns true if it exists
+  public hasAction(actions: Array<ActionItem<any>>, action: Action) {
+    var actionFound = false;
+
+    if (actions.length === 0) return actionFound;
+
+    for (let i = 0; i < actions.length; i++) 
+    {
+      if (actions[i].action === action) return true;
+      if (this.hasAction(actions[i].children, action)) return true;
+    }
+
+
+    return actionFound;
+  }
   
 }

--- a/UI/Web/src/app/cards/bulk-selection.service.ts
+++ b/UI/Web/src/app/cards/bulk-selection.service.ts
@@ -142,16 +142,17 @@ export class BulkSelectionService {
   getActions(callback: (action: ActionItem<any>, data: any) => void) {
     // checks if series is present. If so, returns only series actions
     // else returns volume/chapter items
-    const allowedActions = [Action.AddToReadingList, Action.MarkAsRead, Action.MarkAsUnread, Action.AddToCollection, Action.Delete, Action.AddToWantToReadList, Action.RemoveFromWantToReadList];
+    const allowedActions = [Action.AddToReadingList, Action.MarkAsRead, Action.MarkAsUnread, Action.AddToCollection, 
+      Action.Delete, Action.AddToWantToReadList, Action.RemoveFromWantToReadList];
     if (Object.keys(this.selectedCards).filter(item => item === 'series').length > 0) {
-      return this.actionFactory.getSeriesActions(callback).filter(item => allowedActions.includes(item.action));
+      return this.applyFilterToList(this.actionFactory.getSeriesActions(callback), allowedActions);
     }
 
     if (Object.keys(this.selectedCards).filter(item => item === 'bookmark').length > 0) {
       return this.actionFactory.getBookmarkActions(callback);
     }
 
-    return this.actionFactory.getVolumeActions(callback).filter(item => allowedActions.includes(item.action));
+    return this.applyFilterToList(this.actionFactory.getVolumeActions(callback), allowedActions);
   }
 
   private debugLog(message: string, extraData?: any) {
@@ -163,4 +164,29 @@ export class BulkSelectionService {
       console.log(message);
     }
   }
+
+  private applyFilter(action: ActionItem<any>, allowedActions: Array<Action>) {
+    
+    var ret = false;
+    if (action.action === Action.Submenu || allowedActions.includes(action.action)) {
+      // Do something
+      ret = true;
+    }
+
+    if (action.children === null || action.children?.length === 0) return ret;
+
+    action.children = action.children.filter((childAction) => this.applyFilter(childAction, allowedActions));
+
+    // action.children?.forEach((childAction) => {
+    //   this.applyFilter(childAction, allowedActions);
+    // });
+    return ret;
+  }
+
+	private applyFilterToList(list: Array<ActionItem<any>>, allowedActions: Array<Action>): Array<ActionItem<any>> {
+		const actions = list.map((a) => {
+			return { ...a };
+		});
+    return actions.filter(action => this.applyFilter(action, allowedActions));
+	}
 }

--- a/UI/Web/src/app/cards/series-info-cards/series-info-cards.component.html
+++ b/UI/Web/src/app/cards/series-info-cards/series-info-cards.component.html
@@ -1,7 +1,7 @@
 <div class="row g-0 mb-4 mt-3">
     <ng-container *ngIf="seriesMetadata.releaseYear > 0">
         <div class="col-lg-1 col-md-4 col-sm-4 col-4 mb-3">
-            <app-icon-and-title label="Release Year" [clickable]="false" fontClasses="fa-regular fa-calendar" title="Release Year">
+            <app-icon-and-title label="Release" [clickable]="false" fontClasses="fa-regular fa-calendar" title="Release Year">
                 {{seriesMetadata.releaseYear}}
             </app-icon-and-title>
         </div>

--- a/UI/Web/src/app/manga-reader/manga-reader.component.html
+++ b/UI/Web/src/app/manga-reader/manga-reader.component.html
@@ -66,11 +66,11 @@
                     'fit-to-height-double-offset': FittingOption === FITTING_OPTION.HEIGHT && ShouldRenderDoublePage,
                     'original-double-offset' : FittingOption === FITTING_OPTION.ORIGINAL && ShouldRenderDoublePage}"
                     [style.filter]="'brightness(' + generalSettingsForm.get('darkness')?.value + '%)' | safeStyle" (dblclick)="bookmarkPage($event)">
-                <img #image [src]="canvasImage.src" id="image-1"
+                <img alt=" " #image [src]="canvasImage.src" id="image-1"
                     class="{{getFittingOptionClass()}} {{readerMode === ReaderMode.LeftRight || readerMode === ReaderMode.UpDown ? '' : 'd-none'}} {{showClickOverlay ? 'blur' : ''}}">
 
                 <ng-container *ngIf="(this.canvasImage2.src !== '') && (readerService.imageUrlToPageNum(canvasImage2.src) <= maxPages - 1 && !isCoverImage())">
-                    <img [src]="canvasImage2.src" id="image-2" class="image-2 {{getFittingOptionClass()}} {{readerMode === ReaderMode.LeftRight || readerMode === ReaderMode.UpDown ? '' : 'd-none'}} {{showClickOverlay ? 'blur' : ''}}"> <!--  {{ShouldRenderReverseDouble ? 'reverse' : ''}} -->
+                    <img alt=" " [src]="canvasImage2.src" id="image-2" class="image-2 {{getFittingOptionClass()}} {{readerMode === ReaderMode.LeftRight || readerMode === ReaderMode.UpDown ? '' : 'd-none'}} {{showClickOverlay ? 'blur' : ''}}"> <!--  {{ShouldRenderReverseDouble ? 'reverse' : ''}} -->
                 </ng-container>
             </div>
 

--- a/UI/Web/src/app/manga-reader/manga-reader.component.ts
+++ b/UI/Web/src/app/manga-reader/manga-reader.component.ts
@@ -661,6 +661,8 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
     this.pageNum = 0;
     this.pagingDirection = PAGING_DIRECTION.FORWARD;
     this.inSetup = true;
+    this.canvasImage.src = '';
+    this.canvasImage2.src = '';
     this.cdRef.markForCheck();
 
     if (this.goToPageEvent) {

--- a/UI/Web/src/app/manga-reader/manga-reader.component.ts
+++ b/UI/Web/src/app/manga-reader/manga-reader.component.ts
@@ -1307,6 +1307,7 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       const index = numOffset % this.cachedImages.length;
       if (this.readerService.imageUrlToPageNum(this.cachedImages[index].src) !== numOffset) {
         this.cachedImages[index].src = this.getPageUrl(numOffset);
+        this.cachedImages[index].onload = () => this.cdRef.markForCheck();
       }
     }
 
@@ -1347,6 +1348,7 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
     this.cdRef.markForCheck();
 
     this.renderPage();
+    this.cdRef.markForCheck();
     this.prefetch();
     this.isLoading = false;
     this.cdRef.markForCheck();

--- a/UI/Web/src/app/manga-reader/manga-reader.component.ts
+++ b/UI/Web/src/app/manga-reader/manga-reader.component.ts
@@ -1044,8 +1044,7 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
         this.isCoverImage()
         || this.isWideImage(this.canvasImagePrev)
       ) ? 2 : 1;
-    }
-    if (this.layoutMode === LayoutMode.DoubleReversed) {
+    } else if (this.layoutMode === LayoutMode.DoubleReversed) {
       pageAmount = !(
         this.isCoverImage() 
         || this.isCoverImage(this.pageNum - 1) 
@@ -1302,11 +1301,11 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
    * and also maintains page info (wide image, etc) due to onload event.
    */
   prefetch() {
-    for(let i = 1; i <= PREFETCH_PAGES - 3; i++) {
+    for(let i = 0; i <= PREFETCH_PAGES - 3; i++) {
       const numOffset = this.pageNum + i;
       if (numOffset > this.maxPages - 1) continue;
 
-      const index = numOffset % this.cachedImages.length;
+      const index = (numOffset % this.cachedImages.length + this.cachedImages.length) % this.cachedImages.length;
       if (this.readerService.imageUrlToPageNum(this.cachedImages[index].src) !== numOffset) {
         this.cachedImages[index].src = this.getPageUrl(numOffset);
         this.cachedImages[index].onload = () => this.cdRef.markForCheck();
@@ -1350,7 +1349,6 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
     this.cdRef.markForCheck();
 
     this.renderPage();
-    this.cdRef.markForCheck();
     this.prefetch();
     this.isLoading = false;
     this.cdRef.markForCheck();

--- a/UI/Web/src/app/user-settings/user-preferences/user-preferences.component.ts
+++ b/UI/Web/src/app/user-settings/user-preferences/user-preferences.component.ts
@@ -61,7 +61,7 @@ export class UserPreferencesComponent implements OnInit, OnDestroy {
     {title: 'Theme', fragment: FragmentID.Theme},
     {title: 'Devices', fragment: FragmentID.Devices},
   ];
-  active = this.tabs[0];
+  active = this.tabs[1];
   opdsEnabled: boolean = false;
   makeUrl: (val: string) => string = (val: string) => {return this.transformKeyToOpdsUrl(val)};
 
@@ -87,7 +87,7 @@ export class UserPreferencesComponent implements OnInit, OnDestroy {
       if (tab.length > 0) {
         this.active = tab[0];
       } else {
-        this.active = this.tabs[0]; // Default to first tab
+        this.active = this.tabs[1]; // Default to preferences
       }
       this.cdRef.markForCheck();
     });


### PR DESCRIPTION
# Changed
- Changed: The scan loop is now synchronous. From testing, there is no major performance difference and this fixes duplication issues or some scan errors.
- Changed: Updated the LibraryWatcher to now suspend watching if multiple internal buffer exceptions occur. After an hour, the scanner will restart.
- Changed: The logger will now explicitly say [Kavita] (develop)
- Changed: Release Year on info cards now shows as Year
- Changed: When ScanFolder runs (via api or library watcher), ensure we don't queue duplicate tasks

# Fixed
- Fixed: Fixed a bug where multiple theme scans could occur at the same time, throwing an error (Fixes #1527 )
- Fixed: Bulk actions didn't have all actions due to nested actionable menu changes (develop)
- Fixed: Release Year wasn't populating due to a change in how it was set from a contributor's PR (develop). This may require retouching ever series to get the scan to pick up the year again.
- Fixed: Fixed a bug where user preferences would load Account tab when it should load Preferences by default
- Fixed: Fixed some manga reader bugs where you couldn't page from 1 -> 0 with left arrow key (develop)
- Fixed: Fixed some slowness in manga reader moving between chapters in continuous reader (develop)

