### PR TITLE
Holiday Bugfixes

### DIFF
--- a/API/API.csproj
+++ b/API/API.csproj
@@ -96,6 +96,7 @@
     </PackageReference>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="7.0.6" />
+    <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.24.0" />
     <PackageReference Include="System.IO.Abstractions" Version="17.2.3" />
     <PackageReference Include="VersOne.Epub" Version="3.3.0-alpha1" />

--- a/API/Controllers/ServerController.cs
+++ b/API/Controllers/ServerController.cs
@@ -36,10 +36,11 @@ public class ServerController : BaseApiController
     private readonly IEmailService _emailService;
     private readonly IBookmarkService _bookmarkService;
     private readonly IScannerService _scannerService;
+    private readonly IAccountService _accountService;
 
     public ServerController(IHostApplicationLifetime applicationLifetime, ILogger<ServerController> logger,
         IBackupService backupService, IArchiveService archiveService, IVersionUpdaterService versionUpdaterService, IStatsService statsService,
-        ICleanupService cleanupService, IEmailService emailService, IBookmarkService bookmarkService, IScannerService scannerService)
+        ICleanupService cleanupService, IEmailService emailService, IBookmarkService bookmarkService, IScannerService scannerService, IAccountService accountService)
     {
         _applicationLifetime = applicationLifetime;
         _logger = logger;
@@ -51,6 +52,7 @@ public class ServerController : BaseApiController
         _emailService = emailService;
         _bookmarkService = bookmarkService;
         _scannerService = scannerService;
+        _accountService = accountService;
     }
 
     /// <summary>
@@ -189,12 +191,13 @@ public class ServerController : BaseApiController
     /// <summary>
     /// Is this server accessible to the outside net
     /// </summary>
+    /// <remarks>If the instance has the HostName set, this will return true whether or not it is accessible externally</remarks>
     /// <returns></returns>
     [HttpGet("accessible")]
     [AllowAnonymous]
     public async Task<ActionResult<bool>> IsServerAccessible()
     {
-        return await _emailService.CheckIfAccessible(Request.Host.ToString());
+        return Ok(await _accountService.CheckIfAccessible(Request));
     }
 
     [HttpGet("jobs")]

--- a/API/Controllers/SettingsController.cs
+++ b/API/Controllers/SettingsController.cs
@@ -182,6 +182,13 @@ public class SettingsController : BaseApiController
                 _unitOfWork.SettingsRepository.Update(setting);
             }
 
+            if (setting.Key == ServerSettingKey.HostName && updateSettingsDto.HostName + string.Empty != setting.Value)
+            {
+                setting.Value = updateSettingsDto.HostName + string.Empty;
+                if (setting.Value.EndsWith("/")) setting.Value = setting.Value.Substring(0, setting.Value.Length - 1);
+                _unitOfWork.SettingsRepository.Update(setting);
+            }
+
 
             if (setting.Key == ServerSettingKey.BookmarkDirectory && bookmarkDirectory != setting.Value)
             {

--- a/API/Controllers/SettingsController.cs
+++ b/API/Controllers/SettingsController.cs
@@ -104,7 +104,7 @@ public class SettingsController : BaseApiController
     [HttpPost]
     public async Task<ActionResult<ServerSettingDto>> UpdateSettings(ServerSettingDto updateSettingsDto)
     {
-        _logger.LogInformation("{UserName}  is updating Server Settings", User.GetUsername());
+        _logger.LogInformation("{UserName} is updating Server Settings", User.GetUsername());
 
         // We do not allow CacheDirectory changes, so we will ignore.
         var currentSettings = await _unitOfWork.SettingsRepository.GetSettingsAsync();

--- a/API/Controllers/SettingsController.cs
+++ b/API/Controllers/SettingsController.cs
@@ -184,7 +184,7 @@ public class SettingsController : BaseApiController
 
             if (setting.Key == ServerSettingKey.HostName && updateSettingsDto.HostName + string.Empty != setting.Value)
             {
-                setting.Value = updateSettingsDto.HostName + string.Empty;
+                setting.Value = (updateSettingsDto.HostName + string.Empty).Trim();
                 if (setting.Value.EndsWith("/")) setting.Value = setting.Value.Substring(0, setting.Value.Length - 1);
                 _unitOfWork.SettingsRepository.Update(setting);
             }

--- a/API/Controllers/UsersController.cs
+++ b/API/Controllers/UsersController.cs
@@ -111,6 +111,7 @@ public class UsersController : BaseApiController
         existingPreferences.LayoutMode = preferencesDto.LayoutMode;
         existingPreferences.PromptForDownloadSize = preferencesDto.PromptForDownloadSize;
         existingPreferences.NoTransitions = preferencesDto.NoTransitions;
+        existingPreferences.SwipeToPaginate = preferencesDto.SwipeToPaginate;
 
         _unitOfWork.UserRepository.Update(existingPreferences);
 

--- a/API/DTOs/Settings/ServerSettingDTO.cs
+++ b/API/DTOs/Settings/ServerSettingDTO.cs
@@ -66,4 +66,8 @@ public class ServerSettingDto
     /// If the server should save covers as WebP encoding
     /// </summary>
     public bool ConvertCoverToWebP { get; set; }
+    /// <summary>
+    /// The Host name (ie Reverse proxy domain name) for the server
+    /// </summary>
+    public string HostName { get; set; }
 }

--- a/API/DTOs/UserPreferencesDto.cs
+++ b/API/DTOs/UserPreferencesDto.cs
@@ -46,6 +46,11 @@ public class UserPreferencesDto
     /// </summary>
     [Required]
     public string BackgroundColor { get; set; } = "#000000";
+    [Required]
+    /// <summary>
+    /// Manga Reader Option: Should swiping trigger pagination
+    /// </summary>
+    public bool SwipeToPaginate { get; set; }
     /// <summary>
     /// Manga Reader Option: Allow the menu to close after 6 seconds without interaction
     /// </summary>

--- a/API/Data/Migrations/20230129210741_SwipeToPaginatePref.Designer.cs
+++ b/API/Data/Migrations/20230129210741_SwipeToPaginatePref.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using API.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace API.Data.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20230129210741_SwipeToPaginatePref")]
+    partial class SwipeToPaginatePref
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "6.0.10");

--- a/API/Data/Migrations/20230129210741_SwipeToPaginatePref.cs
+++ b/API/Data/Migrations/20230129210741_SwipeToPaginatePref.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace API.Data.Migrations
+{
+    public partial class SwipeToPaginatePref : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "SwipeToPaginate",
+                table: "AppUserPreferences",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "SwipeToPaginate",
+                table: "AppUserPreferences");
+        }
+    }
+}

--- a/API/Data/Seed.cs
+++ b/API/Data/Seed.cs
@@ -102,6 +102,7 @@ public static class Seed
             new() {Key = ServerSettingKey.TotalLogs, Value = "30"},
             new() {Key = ServerSettingKey.EnableFolderWatching, Value = "false"},
             new() {Key = ServerSettingKey.ConvertCoverToWebP, Value = "false"},
+            new() {Key = ServerSettingKey.HostName, Value = string.Empty},
         }.ToArray());
 
         foreach (var defaultSetting in DefaultSettings)

--- a/API/Entities/AppUserPreferences.cs
+++ b/API/Entities/AppUserPreferences.cs
@@ -1,4 +1,5 @@
-﻿using API.Entities.Enums;
+﻿using System;
+using API.Entities.Enums;
 using API.Entities.Enums.UserPreferences;
 
 namespace API.Entities;
@@ -26,7 +27,6 @@ public class AppUserPreferences
     /// </example>
     /// </summary>
     public ReaderMode ReaderMode { get; set; }
-
     /// <summary>
     /// Manga Reader Option: Allow the menu to close after 6 seconds without interaction
     /// </summary>
@@ -47,6 +47,10 @@ public class AppUserPreferences
     /// Manga Reader Option: Background color of the reader
     /// </summary>
     public string BackgroundColor { get; set; } = "#000000";
+    /// <summary>
+    /// Manga Reader Option: Should swiping trigger pagination
+    /// </summary>
+    public bool SwipeToPaginate { get; set; }
     /// <summary>
     /// Book Reader Option: Override extra Margin
     /// </summary>

--- a/API/Entities/Enums/ServerSettingKey.cs
+++ b/API/Entities/Enums/ServerSettingKey.cs
@@ -105,4 +105,10 @@ public enum ServerSettingKey
     /// </summary>
     [Description("ConvertCoverToWebP")]
     ConvertCoverToWebP = 19,
+    /// <summary>
+    /// The Host name (ie Reverse proxy domain name) for the server. Used for email link generation
+    /// </summary>
+    [Description("HostName")]
+    HostName = 20,
+
 }

--- a/API/Helpers/Converters/ServerSettingConverter.cs
+++ b/API/Helpers/Converters/ServerSettingConverter.cs
@@ -66,6 +66,9 @@ public class ServerSettingConverter : ITypeConverter<IEnumerable<ServerSetting>,
                 case ServerSettingKey.TotalLogs:
                     destination.TotalLogs = int.Parse(row.Value);
                     break;
+                case ServerSettingKey.HostName:
+                    destination.HostName = row.Value;
+                    break;
             }
         }
 

--- a/API/Services/AccountService.cs
+++ b/API/Services/AccountService.cs
@@ -2,12 +2,15 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Web;
 using API.Constants;
 using API.Data;
 using API.Entities;
 using API.Errors;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace API.Services;
@@ -20,6 +23,8 @@ public interface IAccountService
     Task<IEnumerable<ApiException>> ValidateEmail(string email);
     Task<bool> HasBookmarkPermission(AppUser user);
     Task<bool> HasDownloadPermission(AppUser user);
+    Task<bool> CheckIfAccessible(HttpRequest request);
+    Task<string> GenerateEmailLink(HttpRequest request, string token, string routePart, string email, bool withHost = true);
 }
 
 public class AccountService : IAccountService
@@ -27,13 +32,44 @@ public class AccountService : IAccountService
     private readonly UserManager<AppUser> _userManager;
     private readonly ILogger<AccountService> _logger;
     private readonly IUnitOfWork _unitOfWork;
+    private readonly IHostEnvironment _environment;
+    private readonly IEmailService _emailService;
     public const string DefaultPassword = "[k.2@RZ!mxCQkJzE";
+    private const string LocalHost = "localhost:4200";
 
-    public AccountService(UserManager<AppUser> userManager, ILogger<AccountService> logger, IUnitOfWork unitOfWork)
+    public AccountService(UserManager<AppUser> userManager, ILogger<AccountService> logger, IUnitOfWork unitOfWork,
+        IHostEnvironment environment, IEmailService emailService)
     {
         _userManager = userManager;
         _logger = logger;
         _unitOfWork = unitOfWork;
+        _environment = environment;
+        _emailService = emailService;
+    }
+
+    /// <summary>
+    /// Checks if the instance is accessible. If the host name is filled out, then it will assume it is accessible as email generation will use host name.
+    /// </summary>
+    /// <param name="request"></param>
+    /// <returns></returns>
+    public async Task<bool> CheckIfAccessible(HttpRequest request)
+    {
+        var host = _environment.IsDevelopment() ? LocalHost : request.Host.ToString();
+        return !string.IsNullOrEmpty((await _unitOfWork.SettingsRepository.GetSettingsDtoAsync()).HostName) || await _emailService.CheckIfAccessible(host);
+    }
+
+    public async Task<string> GenerateEmailLink(HttpRequest request, string token, string routePart, string email, bool withHost = true)
+    {
+        var serverSettings = await _unitOfWork.SettingsRepository.GetSettingsDtoAsync();
+        var host = _environment.IsDevelopment() ? LocalHost : request.Host.ToString();
+        var basePart = $"{request.Scheme}://{host}{request.PathBase}/";
+        if (!string.IsNullOrEmpty(serverSettings.HostName))
+        {
+            basePart = serverSettings.HostName;
+        }
+
+        if (withHost) return $"{basePart}/registration/{routePart}?token={HttpUtility.UrlEncode(token)}&email={HttpUtility.UrlEncode(email)}";
+        return $"registration/{routePart}?token={HttpUtility.UrlEncode(token)}&email={HttpUtility.UrlEncode(email)}";
     }
 
     public async Task<IEnumerable<ApiException>> ChangeUserPassword(AppUser user, string newPassword)

--- a/UI/Web/src/app/_models/preferences/preferences.ts
+++ b/UI/Web/src/app/_models/preferences/preferences.ts
@@ -19,6 +19,7 @@ export interface Preferences {
     backgroundColor: string;
     showScreenHints: boolean;
     emulateBook: boolean;
+    swipeToPaginate: boolean;
 
     // Book Reader
     bookReaderMargin: number;

--- a/UI/Web/src/app/admin/_models/server-settings.ts
+++ b/UI/Web/src/app/admin/_models/server-settings.ts
@@ -14,4 +14,5 @@ export interface ServerSettings {
     totalBackups: number;
     totalLogs: number;
     enableFolderWatching: boolean;
+    hostName: string;
 }

--- a/UI/Web/src/app/admin/manage-settings/manage-settings.component.html
+++ b/UI/Web/src/app/admin/manage-settings/manage-settings.component.html
@@ -24,7 +24,8 @@
             <label for="settings-hostname" class="form-label">Host Name</label>&nbsp;<i class="fa fa-info-circle" placement="right" [ngbTooltip]="hostNameTooltip" role="button" tabindex="0"></i>
             <ng-template #hostNameTooltip>Domain Name (of Reverse Proxy). If set, email generation will always use this.</ng-template>
             <span class="visually-hidden" id="settings-hostname-help">Domain Name (of Reverse Proxy). If set, email generation will always use this.</span>
-            <input id="settings-hostname" aria-describedby="settings-hostname-help" class="form-control" formControlName="hostName" type="text">
+            <input id="settings-hostname" aria-describedby="settings-hostname-help" class="form-control" formControlName="hostName" type="text" 
+            [class.is-invalid]="settingsForm.get('hostName')?.invalid && settingsForm.get('hostName')?.touched">
             <div id="hostname-validations" class="invalid-feedback" *ngIf="settingsForm.dirty || settingsForm.touched">
                 <div *ngIf="settingsForm.get('hostName')?.errors?.pattern">
                     Host name must start with http(s) and not end in /

--- a/UI/Web/src/app/admin/manage-settings/manage-settings.component.html
+++ b/UI/Web/src/app/admin/manage-settings/manage-settings.component.html
@@ -1,6 +1,6 @@
 <div class="container-fluid">
     <form [formGroup]="settingsForm" *ngIf="serverSettings !== undefined">
-        <p class="text-warning pt-2">Port and Swagger require a manual restart of Kavita to take effect.</p>
+        <p class="text-warning pt-2">Changing Port requires a manual restart of Kavita to take effect.</p>
         <div class="mb-3">
             <label for="settings-cachedir" class="form-label">Cache Directory</label>&nbsp;<i class="fa fa-info-circle" placement="right" [ngbTooltip]="cacheDirectoryTooltip" role="button" tabindex="0"></i>
             <ng-template #cacheDirectoryTooltip>Where the server place temporary files when reading. This will be cleaned up on a regular basis.</ng-template>
@@ -17,6 +17,18 @@
                 <button id="change-bookmarks-dir" class="btn btn-primary" (click)="openDirectoryChooser(settingsForm.get('bookmarksDirectory')?.value, 'bookmarksDirectory')">
                     Change
                 </button>
+            </div>
+        </div>
+
+        <div class="mb-3">
+            <label for="settings-hostname" class="form-label">Host Name</label>&nbsp;<i class="fa fa-info-circle" placement="right" [ngbTooltip]="hostNameTooltip" role="button" tabindex="0"></i>
+            <ng-template #hostNameTooltip>Domain Name (of Reverse Proxy). If set, email generation will always use this.</ng-template>
+            <span class="visually-hidden" id="settings-hostname-help">Domain Name (of Reverse Proxy). If set, email generation will always use this.</span>
+            <input id="settings-hostname" aria-describedby="settings-hostname-help" class="form-control" formControlName="hostName" type="text">
+            <div id="hostname-validations" class="invalid-feedback" *ngIf="settingsForm.dirty || settingsForm.touched">
+                <div *ngIf="settingsForm.get('hostName')?.errors?.pattern">
+                    Host name must start with http(s) and not end in /
+                </div>
             </div>
         </div>
 

--- a/UI/Web/src/app/admin/manage-settings/manage-settings.component.ts
+++ b/UI/Web/src/app/admin/manage-settings/manage-settings.component.ts
@@ -51,7 +51,7 @@ export class ManageSettingsComponent implements OnInit {
       this.settingsForm.addControl('totalLogs', new FormControl(this.serverSettings.totalLogs, [Validators.required, Validators.min(1), Validators.max(30)]));
       this.settingsForm.addControl('enableFolderWatching', new FormControl(this.serverSettings.enableFolderWatching, [Validators.required]));
       this.settingsForm.addControl('convertBookmarkToWebP', new FormControl(this.serverSettings.convertBookmarkToWebP, []));
-      this.settingsForm.addControl('hostName', new FormControl(this.serverSettings.hostName, [Validators.pattern('(http:|https:)+[^\s]+[\w]$')]));
+      this.settingsForm.addControl('hostName', new FormControl(this.serverSettings.hostName, [Validators.pattern(/^(http:|https:)+[^\s]+[\w]$/)]));
     });
   }
 

--- a/UI/Web/src/app/admin/manage-settings/manage-settings.component.ts
+++ b/UI/Web/src/app/admin/manage-settings/manage-settings.component.ts
@@ -51,6 +51,7 @@ export class ManageSettingsComponent implements OnInit {
       this.settingsForm.addControl('totalLogs', new FormControl(this.serverSettings.totalLogs, [Validators.required, Validators.min(1), Validators.max(30)]));
       this.settingsForm.addControl('enableFolderWatching', new FormControl(this.serverSettings.enableFolderWatching, [Validators.required]));
       this.settingsForm.addControl('convertBookmarkToWebP', new FormControl(this.serverSettings.convertBookmarkToWebP, []));
+      this.settingsForm.addControl('hostName', new FormControl(this.serverSettings.hostName, [Validators.pattern('(http:|https:)+[^\s]+[\w]$')]));
     });
   }
 
@@ -69,6 +70,7 @@ export class ManageSettingsComponent implements OnInit {
     this.settingsForm.get('totalLogs')?.setValue(this.serverSettings.totalLogs);
     this.settingsForm.get('enableFolderWatching')?.setValue(this.serverSettings.enableFolderWatching);
     this.settingsForm.get('convertBookmarkToWebP')?.setValue(this.serverSettings.convertBookmarkToWebP);
+    this.settingsForm.get('hostName')?.setValue(this.serverSettings.hostName);
     this.settingsForm.markAsPristine();
   }
 

--- a/UI/Web/src/app/admin/manage-users/manage-users.component.ts
+++ b/UI/Web/src/app/admin/manage-users/manage-users.component.ts
@@ -134,14 +134,12 @@ export class ManageUsersComponent implements OnInit, OnDestroy {
         }
         await this.confirmService.alert(
           'Please click this link to confirm your email. You must confirm to be able to login. You may need to log out of the current account before clicking. <br/> <a href="' + email + '" target="_blank" rel="noopener noreferrer">' + email + '</a>');
-
       });
     });
   }
 
   setup(member: Member) {
     this.accountService.getInviteUrl(member.id, false).subscribe(url => {
-      console.log('Invite Url: ', url);
       if (url) {
         this.router.navigateByUrl(url);
       }

--- a/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.html
+++ b/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.html
@@ -26,7 +26,7 @@
             </div>
         </div>
     </div>
-    <app-loading [loading]="isLoading"></app-loading>
+    <app-loading [loading]="isLoading" [absolute]="true"></app-loading>
     <div class="reading-area" 
             ngSwipe (swipeEnd)="onSwipeEnd($event)" (swipeMove)="onSwipeMove($event)"
             [ngStyle]="{'background-color': backgroundColor, 'height': readerMode === ReaderMode.Webtoon ? 'inherit' : 'calc(var(--vh)*100)'}" #readingArea>

--- a/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.html
+++ b/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.html
@@ -233,6 +233,15 @@
                                 </div>
                             </div>
                         </div>
+
+                        <div class="mb-3">
+                            <div class="mb-3">
+                                <div class="form-check form-switch">
+                                    <input type="checkbox" id="swipe-to-paginate" formControlName="swipeToPaginate" class="form-check-input" >
+                                    <label class="form-check-label" for="swipe-to-paginate">Swipe Enabled</label>
+                                </div>
+                            </div>
+                        </div>
                     </div>
                     <div class="col-md-3 col-sm-12">
                         <div class="mb-3">
@@ -251,8 +260,10 @@
                         <input type="range" class="form-range" id="darkness" 
                                 min="10" max="100" step="1" formControlName="darkness">
                     </div>
+
+
                     <div class="col-md-6 col-sm-12">
-                        <button class="btn btn-primary" (click)="savePref()">Save to Preferences</button>
+                        <button class="btn btn-primary" (click)="savePref()">Save Globally</button>
                     </div>
                 </div>
             </form>

--- a/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.ts
+++ b/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.ts
@@ -467,7 +467,8 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
         fittingOption: new FormControl(this.mangaReaderService.translateScalingOption(this.scalingOption)),
         layoutMode: new FormControl(this.layoutMode),
         darkness: new FormControl(100),
-        emulateBook: new FormControl(this.user.preferences.emulateBook)
+        emulateBook: new FormControl(this.user.preferences.emulateBook),
+        swipeToPaginate: new FormControl(this.user.preferences.swipeToPaginate)
       });
 
       this.readerModeSubject.next(this.readerMode);
@@ -973,6 +974,8 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   triggerSwipePagination(direction: KeyDirection) {
+    if (!this.generalSettingsForm.get('swipeToPaginate')?.value) return;
+    
     switch(direction) {
       case KeyDirection.Down:
         this.nextPage();
@@ -1601,6 +1604,7 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       data.autoCloseMenu = this.autoCloseMenu;
       data.readingDirection = this.readingDirection;
       data.emulateBook = modelSettings.emulateBook;
+      data.swipeToPaginate = modelSettings.swipeToPaginate;
       this.accountService.updatePreferences(data).subscribe((updatedPrefs) => {
         this.toastr.success('User preferences updated');
         if (this.user) {

--- a/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.ts
+++ b/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.ts
@@ -1100,6 +1100,9 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
     }
 
     this.resetSwipeModifiers();
+
+    this.isLoading = true;
+    this.cdRef.markForCheck();
     
     this.pagingDirectionSubject.next(PAGING_DIRECTION.FORWARD);
 
@@ -1127,6 +1130,9 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
     }
     
     this.resetSwipeModifiers();
+
+    this.isLoading = true;
+    this.cdRef.markForCheck();
 
     this.pagingDirectionSubject.next(PAGING_DIRECTION.BACKWARDS);
 
@@ -1244,6 +1250,7 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
     // Originally this was only for fit to height, but when swiping was introduced, it made more sense to do it always to reset to the same view
     this.readingArea.nativeElement.scroll(0,0);
 
+    this.isLoading = false;
     this.cdRef.markForCheck();
   }
 

--- a/UI/Web/src/app/nav/_components/events-widget/events-widget.component.html
+++ b/UI/Web/src/app/nav/_components/events-widget/events-widget.component.html
@@ -165,9 +165,13 @@
                 <li class="list-group-item dark-menu-item" *ngIf="onlineUsers.length > 1">
                     <div>{{onlineUsers.length}} Users online</div>
                 </li>
-                <li class="list-group-item dark-menu-item" *ngIf="activeEvents === 0 && onlineUsers.length <= 1">Not much going on here</li>
                 <li class="list-group-item dark-menu-item" *ngIf="debugMode">Active Events: {{activeEvents}}</li>
             </ng-container>
+
+            <ng-container *ngIf="downloadService.activeDownloads$ | async as activeDownloads">
+                <li class="list-group-item dark-menu-item" *ngIf="activeEvents === 0 && activeDownloads.length === 0">Not much going on here</li>
+            </ng-container>
+            
         </ul>
     </ng-template>
 </ng-container>

--- a/UI/Web/src/app/nav/_components/events-widget/events-widget.component.ts
+++ b/UI/Web/src/app/nav/_components/events-widget/events-widget.component.ts
@@ -55,7 +55,8 @@ export class EventsWidgetComponent implements OnInit, OnDestroy {
 
   constructor(public messageHub: MessageHubService, private modalService: NgbModal, 
     private accountService: AccountService, private confirmService: ConfirmService,
-    private readonly cdRef: ChangeDetectorRef, public downloadService: DownloadService) { }
+    private readonly cdRef: ChangeDetectorRef, public downloadService: DownloadService) {
+    }
 
   ngOnDestroy(): void {
     this.onDestroy.next();

--- a/UI/Web/src/app/pipe/time-ago.pipe.ts
+++ b/UI/Web/src/app/pipe/time-ago.pipe.ts
@@ -42,7 +42,7 @@ export class TimeAgoPipe implements PipeTransform, OnDestroy {
 		const seconds = Math.round(Math.abs((now.getTime() - d.getTime()) / 1000));
 		const timeToUpdate = (Number.isNaN(seconds)) ? 1000 : this.getSecondsUntilUpdate(seconds) * 1000;
 		
-    this.timer = this.ngZone.runOutsideAngular(() => {
+    	this.timer = this.ngZone.runOutsideAngular(() => {
 			if (typeof window !== 'undefined') {
 				return window.setTimeout(() => {
 					this.ngZone.run(() => this.changeDetectorRef.markForCheck());

--- a/UI/Web/src/app/shared/loading/loading.component.html
+++ b/UI/Web/src/app/shared/loading/loading.component.html
@@ -1,7 +1,17 @@
 <ng-container *ngIf="loading">
+  <ng-container *ngIf="absolute; else relative">
+    <div class="position-absolute top-50 start-50 translate-middle" style="z-index: 999">
+      <div class="spinner-border text-primary" role="status">
+        <span class="visually-hidden">Loading...</span>
+      </div>
+  </div>
+  </ng-container>
+
+  <ng-template #relative>
     <div class="d-flex justify-content-center">
-        <div class="spinner-border text-primary" role="status">
-          <span class="visually-hidden">Loading...</span>
-        </div>
+      <div class="spinner-border text-primary" role="status">
+        <span class="visually-hidden">Loading...</span>
+      </div>
     </div>
+  </ng-template> 
 </ng-container>

--- a/UI/Web/src/app/shared/loading/loading.component.ts
+++ b/UI/Web/src/app/shared/loading/loading.component.ts
@@ -10,10 +10,15 @@ export class LoadingComponent implements OnInit {
 
   @Input() loading: boolean = false;
   @Input() message: string = '';
+  /**
+   * Uses absolute positioning to ensure it loads over content
+   */
+  @Input() absolute: boolean = false;
   
   constructor(private readonly cdRef: ChangeDetectorRef) { }
 
   ngOnInit(): void {
+    console.log('absolute: ', this.absolute);
   }
 
 }

--- a/UI/Web/src/app/user-settings/user-preferences/user-preferences.component.html
+++ b/UI/Web/src/app/user-settings/user-preferences/user-preferences.component.html
@@ -179,6 +179,12 @@
                                             </div>
                                         </div>
                                         <div class="col-md-6 col-sm-12 pe-2 mb-2">
+                                            <div class="mb-3 mt-1">
+                                                <div class="form-check form-switch">
+                                                    <input type="checkbox" id="swipe-to-paginate" role="switch" formControlName="swipeToPaginate" class="form-check-input" [value]="true">
+                                                    <label class="form-check-label me-1" for="swipe-to-paginate">Swipe to Paginate</label><i class="fa fa-info-circle" aria-hidden="true" placement="top" ngbTooltip="Should swiping on the screen cause the next or previous page to be triggered" role="button" tabindex="0"></i>
+                                                </div>
+                                            </div>
                                         </div>
                                     </div>
 

--- a/UI/Web/src/app/user-settings/user-preferences/user-preferences.component.ts
+++ b/UI/Web/src/app/user-settings/user-preferences/user-preferences.component.ts
@@ -127,6 +127,7 @@ export class UserPreferencesComponent implements OnInit, OnDestroy {
       this.settingsForm.addControl('readerMode', new FormControl(this.user.preferences.readerMode, []));
       this.settingsForm.addControl('layoutMode', new FormControl(this.user.preferences.layoutMode, []));
       this.settingsForm.addControl('emulateBook', new FormControl(this.user.preferences.emulateBook, []));
+      this.settingsForm.addControl('swipeToPaginate', new FormControl(this.user.preferences.swipeToPaginate, []));
 
       this.settingsForm.addControl('bookReaderFontFamily', new FormControl(this.user.preferences.bookReaderFontFamily, []));
       this.settingsForm.addControl('bookReaderFontSize', new FormControl(this.user.preferences.bookReaderFontSize, []));
@@ -187,6 +188,7 @@ export class UserPreferencesComponent implements OnInit, OnDestroy {
     this.settingsForm.get('promptForDownloadSize')?.setValue(this.user.preferences.promptForDownloadSize);
     this.settingsForm.get('noTransitions')?.setValue(this.user.preferences.noTransitions);
     this.settingsForm.get('emulateBook')?.setValue(this.user.preferences.emulateBook);
+    this.settingsForm.get('swipeToPaginate')?.setValue(this.user.preferences.swipeToPaginate);
     this.cdRef.markForCheck();
     this.settingsForm.markAsPristine();
   }
@@ -217,7 +219,8 @@ export class UserPreferencesComponent implements OnInit, OnDestroy {
       blurUnreadSummaries: modelSettings.blurUnreadSummaries,
       promptForDownloadSize: modelSettings.promptForDownloadSize,
       noTransitions: modelSettings.noTransitions,
-      emulateBook: modelSettings.emulateBook
+      emulateBook: modelSettings.emulateBook,
+      swipeToPaginate: modelSettings.swipeToPaginate
     };
 
     this.observableHandles.push(this.accountService.updatePreferences(data).subscribe((updatedPrefs) => {

--- a/openapi.json
+++ b/openapi.json
@@ -7,7 +7,7 @@
       "name": "GPL-3.0",
       "url": "https://github.com/Kareadita/Kavita/blob/develop/LICENSE"
     },
-    "version": "0.6.1.28"
+    "version": "0.6.1.29"
   },
   "servers": [
     {

--- a/openapi.json
+++ b/openapi.json
@@ -13322,6 +13322,11 @@
           "convertCoverToWebP": {
             "type": "boolean",
             "description": "If the server should save covers as WebP encoding"
+          },
+          "hostName": {
+            "type": "string",
+            "description": "The Host name (ie Reverse proxy domain name) for the server",
+            "nullable": true
           }
         },
         "additionalProperties": false

--- a/openapi.json
+++ b/openapi.json
@@ -9511,6 +9511,10 @@
             "description": "Manga Reader Option: Background color of the reader",
             "nullable": true
           },
+          "swipeToPaginate": {
+            "type": "boolean",
+            "description": "Manga Reader Option: Should swiping trigger pagination"
+          },
           "bookReaderMargin": {
             "type": "integer",
             "description": "Book Reader Option: Override extra Margin",
@@ -14285,7 +14289,8 @@
           "readerMode",
           "readingDirection",
           "scalingOption",
-          "showScreenHints"
+          "showScreenHints",
+          "swipeToPaginate"
         ],
         "type": "object",
         "properties": {
@@ -14312,6 +14317,9 @@
             "minLength": 1,
             "type": "string",
             "description": "Manga Reader Option: Background color of the reader"
+          },
+          "swipeToPaginate": {
+            "type": "boolean"
           },
           "autoCloseMenu": {
             "type": "boolean",

--- a/openapi.json
+++ b/openapi.json
@@ -729,10 +729,12 @@
         "tags": [
           "Account"
         ],
+        "summary": "Resend an invite to a user already invited",
         "parameters": [
           {
             "name": "userId",
             "in": "query",
+            "description": "",
             "schema": {
               "type": "integer",
               "format": "int32"
@@ -7245,6 +7247,7 @@
           "Server"
         ],
         "summary": "Is this server accessible to the outside net",
+        "description": "If the instance has the HostName set, this will return true whether or not it is accessible externally",
         "responses": {
           "200": {
             "description": "Success",


### PR DESCRIPTION
# Added
- Added: New server setting for Host name. If the server sits behind a reverse proxy, this can be set in Host Name and host name will be used for link generation and accessibility checks (aka if the server can be reached from outside the network) will be skipped, thus an email will always send.

# Changed
- Changed: Swipe to Paginate is now behind a toggle in the reader (develop)
- Changed: server/accessible will return true if the host name is set.
- Changed: Loading indicator in the manga reader is now center positioned

# Fixed
- Fixed: Don't show 'not much going on' when we are actively downloading in event widget
- Fixed: Fixed an issue where folder watching could be activated when creating a new library, despite it globally being set off (Fixes #1758 )
- Fixed: Fixed broken markdown parsing in announcements page (Fixes #1753 ) (develop)
