### PR TITLE
v0.7.1 - Stats Hotfix

### DIFF
--- a/Kavita.Common/Kavita.Common.csproj
+++ b/Kavita.Common/Kavita.Common.csproj
@@ -3,7 +3,7 @@
         <TargetFramework>net6.0</TargetFramework>
         <Company>kavitareader.com</Company>
         <Product>Kavita</Product>
-        <AssemblyVersion>0.7.0.0</AssemblyVersion>
+        <AssemblyVersion>0.7.1.0</AssemblyVersion>
         <NeutralLanguage>en</NeutralLanguage>
         <TieredPGO>true</TieredPGO>
     </PropertyGroup>
@@ -18,5 +18,6 @@
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
     </ItemGroup>
+
 </Project>
 


### PR DESCRIPTION
Well, I knew adding 73K lines of code in the last release would cause a few bumps in the release and it looks like I was right. A few users have pointed out some minor issues that escaped release testing and this hotfix closes those issues.

If anyone wants to help ensure these type of hotfixes aren't necessary, please join our Release Tester role in discord and help out in release testing. It's about a week of your time before release and drastically helps catch issues before they go out to our users.

There are some users having an issue that has a workaround and is user error. Read about it [here](https://github.com/Kareadita/Kavita/issues/1806).

# Fixed
- Fixed: Fixed a bug where SignalR wasn't sending events to the UI (and broke Komf) 
- Fixed: Advanced tab on Library settings was not working
- Fixed: Added timeouts on some regex parsing to prevent malicious filenames timeout attack
- Fixed: Some users in GMT+1 were having invalid utc dates, new migration to manually correct those. 
- Fixed: Fixed an issue where convert covers to webp was saving an invalid path and made covers look like they didn't exist
