### PR TITLE
Scanner Performance Improvements

### DIFF
--- a/API.Tests/Helpers/GenreHelperTests.cs
+++ b/API.Tests/Helpers/GenreHelperTests.cs
@@ -13,13 +13,13 @@ public class GenreHelperTests
     {
         var allGenres = new List<Genre>
         {
-            DbFactory.Genre("Action", false),
-            DbFactory.Genre("action", false),
-            DbFactory.Genre("Sci-fi", false),
+            DbFactory.Genre("Action"),
+            DbFactory.Genre("action"),
+            DbFactory.Genre("Sci-fi"),
         };
         var genreAdded = new List<Genre>();
 
-        GenreHelper.UpdateGenre(allGenres, new[] {"Action", "Adventure"}, false, genre =>
+        GenreHelper.UpdateGenre(allGenres, new[] {"Action", "Adventure"}, genre =>
         {
             genreAdded.Add(genre);
         });
@@ -33,19 +33,20 @@ public class GenreHelperTests
     {
         var allGenres = new List<Genre>
         {
-            DbFactory.Genre("Action", false),
-            DbFactory.Genre("action", false),
-            DbFactory.Genre("Sci-fi", false),
+            DbFactory.Genre("Action"),
+            DbFactory.Genre("action"),
+            DbFactory.Genre("Sci-fi"),
 
         };
         var genreAdded = new List<Genre>();
 
-        GenreHelper.UpdateGenre(allGenres, new[] {"Action", "Scifi"}, false, genre =>
+        GenreHelper.UpdateGenre(allGenres, new[] {"Action", "Scifi"}, genre =>
         {
             genreAdded.Add(genre);
         });
 
         Assert.Equal(3, allGenres.Count);
+        Assert.Equal(2, genreAdded.Count);
     }
 
     [Fact]
@@ -53,35 +54,20 @@ public class GenreHelperTests
     {
         var existingGenres = new List<Genre>
         {
-            DbFactory.Genre("Action", false),
-            DbFactory.Genre("action", false),
-            DbFactory.Genre("Sci-fi", false),
+            DbFactory.Genre("Action"),
+            DbFactory.Genre("action"),
+            DbFactory.Genre("Sci-fi"),
         };
 
 
-        GenreHelper.AddGenreIfNotExists(existingGenres, DbFactory.Genre("Action", false));
+        GenreHelper.AddGenreIfNotExists(existingGenres, DbFactory.Genre("Action"));
         Assert.Equal(3, existingGenres.Count);
 
-        GenreHelper.AddGenreIfNotExists(existingGenres, DbFactory.Genre("action", false));
+        GenreHelper.AddGenreIfNotExists(existingGenres, DbFactory.Genre("action"));
         Assert.Equal(3, existingGenres.Count);
 
-        GenreHelper.AddGenreIfNotExists(existingGenres, DbFactory.Genre("Shonen", false));
+        GenreHelper.AddGenreIfNotExists(existingGenres, DbFactory.Genre("Shonen"));
         Assert.Equal(4, existingGenres.Count);
-    }
-
-    [Fact]
-    public void AddGenre_ShouldNotAddSameNameAndExternal()
-    {
-        var existingGenres = new List<Genre>
-        {
-            DbFactory.Genre("Action", false),
-            DbFactory.Genre("action", false),
-            DbFactory.Genre("Sci-fi", false),
-        };
-
-
-        GenreHelper.AddGenreIfNotExists(existingGenres, DbFactory.Genre("Action", true));
-        Assert.Equal(3, existingGenres.Count);
     }
 
     [Fact]
@@ -89,13 +75,13 @@ public class GenreHelperTests
     {
         var existingGenres = new List<Genre>
         {
-            DbFactory.Genre("Action", false),
-            DbFactory.Genre("Sci-fi", false),
+            DbFactory.Genre("Action"),
+            DbFactory.Genre("Sci-fi"),
         };
 
         var peopleFromChapters = new List<Genre>
         {
-            DbFactory.Genre("Action", false),
+            DbFactory.Genre("Action"),
         };
 
         var genreRemoved = new List<Genre>();
@@ -113,8 +99,8 @@ public class GenreHelperTests
     {
         var existingGenres = new List<Genre>
         {
-            DbFactory.Genre("Action", false),
-            DbFactory.Genre("Sci-fi", false),
+            DbFactory.Genre("Action"),
+            DbFactory.Genre("Sci-fi"),
         };
 
         var peopleFromChapters = new List<Genre>();

--- a/API.Tests/Helpers/TagHelperTests.cs
+++ b/API.Tests/Helpers/TagHelperTests.cs
@@ -13,13 +13,13 @@ public class TagHelperTests
     {
         var allTags = new List<Tag>
         {
-            DbFactory.Tag("Action", false),
-            DbFactory.Tag("action", false),
-            DbFactory.Tag("Sci-fi", false),
+            DbFactory.Tag("Action"),
+            DbFactory.Tag("action"),
+            DbFactory.Tag("Sci-fi"),
         };
         var tagAdded = new List<Tag>();
 
-        TagHelper.UpdateTag(allTags, new[] {"Action", "Adventure"}, false, (tag, added) =>
+        TagHelper.UpdateTag(allTags, new[] {"Action", "Adventure"}, (tag, added) =>
         {
             if (added)
             {
@@ -37,14 +37,14 @@ public class TagHelperTests
     {
         var allTags = new List<Tag>
         {
-            DbFactory.Tag("Action", false),
-            DbFactory.Tag("action", false),
-            DbFactory.Tag("Sci-fi", false),
+            DbFactory.Tag("Action"),
+            DbFactory.Tag("action"),
+            DbFactory.Tag("Sci-fi"),
 
         };
         var tagAdded = new List<Tag>();
 
-        TagHelper.UpdateTag(allTags, new[] {"Action", "Scifi"}, false, (tag, added) =>
+        TagHelper.UpdateTag(allTags, new[] {"Action", "Scifi"}, (tag, added) =>
         {
             if (added)
             {
@@ -62,35 +62,20 @@ public class TagHelperTests
     {
         var existingTags = new List<Tag>
         {
-            DbFactory.Tag("Action", false),
-            DbFactory.Tag("action", false),
-            DbFactory.Tag("Sci-fi", false),
+            DbFactory.Tag("Action"),
+            DbFactory.Tag("action"),
+            DbFactory.Tag("Sci-fi"),
         };
 
 
-        TagHelper.AddTagIfNotExists(existingTags, DbFactory.Tag("Action", false));
+        TagHelper.AddTagIfNotExists(existingTags, DbFactory.Tag("Action"));
         Assert.Equal(3, existingTags.Count);
 
-        TagHelper.AddTagIfNotExists(existingTags, DbFactory.Tag("action", false));
+        TagHelper.AddTagIfNotExists(existingTags, DbFactory.Tag("action"));
         Assert.Equal(3, existingTags.Count);
 
-        TagHelper.AddTagIfNotExists(existingTags, DbFactory.Tag("Shonen", false));
+        TagHelper.AddTagIfNotExists(existingTags, DbFactory.Tag("Shonen"));
         Assert.Equal(4, existingTags.Count);
-    }
-
-    [Fact]
-    public void AddTag_ShouldNotAddSameNameAndExternal()
-    {
-        var existingTags = new List<Tag>
-        {
-            DbFactory.Tag("Action", false),
-            DbFactory.Tag("action", false),
-            DbFactory.Tag("Sci-fi", false),
-        };
-
-
-        TagHelper.AddTagIfNotExists(existingTags, DbFactory.Tag("Action", true));
-        Assert.Equal(3, existingTags.Count);
     }
 
     [Fact]
@@ -98,13 +83,13 @@ public class TagHelperTests
     {
         var existingTags = new List<Tag>
         {
-            DbFactory.Tag("Action", false),
-            DbFactory.Tag("Sci-fi", false),
+            DbFactory.Tag("Action"),
+            DbFactory.Tag("Sci-fi"),
         };
 
         var peopleFromChapters = new List<Tag>
         {
-            DbFactory.Tag("Action", false),
+            DbFactory.Tag("Action"),
         };
 
         var tagRemoved = new List<Tag>();
@@ -122,8 +107,8 @@ public class TagHelperTests
     {
         var existingTags = new List<Tag>
         {
-            DbFactory.Tag("Action", false),
-            DbFactory.Tag("Sci-fi", false),
+            DbFactory.Tag("Action"),
+            DbFactory.Tag("Sci-fi"),
         };
 
         var peopleFromChapters = new List<Tag>();

--- a/API.Tests/Services/SeriesServiceTests.cs
+++ b/API.Tests/Services/SeriesServiceTests.cs
@@ -762,7 +762,7 @@ public class SeriesServiceTests : AbstractDbTest
             },
             Metadata = DbFactory.SeriesMetadata(new List<CollectionTag>())
         };
-        var g = DbFactory.Genre("Existing Genre", false);
+        var g = DbFactory.Genre("Existing Genre");
         s.Metadata.Genres = new List<Genre>() {g};
         _context.Series.Add(s);
 
@@ -918,7 +918,7 @@ public class SeriesServiceTests : AbstractDbTest
             },
             Metadata = DbFactory.SeriesMetadata(new List<CollectionTag>())
         };
-        var g = DbFactory.Genre("Existing Genre", false);
+        var g = DbFactory.Genre("Existing Genre");
         s.Metadata.Genres = new List<Genre>() {g};
         s.Metadata.GenresLocked = true;
         _context.Series.Add(s);
@@ -1554,6 +1554,12 @@ public class SeriesServiceTests : AbstractDbTest
 
         Assert.Null(await _unitOfWork.LibraryRepository.GetLibraryForIdAsync(1));
     }
+
+    #endregion
+
+    #region UpdateRelatedList
+
+
 
     #endregion
 }

--- a/API/Data/DbFactory.cs
+++ b/API/Data/DbFactory.cs
@@ -121,23 +121,21 @@ public static class DbFactory
         };
     }
 
-    public static Genre Genre(string name, bool external)
+    public static Genre Genre(string name)
     {
         return new Genre()
         {
             Title = name.Trim().SentenceCase(),
             NormalizedTitle = Services.Tasks.Scanner.Parser.Parser.Normalize(name),
-            ExternalTag = external
         };
     }
 
-    public static Tag Tag(string name, bool external)
+    public static Tag Tag(string name)
     {
         return new Tag()
         {
             Title = name.Trim().SentenceCase(),
             NormalizedTitle = Services.Tasks.Scanner.Parser.Parser.Normalize(name),
-            ExternalTag = external
         };
     }
 

--- a/API/Data/Migrations/20230203112022_RemoveExternalFromTagAndGenre.Designer.cs
+++ b/API/Data/Migrations/20230203112022_RemoveExternalFromTagAndGenre.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using API.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace API.Data.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20230203112022_RemoveExternalFromTagAndGenre")]
+    partial class RemoveExternalFromTagAndGenre
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "6.0.10");

--- a/API/Data/Migrations/20230203112022_RemoveExternalFromTagAndGenre.cs
+++ b/API/Data/Migrations/20230203112022_RemoveExternalFromTagAndGenre.cs
@@ -1,0 +1,77 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace API.Data.Migrations
+{
+    public partial class RemoveExternalFromTagAndGenre : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Tag_NormalizedTitle_ExternalTag",
+                table: "Tag");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Genre_NormalizedTitle_ExternalTag",
+                table: "Genre");
+
+            migrationBuilder.DropColumn(
+                name: "ExternalTag",
+                table: "Tag");
+
+            migrationBuilder.DropColumn(
+                name: "ExternalTag",
+                table: "Genre");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Tag_NormalizedTitle",
+                table: "Tag",
+                column: "NormalizedTitle",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Genre_NormalizedTitle",
+                table: "Genre",
+                column: "NormalizedTitle",
+                unique: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Tag_NormalizedTitle",
+                table: "Tag");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Genre_NormalizedTitle",
+                table: "Genre");
+
+            migrationBuilder.AddColumn<bool>(
+                name: "ExternalTag",
+                table: "Tag",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "ExternalTag",
+                table: "Genre",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Tag_NormalizedTitle_ExternalTag",
+                table: "Tag",
+                columns: new[] { "NormalizedTitle", "ExternalTag" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Genre_NormalizedTitle_ExternalTag",
+                table: "Genre",
+                columns: new[] { "NormalizedTitle", "ExternalTag" },
+                unique: true);
+        }
+    }
+}

--- a/API/Data/Repositories/GenreRepository.cs
+++ b/API/Data/Repositories/GenreRepository.cs
@@ -56,7 +56,7 @@ public class GenreRepository : IGenreRepository
         var genresWithNoConnections = await _context.Genre
             .Include(p => p.SeriesMetadatas)
             .Include(p => p.Chapters)
-            .Where(p => p.SeriesMetadatas.Count == 0 && p.Chapters.Count == 0 && p.ExternalTag == removeExternal)
+            .Where(p => p.SeriesMetadatas.Count == 0 && p.Chapters.Count == 0)
             .AsSplitQuery()
             .ToListAsync();
 

--- a/API/Data/Repositories/TagRepository.cs
+++ b/API/Data/Repositories/TagRepository.cs
@@ -46,7 +46,7 @@ public class TagRepository : ITagRepository
         var tagsWithNoConnections = await _context.Tag
             .Include(p => p.SeriesMetadatas)
             .Include(p => p.Chapters)
-            .Where(p => p.SeriesMetadatas.Count == 0 && p.Chapters.Count == 0 && p.ExternalTag == removeExternal)
+            .Where(p => p.SeriesMetadatas.Count == 0 && p.Chapters.Count == 0)
             .AsSplitQuery()
             .ToListAsync();
 

--- a/API/Entities/Genre.cs
+++ b/API/Entities/Genre.cs
@@ -4,13 +4,12 @@ using Microsoft.EntityFrameworkCore;
 
 namespace API.Entities;
 
-[Index(nameof(NormalizedTitle), nameof(ExternalTag), IsUnique = true)]
+[Index(nameof(NormalizedTitle), IsUnique = true)]
 public class Genre
 {
     public int Id { get; set; }
     public string Title { get; set; }
     public string NormalizedTitle { get; set; }
-    public bool ExternalTag { get; set; }
 
     public ICollection<SeriesMetadata> SeriesMetadatas { get; set; }
     public ICollection<Chapter> Chapters { get; set; }

--- a/API/Entities/Person.cs
+++ b/API/Entities/Person.cs
@@ -4,18 +4,12 @@ using API.Entities.Metadata;
 
 namespace API.Entities;
 
-public enum ProviderSource
-{
-    Local = 1,
-    External = 2
-}
 public class Person
 {
     public int Id { get; set; }
     public string Name { get; set; }
     public string NormalizedName { get; set; }
     public PersonRole Role { get; set; }
-    //public ProviderSource Source { get; set; }
 
     // Relationships
     public ICollection<SeriesMetadata> SeriesMetadatas { get; set; }

--- a/API/Entities/Tag.cs
+++ b/API/Entities/Tag.cs
@@ -4,13 +4,12 @@ using Microsoft.EntityFrameworkCore;
 
 namespace API.Entities;
 
-[Index(nameof(NormalizedTitle), nameof(ExternalTag), IsUnique = true)]
+[Index(nameof(NormalizedTitle), IsUnique = true)]
 public class Tag
 {
     public int Id { get; set; }
     public string Title { get; set; }
     public string NormalizedTitle { get; set; }
-    public bool ExternalTag { get; set; }
 
     public ICollection<SeriesMetadata> SeriesMetadatas { get; set; }
     public ICollection<Chapter> Chapters { get; set; }

--- a/API/Helpers/GenreHelper.cs
+++ b/API/Helpers/GenreHelper.cs
@@ -14,20 +14,18 @@ public static class GenreHelper
     /// </summary>
     /// <param name="allGenres"></param>
     /// <param name="names"></param>
-    /// <param name="isExternal"></param>
     /// <param name="action"></param>
-    public static void UpdateGenre(ICollection<Genre> allGenres, IEnumerable<string> names, bool isExternal, Action<Genre> action)
+    public static void UpdateGenre(ICollection<Genre> allGenres, IEnumerable<string> names, Action<Genre> action)
     {
         foreach (var name in names)
         {
             if (string.IsNullOrEmpty(name.Trim())) continue;
 
             var normalizedName = Services.Tasks.Scanner.Parser.Parser.Normalize(name);
-            var genre = allGenres.FirstOrDefault(p =>
-                p.NormalizedTitle.Equals(normalizedName) && p.ExternalTag == isExternal);
+            var genre = allGenres.FirstOrDefault(p => p.NormalizedTitle.Equals(normalizedName));
             if (genre == null)
             {
-                genre = DbFactory.Genre(name, false);
+                genre = DbFactory.Genre(name);
                 allGenres.Add(genre);
             }
 
@@ -41,7 +39,7 @@ public static class GenreHelper
         var existing = existingGenres.ToList();
         foreach (var genre in existing)
         {
-            var existingPerson = removeAllExcept.FirstOrDefault(g => g.ExternalTag == genre.ExternalTag && genre.NormalizedTitle.Equals(g.NormalizedTitle));
+            var existingPerson = removeAllExcept.FirstOrDefault(g => genre.NormalizedTitle.Equals(g.NormalizedTitle));
             if (existingPerson != null) continue;
             existingGenres.Remove(genre);
             action?.Invoke(genre);

--- a/API/Helpers/TagHelper.cs
+++ b/API/Helpers/TagHelper.cs
@@ -14,9 +14,8 @@ public static class TagHelper
     /// </summary>
     /// <param name="allTags"></param>
     /// <param name="names"></param>
-    /// <param name="isExternal"></param>
     /// <param name="action">Callback for every item. Will give said item back and a bool if item was added</param>
-    public static void UpdateTag(ICollection<Tag> allTags, IEnumerable<string> names, bool isExternal, Action<Tag, bool> action)
+    public static void UpdateTag(ICollection<Tag> allTags, IEnumerable<string> names, Action<Tag, bool> action)
     {
         foreach (var name in names)
         {
@@ -26,11 +25,11 @@ public static class TagHelper
             var normalizedName = Services.Tasks.Scanner.Parser.Parser.Normalize(name);
 
             var genre = allTags.FirstOrDefault(p =>
-                p.NormalizedTitle.Equals(normalizedName) && p.ExternalTag == isExternal);
+                p.NormalizedTitle.Equals(normalizedName));
             if (genre == null)
             {
                 added = true;
-                genre = DbFactory.Tag(name, false);
+                genre = DbFactory.Tag(name);
                 allTags.Add(genre);
             }
 
@@ -43,7 +42,7 @@ public static class TagHelper
         var existing = existingTags.ToList();
         foreach (var genre in existing)
         {
-            var existingPerson = removeAllExcept.FirstOrDefault(g => g.ExternalTag == genre.ExternalTag && genre.NormalizedTitle.Equals(g.NormalizedTitle));
+            var existingPerson = removeAllExcept.FirstOrDefault(g => genre.NormalizedTitle.Equals(g.NormalizedTitle));
             if (existingPerson != null) continue;
             existingTags.Remove(genre);
             action?.Invoke(genre);
@@ -84,12 +83,12 @@ public static class TagHelper
     /// <param name="tags">Tags from metadata</param>
     /// <param name="isExternal">Remove external tags?</param>
     /// <param name="action">Callback which will be executed for each tag removed</param>
-    public static void RemoveTags(ICollection<Tag> existingTags, IEnumerable<string> tags, bool isExternal, Action<Tag> action = null)
+    public static void RemoveTags(ICollection<Tag> existingTags, IEnumerable<string> tags, Action<Tag> action = null)
     {
         var normalizedTags = tags.Select(Services.Tasks.Scanner.Parser.Parser.Normalize).ToList();
         foreach (var person in normalizedTags)
         {
-            var existingTag = existingTags.FirstOrDefault(p => p.ExternalTag == isExternal && person.Equals(p.NormalizedTitle));
+            var existingTag = existingTags.FirstOrDefault(p => person.Equals(p.NormalizedTitle));
             if (existingTag == null) continue;
 
             existingTags.Remove(existingTag);

--- a/API/Services/SeriesService.cs
+++ b/API/Services/SeriesService.cs
@@ -115,7 +115,7 @@ public class SeriesService : ISeriesService
             }
 
             series.Metadata.CollectionTags ??= new List<CollectionTag>();
-            UpdateRelatedList(updateSeriesMetadataDto.CollectionTags, series, allCollectionTags, (tag) =>
+            UpdateCollectionsList(updateSeriesMetadataDto.CollectionTags, series, allCollectionTags, (tag) =>
             {
                 series.Metadata.CollectionTags.Add(tag);
             });
@@ -210,7 +210,7 @@ public class SeriesService : ISeriesService
     }
 
 
-    private static void UpdateRelatedList(ICollection<CollectionTagDto> tags, Series series, IReadOnlyCollection<CollectionTag> allTags,
+    public static void UpdateCollectionsList(ICollection<CollectionTagDto> tags, Series series, IReadOnlyCollection<CollectionTag> allTags,
         Action<CollectionTag> handleAdd)
     {
         // TODO: Move UpdateRelatedList to a helper so we can easily test
@@ -278,7 +278,7 @@ public class SeriesService : ISeriesService
             else
             {
                 // Add new tag
-                handleAdd(DbFactory.Genre(tagTitle, false));
+                handleAdd(DbFactory.Genre(tagTitle));
                 isModified = true;
             }
         }
@@ -320,7 +320,7 @@ public class SeriesService : ISeriesService
             else
             {
                 // Add new tag
-                handleAdd(DbFactory.Tag(tagTitle, false));
+                handleAdd(DbFactory.Tag(tagTitle));
                 isModified = true;
             }
         }

--- a/API/Services/Tasks/Scanner/Parser/Parser.cs
+++ b/API/Services/Tasks/Scanner/Parser/Parser.cs
@@ -945,7 +945,7 @@ public static class Parser
 
     public static string Normalize(string name)
     {
-        return NormalizeRegex.Replace(name, string.Empty).ToLower();
+        return NormalizeRegex.Replace(name, string.Empty).Trim().ToLower();
     }
 
     /// <summary>

--- a/API/Services/Tasks/Scanner/ProcessSeries.cs
+++ b/API/Services/Tasks/Scanner/ProcessSeries.cs
@@ -675,13 +675,11 @@ public class ProcessSeries : IProcessSeries
 
         void AddGenre(Genre genre, bool newTag)
         {
-            //GenreHelper.AddGenreIfNotExists(chapter.Genres, genre);
             chapter.Genres.Add(genre);
         }
 
         void AddTag(Tag tag, bool added)
         {
-            //TagHelper.AddTagIfNotExists(chapter.Tags, tag);
             chapter.Tags.Add(tag);
         }
 
@@ -748,11 +746,11 @@ public class ProcessSeries : IProcessSeries
 
         var genres = GetTagValues(comicInfo.Genre);
         GenreHelper.KeepOnlySameGenreBetweenLists(chapter.Genres,
-            genres.Select(g => DbFactory.Genre(g, false)).ToList());
+            genres.Select(DbFactory.Genre).ToList());
         UpdateGenre(genres, AddGenre);
 
         var tags = GetTagValues(comicInfo.Tags);
-        TagHelper.KeepOnlySameTagBetweenLists(chapter.Tags, tags.Select(t => DbFactory.Tag(t, false)).ToList());
+        TagHelper.KeepOnlySameTagBetweenLists(chapter.Tags, tags.Select(DbFactory.Tag).ToList());
         UpdateTag(tags, AddTag);
     }
 
@@ -802,20 +800,19 @@ public class ProcessSeries : IProcessSeries
     ///
     /// </summary>
     /// <param name="names"></param>
-    /// <param name="isExternal">Not used</param>
-    /// <param name="action"></param>
+    /// <param name="action">Executes for each tag</param>
     private void UpdateGenre(IEnumerable<string> names, Action<Genre, bool> action)
     {
         foreach (var name in names)
         {
-            if (string.IsNullOrEmpty(name.Trim())) continue;
-
             var normalizedName = Parser.Parser.Normalize(name);
+            if (string.IsNullOrEmpty(normalizedName)) continue;
+
             _genres.TryGetValue(normalizedName, out var genre);
             var newTag = genre == null;
             if (newTag)
             {
-                genre = DbFactory.Genre(name, false);
+                genre = DbFactory.Genre(name);
                 lock (_genres)
                 {
                     _genres.Add(normalizedName, genre);
@@ -844,7 +841,7 @@ public class ProcessSeries : IProcessSeries
             var added = tag == null;
             if (tag == null)
             {
-                tag = DbFactory.Tag(name, false);
+                tag = DbFactory.Tag(name);
                 lock (_tags)
                 {
                     _tags.Add(normalizedName, tag);

--- a/openapi.json
+++ b/openapi.json
@@ -7,7 +7,7 @@
       "name": "GPL-3.0",
       "url": "https://github.com/Kareadita/Kavita/blob/develop/LICENSE"
     },
-    "version": "0.6.1.33"
+    "version": "0.6.1.34"
   },
   "servers": [
     {

--- a/openapi.json
+++ b/openapi.json
@@ -10935,9 +10935,6 @@
             "type": "string",
             "nullable": true
           },
-          "externalTag": {
-            "type": "boolean"
-          },
           "seriesMetadatas": {
             "type": "array",
             "items": {
@@ -13561,9 +13558,6 @@
           "normalizedTitle": {
             "type": "string",
             "nullable": true
-          },
-          "externalTag": {
-            "type": "boolean"
           },
           "seriesMetadatas": {
             "type": "array",


### PR DESCRIPTION
# Changed
- Changed: (Performance) Refactored Genre and Tag maintenance methods in the Scan loop to be faster for lookups. 
- Changed: Removed an External flag in Genre and Tag that was unused, but planned for an upcoming feature. It is no longer needed with Plugin architecture. 
- Changed: Ensure when grabbing comma separated tags from that we remove duplicates
