### PR TITLE
Performance Improvements and Some Polish

### DIFF
--- a/API.Benchmark/ArchiveServiceBenchmark.cs
+++ b/API.Benchmark/ArchiveServiceBenchmark.cs
@@ -1,9 +1,14 @@
 ﻿using System;
+using System.IO;
 using System.IO.Abstractions;
 using Microsoft.Extensions.Logging.Abstractions;
 using API.Services;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Order;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats.Png;
+using SixLabors.ImageSharp.Formats.Webp;
+using SixLabors.ImageSharp.Processing;
 
 namespace API.Benchmark;
 
@@ -17,6 +22,10 @@ public class ArchiveServiceBenchmark
     private readonly ArchiveService _archiveService;
     private readonly IDirectoryService _directoryService;
     private readonly IImageService _imageService;
+    private readonly PngEncoder _pngEncoder = new PngEncoder();
+    private readonly WebpEncoder _webPEncoder = new WebpEncoder();
+    private const string SourceImage = "C:/Users/josep/Pictures/obey_by_grrsa-d6llkaa_colored_by_me.png";
+
 
     public ArchiveServiceBenchmark()
     {
@@ -47,6 +56,52 @@ public class ArchiveServiceBenchmark
         if (_archiveService.GetComicInfo("Data/ComicInfo_outside_root.zip") == null) {
             throw new Exception("ComicInfo not found");
         }
+    }
+
+    [Benchmark]
+    public void ImageSharp_ExtractImage_PNG()
+    {
+        var outputDirectory = "C:/Users/josep/Pictures/imagesharp/";
+        _directoryService.ExistOrCreate(outputDirectory);
+
+        using var stream = new FileStream(SourceImage, FileMode.Open);
+        using var thumbnail2 = SixLabors.ImageSharp.Image.Load(stream);
+        thumbnail2.Mutate(x => x.Resize(320, 0));
+        thumbnail2.Save(_directoryService.FileSystem.Path.Join(outputDirectory, "imagesharp.png"), _pngEncoder);
+    }
+
+    [Benchmark]
+    public void ImageSharp_ExtractImage_WebP()
+    {
+        var outputDirectory = "C:/Users/josep/Pictures/imagesharp/";
+        _directoryService.ExistOrCreate(outputDirectory);
+
+        using var stream = new FileStream(SourceImage, FileMode.Open);
+        using var thumbnail2 = SixLabors.ImageSharp.Image.Load(stream);
+        thumbnail2.Mutate(x => x.Resize(320, 0));
+        thumbnail2.Save(_directoryService.FileSystem.Path.Join(outputDirectory, "imagesharp.webp"), _webPEncoder);
+    }
+
+    [Benchmark]
+    public void NetVips_ExtractImage_PNG()
+    {
+        var outputDirectory = "C:/Users/josep/Pictures/netvips/";
+        _directoryService.ExistOrCreate(outputDirectory);
+
+        using var stream = new FileStream(SourceImage, FileMode.Open);
+        using var thumbnail = NetVips.Image.ThumbnailStream(stream, 320);
+        thumbnail.WriteToFile(_directoryService.FileSystem.Path.Join(outputDirectory, "netvips.png"));
+    }
+
+    [Benchmark]
+    public void NetVips_ExtractImage_WebP()
+    {
+        var outputDirectory = "C:/Users/josep/Pictures/netvips/";
+        _directoryService.ExistOrCreate(outputDirectory);
+
+        using var stream = new FileStream(SourceImage, FileMode.Open);
+        using var thumbnail = NetVips.Image.ThumbnailStream(stream, 320);
+        thumbnail.WriteToFile(_directoryService.FileSystem.Path.Join(outputDirectory, "netvips.webp"));
     }
 
     // Benchmark to test default GetNumberOfPages from archive

--- a/API.Benchmark/EpubBenchmark.cs
+++ b/API.Benchmark/EpubBenchmark.cs
@@ -82,8 +82,9 @@ public class EpubBenchmark
         doc.LoadHtml(await bookFile.ReadContentAsTextAsync());
         var delimiter = new char[] {' '};
 
-        return doc.DocumentNode.SelectNodes("//body//text()[not(parent::script)]")
-            .Select(node => node.InnerText)
+        var textNodes = doc.DocumentNode.SelectNodes("//body//text()[not(parent::script)]");
+        if (textNodes == null) return 0;
+        return textNodes.Select(node => node.InnerText)
             .Select(text => text.Split(delimiter, StringSplitOptions.RemoveEmptyEntries)
                 .Where(s => char.IsLetter(s[0])))
             .Select(words => words.Count())
@@ -95,11 +96,10 @@ public class EpubBenchmark
     {
         var doc = new HtmlDocument();
         doc.LoadHtml(await bookFile.ReadContentAsTextAsync());
-        var delimiter = new char[] {' '};
 
         return doc.DocumentNode.SelectNodes("//body//text()[not(parent::script)]")
-            .Select(node => node.InnerText)
-            .Select(text => text.Split(delimiter, StringSplitOptions.RemoveEmptyEntries)
+            .DefaultIfEmpty()
+            .Select(node => node.InnerText.Split(' ', StringSplitOptions.RemoveEmptyEntries)
                 .Where(s => char.IsLetter(s[0])))
             .Sum(words => words.Count());
     }

--- a/API/DTOs/ProgressDto.cs
+++ b/API/DTOs/ProgressDto.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using System;
+using System.ComponentModel.DataAnnotations;
 
 namespace API.DTOs;
 
@@ -19,4 +20,8 @@ public class ProgressDto
     /// on pages that combine multiple "chapters".
     /// </summary>
     public string BookScrollId { get; set; }
+    /// <summary>
+    /// Last time the progress was synced from UI or external app
+    /// </summary>
+    public DateTime LastModified { get; set; }
 }

--- a/API/Data/Repositories/ChapterRepository.cs
+++ b/API/Data/Repositories/ChapterRepository.cs
@@ -52,7 +52,7 @@ public class ChapterRepository : IChapterRepository
         _context.Entry(chapter).State = EntityState.Modified;
     }
 
-    public async Task<IEnumerable<Chapter>> GetChaptersByIdsAsync(IList<int> chapterIds, ChapterIncludes includes)
+    public async Task<IEnumerable<Chapter>> GetChaptersByIdsAsync(IList<int> chapterIds, ChapterIncludes includes = ChapterIncludes.None)
     {
         return await _context.Chapter
             .Where(c => chapterIds.Contains(c.Id))

--- a/API/Services/BookService.cs
+++ b/API/Services/BookService.cs
@@ -49,7 +49,7 @@ public interface IBookService
     /// <summary>
     /// Extracts a PDF file's pages as images to an target directory
     /// </summary>
-    /// <remarks>This method relies on Docnet which has explict patches from Kavita for ARM support. This should only be used with Tachiyomi</remarks>
+    /// <remarks>This method relies on Docnet which has explicit patches from Kavita for ARM support. This should only be used with Tachiyomi</remarks>
     /// <param name="fileFilePath"></param>
     /// <param name="targetDirectory">Where the files will be extracted to. If doesn't exist, will be created.</param>
     void ExtractPdfImages(string fileFilePath, string targetDirectory);
@@ -401,7 +401,7 @@ public class BookService : IBookService
         {
             using var epubBook = EpubReader.OpenBook(filePath, BookReaderOptions);
             var publicationDate =
-                epubBook.Schema.Package.Metadata.Dates.FirstOrDefault(date => date.Event == "publication")?.Date;
+                epubBook.Schema.Package.Metadata.Dates.FirstOrDefault(pDate => pDate.Event == "publication")?.Date;
 
             if (string.IsNullOrEmpty(publicationDate))
             {
@@ -533,7 +533,7 @@ public class BookService : IBookService
         return 0;
     }
 
-    public static string EscapeTags(string content)
+    private static string EscapeTags(string content)
     {
         content = Regex.Replace(content, @"<script(.*)(/>)", "<script$1></script>");
         content = Regex.Replace(content, @"<title(.*)(/>)", "<title$1></title>");
@@ -872,8 +872,8 @@ public class BookService : IBookService
         throw new KavitaException("Could not find the appropriate html for that page");
     }
 
-    private static void CreateToCChapter(EpubNavigationItemRef navigationItem, IList<BookChapterItem> nestedChapters, IList<BookChapterItem> chaptersList,
-        IReadOnlyDictionary<string, int> mappings)
+    private static void CreateToCChapter(EpubNavigationItemRef navigationItem, IList<BookChapterItem> nestedChapters,
+        ICollection<BookChapterItem> chaptersList, IReadOnlyDictionary<string, int> mappings)
     {
         if (navigationItem.Link == null)
         {

--- a/API/Services/BookService.cs
+++ b/API/Services/BookService.cs
@@ -865,7 +865,8 @@ public class BookService : IBookService
             }
         } catch (Exception ex)
         {
-              _logger.LogError(ex, "There was an issue reading one of the pages for {Book}", book.FilePath);
+            // NOTE: We can log this to media analysis service
+            _logger.LogError(ex, "There was an issue reading one of the pages for {Book}", book.FilePath);
         }
 
         throw new KavitaException("Could not find the appropriate html for that page");

--- a/API/Services/ImageService.cs
+++ b/API/Services/ImageService.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using NetVips;
 using SixLabors.ImageSharp;
 using Image = NetVips.Image;
 
@@ -113,15 +114,15 @@ public class ImageService : IImageService
         return filename;
     }
 
-    public async Task<string> ConvertToWebP(string filePath, string outputPath)
+    public Task<string> ConvertToWebP(string filePath, string outputPath)
     {
         var file = _directoryService.FileSystem.FileInfo.FromFileName(filePath);
         var fileName = file.Name.Replace(file.Extension, string.Empty);
         var outputFile = Path.Join(outputPath, fileName + ".webp");
 
-        using var sourceImage = await SixLabors.ImageSharp.Image.LoadAsync(filePath);
-        await sourceImage.SaveAsWebpAsync(outputFile);
-        return outputFile;
+        using var sourceImage = Image.NewFromFile(filePath, false, Enums.Access.SequentialUnbuffered);
+        sourceImage.WriteToFile(outputFile);
+        return Task.FromResult(outputFile);
     }
 
     public async Task<bool> IsImage(string filePath)

--- a/API/Services/StatisticService.cs
+++ b/API/Services/StatisticService.cs
@@ -26,7 +26,6 @@ public interface IStatisticService
     Task<FileExtensionBreakdownDto> GetFileBreakdown();
     Task<IEnumerable<TopReadDto>> GetTopUsers(int days);
     Task<IEnumerable<ReadHistoryEvent>> GetReadingHistory(int userId);
-    Task<IEnumerable<ReadHistoryEvent>> GetHistory();
     Task<IEnumerable<PagesReadOnADayCount<DateTime>>> ReadCountByDay(int userId = 0);
 }
 
@@ -70,20 +69,6 @@ public class StatisticService : IStatisticService
         var timeSpentReading = await _context.Chapter
             .Where(c => chapterIds.Contains(c.Id))
             .SumAsync(c => c.AvgHoursToRead);
-
-        // Maybe make this top 5 genres? But usually there are 3-5 genres that are always common...
-        // Maybe use rating to calculate top genres?
-        // var genres = await _context.Series
-        //     .Where(s => seriesIds.Contains(s.Id))
-        //     .Select(s => s.Metadata)
-        //     .SelectMany(sm => sm.Genres)
-        //     //.DistinctBy(g => g.NormalizedTitle)
-        //     .ToListAsync();
-
-        // How many series of each format have you read? (Epub, Archive, etc)
-
-        // Percentage of libraries read. For each library, get the total pages vs read
-        //var allLibraryIds = await _context.Library.GetUserLibraries(userId).ToListAsync();
 
         var chaptersRead = await _context.AppUserProgresses
             .Where(p => p.AppUserId == userId)
@@ -343,43 +328,6 @@ public class StatisticService : IStatisticService
             .OrderBy(d => d.Value)
             .ToListAsync();
     }
-
-    public Task<IEnumerable<ReadHistoryEvent>> GetHistory()
-    {
-        // _context.AppUserProgresses
-        //     .AsSplitQuery()
-        //     .AsEnumerable()
-        //     .GroupBy(sm => sm.LastModified)
-        //     .Select(sm => new
-        //     {
-        //         User = _context.AppUser.Single(u => u.Id == sm.Key),
-        // Chapters = _context.Chapter.Where(c => _context.AppUserProgresses
-        //     .Where(u => u.AppUserId == sm.Key)
-        //     .Where(p => p.PagesRead > 0)
-        //     .Select(p => p.ChapterId)
-        //     .Distinct()
-        //     .Contains(c.Id))
-        //     })
-        //     .OrderByDescending(d => d.Chapters.Sum(c => c.AvgHoursToRead))
-        //     .Take(5)
-        //     .ToList();
-
-        var firstOfWeek = DateTime.Now.StartOfWeek(DayOfWeek.Monday);
-        var groupedReadingDays = _context.AppUserProgresses
-            .Where(x => x.LastModified >= firstOfWeek)
-            .GroupBy(x => x.LastModified.Day)
-            .Select(g => new StatCount<int>()
-            {
-                Value = g.Key,
-                Count = _context.AppUserProgresses.Where(p => p.LastModified.Day == g.Key).Select(p => p.ChapterId).Distinct().Count()
-            })
-            .AsEnumerable();
-
-        // var records = firstOfWeek.Range(7)
-        //     .GroupJoin(groupedReadingDays, wd => wd.Day, lg => lg.Key, (_, lg) => lg.Any() ? lg.First().Count() : 0).ToArray();
-        return Task.FromResult<IEnumerable<ReadHistoryEvent>>(null);
-    }
-
 
     public async Task<IEnumerable<TopReadDto>> GetTopUsers(int days)
     {

--- a/API/Services/Tasks/Metadata/WordCountAnalyzerService.cs
+++ b/API/Services/Tasks/Metadata/WordCountAnalyzerService.cs
@@ -196,8 +196,7 @@ public class WordCountAnalyzerService : IWordCountAnalyzerService
                             return;
                         }
 
-                        file.LastFileAnalysis = DateTime.Now;
-                        _unitOfWork.MangaFileRepository.Update(file);
+                        UpdateFileAnalysis(file);
                     }
 
                     chapter.WordCount = sum;
@@ -211,8 +210,7 @@ public class WordCountAnalyzerService : IWordCountAnalyzerService
                 chapter.AvgHoursToRead = est.AvgHours;
                 foreach (var file in chapter.Files)
                 {
-                    file.LastFileAnalysis = DateTime.Now;
-                    _unitOfWork.MangaFileRepository.Update(file);
+                    UpdateFileAnalysis(file);
                 }
                 _unitOfWork.ChapterRepository.Update(chapter);
             }
@@ -231,6 +229,12 @@ public class WordCountAnalyzerService : IWordCountAnalyzerService
         series.MaxHoursToRead = seriesEstimate.MaxHours;
         series.AvgHoursToRead = seriesEstimate.AvgHours;
         _unitOfWork.SeriesRepository.Update(series);
+    }
+
+    private void UpdateFileAnalysis(MangaFile file)
+    {
+        file.LastFileAnalysis = DateTime.Now;
+        _unitOfWork.MangaFileRepository.Update(file);
     }
 
 

--- a/API/Services/Tasks/Metadata/WordCountAnalyzerService.cs
+++ b/API/Services/Tasks/Metadata/WordCountAnalyzerService.cs
@@ -239,16 +239,10 @@ public class WordCountAnalyzerService : IWordCountAnalyzerService
         var doc = new HtmlDocument();
         doc.LoadHtml(await bookFile.ReadContentAsTextAsync());
 
-        var textNodes = doc.DocumentNode.SelectNodes("//body//text()[not(parent::script)]");
-        if (textNodes == null) return 0;
-
-        return textNodes
+        return doc.DocumentNode.SelectNodes("//body//text()[not(parent::script)]")
+            .DefaultIfEmpty()
             .Select(node => node.InnerText.Split(' ', StringSplitOptions.RemoveEmptyEntries)
                 .Where(s => char.IsLetter(s[0])))
-            .Select(words => words.Count())
-            .Where(wordCount => wordCount > 0)
-            .Sum();
+            .Sum(words => words.Count());
     }
-
-
 }

--- a/Kavita.sln.DotSettings
+++ b/Kavita.sln.DotSettings
@@ -2,8 +2,14 @@
 	<s:String x:Key="/Default/CodeInspection/ExcludedFiles/FilesAndFoldersToSkip2/=1BC0273F_002DFEBE_002D4DA1_002DBC04_002D3A3167E4C86C_002Fd_003AData_002Fd_003AMigrations/@EntryIndexedValue">ExplicitlyExcluded</s:String>
 	<s:Boolean x:Key="/Default/CodeInspection/Highlighting/RunLongAnalysisInSwa/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/Highlighting/RunValueAnalysisInNullableWarningsEnabledContext2/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Docnet/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=epubs/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=kavitaignore/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=kavitaignores/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=noopener/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=noreferrer/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=OEBPS/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Omake/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Opds/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=rewinded/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=rewinded/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Tachiyomi/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/UI/Web/src/app/admin/manage-media-settings/manage-media-settings.component.html
+++ b/UI/Web/src/app/admin/manage-media-settings/manage-media-settings.component.html
@@ -32,4 +32,7 @@
             <button type="submit" class="flex-fill btn btn-primary" (click)="saveSettings()" [disabled]="!settingsForm.dirty">Save</button>
         </div>
     </form>
+
+    <!-- Accordion with Issues from Media anaysis -->
+    
 </div>

--- a/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.ts
+++ b/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.ts
@@ -349,7 +349,7 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   get SplitIconClass() {
-    // NOTE: This could be rewritten to valueChanges.pipe(map()) and | async in the UI instead of the getter
+    // TODO: make this a pipe
     if (this.mangaReaderService.isSplitLeftToRight(this.pageSplitOption)) {
       return 'left-side';
     } else if (this.mangaReaderService.isNoSplit(this.pageSplitOption)) {
@@ -593,7 +593,7 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       pageSplit: parseInt(this.generalSettingsForm.get('pageSplitOption')?.value, 10),
       fitting: (this.generalSettingsForm.get('fittingOption')?.value as FITTING_OPTION),
       layoutMode: this.layoutMode,
-      darkness: 100,
+      darkness: parseInt(this.generalSettingsForm.get('darkness')?.value + '', 10) || 100,
       pagingDirection: this.pagingDirection,
       readerMode: this.readerMode,
       emulateBook: this.generalSettingsForm.get('emulateBook')?.value,

--- a/UI/Web/src/app/statistics/_components/publication-status-stats/publication-status-stats.component.html
+++ b/UI/Web/src/app/statistics/_components/publication-status-stats/publication-status-stats.component.html
@@ -1,7 +1,6 @@
 <div class="row g-0 mb-2">
     <div class="col-8">
         <h4><span>Publication Status</span>
-            <i class="fa fa-info-circle ms-1" aria-hidden="true" placement="right" [ngbTooltip]="tooltip" role="button" tabindex="0"></i>
         </h4>
     </div>
     <div class="col-4">
@@ -13,8 +12,6 @@
         </form>
     </div>
 </div>
-
-<ng-template #tooltip></ng-template>
 
 
 <ng-container *ngIf="publicationStatues$ | async as statuses">

--- a/UI/Web/src/app/statistics/_components/read-by-day-and/read-by-day-and.component.html
+++ b/UI/Web/src/app/statistics/_components/read-by-day-and/read-by-day-and.component.html
@@ -30,8 +30,9 @@
                 [showGridLines]="false"
                 [showRefLines]="true"
                 [roundDomains]="true"
+                [autoScale]="true"
                 xAxisLabel="Time"
-                yAxisLabel="Reading Events"
+                yAxisLabel="Reading Activity"
                 [timeline]="false"
                 [results]="data"
                 >

--- a/UI/Web/src/app/statistics/_components/stat-list/stat-list.component.html
+++ b/UI/Web/src/app/statistics/_components/stat-list/stat-list.component.html
@@ -9,7 +9,7 @@
             <ng-container *ngIf="image && image(item) as url">
               <app-image *ngIf="url && url.length > 0" width="32px" maxHeight="32px" class="img-top me-1" [imageUrl]="url"></app-image>
             </ng-container>
-            {{item.name}} <span class="float-end" *ngIf="item.value >= 0">{{item.value}} {{label}}</span>
+            {{item.name}} <span class="float-end" *ngIf="item.value >= 0">{{item.value | compactNumber}} {{label}}</span>
           </li>
         </ul>
     </div>

--- a/openapi.json
+++ b/openapi.json
@@ -7,7 +7,7 @@
       "name": "GPL-3.0",
       "url": "https://github.com/Kareadita/Kavita/blob/develop/LICENSE"
     },
-    "version": "0.6.1.16"
+    "version": "0.6.1.17"
   },
   "servers": [
     {


### PR DESCRIPTION
# Changed
- Changed: Reading timeline now auto scales on the Y axis (develop)
- Changed: (Performance) Slightly sped up word count for epubs
- Changed: Update stat lists to use compact numbers (aka 3K) (develop)
- Changed: (Performance) Replaced WebP conversion with NetVips, which is drastically lighter on memory and CPU
- Changed: Progress dtos now have LastModifed timestamp on them for #1700 

# Fixed
- Fixed: Fixed a bug where brightness wasn't applying in the manga reader (develop)
- Fixed: When an epub has a malformed page, Kavita now presents a much better message to the UI than before. 
