### PR TITLE
Fixed Series Relations Schema

### DIFF
--- a/API.Tests/Services/SeriesServiceTests.cs
+++ b/API.Tests/Services/SeriesServiceTests.cs
@@ -1285,7 +1285,7 @@ public class SeriesServiceTests
         {
             await _context.SaveChangesAsync();
         }
-        catch (Exception ex)
+        catch (Exception)
         {
             Assert.Fail("Delete of Target Series Failed");
         }
@@ -1338,7 +1338,7 @@ public class SeriesServiceTests
         {
             await _context.SaveChangesAsync();
         }
-        catch (Exception ex)
+        catch (Exception)
         {
             Assert.Fail("Delete of Target Series Failed");
         }

--- a/API/API.csproj
+++ b/API/API.csproj
@@ -48,6 +48,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.0" />
+    <PackageReference Include="CsvHelper" Version="30.0.1" />
     <PackageReference Include="Docnet.Core" Version="2.4.0-alpha.4" />
     <PackageReference Include="ExCSS" Version="4.1.0" />
     <PackageReference Include="Flurl" Version="3.0.6" />

--- a/API/Controllers/WantToReadController.cs
+++ b/API/Controllers/WantToReadController.cs
@@ -42,7 +42,7 @@ public class WantToReadController : BaseApiController
     }
 
     [HttpGet]
-    public async Task<ActionResult<PagedList<SeriesDto>>> GetWantToRead([FromQuery] int seriesId)
+    public async Task<ActionResult<bool>> GetWantToRead([FromQuery] int seriesId)
     {
         var user = await _unitOfWork.UserRepository.GetUserByUsernameAsync(User.GetUsername());
         return Ok(await _unitOfWork.SeriesRepository.IsSeriesInWantToRead(user.Id, seriesId));

--- a/API/Data/DataContext.cs
+++ b/API/Data/DataContext.cs
@@ -68,13 +68,15 @@ public sealed class DataContext : IdentityDbContext<AppUser, AppRole, int,
             .HasOne(pt => pt.Series)
             .WithMany(p => p.Relations)
             .HasForeignKey(pt => pt.SeriesId)
-            .OnDelete(DeleteBehavior.ClientCascade);
+            .OnDelete(DeleteBehavior.Cascade);
+
 
         builder.Entity<SeriesRelation>()
             .HasOne(pt => pt.TargetSeries)
             .WithMany(t => t.RelationOf)
             .HasForeignKey(pt => pt.TargetSeriesId)
-            .OnDelete(DeleteBehavior.ClientCascade);
+            .OnDelete(DeleteBehavior.Cascade);
+
 
 
         builder.Entity<AppUserPreferences>()

--- a/API/Data/MigrateSeriesRelationsExport.cs
+++ b/API/Data/MigrateSeriesRelationsExport.cs
@@ -1,0 +1,74 @@
+﻿using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using API.Entities.Enums;
+using CsvHelper;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace API.Data;
+
+internal sealed class SeriesRelationMigrationOutput
+{
+    public string SeriesName { get; set; }
+    public int SeriesId { get; set; }
+    public string TargetSeriesName { get; set; }
+    public int TargetId { get; set; }
+    public RelationKind Relationship { get; set; }
+}
+
+/// <summary>
+/// Introduced in v0.6.1.2 and v0.7, this exports to a temp file the existing series relationships. It is a 3 part migration.
+/// This will run first, to export the data, then the DB migration will change the way the DB is constructed, then the last migration
+/// will import said file and re-construct the relationships.
+/// </summary>
+public static class MigrateSeriesRelationsExport
+{
+    public static async Task Migrate(DataContext dataContext, ILogger<Program> logger)
+    {
+        if (new FileInfo("config/temp/relations.csv").Exists)
+        {
+            return;
+        }
+        logger.LogCritical("Running MigrateSeriesRelationsExport migration - Please be patient, this may take some time. This is not an error");
+
+        var seriesWithRelationships = await dataContext.Series
+            .Where(s => s.Relations.Any())
+            .Include(s => s.Relations)
+            .ThenInclude(r => r.TargetSeries)
+            .AsNoTracking()
+            .ToListAsync();
+
+        var records = new List<SeriesRelationMigrationOutput>();
+        var excludedRelationships = new List<RelationKind>()
+        {
+            RelationKind.Parent,
+        };
+        foreach (var series in seriesWithRelationships)
+        {
+            foreach (var relationship in series.Relations.Where(r => !excludedRelationships.Contains(r.RelationKind)))
+            {
+                records.Add(new SeriesRelationMigrationOutput()
+                {
+                    SeriesId = series.Id,
+                    SeriesName = series.Name,
+                    Relationship = relationship.RelationKind,
+                    TargetId = relationship.TargetSeriesId,
+                    TargetSeriesName = relationship.TargetSeries.Name
+
+                });
+            }
+        }
+
+        await using var writer = new StreamWriter("config/temp/relations.csv");
+        await using (var csv = new CsvWriter(writer, CultureInfo.InvariantCulture))
+        {
+            await csv.WriteRecordsAsync(records);
+        }
+
+        logger.LogCritical("Running MigrateSeriesRelationsExport migration - Completed. This is not an error");
+    }
+}

--- a/API/Data/MigrateSeriesRelationsExport.cs
+++ b/API/Data/MigrateSeriesRelationsExport.cs
@@ -29,10 +29,12 @@ public static class MigrateSeriesRelationsExport
 {
     public static async Task Migrate(DataContext dataContext, ILogger<Program> logger)
     {
+        // TODO: Put a version check in here
         if (new FileInfo("config/temp/relations.csv").Exists)
         {
             return;
         }
+
         logger.LogCritical("Running MigrateSeriesRelationsExport migration - Please be patient, this may take some time. This is not an error");
 
         var seriesWithRelationships = await dataContext.Series

--- a/API/Data/MigrateSeriesRelationsExport.cs
+++ b/API/Data/MigrateSeriesRelationsExport.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -6,6 +7,7 @@ using System.Text;
 using System.Threading.Tasks;
 using API.Entities.Enums;
 using CsvHelper;
+using Kavita.Common.EnvironmentInfo;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
@@ -32,7 +34,9 @@ public static class MigrateSeriesRelationsExport
     public static async Task Migrate(DataContext dataContext, ILogger<Program> logger)
     {
         logger.LogCritical("Running MigrateSeriesRelationsExport migration - Please be patient, this may take some time. This is not an error");
-        if (new FileInfo(OutputFile).Exists || new FileInfo(CompleteOutputFile).Exists)
+        if (BuildInfo.Version > new Version(0, 6, 1, 3)
+            || new FileInfo(OutputFile).Exists
+            || new FileInfo(CompleteOutputFile).Exists)
         {
             logger.LogCritical("Running MigrateSeriesRelationsExport migration - complete. Nothing to do");
             return;
@@ -41,7 +45,6 @@ public static class MigrateSeriesRelationsExport
         var seriesWithRelationships = await dataContext.Series
             .Where(s => s.Relations.Any())
             .Include(s => s.Relations)
-            //.Include(s => s.RelationOf)
             .ThenInclude(r => r.TargetSeries)
             .ToListAsync();
 

--- a/API/Data/MigrateSeriesRelationsImport.cs
+++ b/API/Data/MigrateSeriesRelationsImport.cs
@@ -1,0 +1,65 @@
+﻿using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using API.Entities.Enums;
+using API.Entities.Metadata;
+using CsvHelper;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace API.Data;
+
+/// <summary>
+/// Introduced in v0.6.1.2 and v0.7, this imports to a temp file the existing series relationships. It is a 3 part migration.
+/// This will run last, to import the data and re-construct the relationships.
+/// </summary>
+public static class MigrateSeriesRelationsImport
+{
+    private const string OutputFile = "config/relations.csv";
+    private const string CompleteOutputFile = "config/relations-imported.csv";
+    public static async Task Migrate(DataContext dataContext, ILogger<Program> logger)
+    {
+        logger.LogCritical("Running MigrateSeriesRelationsImport migration - Please be patient, this may take some time. This is not an error");
+        // TODO: Put a version check in here
+        if (!new FileInfo(OutputFile).Exists)
+        {
+            logger.LogCritical("Running MigrateSeriesRelationsImport migration - complete. Nothing to do");
+            return;
+        }
+
+        logger.LogCritical("Loading backed up relationships into the DB");
+        List<SeriesRelationMigrationOutput> records;
+        using var reader = new StreamReader(OutputFile);
+        using (var csv = new CsvReader(reader, CultureInfo.InvariantCulture))
+        {
+            records = csv.GetRecords<SeriesRelationMigrationOutput>().ToList();
+        }
+
+        foreach (var relation in records)
+        {
+            logger.LogCritical("Importing {SeriesName} --{RelationshipKind}--> {TargetSeriesName}",
+                relation.SeriesName, relation.Relationship, relation.TargetSeriesName);
+
+            // Filter out series that don't exist
+            if (!await dataContext.Series.AnyAsync(s => s.Id == relation.SeriesId) ||
+                !await dataContext.Series.AnyAsync(s => s.Id == relation.TargetId))
+                continue;
+
+            await dataContext.SeriesRelation.AddAsync(new SeriesRelation()
+            {
+                SeriesId = relation.SeriesId,
+                TargetSeriesId = relation.TargetId,
+                RelationKind = relation.Relationship
+            });
+
+        }
+        await dataContext.SaveChangesAsync();
+
+        File.Move(OutputFile, CompleteOutputFile);
+
+        logger.LogCritical("Running MigrateSeriesRelationsImport migration - Completed. This is not an error");
+    }
+}

--- a/API/Data/MigrateSeriesRelationsImport.cs
+++ b/API/Data/MigrateSeriesRelationsImport.cs
@@ -23,7 +23,6 @@ public static class MigrateSeriesRelationsImport
     public static async Task Migrate(DataContext dataContext, ILogger<Program> logger)
     {
         logger.LogCritical("Running MigrateSeriesRelationsImport migration - Please be patient, this may take some time. This is not an error");
-        // TODO: Put a version check in here
         if (!new FileInfo(OutputFile).Exists)
         {
             logger.LogCritical("Running MigrateSeriesRelationsImport migration - complete. Nothing to do");

--- a/API/Data/Migrations/20221115021908_SeriesRelationChange.Designer.cs
+++ b/API/Data/Migrations/20221115021908_SeriesRelationChange.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using API.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace API.Data.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20221115021908_SeriesRelationChange")]
+    partial class SeriesRelationChange
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "6.0.10");

--- a/API/Data/Migrations/20221115021908_SeriesRelationChange.cs
+++ b/API/Data/Migrations/20221115021908_SeriesRelationChange.cs
@@ -1,0 +1,61 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace API.Data.Migrations
+{
+    public partial class SeriesRelationChange : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_SeriesRelation_Series_SeriesId",
+                table: "SeriesRelation");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_SeriesRelation_Series_TargetSeriesId",
+                table: "SeriesRelation");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_SeriesRelation_Series_SeriesId",
+                table: "SeriesRelation",
+                column: "SeriesId",
+                principalTable: "Series",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_SeriesRelation_Series_TargetSeriesId",
+                table: "SeriesRelation",
+                column: "TargetSeriesId",
+                principalTable: "Series",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_SeriesRelation_Series_SeriesId",
+                table: "SeriesRelation");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_SeriesRelation_Series_TargetSeriesId",
+                table: "SeriesRelation");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_SeriesRelation_Series_SeriesId",
+                table: "SeriesRelation",
+                column: "SeriesId",
+                principalTable: "Series",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_SeriesRelation_Series_TargetSeriesId",
+                table: "SeriesRelation",
+                column: "TargetSeriesId",
+                principalTable: "Series",
+                principalColumn: "Id");
+        }
+    }
+}

--- a/API/Data/Repositories/SeriesRepository.cs
+++ b/API/Data/Repositories/SeriesRepository.cs
@@ -1257,15 +1257,6 @@ public class SeriesRepository : ISeriesRepository
             .Where(s => !ids.Contains(s.Id))
             .ToListAsync();
 
-        // If the series to remove has Relation (related series), we must manually unlink due to the DB not being
-        // setup correctly (if this is not done, a foreign key constraint will be thrown)
-        // TODO: Fix Series Relations here
-        foreach (var sr in seriesToRemove)
-        {
-            sr.Relations = new List<SeriesRelation>();
-            Update(sr);
-        }
-
         _context.Series.RemoveRange(seriesToRemove);
 
         return seriesToRemove;

--- a/API/Data/Repositories/SeriesRepository.cs
+++ b/API/Data/Repositories/SeriesRepository.cs
@@ -1387,14 +1387,26 @@ public class SeriesRepository : ISeriesRepository
             AlternativeSettings = await GetRelatedSeriesQuery(seriesId, usersSeriesIds, RelationKind.AlternativeSetting, userRating),
             AlternativeVersions = await GetRelatedSeriesQuery(seriesId, usersSeriesIds, RelationKind.AlternativeVersion, userRating),
             Doujinshis = await GetRelatedSeriesQuery(seriesId, usersSeriesIds, RelationKind.Doujinshi, userRating),
-            Parent = await _context.Series
-                .SelectMany(s =>
-                    s.RelationOf.Where(r => r.TargetSeriesId == seriesId
-                                             && usersSeriesIds.Contains(r.TargetSeriesId)
-                                             && r.RelationKind != RelationKind.Prequel
-                                             && r.RelationKind != RelationKind.Sequel
-                                             && r.RelationKind != RelationKind.Edition)
-                        .Select(sr => sr.Series))
+            // Parent = await _context.Series
+            //     .SelectMany(s =>
+            //         s.TargetSeries.Where(r => r.TargetSeriesId == seriesId
+            //                                  && usersSeriesIds.Contains(r.TargetSeriesId)
+            //                                  && r.RelationKind != RelationKind.Prequel
+            //                                  && r.RelationKind != RelationKind.Sequel
+            //                                  && r.RelationKind != RelationKind.Edition)
+            //             .Select(sr => sr.Series))
+            //     .RestrictAgainstAgeRestriction(userRating)
+            //     .AsSplitQuery()
+            //     .AsNoTracking()
+            //     .ProjectTo<SeriesDto>(_mapper.ConfigurationProvider)
+            //     .ToListAsync(),
+            Parent = await _context.SeriesRelation
+                .Where(r => r.TargetSeriesId == seriesId
+                                              && usersSeriesIds.Contains(r.TargetSeriesId)
+                                              && r.RelationKind != RelationKind.Prequel
+                                              && r.RelationKind != RelationKind.Sequel
+                                              && r.RelationKind != RelationKind.Edition)
+                        .Select(sr => sr.Series)
                 .RestrictAgainstAgeRestriction(userRating)
                 .AsSplitQuery()
                 .AsNoTracking()

--- a/API/Data/Repositories/SeriesRepository.cs
+++ b/API/Data/Repositories/SeriesRepository.cs
@@ -1477,13 +1477,14 @@ public class SeriesRepository : ISeriesRepository
 
     public async Task<bool> IsSeriesInWantToRead(int userId, int seriesId)
     {
+        // BUG: This is always returning true for any series
         var libraryIds = GetLibraryIdsForUser(userId);
         return await _context.AppUser
             .Where(user => user.Id == userId)
-            .SelectMany(u => u.WantToRead)
+            .SelectMany(u => u.WantToRead.Where(s => s.Id == seriesId && libraryIds.Contains(s.LibraryId)))
             .AsSplitQuery()
             .AsNoTracking()
-            .AnyAsync(s => libraryIds.Contains(s.LibraryId) && s.Id == seriesId);
+            .AnyAsync();
     }
 
     public async Task<IDictionary<string, IList<SeriesModified>>> GetFolderPathMap(int libraryId)

--- a/API/Data/Repositories/SeriesRepository.cs
+++ b/API/Data/Repositories/SeriesRepository.cs
@@ -1259,7 +1259,7 @@ public class SeriesRepository : ISeriesRepository
 
         // If the series to remove has Relation (related series), we must manually unlink due to the DB not being
         // setup correctly (if this is not done, a foreign key constraint will be thrown)
-
+        // TODO: Fix Series Relations here
         foreach (var sr in seriesToRemove)
         {
             sr.Relations = new List<SeriesRelation>();

--- a/API/Entities/Metadata/SeriesRelation.cs
+++ b/API/Entities/Metadata/SeriesRelation.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations.Schema;
-using API.Entities.Enums;
+﻿using API.Entities.Enums;
 
 namespace API.Entities.Metadata;
 

--- a/API/Program.cs
+++ b/API/Program.cs
@@ -39,6 +39,8 @@ public class Program
         Console.OutputEncoding = System.Text.Encoding.UTF8;
         Log.Logger = new LoggerConfiguration()
             .WriteTo.Console()
+            .MinimumLevel
+            .Information()
             .CreateBootstrapLogger();
 
         var directoryService = new DirectoryService(null, new FileSystem());

--- a/API/Program.cs
+++ b/API/Program.cs
@@ -79,6 +79,8 @@ public class Program
                     }
                 }
 
+                await MigrateSeriesRelationsExport.Migrate(context, logger);
+
                 await context.Database.MigrateAsync();
 
                 await Seed.SeedRoles(services.GetRequiredService<RoleManager<AppRole>>());

--- a/API/Program.cs
+++ b/API/Program.cs
@@ -79,6 +79,7 @@ public class Program
                     }
                 }
 
+                // This must run before the migration
                 await MigrateSeriesRelationsExport.Migrate(context, logger);
 
                 await context.Database.MigrateAsync();

--- a/API/Startup.cs
+++ b/API/Startup.cs
@@ -209,6 +209,7 @@ public class Startup
                     var readingListService = serviceProvider.GetRequiredService<IReadingListService>();
 
 
+                    logger.LogInformation("Running Migrations");
                     // Only run this if we are upgrading
                     await MigrateChangePasswordRoles.Migrate(unitOfWork, userManager);
                     await MigrateRemoveExtraThemes.Migrate(unitOfWork, themeService);
@@ -229,6 +230,7 @@ public class Startup
                     unitOfWork.SettingsRepository.Update(installVersion);
 
                     await unitOfWork.CommitAsync();
+                    logger.LogInformation("Running Migrations - done");
                 }).GetAwaiter()
                 .GetResult();
         }

--- a/API/Startup.cs
+++ b/API/Startup.cs
@@ -220,6 +220,9 @@ public class Startup
                     await MigrateChangeRestrictionRoles.Migrate(unitOfWork, userManager, logger);
                     await MigrateReadingListAgeRating.Migrate(unitOfWork, dataContext, readingListService, logger);
 
+                    // v0.6.2 or v0.7
+                    await MigrateSeriesRelationsImport.Migrate(dataContext, logger);
+
                     //  Update the version in the DB after all migrations are run
                     var installVersion = await unitOfWork.SettingsRepository.GetSettingAsync(ServerSettingKey.InstallVersion);
                     installVersion.Value = BuildInfo.Version.ToString();

--- a/API/config/relations-imported.csv
+++ b/API/config/relations-imported.csv
@@ -1,0 +1,10 @@
+SeriesName,SeriesId,TargetSeriesName,TargetId,Relationship
+Kaguya-sama - Love Is War,308,Kaguya-sama - Love Is War - Digital Colored Comics,307,AlternativeVersion
+Kaguya-sama - Love Is War,308,Kaguya Wants To Be Confessed To Official Doujin,306,SpinOff
+Konosuba,341,Konosuba - An Explosion on This Wonderful World!,342,SideStory
+Konosuba,341,Kono Subarashii Sekai ni Nichijou wo!,337,SideStory
+Accel World,1739,Accel World,887,Edition
+24 Hours in Ancient Athens,1748,Kono Subarashii Sekai ni Nichijou wo!,337,Adaptation
+24 Hours in Ancient Athens,1748,Accel World,887,Adaptation
+Subete no Jidai o Tsuujite no Satsujinjutsu,1877,Accel World,887,Adaptation
+KonoSuba,2032,Konosuba,341,Adaptation

--- a/UI/Web/package-lock.json
+++ b/UI/Web/package-lock.json
@@ -5089,9 +5089,9 @@
           },
           "dependencies": {
             "loader-utils": {
-              "version": "2.0.2",
-              "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-              "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+              "version": "2.0.3",
+              "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.3.tgz",
+              "integrity": "sha512-THWqIsn8QRnvLl0shHYVBN9syumU8pYWEHPTmkiVGd+7K5eFNVSY6AJhRvgGF70gg1Dz+l/k8WicvFCxdEs60A==",
               "requires": {
                 "big.js": "^5.2.2",
                 "emojis-list": "^3.0.0",
@@ -6746,9 +6746,9 @@
       },
       "dependencies": {
         "loader-utils": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-          "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.3.tgz",
+          "integrity": "sha512-THWqIsn8QRnvLl0shHYVBN9syumU8pYWEHPTmkiVGd+7K5eFNVSY6AJhRvgGF70gg1Dz+l/k8WicvFCxdEs60A==",
           "requires": {
             "big.js": "^5.2.2",
             "emojis-list": "^3.0.0",
@@ -7115,9 +7115,9 @@
       },
       "dependencies": {
         "loader-utils": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-          "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.3.tgz",
+          "integrity": "sha512-THWqIsn8QRnvLl0shHYVBN9syumU8pYWEHPTmkiVGd+7K5eFNVSY6AJhRvgGF70gg1Dz+l/k8WicvFCxdEs60A==",
           "dev": true,
           "requires": {
             "big.js": "^5.2.2",
@@ -14660,9 +14660,9 @@
       },
       "dependencies": {
         "loader-utils": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-          "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.3.tgz",
+          "integrity": "sha512-THWqIsn8QRnvLl0shHYVBN9syumU8pYWEHPTmkiVGd+7K5eFNVSY6AJhRvgGF70gg1Dz+l/k8WicvFCxdEs60A==",
           "requires": {
             "big.js": "^5.2.2",
             "emojis-list": "^3.0.0",

--- a/UI/Web/src/app/_services/series.service.ts
+++ b/UI/Web/src/app/_services/series.service.ts
@@ -131,7 +131,10 @@ export class SeriesService {
   }
 
   isWantToRead(seriesId: number) {
-    return this.httpClient.get<boolean>(this.baseUrl + 'want-to-read?seriesId=' + seriesId, {responseType: 'text' as 'json'});
+    return this.httpClient.get<string>(this.baseUrl + 'want-to-read?seriesId=' + seriesId, {responseType: 'text' as 'json'})
+    .pipe(map(val => {
+      return val === 'true';
+    }));
   }
 
   getOnDeck(libraryId: number = 0, pageNum?: number, itemsPerPage?: number, filter?: SeriesFilter) {

--- a/UI/Web/src/app/series-detail/series-detail.component.html
+++ b/UI/Web/src/app/series-detail/series-detail.component.html
@@ -64,7 +64,7 @@
             </div>
             <app-image height="100%" maxHeight="400px" objectFit="contain" background="none" [imageUrl]="seriesImage"></app-image>
             <div class="under-image mt-1" *ngIf="hasReadingProgress && currentlyReadingChapter && !currentlyReadingChapter.isSpecial">
-                From {{ContinuePointTitle}}
+                Continue {{ContinuePointTitle}}
             </div>
         </div>
         <div class="col-xlg-10 col-lg-8 col-md-8 col-xs-8 col-sm-6 mt-2">

--- a/UI/Web/src/app/series-detail/series-detail.component.html
+++ b/UI/Web/src/app/series-detail/series-detail.component.html
@@ -80,7 +80,7 @@
                 <div class="col-auto ms-2">
                     <button class="btn btn-secondary" (click)="toggleWantToRead()" placement="top" [closeDelay]="100000" ngbTooltip="{{isWantToRead ? 'Remove from' : 'Add to'}} Want to Read">
                         <span>
-                            <i class="fa-{{isWantToRead ? 'solid' : 'regular'}} fa-star" aria-hidden="true"></i>
+                            <i class="{{isWantToRead ? 'fa-solid' : 'fa-regular'}} fa-star" aria-hidden="true"></i>
                         </span>
                     </button>
                 </div>

--- a/UI/Web/src/app/series-detail/series-detail.component.html
+++ b/UI/Web/src/app/series-detail/series-detail.component.html
@@ -78,14 +78,14 @@
                     </button>
                 </div>
                 <div class="col-auto ms-2">
-                    <button class="btn btn-secondary" (click)="toggleWantToRead()" placement="top" [closeDelay]="100000" ngbTooltip="{{isWantToRead ? 'Remove from' : 'Add to'}} Want to Read">
+                    <button class="btn btn-secondary" (click)="toggleWantToRead()" title="{{isWantToRead ? 'Remove from' : 'Add to'}} Want to Read">
                         <span>
                             <i class="{{isWantToRead ? 'fa-solid' : 'fa-regular'}} fa-star" aria-hidden="true"></i>
                         </span>
                     </button>
                 </div>
                 <div class="col-auto ms-2" *ngIf="isAdmin">
-                    <button class="btn btn-secondary" (click)="openEditSeriesModal()" placement="top" ngbTooltip="Edit Series information">
+                    <button class="btn btn-secondary" (click)="openEditSeriesModal()"  title="Edit Series information">
                         <span>
                             <i class="fa fa-pen" aria-hidden="true"></i>
                         </span>

--- a/UI/Web/src/app/series-detail/series-detail.component.scss
+++ b/UI/Web/src/app/series-detail/series-detail.component.scss
@@ -2,17 +2,8 @@
   font-style: italic;
 }
 
-.want-to-read-star {
-  //position: absolute;
-  //top: 15px;
-  //left: 20px;
-  //color: var(--primary-color);
-}
-
 .to-read-counter {
   position: absolute;
-  // top: 15px;
-  // right: 20px;
   top: 15px;
   left: 20px;
 }

--- a/UI/Web/src/app/series-detail/series-detail.component.ts
+++ b/UI/Web/src/app/series-detail/series-detail.component.ts
@@ -480,8 +480,6 @@ export class SeriesDetailComponent implements OnInit, OnDestroy, AfterContentChe
 
     this.seriesService.isWantToRead(seriesId).subscribe(isWantToRead => {
       this.isWantToRead = isWantToRead;
-      console.log(this.isWantToRead);
-      console.log(typeof(this.isWantToRead))
       this.changeDetectionRef.markForCheck();
     });
 

--- a/UI/Web/src/app/series-detail/series-detail.component.ts
+++ b/UI/Web/src/app/series-detail/series-detail.component.ts
@@ -480,6 +480,8 @@ export class SeriesDetailComponent implements OnInit, OnDestroy, AfterContentChe
 
     this.seriesService.isWantToRead(seriesId).subscribe(isWantToRead => {
       this.isWantToRead = isWantToRead;
+      console.log(this.isWantToRead);
+      console.log(typeof(this.isWantToRead))
       this.changeDetectionRef.markForCheck();
     });
 


### PR DESCRIPTION
This is a migration that will fix the series relationship DB Schema in Kavita by backing up all relationships into a config/relations.csv file. Then drop every row from the table, fix the scheme design, then re-import from relations.csv. This will only run once. If you need to re-run due to some issues, delete the relations.csv or relations-imported.csv.

# Changed
- Changed: Changed From -> Continue to be more explicit of the continue point under series detail cover (develop)
- Changed: Changed the dedicated tooltips on series detail buttons to normal title due to overlapping with header (develop)

# Fixed
- Fixed: Fixed a bug where FOREIGN KEY constraints could be thrown when deleting Series with relations (Fixes #1634, Closes #1637 )
- Fixed: Is Want to read is showing incorrectly on series detail (develop)

