### PR TITLE
Quick fix for Double Renderer

### DIFF
--- a/UI/Web/src/app/manga-reader/_components/double-renderer/double-renderer.component.scss
+++ b/UI/Web/src/app/manga-reader/_components/double-renderer/double-renderer.component.scss
@@ -8,6 +8,10 @@
     }
 }
 
+.image-container.full-height {
+    display: inline-block !important;
+}
+
 .full-width {
     width: 100%;
     margin: 0 auto;

--- a/UI/Web/src/app/manga-reader/_components/double-reverse-renderer/double-reverse-renderer.component.scss
+++ b/UI/Web/src/app/manga-reader/_components/double-reverse-renderer/double-reverse-renderer.component.scss
@@ -27,6 +27,10 @@
     }
 }
 
+.image-container.full-height {
+    display: inline-block;
+}
+
 .full-width {
     width: 100%;
     margin: 0 auto;

--- a/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.html
+++ b/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.html
@@ -224,7 +224,7 @@
                         <div class="mb-3">
                             <div class="mb-3">
                                 <div class="form-check form-switch">
-                                    <input type="checkbox" id="auto-close" formControlName="autoCloseMenu" class="form-check-input" [value]="true">
+                                    <input type="checkbox" id="auto-close" formControlName="autoCloseMenu" class="form-check-input" >
                                     <label class="form-check-label" for="auto-close">Auto Close Menu</label>
                                 </div>
                             </div>
@@ -234,7 +234,7 @@
                         <div class="mb-3">
                             <div class="mb-3">
                                 <div class="form-check form-switch">
-                                    <input type="checkbox" id="emulate-book" formControlName="emulateBook" class="form-check-input" [value]="true">
+                                    <input type="checkbox" id="emulate-book" formControlName="emulateBook" class="form-check-input">
                                     <label class="form-check-label" for="emulate-book">Emulate comic book</label>
                                 </div>
                             </div>

--- a/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.ts
+++ b/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.ts
@@ -147,36 +147,12 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
    * @remarks Used for rendering to screen.
    */
   canvasImage = new Image();
-  /**
-   * Used solely for LayoutMode.Double rendering. 
-   * @remarks Used for rendering to screen.
-   */
-  canvasImage2 = new Image();
-  /**
-   * Used solely for LayoutMode.Double rendering. Will always hold the previous image to canvasImage
-   * @see canvasImage
-   */
-  canvasImagePrev = new Image();
-  /**
-   * Used solely for LayoutMode.Double rendering. Will always hold the next image to canvasImage
-   * @see canvasImage
-   */
-  canvasImageNext = new Image();
-  /**
-   * Responsible to hold current page + 2. Used to know if we should render 
-   * @remarks Used solely for LayoutMode.DoubleReverse rendering. 
-   */
-   canvasImageAheadBy2 = new Image();
-   /**
-   * Responsible to hold current page -2 2. Used to know if we should render 
-   * @remarks Used solely for LayoutMode.DoubleReverse rendering. 
-   */
-  canvasImageBehindBy2 = new Image();
+  
   /**
    * Dictates if we use render with canvas or with image. 
    * @remarks This is only for Splitting.
    */
-  renderWithCanvas: boolean = false;
+  //renderWithCanvas: boolean = false;
 
   /**
    * A circular array of size PREFETCH_PAGES. Maintains prefetched Images around the current page to load from to avoid loading animation.
@@ -468,11 +444,13 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
           this.generalSettingsForm.get('pageSplitOption')?.setValue(this.user.preferences.pageSplitOption);
           this.generalSettingsForm.get('pageSplitOption')?.enable();
           this.generalSettingsForm.get('fittingOption')?.enable();
+          this.generalSettingsForm.get('emulateBook')?.disable();
         } else {
           this.generalSettingsForm.get('pageSplitOption')?.setValue(PageSplitOption.NoSplit);
           this.generalSettingsForm.get('pageSplitOption')?.disable();
           this.generalSettingsForm.get('fittingOption')?.setValue(this.mangaReaderService.translateScalingOption(ScalingOption.FitToHeight));
           this.generalSettingsForm.get('fittingOption')?.disable();
+          this.generalSettingsForm.get('emulateBook')?.enable();
         }
         this.cdRef.markForCheck();
 
@@ -682,7 +660,6 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
     this.pagingDirectionSubject.next(PAGING_DIRECTION.FORWARD);
     this.inSetup = true;
     this.canvasImage.src = '';
-    this.canvasImage2.src = '';
     this.cdRef.markForCheck();
 
     this.cachedImages = [];


### PR DESCRIPTION
# Changed
- Changed: Emulate Comic Book will now disable if you're in single renderer mode. 

# Fixed
- Fixed: Fixed a bug where double renderer wouldn't lay out the images correctly due to a change in the last PR (develop)
