### PR TITLE
Send Non books to your Devices

### DIFF
--- a/API/Services/DeviceService.cs
+++ b/API/Services/DeviceService.cs
@@ -7,6 +7,7 @@ using API.DTOs.Device;
 using API.DTOs.Email;
 using API.Entities;
 using API.Entities.Enums;
+using API.Entities.Enums.Device;
 using API.SignalR;
 using Kavita.Common;
 using Microsoft.Extensions.Logging;
@@ -105,12 +106,14 @@ public class DeviceService : IDeviceService
 
     public async Task<bool> SendTo(IReadOnlyList<int> chapterIds, int deviceId)
     {
-        var files = await _unitOfWork.ChapterRepository.GetFilesForChaptersAsync(chapterIds);
-        if (files.Any(f => f.Format is not (MangaFormat.Epub or MangaFormat.Pdf)))
-            throw new KavitaException("Cannot Send non Epub or Pdf to devices as not supported");
-
         var device = await _unitOfWork.DeviceRepository.GetDeviceById(deviceId);
         if (device == null) throw new KavitaException("Device doesn't exist");
+
+        var files = await _unitOfWork.ChapterRepository.GetFilesForChaptersAsync(chapterIds);
+        if (files.Any(f => f.Format is not (MangaFormat.Epub or MangaFormat.Pdf)) && device.Platform == DevicePlatform.Kindle)
+            throw new KavitaException("Cannot Send non Epub or Pdf to devices as not supported on Kindle");
+
+
         device.LastUsed = DateTime.Now;
         _unitOfWork.DeviceRepository.Update(device);
         await _unitOfWork.CommitAsync();

--- a/UI/Web/src/app/_services/action-factory.service.ts
+++ b/UI/Web/src/app/_services/action-factory.service.ts
@@ -174,10 +174,10 @@ export class ActionFactoryService {
   dummyCallback(action: ActionItem<any>, data: any) {}
 
   filterSendToAction(actions: Array<ActionItem<Chapter>>, chapter: Chapter) {
-    if (chapter.files.filter(f => f.format === MangaFormat.EPUB || f.format === MangaFormat.PDF).length !== chapter.files.length) {
-      // Remove Send To as it doesn't apply
-      return actions.filter(item => item.title !== 'Send To');
-    }
+    // if (chapter.files.filter(f => f.format === MangaFormat.EPUB || f.format === MangaFormat.PDF).length !== chapter.files.length) {
+    //   // Remove Send To as it doesn't apply
+    //   return actions.filter(item => item.title !== 'Send To');
+    // }
     return actions;
   }
 

--- a/UI/Web/src/app/cards/card-item/card-item.component.ts
+++ b/UI/Web/src/app/cards/card-item/card-item.component.ts
@@ -319,9 +319,9 @@ export class CardItemComponent implements OnInit, OnDestroy {
       this.actions = this.actionFactoryService.filterSendToAction(this.actions, vol.chapters[0]);
     } else if (this.utilityService.isSeries(this.entity)) {
       const series = (this.entity as Series);
-      if (series.format === MangaFormat.EPUB || series.format === MangaFormat.PDF) {
-        this.actions = this.actions.filter(a => a.title !== 'Send To');
-      }
+      // if (series.format === MangaFormat.EPUB || series.format === MangaFormat.PDF) {
+      //   this.actions = this.actions.filter(a => a.title !== 'Send To');
+      // }
     }
   }
 }

--- a/openapi.json
+++ b/openapi.json
@@ -7,7 +7,7 @@
       "name": "GPL-3.0",
       "url": "https://github.com/Kareadita/Kavita/blob/develop/LICENSE"
     },
-    "version": "0.6.1.10"
+    "version": "0.6.1.11"
   },
   "servers": [
     {
@@ -3481,6 +3481,66 @@
         "responses": {
           "200": {
             "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/Reader/file-dimensions": {
+      "get": {
+        "tags": [
+          "Reader"
+        ],
+        "summary": "Returns the file dimensions for all pages in a chapter. If the underlying chapter is PDF, use extractPDF to unpack as images.",
+        "description": "This has a side effect of caching the images.\r\n            This will only be populated on archive filetypes and not in bookmark mode",
+        "parameters": [
+          {
+            "name": "chapterId",
+            "in": "query",
+            "description": "",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "extractPdf",
+            "in": "query",
+            "description": "",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/FileDimensionDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/FileDimensionDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/FileDimensionDto"
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -9829,14 +9889,6 @@
             "type": "string",
             "description": "Series Title",
             "nullable": true
-          },
-          "fileDimensions": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/FileDimensionDto"
-            },
-            "description": "A list of images and their dimensions to be used with double page readers",
-            "nullable": true
           }
         },
         "additionalProperties": false,
@@ -10253,6 +10305,12 @@
           "pageNumber": {
             "type": "integer",
             "format": "int32"
+          },
+          "fileName": {
+            "type": "string",
+            "description": "The filename of the cached file. If this was nested in a subfolder, the foldername will be appended with _",
+            "nullable": true,
+            "example": "chapter01_page01.png"
           }
         },
         "additionalProperties": false


### PR DESCRIPTION
# Changed
- Changed: Users can now send non pdf/epub to their devices, so long as they are not Kindle. Requires latest Kavita Email service. Closes #1688 
