### PR TITLE
v0.7.1.4 Hotfix: Synology Fix

### DIFF
--- a/Kavita.Common/Kavita.Common.csproj
+++ b/Kavita.Common/Kavita.Common.csproj
@@ -3,7 +3,7 @@
         <TargetFramework>net6.0</TargetFramework>
         <Company>kavitareader.com</Company>
         <Product>Kavita</Product>
-        <AssemblyVersion>0.7.1.0</AssemblyVersion>
+        <AssemblyVersion>0.7.1.4</AssemblyVersion>
         <NeutralLanguage>en</NeutralLanguage>
         <TieredPGO>true</TieredPGO>
     </PropertyGroup>

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,18 +1,18 @@
 #! /bin/bash
 
-# Set default UID and GID for Kavita but allow overrides
-PUID=${PUID:-0}
-PGID=${PGID:-0}
-
-# Add Kavita group if it doesn't already exist
-if [[ -z "$(getent group "$PGID" | cut -d':' -f1)" ]]; then
-    groupadd -o -g "$PGID" kavita
-fi
-
-# Add Kavita user if it doesn't already exist
-if [[ -z "$(getent passwd "$PUID" | cut -d':' -f1)" ]]; then
-    useradd -o -u "$PUID" -g "$PGID" -d /kavita kavita
-fi
+## Set default UID and GID for Kavita but allow overrides
+#PUID=${PUID:-0}
+#PGID=${PGID:-0}
+#
+## Add Kavita group if it doesn't already exist
+#if [[ -z "$(getent group "$PGID" | cut -d':' -f1)" ]]; then
+#    groupadd -o -g "$PGID" kavita
+#fi
+#
+## Add Kavita user if it doesn't already exist
+#if [[ -z "$(getent passwd "$PUID" | cut -d':' -f1)" ]]; then
+#    useradd -o -u "$PUID" -g "$PGID" -d /kavita kavita
+#fi
 
 if [ ! -f "/kavita/config/appsettings.json" ]; then
     echo "Kavita configuration file does not exist, creating..."
@@ -24,24 +24,25 @@ fi
 
 chmod +x Kavita
 
-if [[ "$PUID" -eq 0 ]]; then
-    # Run as root
-    ./Kavita
-else
-    # Set ownership on config dir if running non-root and current ownership is different
-    if [[ ! "$(stat -c %u /kavita/config)" = "$PUID" ]]; then
-        echo "Specified PUID differs from Kavita config dir ownership, updating permissions now..."
-        if [[ ! "$(stat -c %g /kavita/config)" = "$PGID" ]]; then
-            chown -R "$PUID":"$PGID" /kavita/config
-        else
-            chown -R "$PUID" /kavita/config
-        fi
-
-    elif [[ ! "$(stat -c %g /kavita/config)" = "$PGID" ]]; then
-        echo "Specified PGID differs from Kavita config dir ownership, updating permissions now..."
-        chgrp -R "$PGID" /kavita/config
-    fi
-
-    # Run as non-root user
-    su -l kavita -c ./Kavita
-fi
+./Kavita
+#if [[ "$PUID" -eq 0 ]]; then
+#    # Run as root
+#    ./Kavita
+#else
+#    # Set ownership on config dir if running non-root and current ownership is different
+#    if [[ ! "$(stat -c %u /kavita/config)" = "$PUID" ]]; then
+#        echo "Specified PUID differs from Kavita config dir ownership, updating permissions now..."
+#        if [[ ! "$(stat -c %g /kavita/config)" = "$PGID" ]]; then
+#            chown -R "$PUID":"$PGID" /kavita/config
+#        else
+#            chown -R "$PUID" /kavita/config
+#        fi
+#
+#    elif [[ ! "$(stat -c %g /kavita/config)" = "$PGID" ]]; then
+#        echo "Specified PGID differs from Kavita config dir ownership, updating permissions now..."
+#        chgrp -R "$PGID" /kavita/config
+#    fi
+#
+#    # Run as non-root user
+#    su -l kavita -c ./Kavita
+#fi


### PR DESCRIPTION
If you are on nightly, you can stay on your current nightly, you will not receive an update. If you are on stable and have been having issues updating to v0.7.1, use this version. From our Synology tester, this will fix your issues. 

# Fixed
- Fixed: You can no longer run the docker as non-root (Reverts functionality as it was breaking Synology installs)
