### PR TITLE
OPDS Flattening

### DIFF
--- a/API.Tests/Services/ReaderServiceTests.cs
+++ b/API.Tests/Services/ReaderServiceTests.cs
@@ -1367,6 +1367,45 @@ public class ReaderServiceTests
     }
 
     [Fact]
+    public async Task GetContinuePoint_ShouldReturnFirstVolume_WhenFirstVolumeIsAlsoTaggedAsChapter1Through11_WithProgress()
+    {
+        await ResetDb();
+        var series = new SeriesBuilder("Test")
+            .WithVolume(new VolumeBuilder("1")
+                .WithChapter(new ChapterBuilder("1", "1-11").WithPages(3).Build())
+                .Build())
+            .WithVolume(new VolumeBuilder("2")
+                .WithChapter(new ChapterBuilder("0").WithPages(1).Build())
+                .Build())
+            .WithPages(4)
+            .Build();
+        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
+
+        _context.Series.Add(series);
+
+        _context.AppUser.Add(new AppUser()
+        {
+            UserName = "majora2007"
+        });
+
+        await _context.SaveChangesAsync();
+
+
+
+
+        await _readerService.SaveReadingProgress(new ProgressDto()
+        {
+            PageNum = 2,
+            ChapterId = 1,
+            SeriesId = 1,
+            VolumeId = 1
+        }, 1);
+        var nextChapter = await _readerService.GetContinuePoint(1, 1);
+
+        Assert.Equal("1-11", nextChapter.Range);
+    }
+
+    [Fact]
     public async Task GetContinuePoint_ShouldReturnFirstNonSpecial()
     {
         await ResetDb();

--- a/API/API.csproj
+++ b/API/API.csproj
@@ -78,6 +78,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.4" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.3.2" />
+    <PackageReference Include="MimeTypeMapOfficial" Version="1.0.17" />
     <PackageReference Include="NetVips" Version="2.2.0" />
     <PackageReference Include="NetVips.Native" Version="8.13.2" />
     <PackageReference Include="NReco.Logging.File" Version="1.1.6" />

--- a/API/Controllers/ImageController.cs
+++ b/API/Controllers/ImageController.cs
@@ -8,6 +8,7 @@ using API.Extensions;
 using API.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using MimeTypes;
 
 namespace API.Controllers;
 
@@ -38,9 +39,9 @@ public class ImageController : BaseApiController
     {
         var path = Path.Join(_directoryService.CoverImageDirectory, await _unitOfWork.ChapterRepository.GetChapterCoverImageAsync(chapterId));
         if (string.IsNullOrEmpty(path) || !_directoryService.FileSystem.File.Exists(path)) return BadRequest($"No cover image");
-        var format = _directoryService.FileSystem.Path.GetExtension(path).Replace(".", string.Empty);
+        var format = _directoryService.FileSystem.Path.GetExtension(path);
 
-        return PhysicalFile(path, "image/" + format, _directoryService.FileSystem.Path.GetFileName(path));
+        return PhysicalFile(path, MimeTypeMap.GetMimeType(format), _directoryService.FileSystem.Path.GetFileName(path));
     }
 
     /// <summary>
@@ -54,9 +55,9 @@ public class ImageController : BaseApiController
     {
         var path = Path.Join(_directoryService.CoverImageDirectory, await _unitOfWork.LibraryRepository.GetLibraryCoverImageAsync(libraryId));
         if (string.IsNullOrEmpty(path) || !_directoryService.FileSystem.File.Exists(path)) return BadRequest($"No cover image");
-        var format = _directoryService.FileSystem.Path.GetExtension(path).Replace(".", string.Empty);
+        var format = _directoryService.FileSystem.Path.GetExtension(path);
 
-        return PhysicalFile(path, "image/" + format, _directoryService.FileSystem.Path.GetFileName(path));
+        return PhysicalFile(path, MimeTypeMap.GetMimeType(format), _directoryService.FileSystem.Path.GetFileName(path));
     }
 
     /// <summary>
@@ -70,9 +71,9 @@ public class ImageController : BaseApiController
     {
         var path = Path.Join(_directoryService.CoverImageDirectory, await _unitOfWork.VolumeRepository.GetVolumeCoverImageAsync(volumeId));
         if (string.IsNullOrEmpty(path) || !_directoryService.FileSystem.File.Exists(path)) return BadRequest($"No cover image");
-        var format = _directoryService.FileSystem.Path.GetExtension(path).Replace(".", string.Empty);
+        var format = _directoryService.FileSystem.Path.GetExtension(path);
 
-        return PhysicalFile(path, "image/" + format, _directoryService.FileSystem.Path.GetFileName(path));
+        return PhysicalFile(path, MimeTypeMap.GetMimeType(format), _directoryService.FileSystem.Path.GetFileName(path));
     }
 
     /// <summary>
@@ -86,11 +87,11 @@ public class ImageController : BaseApiController
     {
         var path = Path.Join(_directoryService.CoverImageDirectory, await _unitOfWork.SeriesRepository.GetSeriesCoverImageAsync(seriesId));
         if (string.IsNullOrEmpty(path) || !_directoryService.FileSystem.File.Exists(path)) return BadRequest($"No cover image");
-        var format = _directoryService.FileSystem.Path.GetExtension(path).Replace(".", string.Empty);
+        var format = _directoryService.FileSystem.Path.GetExtension(path);
 
         Response.AddCacheHeader(path);
 
-        return PhysicalFile(path, "image/" + format, _directoryService.FileSystem.Path.GetFileName(path));
+        return PhysicalFile(path, MimeTypeMap.GetMimeType(format), _directoryService.FileSystem.Path.GetFileName(path));
     }
 
     /// <summary>
@@ -104,9 +105,9 @@ public class ImageController : BaseApiController
     {
         var path = Path.Join(_directoryService.CoverImageDirectory, await _unitOfWork.CollectionTagRepository.GetCoverImageAsync(collectionTagId));
         if (string.IsNullOrEmpty(path) || !_directoryService.FileSystem.File.Exists(path)) return BadRequest($"No cover image");
-        var format = _directoryService.FileSystem.Path.GetExtension(path).Replace(".", string.Empty);
+        var format = _directoryService.FileSystem.Path.GetExtension(path);
 
-        return PhysicalFile(path, "image/" + format, _directoryService.FileSystem.Path.GetFileName(path));
+        return PhysicalFile(path, MimeTypeMap.GetMimeType(format), _directoryService.FileSystem.Path.GetFileName(path));
     }
 
     /// <summary>
@@ -119,13 +120,10 @@ public class ImageController : BaseApiController
     public async Task<ActionResult> GetReadingListCoverImage(int readingListId)
     {
         var path = Path.Join(_directoryService.CoverImageDirectory, await _unitOfWork.ReadingListRepository.GetCoverImageAsync(readingListId));
-        if (string.IsNullOrEmpty(path) || !_directoryService.FileSystem.File.Exists(path))
-        {
-            return BadRequest($"No cover image");
-        }
-        var format = _directoryService.FileSystem.Path.GetExtension(path).Replace(".", string.Empty);
+        if (string.IsNullOrEmpty(path) || !_directoryService.FileSystem.File.Exists(path)) return BadRequest($"No cover image");
+        var format = _directoryService.FileSystem.Path.GetExtension(path);
 
-        return PhysicalFile(path, "image/" + format, _directoryService.FileSystem.Path.GetFileName(path));
+        return PhysicalFile(path, MimeTypeMap.GetMimeType(format), _directoryService.FileSystem.Path.GetFileName(path));
     }
 
     /// <summary>
@@ -147,9 +145,9 @@ public class ImageController : BaseApiController
         var bookmarkDirectory =
             (await _unitOfWork.SettingsRepository.GetSettingAsync(ServerSettingKey.BookmarkDirectory)).Value;
         var file = new FileInfo(Path.Join(bookmarkDirectory, bookmark.FileName));
-        var format = Path.GetExtension(file.FullName).Replace(".", string.Empty);
+        var format = Path.GetExtension(file.FullName);
 
-        return PhysicalFile(file.FullName, "image/" + format, Path.GetFileName(file.FullName));
+        return PhysicalFile(file.FullName, MimeTypeMap.GetMimeType(format), Path.GetFileName(file.FullName));
     }
 
     /// <summary>
@@ -166,8 +164,8 @@ public class ImageController : BaseApiController
 
         var path = Path.Join(_directoryService.TempDirectory, filename);
         if (string.IsNullOrEmpty(path) || !_directoryService.FileSystem.File.Exists(path)) return BadRequest($"File does not exist");
-        var format = _directoryService.FileSystem.Path.GetExtension(path).Replace(".", string.Empty);
+        var format = _directoryService.FileSystem.Path.GetExtension(path);
 
-        return PhysicalFile(path, "image/" + format, _directoryService.FileSystem.Path.GetFileName(path));
+        return PhysicalFile(path, MimeTypeMap.GetMimeType(format), _directoryService.FileSystem.Path.GetFileName(path));
     }
 }

--- a/API/Controllers/OPDSController.cs
+++ b/API/Controllers/OPDSController.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/API/Controllers/OPDSController.cs
+++ b/API/Controllers/OPDSController.cs
@@ -776,6 +776,7 @@ public class OpdsController : BaseApiController
     private async Task<FeedEntry> CreateChapterWithFile(int seriesId, int volumeId, int chapterId, MangaFile mangaFile, SeriesDto series, ChapterDto chapter, string apiKey)
     {
         var fileSize =
+            mangaFile.Bytes > 0 ? DirectoryService.GetHumanReadableBytes(mangaFile.Bytes) :
             DirectoryService.GetHumanReadableBytes(_directoryService.GetTotalSize(new List<string>()
                 {mangaFile.FilePath}));
         var fileType = _downloadService.GetContentTypeFromFile(mangaFile.FilePath);

--- a/API/Controllers/OPDSController.cs
+++ b/API/Controllers/OPDSController.cs
@@ -21,7 +21,6 @@ using Kavita.Common;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using MimeTypes;
-using SharpCompress.Common;
 
 namespace API.Controllers;
 
@@ -732,25 +731,6 @@ public class OpdsController : BaseApiController
                 CreateLink(FeedLinkRelation.SubSection, FeedLinkType.AtomNavigation, Prefix + $"{apiKey}/series/{searchResultDto.SeriesId}"),
                 CreateLink(FeedLinkRelation.Image, FeedLinkType.Image, $"/api/image/series-cover?seriesId={searchResultDto.SeriesId}"),
                 CreateLink(FeedLinkRelation.Thumbnail, FeedLinkType.Image, $"/api/image/series-cover?seriesId={searchResultDto.SeriesId}")
-            }
-        };
-    }
-
-    private static FeedEntry CreateVolume(VolumeDto volumeDto, int seriesId, string apiKey)
-    {
-        return new FeedEntry()
-        {
-            Id = volumeDto.Id.ToString(),
-            Title = volumeDto.Name,
-            Summary = volumeDto.Chapters.First().Summary ?? string.Empty,
-            Links = new List<FeedLink>()
-            {
-                CreateLink(FeedLinkRelation.SubSection, FeedLinkType.AtomNavigation,
-                    Prefix + $"{apiKey}/series/{seriesId}/volume/{volumeDto.Id}"),
-                CreateLink(FeedLinkRelation.Image, FeedLinkType.Image,
-                    $"/api/image/volume-cover?volumeId={volumeDto.Id}"),
-                CreateLink(FeedLinkRelation.Thumbnail, FeedLinkType.Image,
-                    $"/api/image/volume-cover?volumeId={volumeDto.Id}")
             }
         };
     }

--- a/API/Controllers/OPDSController.cs
+++ b/API/Controllers/OPDSController.cs
@@ -790,7 +790,7 @@ public class OpdsController : BaseApiController
             SeriesService.RenameVolumeName(volume.Chapters.First(), volume, libraryType);
             if (volume.Name != "0")
             {
-                title += $"- {volume.Name}";
+                title += $" - {volume.Name}";
             }
         }
         else if (volume.Number != 0)

--- a/API/Controllers/ReaderController.cs
+++ b/API/Controllers/ReaderController.cs
@@ -19,6 +19,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Microsoft.IdentityModel.Tokens;
+using MimeTypes;
 
 namespace API.Controllers;
 
@@ -103,9 +104,9 @@ public class ReaderController : BaseApiController
         {
             var path = _cacheService.GetCachedPagePath(chapter.Id, page);
             if (string.IsNullOrEmpty(path) || !System.IO.File.Exists(path)) return BadRequest($"No such image for page {page}. Try refreshing to allow re-cache.");
-            var format = Path.GetExtension(path).Replace(".", string.Empty);
+            var format = Path.GetExtension(path);
 
-            return PhysicalFile(path, "image/" + format, Path.GetFileName(path), true);
+            return PhysicalFile(path, MimeTypeMap.GetMimeType(format), Path.GetFileName(path), true);
         }
         catch (Exception)
         {
@@ -124,8 +125,8 @@ public class ReaderController : BaseApiController
         var images = _cacheService.GetCachedPages(chapterId);
 
         var path = await _readerService.GetThumbnail(chapter, pageNum, images);
-        var format = Path.GetExtension(path).Replace(".", string.Empty); // TODO: Make this an extension
-        return PhysicalFile(path, "image/" + format, Path.GetFileName(path), true);
+        var format = Path.GetExtension(path);
+        return PhysicalFile(path, MimeTypeMap.GetMimeType(format), Path.GetFileName(path), true);
     }
 
     /// <summary>
@@ -154,9 +155,9 @@ public class ReaderController : BaseApiController
         {
             var path = _cacheService.GetCachedBookmarkPagePath(seriesId, page);
             if (string.IsNullOrEmpty(path) || !System.IO.File.Exists(path)) return BadRequest($"No such image for page {page}");
-            var format = Path.GetExtension(path).Replace(".", string.Empty);
+            var format = Path.GetExtension(path);
 
-            return PhysicalFile(path, "image/" + format, Path.GetFileName(path));
+            return PhysicalFile(path, MimeTypeMap.GetMimeType(format), Path.GetFileName(path));
         }
         catch (Exception)
         {

--- a/API/Services/DownloadService.cs
+++ b/API/Services/DownloadService.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using API.Entities;
 using Microsoft.AspNetCore.StaticFiles;
+using MimeTypes;
 
 namespace API.Services;
 
@@ -47,7 +48,7 @@ public class DownloadService : IDownloadService
                 ".zip" => "application/zip",
                 ".tar.gz" => "application/gzip",
                 ".pdf" => "application/pdf",
-                _ => contentType
+                _ => MimeTypeMap.GetMimeType(contentType)
             };
         }
 

--- a/API/Services/ReaderService.cs
+++ b/API/Services/ReaderService.cs
@@ -495,7 +495,7 @@ public class ReaderService : IReaderService
         // NOTE: If volume 1 has chapter 1 and volume 2 is just chapter 0 due to being a full volume file, then this fails
         // If there are any volumes that have progress, return those. If not, move on.
         var currentlyReadingChapter = volumeChapters
-            .OrderBy(c => double.Parse(c.Range), _chapterSortComparer)
+            .OrderBy(c => double.Parse(c.Number), _chapterSortComparer) // BUG: This is throwing an exception when Range is 1-11
             .FirstOrDefault(chapter => chapter.PagesRead < chapter.Pages && chapter.PagesRead > 0);
         if (currentlyReadingChapter != null) return currentlyReadingChapter;
 

--- a/API/Services/SeriesService.cs
+++ b/API/Services/SeriesService.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/API/Services/SeriesService.cs
+++ b/API/Services/SeriesService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -468,7 +468,7 @@ public class SeriesService : ISeriesService
             }
             else
             {
-                volume.Name += $" - {firstChapter.TitleName}";
+                volume.Name += $"";
             }
 
             return;

--- a/API/Services/SeriesService.cs
+++ b/API/Services/SeriesService.cs
@@ -466,6 +466,10 @@ public class SeriesService : ISeriesService
                 if (string.IsNullOrEmpty(title)) return;
                 volume.Name += $" - {title}";
             }
+            else if (volume.Name != "0")
+            {
+                volume.Name += $" - {firstChapter.TitleName}";
+            }
             else
             {
                 volume.Name += $"";

--- a/openapi.json
+++ b/openapi.json
@@ -7,7 +7,7 @@
       "name": "GPL-3.0",
       "url": "https://github.com/Kareadita/Kavita/blob/develop/LICENSE"
     },
-    "version": "0.7.1.27"
+    "version": "0.7.1.28"
   },
   "servers": [
     {


### PR DESCRIPTION
# Changed
- Changed: Further flattened the OPDS structure so now after a series you have all the items then the acquire links. Max depth is 2 from a series (plus acquire link). Closes #1891 (Thank you @therobbiedavis for taking this up)
- Changed: Optimized the Size property in OPDS acquire links to use pre-computed size to avoid an I/O operation

# Fixed
- Fixed: Fixed a bug where some images would report the wrong MIME type (Fixes #1898 )
- Fixed: Fixed a bug where continue point would fail to get if a chapter had a range  (ie 1-11) inside a volume (volume 1). 
