### PR TITLE
Reworks how the image sizes in the book reader gets handled

### DIFF
--- a/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.html
+++ b/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.html
@@ -1,4 +1,4 @@
-<div class="container-flex {{darkMode ? 'dark-mode' : ''}} reader-container {{ColumnLayout}} {{WritingStyleClass}}" tabindex="0" #reader>
+<div class="container-flex {{darkMode ? 'dark-mode' : ''}} reader-container {{ColumnLayout}} {{WritingStyle}}" tabindex="0" #reader>
     <div class="fixed-top" #stickyTop>
         <a class="visually-hidden-focusable focus-visible" href="javascript:void(0);" (click)="moveFocus()">Skip to main content</a>
         <ng-container [ngTemplateOutlet]="actionBar"></ng-container>
@@ -73,7 +73,7 @@
         </app-drawer>
     </div>
 
-    <div #readingSection class="reading-section {{ColumnLayout}} {{WritingStyleClass}}" [ngStyle]="{'width': PageWidthForPagination}" [ngClass]="{'immersive' : immersiveMode || !actionBarVisible}" [@isLoading]="isLoading ? true : false">
+    <div #readingSection class="reading-section {{ColumnLayout}} {{WritingStyle}}" [ngStyle]="{'width': PageWidthForPagination}" [ngClass]="{'immersive' : immersiveMode || !actionBarVisible}" [@isLoading]="isLoading ? true : false">
 
         <ng-container *ngIf="clickToPaginate">
             <div class="left {{clickOverlayClass('left')}} no-observe" [ngClass]="{'immersive' : immersiveMode}"
@@ -84,16 +84,15 @@
                 (click)="movePage(readingDirection === ReadingDirection.LeftToRight ? PAGING_DIRECTION.FORWARD : PAGING_DIRECTION.BACKWARDS)"
                  tabindex="-1" [ngStyle]="{height: PageHeightForPagination}"></div>
         </ng-container>
-        <div #bookContainer class="book-container {{WritingStyleClass}}" [ngClass]="{'immersive' : immersiveMode}">
+        <div #bookContainer class="book-container {{WritingStyle}}" [ngClass]="{'immersive' : immersiveMode}">
 
-            <div #readingHtml class="book-content {{ColumnLayout}} {{WritingStyleClass}}" [ngStyle]="{'max-height': ColumnHeight, 'max-width': VerticalBookContentWidth, 'width': VerticalBookContentWidth, 'column-width': ColumnWidth}"
+            <div #readingHtml class="book-content {{ColumnLayout}} {{WritingStyle}}" [ngStyle]="{'max-height': ColumnHeight, 'max-width': VerticalBookContentWidth, 'width': VerticalBookContentWidth, 'column-width': ColumnWidth}"
                  [ngClass]="{'immersive': immersiveMode && actionBarVisible}"
                  [innerHtml]="page" *ngIf="page !== undefined" (click)="toggleMenu($event)" (mousedown)="mouseDown($event)" (wheel)="onWheel($event)"></div>
 
 
-            <div *ngIf="page !== undefined && (scrollbarNeeded || layoutMode !== BookPageLayoutMode.Default) && !(writingStyle === WritingStyle.Vertical && layoutMode === BookPageLayoutMode.Default)"
-                 (click)="$event.stopPropagation();"
-                 [ngClass]="{'bottom-bar': layoutMode !== BookPageLayoutMode.Default}">
+            <div *ngIf="page !== undefined && (scrollbarNeeded || layoutMode !== BookPageLayoutMode.Default)" (click)="$event.stopPropagation();"
+                [ngClass]="{'bottom-bar': layoutMode !== BookPageLayoutMode.Default}">
                 <ng-container [ngTemplateOutlet]="actionBar"></ng-container>
             </div>
         </div>

--- a/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.html
+++ b/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.html
@@ -1,4 +1,4 @@
-<div class="container-flex {{darkMode ? 'dark-mode' : ''}} reader-container {{ColumnLayout}} {{WritingStyle}}" tabindex="0" #reader>
+<div class="container-flex {{darkMode ? 'dark-mode' : ''}} reader-container {{ColumnLayout}} {{WritingStyleClass}}" tabindex="0" #reader>
     <div class="fixed-top" #stickyTop>
         <a class="visually-hidden-focusable focus-visible" href="javascript:void(0);" (click)="moveFocus()">Skip to main content</a>
         <ng-container [ngTemplateOutlet]="actionBar"></ng-container>
@@ -73,7 +73,7 @@
         </app-drawer>
     </div>
 
-    <div #readingSection class="reading-section {{ColumnLayout}} {{WritingStyle}}" [ngStyle]="{'width': PageWidthForPagination}" [ngClass]="{'immersive' : immersiveMode || !actionBarVisible}" [@isLoading]="isLoading ? true : false">
+    <div #readingSection class="reading-section {{ColumnLayout}} {{WritingStyleClass}}" [ngStyle]="{'width': PageWidthForPagination}" [ngClass]="{'immersive' : immersiveMode || !actionBarVisible}" [@isLoading]="isLoading ? true : false">
 
         <ng-container *ngIf="clickToPaginate">
             <div class="left {{clickOverlayClass('left')}} no-observe" [ngClass]="{'immersive' : immersiveMode}"
@@ -84,15 +84,16 @@
                 (click)="movePage(readingDirection === ReadingDirection.LeftToRight ? PAGING_DIRECTION.FORWARD : PAGING_DIRECTION.BACKWARDS)"
                  tabindex="-1" [ngStyle]="{height: PageHeightForPagination}"></div>
         </ng-container>
-        <div #bookContainer class="book-container {{WritingStyle}}" [ngClass]="{'immersive' : immersiveMode}">
+        <div #bookContainer class="book-container {{WritingStyleClass}}" [ngClass]="{'immersive' : immersiveMode}">
 
-            <div #readingHtml class="book-content {{ColumnLayout}} {{WritingStyle}}" [ngStyle]="{'max-height': ColumnHeight, 'max-width': VerticalBookContentWidth, 'width': VerticalBookContentWidth, 'column-width': ColumnWidth}"
+            <div #readingHtml class="book-content {{ColumnLayout}} {{WritingStyleClass}}" [ngStyle]="{'max-height': ColumnHeight, 'max-width': VerticalBookContentWidth, 'width': VerticalBookContentWidth, 'column-width': ColumnWidth}"
                  [ngClass]="{'immersive': immersiveMode && actionBarVisible}"
                  [innerHtml]="page" *ngIf="page !== undefined" (click)="toggleMenu($event)" (mousedown)="mouseDown($event)" (wheel)="onWheel($event)"></div>
 
 
-            <div *ngIf="page !== undefined && (scrollbarNeeded || layoutMode !== BookPageLayoutMode.Default)" (click)="$event.stopPropagation();"
-                [ngClass]="{'bottom-bar': layoutMode !== BookPageLayoutMode.Default}">
+            <div *ngIf="page !== undefined && (scrollbarNeeded || layoutMode !== BookPageLayoutMode.Default) && !(writingStyle === WritingStyle.Vertical && layoutMode === BookPageLayoutMode.Default)"
+                 (click)="$event.stopPropagation();"
+                 [ngClass]="{'bottom-bar': layoutMode !== BookPageLayoutMode.Default}">
                 <ng-container [ngTemplateOutlet]="actionBar"></ng-container>
             </div>
         </div>

--- a/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.scss
+++ b/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.scss
@@ -212,7 +212,6 @@ $action-bar-height: 38px;
         height: calc((var(--vh) * 100) - calc($action-bar-height)); //  * 2
 
         &.writing-style-vertical {
-            height: auto;
             padding: 0 10px 0 0;
             margin: 20px 0;
         }
@@ -222,10 +221,13 @@ $action-bar-height: 38px;
         height: calc((var(--vh) * 100) - calc($action-bar-height)); //  * 2
 
         &.writing-style-vertical {
-            height: auto;
             padding: 0 10px 0 0;
             margin: 20px 0;
         }
+    }
+
+    &.writing-style-vertical {
+        height: auto;
     }
 
     // &.immersive {
@@ -301,11 +303,18 @@ $action-bar-height: 38px;
 ::ng-deep .kavita-scale-width-container {
     width: auto;
     max-height: calc(var(--book-reader-content-max-height) - ($action-bar-height)) !important;
+    max-width: calc(var(--book-reader-content-max-width)) !important;
+    position: var(--book-reader-content-position) !important;
+    top: var(--book-reader-content-top) !important;
+    left: var(--book-reader-content-left) !important;
+    transform: var(--book-reader-content-transform) !important;
+
 }
 
 // This is applied to images in the backend
 ::ng-deep .kavita-scale-width {
-    max-width: 100%;
+    max-height: calc(var(--book-reader-content-max-height) - ($action-bar-height)) !important;
+    max-width: calc(var(--book-reader-content-max-width)) !important;
     object-fit: contain;
     object-position: top center;
     break-inside: avoid;

--- a/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.ts
+++ b/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.ts
@@ -866,35 +866,35 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
    * Updates the image properties to fit the current layout mode and screen size
    */
   updateImageSizes() {
-    const isVerticalWritingStyle = this.writingStyle === WritingStyle.Vertical
-    const height = this.windowHeight - (this.topOffset * 2)
-    let maxHeight = 'unset'
-    let maxWidth = ''
+    const isVerticalWritingStyle = this.writingStyle === WritingStyle.Vertical;
+    const height = this.windowHeight - (this.topOffset * 2);
+    let maxHeight = 'unset';
+    let maxWidth = '';
     switch (this.layoutMode) {
       case BookPageLayoutMode.Default:
         if (isVerticalWritingStyle) {
-          maxHeight = `${height}px`
+          maxHeight = `${height}px`;
         } else {
-          maxWidth = `${this.getVerticalPageWidth()}px`
+          maxWidth = `${this.getVerticalPageWidth()}px`;
         }
         break
 
       case BookPageLayoutMode.Column1:
-        maxHeight = `${height}px`
-        maxWidth = `${this.getVerticalPageWidth()}px`
+        maxHeight = `${height}px`;
+        maxWidth = `${this.getVerticalPageWidth()}px`;
         break
 
       case BookPageLayoutMode.Column2:
-        maxWidth = `${this.getVerticalPageWidth()}px`
+        maxWidth = `${this.getVerticalPageWidth()}px`;
         if (isVerticalWritingStyle && !this.isSingleImagePage)  {
-          maxHeight = `${height / 2}px`
+          maxHeight = `${height / 2}px`;
         } else {
-          maxHeight = `${height}px`
+          maxHeight = `${height}px`;
         }
         break
     }
-    this.document.documentElement.style.setProperty('--book-reader-content-max-height', maxHeight)
-    this.document.documentElement.style.setProperty('--book-reader-content-max-width', maxWidth)
+    this.document.documentElement.style.setProperty('--book-reader-content-max-height', maxHeight);
+    this.document.documentElement.style.setProperty('--book-reader-content-max-width', maxWidth);
 
   }
 

--- a/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.ts
+++ b/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.ts
@@ -381,7 +381,7 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   get VerticalBookContentWidth() {
-    if (this.layoutMode !== BookPageLayoutMode.Default) {
+    if (this.layoutMode !== BookPageLayoutMode.Default && this.writingStyle !== WritingStyle.Horizontal ) {
       const width = this.getVerticalPageWidth()
       return width + 'px';
     }

--- a/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.ts
+++ b/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.ts
@@ -156,6 +156,7 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
   clickToPaginateVisualOverlay = false;
   clickToPaginateVisualOverlayTimeout: any = undefined; // For animation
   clickToPaginateVisualOverlayTimeout2: any = undefined; // For kicking off animation, giving enough time to render html
+  updateImageSizeTimeout: any = undefined;
   /**
    * This is the html we get from the server
    */
@@ -590,7 +591,6 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
         });
 
         this.updateImageSizes();
-
 
         if (this.pageNum >= this.maxPages) {
           this.pageNum = this.maxPages - 1;
@@ -1373,7 +1373,7 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
 
   updateWritingStyle(writingStyle: WritingStyle) {
     this.writingStyle = writingStyle;
-    this.updateImageSizes()
+    setTimeout(() => this.updateImageSizes());
     if (this.layoutMode !== BookPageLayoutMode.Default) {
       const lastSelector = this.lastSeenScrollPartPath;
       setTimeout(() => {
@@ -1394,8 +1394,12 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
     const layoutModeChanged = mode !== this.layoutMode;
     this.layoutMode = mode;
     this.cdRef.markForCheck();
-    // Remove any max-heights from column layout
-    this.updateImageSizes();
+
+    this.clearTimeout(this.updateImageSizeTimeout);
+    this.updateImageSizeTimeout = setTimeout( () => {
+      this.updateImageSizes()
+    }, 200);
+
     this.updateSingleImagePageStyles()
 
     // Calulate if bottom actionbar is needed. On a timeout to get accurate heights

--- a/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.ts
+++ b/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.ts
@@ -272,6 +272,9 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
     return BookPageLayoutMode;
   }
 
+  get WritingStyle() {
+    return WritingStyle;
+  }
   get TabID(): typeof TabID {
     return TabID;
   }
@@ -396,7 +399,7 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
     }
   }
 
-  get WritingStyle() {
+  get WritingStyleClass() {
     switch (this.writingStyle) {
         case WritingStyle.Horizontal:
           return '';
@@ -913,9 +916,9 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
         this.scrollService.scrollTo(0, this.reader.nativeElement);
       } else if (this.writingStyle === WritingStyle.Vertical) {
         if (this.pagingDirection === PAGING_DIRECTION.BACKWARDS) {
-            setTimeout(() => this.scrollService.scrollTo(this.bookContentElemRef.nativeElement.scrollHeight, this.bookContentElemRef.nativeElement));
+            setTimeout(() => this.scrollService.scrollTo(this.bookContentElemRef.nativeElement.scrollHeight, this.bookContentElemRef.nativeElement, 'auto'));
         } else {
-            setTimeout(() => this.scrollService.scrollTo(0, this.bookContentElemRef.nativeElement));
+            setTimeout(() => this.scrollService.scrollTo(0, this.bookContentElemRef.nativeElement,'auto' ));
         }
       }
       else {
@@ -1000,7 +1003,7 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       if (currentVirtualPage > 1) {
         // -2 apparently goes back 1 virtual page...
         if (this.writingStyle === WritingStyle.Vertical) {
-          this.scrollService.scrollTo((currentVirtualPage - 2) * pageWidth, this.bookContentElemRef.nativeElement, "auto");
+          this.scrollService.scrollTo((currentVirtualPage - 2) * pageWidth, this.bookContentElemRef.nativeElement, 'auto');
         } else {
           this.scrollService.scrollToX((currentVirtualPage - 2) * pageWidth, this.bookContentElemRef.nativeElement);
         }

--- a/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.ts
+++ b/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.ts
@@ -275,9 +275,6 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
     return BookPageLayoutMode;
   }
 
-  get WritingStyle() {
-    return WritingStyle;
-  }
   get TabID(): typeof TabID {
     return TabID;
   }
@@ -399,7 +396,7 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
     }
   }
 
-  get WritingStyleClass() {
+  get WritingStyle() {
     switch (this.writingStyle) {
         case WritingStyle.Horizontal:
           return '';
@@ -958,9 +955,9 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
         this.scrollService.scrollTo(0, this.reader.nativeElement);
       } else if (this.writingStyle === WritingStyle.Vertical) {
         if (this.pagingDirection === PAGING_DIRECTION.BACKWARDS) {
-            setTimeout(() => this.scrollService.scrollTo(this.bookContentElemRef.nativeElement.scrollHeight, this.bookContentElemRef.nativeElement, 'auto'));
+            setTimeout(() => this.scrollService.scrollTo(this.bookContentElemRef.nativeElement.scrollHeight, this.bookContentElemRef.nativeElement));
         } else {
-            setTimeout(() => this.scrollService.scrollTo(0, this.bookContentElemRef.nativeElement,'auto' ));
+            setTimeout(() => this.scrollService.scrollTo(0, this.bookContentElemRef.nativeElement));
         }
       }
       else {
@@ -1045,7 +1042,7 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       if (currentVirtualPage > 1) {
         // -2 apparently goes back 1 virtual page...
         if (this.writingStyle === WritingStyle.Vertical) {
-          this.scrollService.scrollTo((currentVirtualPage - 2) * pageWidth, this.bookContentElemRef.nativeElement, 'auto');
+          this.scrollService.scrollTo((currentVirtualPage - 2) * pageWidth, this.bookContentElemRef.nativeElement, "auto");
         } else {
           this.scrollService.scrollToX((currentVirtualPage - 2) * pageWidth, this.bookContentElemRef.nativeElement);
         }


### PR DESCRIPTION
This is a fairly large PR of changes to how images are handled with the epub reader. Please test this out and report any issues you see, even if they are small.

# Added
- Added: If a page only contains a single image. It gets positioned to the center in column mode
- Added: Added a check for if the current page only contains a single image. Happens during loading as to not have the image pop in place. 

# Changed
- Changed: Previously the preserveAspectRatio got ignored due to lacking max-width. Meaning that whether an image's aspectRatio gets changed is decided by the book. Because of this most cover image's aspect ratio will no longer be preserved 
- Changed: The image sizes is no longer handled by the side effect of getters, instead a separate method.
- Changed: Image now only gets scaled through properties, and no longer looping through every image and setting max-height


# Fixed
- Fixed: Fixed a bug where images would not resize in column-mode vertically due the image escaping the container.
- Fixed: Fixed a bug where in scroll mode, the max-height of an image would not be unset again after returning from column-mode 
