### PR TITLE
Docker nonroot

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,21 @@
 #! /bin/bash
 
-if [ ! -f "/kavita/config/appsettings.json" ]; then
+# Set default username, UID and GID for Kavita but allow overrides
+PUID=${PUID:-1000}
+PGID=${PGID:-1000}
+KAVITAUSER=${KAVITAUSER:-kavita}
+
+# Add Kavita group if it doesn't already exist
+if [[ $(getent group "$PGID" | cut -d':' -f1) != "$KAVITAUSER" ]]; then
+    groupadd -o -g "$PGID" "$KAVITAUSER"
+fi
+
+# Add Kavita user if it doesn't already exist
+if [[ $(getent passwd "$PUID" | cut -d':' -f1) != "$KAVITAUSER" ]]; then
+    useradd -o -u "$PUID" -g "$PGID" -d /kavita "$KAVITAUSER"
+fi
+
+if [ ! -f /kavita/config/appsettings.json" ]; then
     echo "Kavita configuration file does not exist, creating..."
     echo '{
   "TokenKey": "super secret unguessable key",
@@ -8,6 +23,7 @@ if [ ! -f "/kavita/config/appsettings.json" ]; then
 }' >> /kavita/config/appsettings.json
 fi
 
-chmod +x Kavita
+chown -R "$PUID":"$PGID" /kavita
+chmod 0500 /kavita/Kavita
 
-./Kavita
+su -l "$KAVITAUSER" -c ./Kavita

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,7 +23,8 @@ if [ ! -f /kavita/config/appsettings.json" ]; then
 }' >> /kavita/config/appsettings.json
 fi
 
-chown -R "$PUID":"$PGID" /kavita
+# Set ownership on all files except the library
+find /kavita -path /kavita/library -prune -o -exec chown "$PUID":"$PGID" {} \;
 chmod 0500 /kavita/Kavita
 
 su -l "$KAVITAUSER" -c ./Kavita

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,7 +22,7 @@ if [ ! -f "/kavita/config/appsettings.json" ]; then
 }' >> /kavita/config/appsettings.json
 fi
 
-chmod 0500 /kavita/Kavita
+chmod +x Kavita
 
 if [[ "$PUID" -eq 0 ]]; then
     # Run as root

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,8 +28,19 @@ if [[ "$PUID" -eq 0 ]]; then
     # Run as root
     ./Kavita
 else
-    # Set ownership on all files except the library if running non-root
-    find /kavita -path /kavita/library -prune -o -exec chown "$PUID":"$PGID" {} \;
+    # Set ownership on config dir if running non-root and current ownership is different
+    if [[ ! "$(stat -c %u /kavita/config)" = "$PUID" ]]; then
+        echo "Specified PUID differs from Kavita config dir ownership, updating permissions now..."
+        if [[ ! "$(stat -c %g /kavita/config)" = "$PGID" ]]; then
+            chown -R "$PUID":"$PGID" /kavita/config
+        else
+            chown -R "$PUID" /kavita/config
+        fi
+
+    elif [[ ! "$(stat -c %g /kavita/config)" = "$PGID" ]]; then
+        echo "Specified PGID differs from Kavita config dir ownership, updating permissions now..."
+        chgrp -R "$PGID" /kavita/config
+    fi
 
     # Run as non-root user
     su -l kavita -c ./Kavita


### PR DESCRIPTION
# Added
- Added: Ability to provide environment variables PUID and PGID which allow running Kavita as a non-root user in a Docker container.  If you do not specify these variables, Kavita will run as root.  If specified, user and group 'kavita' will be created in the container with the specified UID and GID if they don't already exist. Kavita will then run as that user.
