### PR TITLE
ComicInfo Derived Reading Lists

### DIFF
--- a/API.Tests/Services/ProcessSeriesTests.cs
+++ b/API.Tests/Services/ProcessSeriesTests.cs
@@ -60,7 +60,7 @@ public class ProcessSeriesTests
             , Substitute.For<ICacheHelper>(), Substitute.For<IReadingItemService>(), Substitute.For<IFileService>(),
             Substitute.For<IMetadataService>(),
             Substitute.For<IWordCountAnalyzerService>(),
-            Substitute.For<ICollectionTagService>());
+            Substitute.For<ICollectionTagService>(), Substitute.For<IReadingListService>());
 
         ps.UpdateChapterFromComicInfo(chapter, new ComicInfo()
         {

--- a/API/Data/DataContext.cs
+++ b/API/Data/DataContext.cs
@@ -110,6 +110,9 @@ public sealed class DataContext : IdentityDbContext<AppUser, AppRole, int,
         builder.Entity<Library>()
             .Property(b => b.ManageCollections)
             .HasDefaultValue(true);
+        builder.Entity<Library>()
+            .Property(b => b.ManageReadingLists)
+            .HasDefaultValue(true);
     }
 
 

--- a/API/Data/Metadata/ComicInfo.cs
+++ b/API/Data/Metadata/ComicInfo.cs
@@ -61,7 +61,7 @@ public class ComicInfo
     public string SeriesGroup { get; set; } = string.Empty;
 
     /// <summary>
-    ///
+    /// Can contain multiple comma separated numbers that match with StoryArcNumber
     /// </summary>
     public string StoryArc { get; set; } = string.Empty;
     /// <summary>

--- a/API/Data/Migrations/20230415123449_ManageReadingListOnLibrary.Designer.cs
+++ b/API/Data/Migrations/20230415123449_ManageReadingListOnLibrary.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using API.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace API.Data.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20230415123449_ManageReadingListOnLibrary")]
+    partial class ManageReadingListOnLibrary
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "7.0.5");

--- a/API/Data/Migrations/20230415123449_ManageReadingListOnLibrary.cs
+++ b/API/Data/Migrations/20230415123449_ManageReadingListOnLibrary.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace API.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class ManageReadingListOnLibrary : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "ManageReadingLists",
+                table: "Library",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ManageReadingLists",
+                table: "Library");
+        }
+    }
+}

--- a/API/Data/Repositories/ReadingListRepository.cs
+++ b/API/Data/Repositories/ReadingListRepository.cs
@@ -48,6 +48,7 @@ public interface IReadingListRepository
     Task<IList<ReadingList>> GetAllWithNonWebPCovers();
     Task<IList<string>> GetFirstFourCoverImagesByReadingListId(int readingListId);
     Task<int> RemoveReadingListsWithoutSeries();
+    Task<ReadingList?> GetReadingListByTitleAsync(string name, int userId, ReadingListIncludes includes = ReadingListIncludes.Items);
 }
 
 public class ReadingListRepository : IReadingListRepository
@@ -143,6 +144,15 @@ public class ReadingListRepository : IReadingListRepository
         _context.RemoveRange(listsToDelete);
 
         return await _context.SaveChangesAsync();
+    }
+
+
+    public async Task<ReadingList?> GetReadingListByTitleAsync(string name, int userId, ReadingListIncludes includes = ReadingListIncludes.Items)
+    {
+        var normalized = name.ToNormalized();
+        return await _context.ReadingList
+            .Includes(includes)
+            .FirstOrDefaultAsync(x => x.NormalizedTitle != null && x.NormalizedTitle.Equals(normalized) && x.AppUserId == userId);
     }
 
     public void Remove(ReadingListItem item)

--- a/API/Data/Repositories/UserRepository.cs
+++ b/API/Data/Repositories/UserRepository.cs
@@ -62,6 +62,7 @@ public interface IUserRepository
     Task<bool> HasAccessToLibrary(int libraryId, int userId);
     Task<IEnumerable<AppUser>> GetAllUsersAsync(AppUserIncludes includeFlags = AppUserIncludes.None);
     Task<AppUser?> GetUserByConfirmationToken(string token);
+    Task<AppUser> GetDefaultAdminUser();
 }
 
 public class UserRepository : IUserRepository
@@ -218,6 +219,17 @@ public class UserRepository : IUserRepository
     {
         return await _context.AppUser
             .SingleOrDefaultAsync(u => u.ConfirmationToken != null && u.ConfirmationToken.Equals(token));
+    }
+
+    /// <summary>
+    /// Returns the first admin account created
+    /// </summary>
+    /// <returns></returns>
+    public async Task<AppUser> GetDefaultAdminUser()
+    {
+        return (await _userManager.GetUsersInRoleAsync(PolicyConstants.AdminRole))
+            .OrderByDescending(u => u.Created)
+            .First();
     }
 
     public async Task<IEnumerable<AppUser>> GetAdminUsersAsync()

--- a/API/Entities/Library.cs
+++ b/API/Entities/Library.cs
@@ -28,9 +28,13 @@ public class Library : IEntityDate
     /// </summary>
     public bool IncludeInSearch { get; set; } = true;
     /// <summary>
-    /// Should this library create and manage collections from Metadata
+    /// Should this library create collections from Metadata
     /// </summary>
     public bool ManageCollections { get; set; } = true;
+    /// <summary>
+    /// Should this library create reading lists from Metadata
+    /// </summary>
+    public bool ManageReadingLists { get; set; } = true;
     public DateTime Created { get; set; }
     public DateTime LastModified { get; set; }
     public DateTime CreatedUtc { get; set; }

--- a/API/Helpers/Builders/ReadingListBuilder.cs
+++ b/API/Helpers/Builders/ReadingListBuilder.cs
@@ -54,4 +54,10 @@ public class ReadingListBuilder : IEntityBuilder<ReadingList>
         _readingList.CoverImage = coverImage;
         return this;
     }
+
+    public ReadingListBuilder WithAppUserId(int userId)
+    {
+        _readingList.AppUserId = userId;
+        return this;
+    }
 }

--- a/API/Services/ReadingListService.cs
+++ b/API/Services/ReadingListService.cs
@@ -494,15 +494,16 @@ public class ReadingListService : IReadingListService
         if (string.IsNullOrEmpty(storyArc)) return data;
 
         var arcs = storyArc.Split(",");
-        var arcNumbers = storyArcNumbers.Split(",").Where(s => int.TryParse(s, out _)).ToList();
-        if (arcNumbers.Count != arcs.Length)
+        var arcNumbers = storyArcNumbers.Split(",");
+        if (arcNumbers.Length != arcs.Length)
         {
             _logger.LogError("There is a mismatch on StoryArc and StoryArcNumber for {FileName}", filename);
         }
 
-        var maxPairs = Math.Min(arcs.Length, arcNumbers.Count);
+        var maxPairs = Math.Min(arcs.Length, arcNumbers.Length);
         for (var i = 0; i < maxPairs; i++)
         {
+            if (string.IsNullOrEmpty(arcs[i]) || !int.TryParse(arcNumbers[i], out _)) continue;
             data.Add(new Tuple<string, string>(arcs[i], arcNumbers[i]));
         }
 

--- a/openapi.json
+++ b/openapi.json
@@ -11837,7 +11837,11 @@
           },
           "manageCollections": {
             "type": "boolean",
-            "description": "Should this library create and manage collections from Metadata"
+            "description": "Should this library create collections from Metadata"
+          },
+          "manageReadingLists": {
+            "type": "boolean",
+            "description": "Should this library create reading lists from Metadata"
           },
           "created": {
             "type": "string",


### PR DESCRIPTION
# Added
- Added: Added the ability to create reading lists from ComicInfo StoryArc and AlternativeSeries. (Closes #546 ) The implementation matches Komga to ensure consistent experience for users. Comma-separated values are supported in StoryArc and AlternativeSeries and will build pairs for ordering. 

