### PR TITLE
Random Changes and Enhancements

### DIFF
--- a/API.Tests/Services/DirectoryServiceTests.cs
+++ b/API.Tests/Services/DirectoryServiceTests.cs
@@ -75,7 +75,7 @@ public class DirectoryServiceTests
     [Fact]
     public void TraverseTreeParallelForEach_DontCountExcludedDirectories_ShouldBe28()
     {
-        var testDirectory = "/manga/";
+        const string testDirectory = "/manga/";
         var fileSystem = new MockFileSystem();
         for (var i = 0; i < 28; i++)
         {
@@ -85,6 +85,7 @@ public class DirectoryServiceTests
         fileSystem.AddFile($"{Path.Join(testDirectory, "@eaDir")}file_{29}.jpg", new MockFileData(""));
         fileSystem.AddFile($"{Path.Join(testDirectory, ".DS_Store")}file_{30}.jpg", new MockFileData(""));
         fileSystem.AddFile($"{Path.Join(testDirectory, ".qpkg")}file_{30}.jpg", new MockFileData(""));
+        fileSystem.AddFile($"{Path.Join(testDirectory, ".@_thumb")}file_{30}.jpg", new MockFileData(""));
 
         var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), fileSystem);
         var files = new List<string>();

--- a/API/Controllers/LibraryController.cs
+++ b/API/Controllers/LibraryController.cs
@@ -335,6 +335,7 @@ public class LibraryController : BaseApiController
         library.IncludeInRecommended = dto.IncludeInRecommended;
         library.IncludeInSearch = dto.IncludeInSearch;
         library.ManageCollections = dto.ManageCollections;
+        library.CollapseSeriesRelationships = dto.CollapseSeriesRelationships;
 
         _unitOfWork.LibraryRepository.Update(library);
 

--- a/API/DTOs/LibraryDto.cs
+++ b/API/DTOs/LibraryDto.cs
@@ -37,5 +37,9 @@ public class LibraryDto
     /// Include library series in Search
     /// </summary>
     public bool IncludeInSearch { get; set; } = true;
+    /// <summary>
+    /// When showing series, only parent series or series with no relationships will be returned
+    /// </summary>
+    public bool CollapseSeriesRelationships { get; set; } = false;
     public ICollection<string> Folders { get; init; }
 }

--- a/API/DTOs/UpdateLibraryDto.cs
+++ b/API/DTOs/UpdateLibraryDto.cs
@@ -24,5 +24,7 @@ public class UpdateLibraryDto
     public bool IncludeInSearch { get; init; }
     [Required]
     public bool ManageCollections { get; init; }
+    [Required]
+    public bool CollapseSeriesRelationships { get; init; }
 
 }

--- a/API/Data/Migrations/20230220203128_CollapseSeriesRelationships.Designer.cs
+++ b/API/Data/Migrations/20230220203128_CollapseSeriesRelationships.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using API.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace API.Data.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20230220203128_CollapseSeriesRelationships")]
+    partial class CollapseSeriesRelationships
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "6.0.10");

--- a/API/Data/Migrations/20230220203128_CollapseSeriesRelationships.cs
+++ b/API/Data/Migrations/20230220203128_CollapseSeriesRelationships.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace API.Data.Migrations
+{
+    public partial class CollapseSeriesRelationships : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "CollapseSeriesRelationships",
+                table: "Library",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CollapseSeriesRelationships",
+                table: "Library");
+        }
+    }
+}

--- a/API/Data/Repositories/SeriesRepository.cs
+++ b/API/Data/Repositories/SeriesRepository.cs
@@ -754,6 +754,7 @@ public class SeriesRepository : ISeriesRepository
             out var hasPublicationFilter, out var hasSeriesNameFilter, out var hasReleaseYearMinFilter, out var hasReleaseYearMaxFilter);
 
         var query = _context.Series
+            .AsNoTracking()
             .WhereIf(hasGenresFilter, s => s.Metadata.Genres.Any(g => filter.Genres.Contains(g.Id)))
             .WhereIf(hasPeopleFilter, s => s.Metadata.People.Any(p => allPeopleIds.Contains(p.Id)))
             .WhereIf(hasCollectionTagFilter,
@@ -775,8 +776,9 @@ public class SeriesRepository : ISeriesRepository
         {
             query = query.RestrictAgainstAgeRestriction(userRating);
         }
+        // We only want to return series where they have the prequel relationshipOf or don't have any relationshipOfs
+        //query = query.WhereIf(true, s => s.RelationOf.Count == 0 || s.RelationOf.All(p => p.RelationKind == RelationKind.Prequel));
 
-        query = query.AsNoTracking();
 
         // If no sort options, default to using SortName
         filter.SortOptions ??= new SortOptions()

--- a/API/Entities/Library.cs
+++ b/API/Entities/Library.cs
@@ -31,6 +31,10 @@ public class Library : IEntityDate
     /// Should this library create and manage collections from Metadata
     /// </summary>
     public bool ManageCollections { get; set; } = true;
+    /// <summary>
+    /// When showing series, only parent series or series with no relationships will be returned
+    /// </summary>
+    public bool CollapseSeriesRelationships { get; set; } = false;
     public DateTime Created { get; set; }
     public DateTime LastModified { get; set; }
     public DateTime CreatedUtc { get; set; }

--- a/API/Extensions/QueryableExtensions.cs
+++ b/API/Extensions/QueryableExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Threading.Tasks;
 using API.Data.Misc;
 using API.Data.Repositories;
@@ -234,4 +235,10 @@ public static class QueryableExtensions
 
     public static IEnumerable<DateTime> Range(this DateTime startDate, int numberOfDays) =>
         Enumerable.Range(0, numberOfDays).Select(e => startDate.AddDays(e));
+
+    public static IQueryable<T> WhereIf<T>(this IQueryable<T> queryable, bool condition,
+        Expression<Func<T, bool>> predicate)
+    {
+        return condition ? queryable.Where(predicate) : queryable;
+    }
 }

--- a/API/Services/DirectoryService.cs
+++ b/API/Services/DirectoryService.cs
@@ -89,7 +89,7 @@ public class DirectoryService : IDirectoryService
     private readonly ILogger<DirectoryService> _logger;
 
     private static readonly Regex ExcludeDirectories = new Regex(
-        @"@eaDir|\.DS_Store|\.qpkg|__MACOSX|@Recently-Snapshot|@recycle",
+        @"@eaDir|\.DS_Store|\.qpkg|__MACOSX|@Recently-Snapshot|@recycle|\.@__thumb",
         RegexOptions.Compiled | RegexOptions.IgnoreCase,
         Tasks.Scanner.Parser.Parser.RegexTimeout);
     private static readonly Regex FileCopyAppend = new Regex(@"\(\d+\)",

--- a/API/Services/Tasks/Scanner/LibraryWatcher.cs
+++ b/API/Services/Tasks/Scanner/LibraryWatcher.cs
@@ -55,6 +55,7 @@ public class LibraryWatcher : ILibraryWatcher
     /// Counts within a time frame how many times the buffer became full. Is used to reschedule LibraryWatcher to start monitoring much later rather than instantly
     /// </summary>
     private int _bufferFullCounter;
+    private DateTime _lastErrorTime = DateTime.MinValue;
     /// <summary>
     /// Used to lock buffer Full Counter
     /// </summary>
@@ -180,7 +181,9 @@ public class LibraryWatcher : ILibraryWatcher
         lock (Lock)
         {
             _bufferFullCounter += 1;
-            condition = _bufferFullCounter >= 3;
+            _lastErrorTime = DateTime.Now;
+            //condition = _bufferFullCounter >= 3;
+            condition = _bufferFullCounter >= 3 && (DateTime.Now - _lastErrorTime).TotalMinutes <= 10;
         }
 
         if (condition)
@@ -191,7 +194,7 @@ public class LibraryWatcher : ILibraryWatcher
             return;
         }
         Task.Run(RestartWatching);
-        BackgroundJob.Schedule(() => UpdateLastBufferOverflow(), TimeSpan.FromMinutes(10));
+        //BackgroundJob.Schedule(() => UpdateLastBufferOverflow(), TimeSpan.FromMinutes(10));
     }
 
 

--- a/API/Services/Tasks/Scanner/LibraryWatcher.cs
+++ b/API/Services/Tasks/Scanner/LibraryWatcher.cs
@@ -184,14 +184,12 @@ public class LibraryWatcher : ILibraryWatcher
         {
             _bufferFullCounter += 1;
             _lastErrorTime = DateTime.Now;
-            //condition = _bufferFullCounter >= 3;
             condition = _bufferFullCounter >= 3 && (DateTime.Now - _lastErrorTime).TotalMinutes <= 10;
         }
 
         if (_restartCounter >= 3)
         {
             _logger.LogInformation("[LibraryWatcher] Too many restarts occured, you either have limited inotify or an OS constraint. Kavita will turn off folder watching to prevent high utilization of resources");
-            StopWatching();
             Task.Run(TurnOffWatching);
             return;
         }
@@ -205,7 +203,7 @@ public class LibraryWatcher : ILibraryWatcher
             return;
         }
         Task.Run(RestartWatching);
-        //BackgroundJob.Schedule(() => UpdateLastBufferOverflow(), TimeSpan.FromMinutes(10));
+        BackgroundJob.Schedule(() => UpdateLastBufferOverflow(), TimeSpan.FromMinutes(10));
     }
 
     private async Task TurnOffWatching()
@@ -214,6 +212,7 @@ public class LibraryWatcher : ILibraryWatcher
         setting.Value = "false";
         _unitOfWork.SettingsRepository.Update(setting);
         await _unitOfWork.CommitAsync();
+        StopWatching();
         _logger.LogInformation("[LibraryWatcher] Folder watching has been disabled");
     }
 

--- a/API/Services/Tasks/Scanner/LibraryWatcher.cs
+++ b/API/Services/Tasks/Scanner/LibraryWatcher.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using API.Data;
+using API.Entities.Enums;
 using Hangfire;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -55,6 +56,7 @@ public class LibraryWatcher : ILibraryWatcher
     /// Counts within a time frame how many times the buffer became full. Is used to reschedule LibraryWatcher to start monitoring much later rather than instantly
     /// </summary>
     private int _bufferFullCounter;
+    private int _restartCounter;
     private DateTime _lastErrorTime = DateTime.MinValue;
     /// <summary>
     /// Used to lock buffer Full Counter
@@ -186,15 +188,33 @@ public class LibraryWatcher : ILibraryWatcher
             condition = _bufferFullCounter >= 3 && (DateTime.Now - _lastErrorTime).TotalMinutes <= 10;
         }
 
+        if (_restartCounter >= 3)
+        {
+            _logger.LogInformation("[LibraryWatcher] Too many restarts occured, you either have limited inotify or an OS constraint. Kavita will turn off folder watching to prevent high utilization of resources");
+            StopWatching();
+            Task.Run(TurnOffWatching);
+            return;
+        }
+
         if (condition)
         {
-            _logger.LogInformation("[LibraryWatcher] Internal buffer has been overflown multiple times in past 10 minutes. Suspending file watching for an hour");
+            _logger.LogInformation("[LibraryWatcher] Internal buffer has been overflown multiple times in past 10 minutes. Suspending file watching for an hour. Restart count: {RestartCount}", _restartCounter);
+            _restartCounter++;
             StopWatching();
             BackgroundJob.Schedule(() => RestartWatching(), TimeSpan.FromHours(1));
             return;
         }
         Task.Run(RestartWatching);
         //BackgroundJob.Schedule(() => UpdateLastBufferOverflow(), TimeSpan.FromMinutes(10));
+    }
+
+    private async Task TurnOffWatching()
+    {
+        var setting = await _unitOfWork.SettingsRepository.GetSettingAsync(ServerSettingKey.EnableFolderWatching);
+        setting.Value = "false";
+        _unitOfWork.SettingsRepository.Update(setting);
+        await _unitOfWork.CommitAsync();
+        _logger.LogInformation("[LibraryWatcher] Folder watching has been disabled");
     }
 
 

--- a/API/Services/Tasks/Scanner/ParseScannedFiles.cs
+++ b/API/Services/Tasks/Scanner/ParseScannedFiles.cs
@@ -289,6 +289,8 @@ public class ParseScannedFiles
                 }).ToList();
                 await processSeriesInfos.Invoke(new Tuple<bool, IList<ParserInfo>>(true, parsedInfos));
                 _logger.LogDebug("[ScannerService] Skipped File Scan for {Folder} as it hasn't changed since last scan", folder);
+                await _eventHub.SendMessageAsync(MessageFactory.NotificationProgress,
+                    MessageFactory.FileScanProgressEvent("Skipped " + normalizedFolder, libraryName, ProgressEventType.Updated));
                 return;
             }
 

--- a/Kavita.Common/Kavita.Common.csproj
+++ b/Kavita.Common/Kavita.Common.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net6.0</TargetFramework>
         <Company>kavitareader.com</Company>
         <Product>Kavita</Product>
-        <AssemblyVersion>0.7.0.3</AssemblyVersion>
+        <AssemblyVersion>0.7.1.1</AssemblyVersion>
         <NeutralLanguage>en</NeutralLanguage>
         <TieredPGO>true</TieredPGO>
     </PropertyGroup>

--- a/UI/Web/src/app/_models/library.ts
+++ b/UI/Web/src/app/_models/library.ts
@@ -16,4 +16,5 @@ export interface Library {
     includeInRecommended: boolean;
     includeInSearch: boolean;
     manageCollections: boolean;
+    collapseSeriesRelationships: boolean;
 }

--- a/UI/Web/src/app/cards/card-detail-layout/card-detail-layout.component.html
+++ b/UI/Web/src/app/cards/card-detail-layout/card-detail-layout.component.html
@@ -52,7 +52,7 @@
 <ng-template #jumpBar>
     <div class="jump-bar">
         <ng-container *ngFor="let jumpKey of jumpBarKeysToRender; let i = index;">
-            <button class="btn btn-link" [ngClass]="{'disabled': hasCustomSort()}" (click)="scrollTo(jumpKey)">
+            <button class="btn btn-link" [ngClass]="{'disabled': hasCustomSort()}" (click)="scrollTo(jumpKey)" [ngbTooltip]="jumpKey.size + ' Series'" placement="left">
                 {{jumpKey.title}}
             </button>
         </ng-container>

--- a/UI/Web/src/app/pipe/pipe.module.ts
+++ b/UI/Web/src/app/pipe/pipe.module.ts
@@ -17,6 +17,7 @@ import { SafeStylePipe } from './safe-style.pipe';
 import { DefaultDatePipe } from './default-date.pipe';
 import { BytesPipe } from './bytes.pipe';
 import { TimeAgoPipe } from './time-ago.pipe';
+import { TimeDurationPipe } from './time-duration.pipe';
 
 
 
@@ -39,6 +40,7 @@ import { TimeAgoPipe } from './time-ago.pipe';
     DefaultDatePipe,
     BytesPipe,
     TimeAgoPipe,
+    TimeDurationPipe,
   ],
   imports: [
     CommonModule,
@@ -60,7 +62,8 @@ import { TimeAgoPipe } from './time-ago.pipe';
     SafeStylePipe,
     DefaultDatePipe,
     BytesPipe,
-    TimeAgoPipe
+    TimeAgoPipe,
+    TimeDurationPipe
   ]
 })
 export class PipeModule { }

--- a/UI/Web/src/app/pipe/time-ago.pipe.ts
+++ b/UI/Web/src/app/pipe/time-ago.pipe.ts
@@ -35,7 +35,7 @@ export class TimeAgoPipe implements PipeTransform, OnDestroy {
 
   private timer: number | null = null;
 	constructor(private changeDetectorRef: ChangeDetectorRef, private ngZone: NgZone) {}
-	transform(value:string) {
+	transform(value: string) {
 		this.removeTimer();
 		const d = new Date(value);
 		const now = new Date();

--- a/UI/Web/src/app/pipe/time-duration.pipe.ts
+++ b/UI/Web/src/app/pipe/time-duration.pipe.ts
@@ -1,0 +1,26 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+/**
+ * Converts hours -> days, months, years, etc
+ */
+@Pipe({
+  name: 'timeDuration'
+})
+export class TimeDurationPipe implements PipeTransform {
+
+  transform(hours: number): string {
+    if (hours === 0) return `${hours} hours`;
+    if (hours < 1) {
+      return `${(hours * 60).toFixed(1)} minutes`;
+    } else if (hours < 24) {
+      return `${hours} hours`;
+    } else if (hours < 720) {
+      return `${(hours / 24).toFixed(1)} days`;
+    } else if (hours < 8760) {
+      return `${(hours / 720).toFixed(1)} months`;
+    } else {
+      return `${(hours / 8760).toFixed(1)} years`;
+    }
+  }
+
+}

--- a/UI/Web/src/app/sidenav/_modals/library-settings-modal/library-settings-modal.component.html
+++ b/UI/Web/src/app/sidenav/_modals/library-settings-modal/library-settings-modal.component.html
@@ -110,6 +110,20 @@
                         <div class="col-md-12 col-sm-12 pe-2 mb-2">
                             <div class="mb-3 mt-1">
                                 <div class="form-check form-switch">
+                                    <input type="checkbox" id="collapse-relationships" role="switch" formControlName="collapseSeriesRelationships" class="form-check-input" aria-labelledby="auto-close-label">
+                                    <label class="form-check-label" for="collapse-relationships">Collapse Series Relationships</label>
+                                </div>
+                            </div>
+                            <p class="accent">
+                                Experiemental: Should Kavita show Series that have no relationships or is the parent/prequel
+                            </p>
+                        </div>
+                    </div>
+
+                    <div class="row">
+                        <div class="col-md-12 col-sm-12 pe-2 mb-2">
+                            <div class="mb-3 mt-1">
+                                <div class="form-check form-switch">
                                     <input type="checkbox" id="lib-folder-watching" role="switch" formControlName="folderWatching" class="form-check-input" aria-labelledby="auto-close-label">
                                     <label class="form-check-label" for="lib-folder-watching">Folder Watching</label>
                                 </div>

--- a/UI/Web/src/app/sidenav/_modals/library-settings-modal/library-settings-modal.component.ts
+++ b/UI/Web/src/app/sidenav/_modals/library-settings-modal/library-settings-modal.component.ts
@@ -47,6 +47,7 @@ export class LibrarySettingsModalComponent implements OnInit, OnDestroy {
     includeInRecommended: new FormControl<boolean>(true, { nonNullable: true, validators: [Validators.required] }),
     includeInSearch: new FormControl<boolean>(true, { nonNullable: true, validators: [Validators.required] }),
     manageCollections: new FormControl<boolean>(true, { nonNullable: true, validators: [Validators.required] }),
+    collapseSeriesRelationships: new FormControl<boolean>(false, { nonNullable: true, validators: [Validators.required] }),
   });
 
   selectedFolders: string[] = [];
@@ -119,6 +120,7 @@ export class LibrarySettingsModalComponent implements OnInit, OnDestroy {
       this.libraryForm.get('includeInRecommended')?.setValue(this.library.includeInRecommended);
       this.libraryForm.get('includeInSearch')?.setValue(this.library.includeInSearch);
       this.libraryForm.get('manageCollections')?.setValue(this.library.manageCollections);
+      this.libraryForm.get('collapseSeriesRelationships')?.setValue(this.library.collapseSeriesRelationships);
       this.selectedFolders = this.library.folders;
       this.madeChanges = false;
       this.cdRef.markForCheck();

--- a/UI/Web/src/app/statistics/_components/server-stats/server-stats.component.html
+++ b/UI/Web/src/app/statistics/_components/server-stats/server-stats.component.html
@@ -66,7 +66,7 @@
         <ng-container>
             <div class="col-auto mb-2">
                 <app-icon-and-title label="Total Read Time" [clickable]="false" fontClasses="fas fa-eye" title="Total Read Time: {{stats.totalReadingTime | number}}">
-                    {{stats.totalReadingTime | compactNumber}} Hours
+                    {{stats.totalReadingTime | timeDuration}}
                 </app-icon-and-title>
             </div>
         </ng-container>

--- a/UI/Web/src/app/statistics/_components/user-stats-info-cards/user-stats-info-cards.component.html
+++ b/UI/Web/src/app/statistics/_components/user-stats-info-cards/user-stats-info-cards.component.html
@@ -20,7 +20,7 @@
     <ng-container >
         <div class="col-auto mb-2">
             <app-icon-and-title label="Time Spent Reading" [clickable]="false" fontClasses="fas fa-eye" title="Time Spent Reading: {{timeSpentReading | number}}">
-                {{timeSpentReading | compactNumber}} hours
+                {{timeSpentReading | timeDuration}}
             </app-icon-and-title>
         </div>
         <div class="vr d-none d-lg-block m-2"></div>
@@ -28,8 +28,8 @@
 
     <ng-container>
         <div class="col-auto mb-2">
-            <app-icon-and-title label="Average Hours Read / Week" [clickable]="false" fontClasses="fas fa-eye" title="Average Hours Read / Week: {{avgHoursPerWeekSpentReading | number:'1.0-2'}}">
-                {{avgHoursPerWeekSpentReading | compactNumber | number: '1.0-2'}} hours
+            <app-icon-and-title label="Average Reading / Week" [clickable]="false" fontClasses="fas fa-eye">
+                {{avgHoursPerWeekSpentReading |  timeDuration}}
             </app-icon-and-title>
         </div>
         <div class="vr d-none d-lg-block m-2"></div>

--- a/openapi.json
+++ b/openapi.json
@@ -11441,6 +11441,10 @@
             "type": "boolean",
             "description": "Should this library create and manage collections from Metadata"
           },
+          "collapseSeriesRelationships": {
+            "type": "boolean",
+            "description": "When showing series, only parent series or series with no relationships will be returned"
+          },
           "created": {
             "type": "string",
             "format": "date-time"
@@ -11529,6 +11533,10 @@
           "includeInSearch": {
             "type": "boolean",
             "description": "Include library series in Search"
+          },
+          "collapseSeriesRelationships": {
+            "type": "boolean",
+            "description": "When showing series, only parent series or series with no relationships will be returned"
           },
           "folders": {
             "type": "array",
@@ -14070,6 +14078,7 @@
       },
       "UpdateLibraryDto": {
         "required": [
+          "collapseSeriesRelationships",
           "folders",
           "folderWatching",
           "id",
@@ -14112,6 +14121,9 @@
             "type": "boolean"
           },
           "manageCollections": {
+            "type": "boolean"
+          },
+          "collapseSeriesRelationships": {
             "type": "boolean"
           }
         },

--- a/openapi.json
+++ b/openapi.json
@@ -7,7 +7,7 @@
       "name": "GPL-3.0",
       "url": "https://github.com/Kareadita/Kavita/blob/develop/LICENSE"
     },
-    "version": "0.7.0.3"
+    "version": "0.7.1.1"
   },
   "servers": [
     {

--- a/openapi.json
+++ b/openapi.json
@@ -7,7 +7,7 @@
       "name": "GPL-3.0",
       "url": "https://github.com/Kareadita/Kavita/blob/develop/LICENSE"
     },
-    "version": "0.7.0.2"
+    "version": "0.7.0.3"
   },
   "servers": [
     {


### PR DESCRIPTION
# Added
- Added: New library setting to collapse series that have relationships in the library view. This means if you have Batman and Batman the Sequel linked, only Batman will show on library page. Configurable in library settings, only applies when all libraries in a filter have the property to true. **Please give feedback on how this feels. This may be removed in future updates.**

# Changed
- Changed: When skipping over folders in a scan, inform the UI event widget
- Changed: Adjusted the folder watcher to turn off folder watching if too many restarts get triggered
- Changed: Don't scan .@_thumb directory on QNAP systems
- Changed: Some time displays in hours will now show days or minutes. This is mainly on the stats page to give an easier way to understand the data. 
