### PR TITLE
Added vertical reading mode to the book reader

### DIFF
--- a/UI/Web/angular.json
+++ b/UI/Web/angular.json
@@ -85,7 +85,7 @@
                 {
                   "type": "anyComponentStyle",
                   "maximumWarning": "2kb",
-                  "maximumError": "5kb"
+                  "maximumError": "6kb"
                 }
               ]
             }


### PR DESCRIPTION
# Added
- Added: Vertical reading mode support added to the web-based book reader. This feature is particularly useful for reading genres like Japanese light novels. The API backend and settings user interface have also been updated to allow users to switch between horizontal and vertical reading modes

# Changed
- Changed: Margin handling has been refined. The units were changed from percentage (%) to viewport width (vw) to accommodate resizing when the reading direction is set to right-to-left (rtl).

