### PR TITLE
Release Testing Day 1

### DIFF
--- a/API/Controllers/PluginController.cs
+++ b/API/Controllers/PluginController.cs
@@ -43,6 +43,7 @@ public class PluginController : BaseApiController
         {
             Username = user.UserName!,
             Token = await _tokenService.CreateToken(user),
+            RefreshToken = await _tokenService.CreateRefreshToken(user),
             ApiKey = user.ApiKey,
         };
     }

--- a/API/DTOs/Reader/BookmarkInfoDto.cs
+++ b/API/DTOs/Reader/BookmarkInfoDto.cs
@@ -1,4 +1,5 @@
-﻿using API.Entities.Enums;
+﻿using System.Collections.Generic;
+using API.Entities.Enums;
 
 namespace API.DTOs.Reader;
 
@@ -10,4 +11,14 @@ public class BookmarkInfoDto
     public int LibraryId { get; set; }
     public LibraryType LibraryType { get; set; }
     public int Pages { get; set; }
+    /// <summary>
+    /// List of all files with their inner archive structure maintained in filename and dimensions
+    /// </summary>
+    /// <remarks>This is optionally returned by includeDimensions</remarks>
+    public IEnumerable<FileDimensionDto>? PageDimensions { get; set; }
+    /// <summary>
+    /// For Double Page reader, this will contain snap points to ensure the reader always resumes on correct page
+    /// </summary>
+    /// <remarks>This is optionally returned by includeDimensions</remarks>
+    public IDictionary<int, int>? DoublePairs { get; set; }
 }

--- a/API/Data/Metadata/ComicInfo.cs
+++ b/API/Data/Metadata/ComicInfo.cs
@@ -154,7 +154,7 @@ public class ComicInfo
             return Math.Max(Count, (int) Math.Floor(float.Parse(Volume)));
         }
 
-        return Count;
+        return 0;
     }
 
 

--- a/API/Entities/Metadata/SeriesMetadata.cs
+++ b/API/Entities/Metadata/SeriesMetadata.cs
@@ -39,7 +39,7 @@ public class SeriesMetadata : IHasConcurrencyToken
     /// </summary>
     public int TotalCount { get; set; } = 0;
     /// <summary>
-    /// Max number of issues/volumes in the series (Max of Volume/Issue field in ComicInfo)
+    /// Max number of issues/volumes in the series (Max of Volume/Number field in ComicInfo)
     /// </summary>
     public int MaxCount { get; set; } = 0;
     public PublicationStatus PublicationStatus { get; set; }

--- a/API/Services/Tasks/Scanner/ProcessSeries.cs
+++ b/API/Services/Tasks/Scanner/ProcessSeries.cs
@@ -276,7 +276,9 @@ public class ProcessSeries : IProcessSeries
         // Set the AgeRating as highest in all the comicInfos
         if (!series.Metadata.AgeRatingLocked) series.Metadata.AgeRating = chapters.Max(chapter => chapter.AgeRating);
 
+        // Count (aka expected total number of chapters or volumes from metadata) across all chapters
         series.Metadata.TotalCount = chapters.Max(chapter => chapter.TotalCount);
+        // The actual number of count's defined across all chapter's metadata
         series.Metadata.MaxCount = chapters.Max(chapter => chapter.Count);
         // To not have to rely completely on ComicInfo, try to parse out if the series is complete by checking parsed filenames as well.
         if (series.Metadata.MaxCount != series.Metadata.TotalCount)

--- a/API/Services/Tasks/Scanner/ProcessSeries.cs
+++ b/API/Services/Tasks/Scanner/ProcessSeries.cs
@@ -296,7 +296,7 @@ public class ProcessSeries : IProcessSeries
             if (series.Metadata.MaxCount >= series.Metadata.TotalCount && series.Metadata.TotalCount > 0)
             {
                 series.Metadata.PublicationStatus = PublicationStatus.Completed;
-            } else if (series.Metadata.TotalCount > 0 && series.Metadata.MaxCount > 0)
+            } else if (series.Metadata.TotalCount > 0)
             {
                 series.Metadata.PublicationStatus = PublicationStatus.Ended;
             }

--- a/Kavita.sln.DotSettings
+++ b/Kavita.sln.DotSettings
@@ -12,4 +12,5 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Omake/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Opds/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=rewinded/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=Tachiyomi/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Tachiyomi/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=unbookmark/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/UI/Web/src/app/_models/manga-reader/bookmark-info.ts
+++ b/UI/Web/src/app/_models/manga-reader/bookmark-info.ts
@@ -1,3 +1,4 @@
+import { FileDimension } from "src/app/manga-reader/_models/file-dimension";
 import { LibraryType } from "../library";
 import { MangaFormat } from "../manga-format";
 
@@ -8,4 +9,12 @@ export interface BookmarkInfo {
     libraryId: number;
     libraryType: LibraryType;
     pages: number;
+    /**
+     * This will not always be present. Depends on if asked from backend.
+     */
+    pageDimensions?: Array<FileDimension>;
+    /**
+     * This will not always be present. Depends on if asked from backend.
+     */
+    doublePairs?: {[key: number]: number};
 }

--- a/UI/Web/src/app/cards/_modals/edit-series-modal/edit-series-modal.component.html
+++ b/UI/Web/src/app/cards/_modals/edit-series-modal/edit-series-modal.component.html
@@ -380,11 +380,11 @@
                     <div class="row g-0 mb-2" *ngIf="metadata">
                         <div class="col-md-6">
                             Max Items: {{metadata.maxCount}}
-                            <i class="fa fa-info-circle ms-1" placement="right" ngbTooltip="Max of Volume/Issue field in ComicInfo. Used in conjunction with total items to determine publication status." role="button" tabindex="0"></i>
+                            <i class="fa fa-info-circle ms-1" placement="right" ngbTooltip="Highest Count found across all ComicInfo in the Series" role="button" tabindex="0"></i>
                         </div>
                         <div class="col-md-6">
                             Total Items: {{metadata.totalCount}}
-                            <i class="fa fa-info-circle ms-1" placement="right" ngbTooltip="Total number of issues/volumes in the series" role="button" tabindex="0"></i>
+                            <i class="fa fa-info-circle ms-1" placement="right" ngbTooltip="Max Issue or Volume field from all ComicInfo in the series" role="button" tabindex="0"></i>
                         </div>
                         <div class="col-md-6">Publication Status: {{metadata.publicationStatus | publicationStatus}}</div>
                         <div class="col-md-6">Total Pages: {{series.pages}}</div>

--- a/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.ts
+++ b/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.ts
@@ -371,8 +371,10 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
 
   get ImageHeight() {
     if (this.FittingOption !== FITTING_OPTION.HEIGHT) {
+      console.log('ImageHeight: ', this.mangaReaderService.getPageDimensions(this.pageNum)?.height);
       return this.mangaReaderService.getPageDimensions(this.pageNum)?.height  + 'px';
     }
+    
     return this.readingArea?.nativeElement?.clientHeight + 'px';
   }
 
@@ -806,6 +808,7 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
         this.subtitle = 'Bookmarks';
         this.libraryType = bookmarkInfo.libraryType;
         this.maxPages = bookmarkInfo.pages;
+        this.mangaReaderService.load(bookmarkInfo);
 
         // Due to change detection rules in Angular, we need to re-create the options object to apply the change
         const newOptions: Options = Object.assign({}, this.pageOptions);

--- a/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.ts
+++ b/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.ts
@@ -371,7 +371,6 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
 
   get ImageHeight() {
     if (this.FittingOption !== FITTING_OPTION.HEIGHT) {
-      console.log('ImageHeight: ', this.mangaReaderService.getPageDimensions(this.pageNum)?.height);
       return this.mangaReaderService.getPageDimensions(this.pageNum)?.height  + 'px';
     }
     
@@ -380,10 +379,17 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
 
   // This is for the pagination area
   get MaxHeight() {
-    if (this.FittingOption !== FITTING_OPTION.HEIGHT) {
-      return Math.min(this.readingArea?.nativeElement?.clientHeight, this.mangaReaderService.getPageDimensions(this.pageNum)?.height!) + 'px';
+    if (this.FittingOption ===  FITTING_OPTION.HEIGHT) {
+      return 'calc(var(--vh) * 100)';
     }
-    return 'calc(var(--vh) * 100)';
+
+    const needsScrolling = this.readingArea?.nativeElement?.scrollHeight > this.readingArea?.nativeElement?.clientHeight;
+    if (this.readingArea?.nativeElement?.clientHeight <= this.mangaReaderService.getPageDimensions(this.pageNum)?.height!) {
+      if (needsScrolling) {
+        return Math.min(this.readingArea?.nativeElement?.scrollHeight, this.mangaReaderService.getPageDimensions(this.pageNum)?.height!) + 'px';
+      }
+    }
+    return this.readingArea?.nativeElement?.clientHeight + 'px';
   }
 
   get RightPaginationOffset() {

--- a/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.ts
+++ b/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.ts
@@ -1634,7 +1634,9 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       data.readingDirection = this.readingDirection;
       data.emulateBook = modelSettings.emulateBook;
       data.swipeToPaginate = modelSettings.swipeToPaginate;
-      this.accountService.updatePreferences(data).subscribe((updatedPrefs) => {
+      data.pageSplitOption = parseInt(modelSettings.pageSplitOption, 10);
+
+      this.accountService.updatePreferences(data).subscribe(updatedPrefs => {
         this.toastr.success('User preferences updated');
         if (this.user) {
           this.user.preferences = updatedPrefs;

--- a/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.ts
+++ b/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.ts
@@ -823,10 +823,6 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
         this.inSetup = false;
         this.cdRef.markForCheck();
 
-        for (let i = 0; i < PREFETCH_PAGES; i++) {
-          this.cachedImages.push(new Image())
-        }
-
         this.goToPageEvent = new BehaviorSubject<number>(this.pageNum);
 
         this.render();

--- a/UI/Web/src/app/manga-reader/_series/managa-reader.service.ts
+++ b/UI/Web/src/app/manga-reader/_series/managa-reader.service.ts
@@ -5,6 +5,7 @@ import { ReaderService } from 'src/app/_services/reader.service';
 import { ChapterInfo } from '../_models/chapter-info';
 import { DimensionMap } from '../_models/file-dimension';
 import { FITTING_OPTION } from '../_models/reader-enums';
+import { BookmarkInfo } from 'src/app/_models/manga-reader/bookmark-info';
 
 @Injectable({
   providedIn: 'root'
@@ -19,7 +20,7 @@ export class ManagaReaderService {
     this.renderer = rendererFactory.createRenderer(null, null);
   }
 
-  load(chapterInfo: ChapterInfo) {
+  load(chapterInfo: ChapterInfo | BookmarkInfo) {
     chapterInfo.pageDimensions!.forEach(d => {
       this.pageDimensions[d.pageNumber] = {
         height: d.height,

--- a/UI/Web/src/app/metadata-filter/metadata-filter.component.html
+++ b/UI/Web/src/app/metadata-filter/metadata-filter.component.html
@@ -321,7 +321,7 @@
                         <label for="series-name" class="form-label me-1">Series Name</label><i class="fa fa-info-circle" aria-hidden="true" placement="right" [ngbTooltip]="seriesNameFilterTooltip" role="button" tabindex="0"></i>
                         <span class="visually-hidden" id="filter-series-name-help"><ng-container [ngTemplateOutlet]="seriesNameFilterTooltip"></ng-container></span>
                         <ng-template #seriesNameFilterTooltip>Series name will filter against Name, Sort Name, or Localized Name</ng-template>
-                        <input type="text" id="series-name" formControlName="seriesNameQuery" class="form-control" aria-describedby="filter-series-name-help">
+                        <input type="text" id="series-name" formControlName="seriesNameQuery" class="form-control" aria-describedby="filter-series-name-help" (keyup.enter)="apply()">
                     </div>
                 </form>
             </div>
@@ -329,14 +329,14 @@
                 <form [formGroup]="releaseYearRange" class="d-flex justify-content-between">
                     <div class="mb-3">
                         <label for="release-year-min" class="form-label">Release</label>
-                        <input type="text" id="release-year-min" formControlName="min" class="form-control" style="width: 62px" placeholder="Min">
+                        <input type="text" id="release-year-min" formControlName="min" class="form-control" style="width: 62px" placeholder="Min" (keyup.enter)="apply()">
                     </div>
                     <div style="margin-top: 37px !important;">
                         <i class="fa-solid fa-minus" aria-hidden="true"></i>
                     </div>
                     <div class="mb-3" style="margin-top: 0.5rem">
                         <label for="release-year-max" class="form-label"><span class="visually-hidden">Max</span></label>
-                        <input type="text" id="release-year-max" formControlName="max" class="form-control" style="width: 62px" placeholder="Max">
+                        <input type="text" id="release-year-max" formControlName="max" class="form-control" style="width: 62px" placeholder="Max" (keyup.enter)="apply()">
                     </div>
                 </form>
             </div>

--- a/openapi.json
+++ b/openapi.json
@@ -13559,7 +13559,7 @@
           },
           "maxCount": {
             "type": "integer",
-            "description": "Max number of issues/volumes in the series (Max of Volume/Issue field in ComicInfo)",
+            "description": "Max number of issues/volumes in the series (Max of Volume/Number field in ComicInfo)",
             "format": "int32"
           },
           "publicationStatus": {

--- a/openapi.json
+++ b/openapi.json
@@ -3909,6 +3909,15 @@
               "type": "integer",
               "format": "int32"
             }
+          },
+          {
+            "name": "includeDimensions",
+            "in": "query",
+            "description": "Include file dimensions (extra I/O). Defaults to true.",
+            "schema": {
+              "type": "boolean",
+              "default": true
+            }
           }
         ],
         "responses": {
@@ -10191,6 +10200,23 @@
           "pages": {
             "type": "integer",
             "format": "int32"
+          },
+          "pageDimensions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FileDimensionDto"
+            },
+            "description": "List of all files with their inner archive structure maintained in filename and dimensions",
+            "nullable": true
+          },
+          "doublePairs": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "description": "For Double Page reader, this will contain snap points to ensure the reader always resumes on correct page",
+            "nullable": true
           }
         },
         "additionalProperties": false

--- a/openapi.json
+++ b/openapi.json
@@ -7,7 +7,7 @@
       "name": "GPL-3.0",
       "url": "https://github.com/Kareadita/Kavita/blob/develop/LICENSE"
     },
-    "version": "0.7.1.37"
+    "version": "0.7.1.38"
   },
   "servers": [
     {


### PR DESCRIPTION
# Added
- Added: Plugin/Authenticate will now return a refresh token with the payload

# Changed
- Changed: When typing a series name, min, or max filter, press enter to apply metadata filters.
- Changed: Cleaned up the documentation around MaxCount and TotalCount in Series info
- Changed: Slight memory consumption savings in Manga reader under bookmark mode. 

# Fixed
- Fixed: Fixed a long standing bug where PublicationStatus wasn't being set correctly in some conditions where it should have (Fixes #1697) (Thanks @scare376 for the persistent pushing on this)
- Fixed: Fixed bookmark mode not having access to critical page dimensions for the reader. Fetching bookmark info api now returns dimensions by default.
- Fixed: Fixed pagination scaling code for different fitting options in manga reader
- Fixed: Fixed missing code to persist page split in manga reader
