### PR TITLE
Run Kavita as non-root user in Docker container

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,21 @@
 #! /bin/bash
 
-if [ ! -f "/kavita/config/appsettings.json" ]; then
+# Set default username, UID and GID for Kavita but allow overrides
+PUID=${PUID:-1000}
+PGID=${PGID:-1000}
+KAVITAUSER=${KAVITAUSER:-kavita}
+
+# Add Kavita group if it doesn't already exist
+if [[ $(getent group "$PGID" | cut -d':' -f1) != "$KAVITAUSER" ]]; then
+    groupadd -o -g "$PGID" "$KAVITAUSER"
+fi
+
+# Add Kavita user if it doesn't already exist
+if [[ $(getent passwd "$PUID" | cut -d':' -f1) != "$KAVITAUSER" ]]; then
+    useradd -o -u "$PUID" -g "$PGID" -d /kavita "$KAVITAUSER"
+fi
+
+if [ ! -f /kavita/config/appsettings.json" ]; then
     echo "Kavita configuration file does not exist, creating..."
     echo '{
   "TokenKey": "super secret unguessable key",
@@ -8,6 +23,7 @@ if [ ! -f "/kavita/config/appsettings.json" ]; then
 }' >> /kavita/config/appsettings.json
 fi
 
-chmod +x Kavita
+chown -R "$PUID":"$PGID" /kavita
+chmod 0500 /kavita/Kavita
 
-./Kavita
+su -l "$KAVITAUSER" -c ./Kavita

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,7 +23,8 @@ if [ ! -f /kavita/config/appsettings.json" ]; then
 }' >> /kavita/config/appsettings.json
 fi
 
-chown -R "$PUID":"$PGID" /kavita
+# Set ownership on all files except the library
+find /kavita -path /kavita/library -prune -o -exec chown "$PUID":"$PGID" {} \;
 chmod 0500 /kavita/Kavita
 
 su -l "$KAVITAUSER" -c ./Kavita


### PR DESCRIPTION
# Added
- Added: Ability to provide environment variables PUID, PGID, and KAVITAUSER which will set the uid, gid and optionally the username under which Kavita will be started in a Docker container.  The defaults are set to 1000, 1000, "kavita".  The user and group will be created in the container if they don't already exist.  Execution of "./Kavita" will be done as that user.