### PR TITLE
Scan Loop Fixes

### DIFF
--- a/API.Tests/Services/SeriesServiceTests.cs
+++ b/API.Tests/Services/SeriesServiceTests.cs
@@ -1001,6 +1001,41 @@ public class SeriesServiceTests
         Assert.True(series.Metadata.GenresLocked);
     }
 
+    [Fact]
+    public async Task UpdateSeriesMetadata_ShouldNotUpdateReleaseYear_IfLessThan1000()
+    {
+        await ResetDb();
+        var s = new Series()
+        {
+            Name = "Test",
+            Library = new Library()
+            {
+                Name = "Test LIb",
+                Type = LibraryType.Book,
+            },
+            Metadata = DbFactory.SeriesMetadata(new List<CollectionTag>())
+        };
+        _context.Series.Add(s);
+        await _context.SaveChangesAsync();
+
+        var success = await _seriesService.UpdateSeriesMetadata(new UpdateSeriesMetadataDto()
+        {
+            SeriesMetadata = new SeriesMetadataDto()
+            {
+                SeriesId = 1,
+                ReleaseYear = 100,
+            },
+            CollectionTags = new List<CollectionTagDto>()
+        });
+
+        Assert.True(success);
+
+        var series = await _unitOfWork.SeriesRepository.GetSeriesByIdAsync(1);
+        Assert.NotNull(series.Metadata);
+        Assert.Equal(0, series.Metadata.ReleaseYear);
+        Assert.False(series.Metadata.ReleaseYearLocked);
+    }
+
     #endregion
 
     #region GetFirstChapterForMetadata

--- a/API/Controllers/SeriesController.cs
+++ b/API/Controllers/SeriesController.cs
@@ -377,6 +377,7 @@ public class SeriesController : BaseApiController
     /// <param name="seriesId"></param>
     /// <returns></returns>
     /// <remarks>Do not rely on this API externally. May change without hesitation. </remarks>
+    [ResponseCache(Duration = 60, Location = ResponseCacheLocation.Any, VaryByQueryKeys = new [] {"seriesId"})]
     [HttpGet("series-detail")]
     public async Task<ActionResult<SeriesDetailDto>> GetSeriesDetailBreakdown(int seriesId)
     {

--- a/API/DTOs/Account/UpdateUserDto.cs
+++ b/API/DTOs/Account/UpdateUserDto.cs
@@ -8,7 +8,6 @@ public record UpdateUserDto
     public string Username { get; set; }
     /// List of Roles to assign to user. If admin not present, Pleb will be applied.
     /// If admin present, all libraries will be granted access and will ignore those from DTO.
-    /// </summary>
     public IList<string> Roles { get; init; }
     /// <summary>
     /// A list of libraries to grant access to

--- a/API/DTOs/SeriesMetadataDto.cs
+++ b/API/DTOs/SeriesMetadataDto.cs
@@ -79,6 +79,7 @@ public class SeriesMetadataDto
     public bool PublishersLocked { get; set; }
     public bool TranslatorsLocked { get; set; }
     public bool CoverArtistsLocked { get; set; }
+    public bool ReleaseYearLocked { get; set; }
 
 
     public int SeriesId { get; set; }

--- a/API/Data/Migrations/20221006013956_ReleaseYearOnSeriesEdit.Designer.cs
+++ b/API/Data/Migrations/20221006013956_ReleaseYearOnSeriesEdit.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using API.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace API.Data.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20221006013956_ReleaseYearOnSeriesEdit")]
+    partial class ReleaseYearOnSeriesEdit
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "6.0.9");

--- a/API/Data/Migrations/20221006013956_ReleaseYearOnSeriesEdit.cs
+++ b/API/Data/Migrations/20221006013956_ReleaseYearOnSeriesEdit.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace API.Data.Migrations
+{
+    public partial class ReleaseYearOnSeriesEdit : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "ReleaseYearLocked",
+                table: "SeriesMetadata",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ReleaseYearLocked",
+                table: "SeriesMetadata");
+        }
+    }
+}

--- a/API/Entities/Metadata/SeriesMetadata.cs
+++ b/API/Entities/Metadata/SeriesMetadata.cs
@@ -67,6 +67,7 @@ public class SeriesMetadata : IHasConcurrencyToken
     public bool PublisherLocked { get; set; }
     public bool TranslatorLocked { get; set; }
     public bool CoverArtistLocked { get; set; }
+    public bool ReleaseYearLocked { get; set; }
 
 
     // Relationship

--- a/API/Services/DirectoryService.cs
+++ b/API/Services/DirectoryService.cs
@@ -645,12 +645,15 @@ public class DirectoryService : IDirectoryService
     /// <summary>
     /// Recursively scans a folder and returns the max last write time on any folders and files
     /// </summary>
+    /// <remarks>If the folder is empty, this will return MaxValue for a DateTime</remarks>
     /// <param name="folderPath"></param>
     /// <returns>Max Last Write Time</returns>
     public DateTime GetLastWriteTime(string folderPath)
     {
         if (!FileSystem.Directory.Exists(folderPath)) throw new IOException($"{folderPath} does not exist");
-        return Directory.GetFileSystemEntries(folderPath, "*.*", SearchOption.AllDirectories).Max(path => FileSystem.File.GetLastWriteTime(path));
+        var fileEntries = Directory.GetFileSystemEntries(folderPath, "*.*", SearchOption.AllDirectories);
+        if (fileEntries.Length == 0) return DateTime.MaxValue;
+        return fileEntries.Max(path => FileSystem.File.GetLastWriteTime(path));
     }
 
     /// <summary>

--- a/API/Services/SeriesService.cs
+++ b/API/Services/SeriesService.cs
@@ -76,6 +76,12 @@ public class SeriesService : ISeriesService
                 series.Metadata.AgeRatingLocked = true;
             }
 
+            if (updateSeriesMetadataDto.SeriesMetadata.ReleaseYear > 1000 && series.Metadata.ReleaseYear != updateSeriesMetadataDto.SeriesMetadata.ReleaseYear)
+            {
+                series.Metadata.ReleaseYear = updateSeriesMetadataDto.SeriesMetadata.ReleaseYear;
+                series.Metadata.ReleaseYearLocked = true;
+            }
+
             if (series.Metadata.PublicationStatus != updateSeriesMetadataDto.SeriesMetadata.PublicationStatus)
             {
                 series.Metadata.PublicationStatus = updateSeriesMetadataDto.SeriesMetadata.PublicationStatus;
@@ -167,6 +173,7 @@ public class SeriesService : ISeriesService
             series.Metadata.CoverArtistLocked = updateSeriesMetadataDto.SeriesMetadata.CoverArtistsLocked;
             series.Metadata.WriterLocked = updateSeriesMetadataDto.SeriesMetadata.WritersLocked;
             series.Metadata.SummaryLocked = updateSeriesMetadataDto.SeriesMetadata.SummaryLocked;
+            series.Metadata.ReleaseYearLocked = updateSeriesMetadataDto.SeriesMetadata.ReleaseYearLocked;
 
             if (!_unitOfWork.HasChanges())
             {

--- a/API/Services/Tasks/Scanner/ProcessSeries.cs
+++ b/API/Services/Tasks/Scanner/ProcessSeries.cs
@@ -440,7 +440,7 @@ public class ProcessSeries : IProcessSeries
         _logger.LogDebug("[ScannerService] Updating {DistinctVolumes} volumes on {SeriesName}", distinctVolumes.Count, series.Name);
         foreach (var volumeNumber in distinctVolumes)
         {
-            _logger.LogDebug("[ScannerService] Looking up volume for {volumeNumber}", volumeNumber);
+            _logger.LogDebug("[ScannerService] Looking up volume for {VolumeNumber}", volumeNumber);
             var volume = series.Volumes.SingleOrDefault(s => s.Name == volumeNumber);
             if (volume == null)
             {
@@ -496,7 +496,7 @@ public class ProcessSeries : IProcessSeries
             series.Volumes = nonDeletedVolumes;
         }
 
-        _logger.LogDebug("[ScannerService] Updated {SeriesName} volumes from {StartingVolumeCount} to {VolumeCount}",
+        _logger.LogDebug("[ScannerService] Updated {SeriesName} volumes from count of {StartingVolumeCount} to {VolumeCount}",
             series.Name, startingVolumeCount, series.Volumes.Count);
     }
 

--- a/API/Services/Tasks/Scanner/ProcessSeries.cs
+++ b/API/Services/Tasks/Scanner/ProcessSeries.cs
@@ -236,7 +236,7 @@ public class ProcessSeries : IProcessSeries
         var chapters = series.Volumes.SelectMany(volume => volume.Chapters).ToList();
 
         // Update Metadata based on Chapter metadata
-        series.Metadata.ReleaseYear = chapters.Select(v => v.ReleaseDate.Year).Where(y => y >= 1000).Min();
+        series.Metadata.ReleaseYear = chapters.Select(v => v.ReleaseDate.Year).Where(y => y >= 1000).DefaultIfEmpty().Min();
 
         if (series.Metadata.ReleaseYear < 1000)
         {

--- a/API/Services/Tasks/Scanner/ProcessSeries.cs
+++ b/API/Services/Tasks/Scanner/ProcessSeries.cs
@@ -236,12 +236,15 @@ public class ProcessSeries : IProcessSeries
         var chapters = series.Volumes.SelectMany(volume => volume.Chapters).ToList();
 
         // Update Metadata based on Chapter metadata
-        series.Metadata.ReleaseYear = chapters.Select(v => v.ReleaseDate.Year).Where(y => y >= 1000).DefaultIfEmpty().Min();
-
-        if (series.Metadata.ReleaseYear < 1000)
+        if (!series.Metadata.ReleaseYearLocked)
         {
-            // Not a valid year, default to 0
-            series.Metadata.ReleaseYear = 0;
+            series.Metadata.ReleaseYear = chapters.Select(v => v.ReleaseDate.Year).Where(y => y >= 1000).DefaultIfEmpty().Min();
+
+            if (series.Metadata.ReleaseYear < 1000)
+            {
+                // Not a valid year, default to 0
+                series.Metadata.ReleaseYear = 0;
+            }
         }
 
         // Set the AgeRating as highest in all the comicInfos

--- a/API/Services/Tasks/Scanner/ProcessSeries.cs
+++ b/API/Services/Tasks/Scanner/ProcessSeries.cs
@@ -15,6 +15,7 @@ using API.Parser;
 using API.Services.Tasks.Metadata;
 using API.SignalR;
 using Hangfire;
+using Kavita.Common;
 using Microsoft.Extensions.Logging;
 
 namespace API.Services.Tasks.Scanner;
@@ -451,8 +452,8 @@ public class ProcessSeries : IProcessSeries
                 if (ex.Message.Equals("Sequence contains more than one matching element"))
                 {
                     _logger.LogCritical("[ScannerService] Kavita found corrupted volume entries on {SeriesName}. Please delete the series from Kavita via UI and rescan", series.Name);
-                    Task.Run(() => _eventHub.SendMessageAsync(MessageFactory.Error,
-                        MessageFactory.ErrorEvent($"Kavita found corrupted volume entries on {series.Name}. Please delete the series from Kavita via UI and rescan", string.Empty)));
+                    throw new KavitaException(
+                        $"Kavita found corrupted volume entries on {series.Name}. Please delete the series from Kavita via UI and rescan");
                 }
                 throw;
             }

--- a/API/Services/Tasks/Scanner/ProcessSeries.cs
+++ b/API/Services/Tasks/Scanner/ProcessSeries.cs
@@ -118,7 +118,7 @@ public class ProcessSeries : IProcessSeries
             _logger.LogInformation("[ScannerService] Processing series {SeriesName}", series.OriginalName);
 
             // parsedInfos[0] is not the first volume or chapter. We need to find it using a ComicInfo check (as it uses firstParsedInfo for series sort)
-            var firstParsedInfo = parsedInfos.FirstOrDefault(p => p.ComicInfo != null, parsedInfos[0]);
+            var firstParsedInfo = parsedInfos.FirstOrDefault(p => p.ComicInfo != null, firstInfo);
 
             UpdateVolumes(series, parsedInfos);
             series.Pages = series.Volumes.Sum(v => v.Pages);

--- a/UI/Web/src/app/admin/manage-settings/manage-settings.component.html
+++ b/UI/Web/src/app/admin/manage-settings/manage-settings.component.html
@@ -108,7 +108,7 @@
         </div>
 
         <div class="mb-3">
-            <label for="folder-watching" class="form-label" aria-describedby="folder-watching-info">Folder Watching</label><app-tag-badge [selectionMode]="TagBadgeCursor.Clickable" class="ms-1" ngbTooltip="This feature may not always work reliably">Experimental</app-tag-badge>
+            <label for="folder-watching" class="form-label" aria-describedby="folder-watching-info">Folder Watching</label>
             <p class="accent" id="folder-watching-info">Allows Kavita to monitor Library Folders to detect changes and invoke scanning on those changes. This allows content to be updated without manually invoking scans or waiting for nightly scans.</p>
             <div class="form-check form-switch">
                 <input id="folder-watching" type="checkbox" class="form-check-input" formControlName="enableFolderWatching" role="switch">

--- a/UI/Web/src/app/cards/_modals/edit-series-modal/edit-series-modal.component.html
+++ b/UI/Web/src/app/cards/_modals/edit-series-modal/edit-series-modal.component.html
@@ -70,7 +70,7 @@
                     <ng-template ngbNavContent>
 
                         <div class="row g-0">
-                            <div class="col-md-12">
+                            <div class="col-lg-8 col-md-12 pe-2">
                                 <div class="mb-3">
                                     <label for="collections" class="form-label">Collections </label>
                                     <app-typeahead (selectedData)="updateCollections($event)" [settings]="collectionTagSettings" [locked]="true">
@@ -81,6 +81,20 @@
                                             {{item.title}}
                                         </ng-template>
                                     </app-typeahead>
+                                </div>
+                            </div>
+                            <div class="col-lg-4 col-md-12">
+                                <div class="mb-3" style="width: 100%">
+                                    <label for="release-year" class="form-label">Release Year</label>
+                                    <div class="input-group {{metadata.releaseYearLocked ? 'lock-active' : ''}}">
+                                        <ng-container [ngTemplateOutlet]="lock" [ngTemplateOutletContext]="{ item: metadata, field: 'releaseYearLocked' }"></ng-container>
+                                        <input type="number" class="form-control" id="release-year" formControlName="releaseYear" maxlength="4" minlength="4" [class.is-invalid]="editSeriesForm.get('releaseYear')?.invalid && editSeriesForm.get('releaseYear')?.touched">
+                                        <ng-container *ngIf="editSeriesForm.get('releaseYear')?.errors as errors">
+                                            <p class="invalid-feedback" *ngIf="errors.pattern">
+                                                This must be a valid year greater than 1000 and 4 characters long
+                                            </p>
+                                        </ng-container>
+                                    </div>
                                 </div>
                             </div>
                         </div>
@@ -137,7 +151,7 @@
                                     </app-typeahead>
                                 </div>
                             </div>
-                            <div class="col-lg-4  col-md-12 pe-2">
+                            <div class="col-lg-4 col-md-12 pe-2">
                                 <div class="mb-3">
                                     <label for="age-rating" class="form-label">Age Rating</label>
                                     <div class="input-group {{metadata.ageRatingLocked ? 'lock-active' : ''}}">

--- a/UI/Web/src/app/cards/_modals/edit-series-modal/edit-series-modal.component.ts
+++ b/UI/Web/src/app/cards/_modals/edit-series-modal/edit-series-modal.component.ts
@@ -137,6 +137,7 @@ export class EditSeriesModalComponent implements OnInit, OnDestroy {
       ageRating: new FormControl('', []),
       publicationStatus: new FormControl('', []),
       language: new FormControl('', []),
+      releaseYear: new FormControl('', [Validators.minLength(4), Validators.maxLength(4), Validators.pattern(/[1-9]\d{3}/)]),
     });
     this.cdRef.markForCheck();
 
@@ -165,6 +166,7 @@ export class EditSeriesModalComponent implements OnInit, OnDestroy {
         this.editSeriesForm.get('ageRating')?.patchValue(this.metadata.ageRating);
         this.editSeriesForm.get('publicationStatus')?.patchValue(this.metadata.publicationStatus);
         this.editSeriesForm.get('language')?.patchValue(this.metadata.language);
+        this.editSeriesForm.get('releaseYear')?.patchValue(this.metadata.releaseYear);
         this.cdRef.markForCheck();
 
         this.editSeriesForm.get('name')?.valueChanges.pipe(takeUntil(this.onDestroy)).subscribe(val => {
@@ -198,6 +200,12 @@ export class EditSeriesModalComponent implements OnInit, OnDestroy {
         this.editSeriesForm.get('publicationStatus')?.valueChanges.pipe(takeUntil(this.onDestroy)).subscribe(val => {
           this.metadata.publicationStatus = parseInt(val + '', 10);
           this.metadata.publicationStatusLocked = true;
+          this.cdRef.markForCheck();
+        });
+
+        this.editSeriesForm.get('releaseYear')?.valueChanges.pipe(takeUntil(this.onDestroy)).subscribe(val => {
+          this.metadata.releaseYear = parseInt(val + '', 10);
+          this.metadata.releaseYearLocked = true;
           this.cdRef.markForCheck();
         });
       }


### PR DESCRIPTION
# Added
- Added: Added the ability to edit Release Year on the Series (Closes #1570 )

# Changed
- Changed: Series Detail api will now cache for a min to reduce load
- Changed: The scan loop log will now complain if there is a corrupted volume from buggy code in v0.5.6. This new log informs users to delete the series and rescan.
- Changed: Moved Folder Watching out of experimental. It is now stable to a point that it can be used as a primary driver for changes.

# Fixed
- Fixed: Fixed an issue with last PR where scan loop wasn't running in a synchronous mode (develop)
- Fixed: Fixed an issue where empty folders could break scan loop
- Fixed: Fixed an issue where invalid dates (aka dates less than 1000) could break the scan loop (develop)
