### PR TITLE
Docker failing to load issue

### DIFF
--- a/API/config/appsettings.json
+++ b/API/config/appsettings.json
@@ -1,5 +1,5 @@
 {
   "TokenKey": "super secret unguessable key",
   "Port": 5000,
-  "IpAddresses": "0.0.0.0,::"
+  "IpAddresses": ""
 }


### PR DESCRIPTION
# Fixed
- Fixed: Fixed docker instances not being able to start due to misconfiguration of default for IpAddress binding (develop)
