### PR TITLE
Release Testing Day 2

### DIFF
--- a/API.Tests/Services/ReadingListServiceTests.cs
+++ b/API.Tests/Services/ReadingListServiceTests.cs
@@ -1247,24 +1247,24 @@ public class ReadingListServiceTests
         return new Tuple<Series, Series>(series1, series2);
     }
 
-    [Fact]
-    public async Task CreateReadingListsFromSeries_ShouldCreateFromSinglePair()
-    {
-        //await SetupData();
-
-        var series1 = new SeriesBuilder("Series 1")
-            .WithFormat(MangaFormat.Archive)
-            .WithVolume(new VolumeBuilder("1")
-                .WithChapter(new ChapterBuilder("1")
-                    .WithStoryArc("CreateReadingListsFromSeries")
-                    .WithStoryArcNumber("1")
-                    .Build())
-                .WithChapter(new ChapterBuilder("2").Build())
-                .Build())
-            .Build();
-
-        _readingListService.CreateReadingListsFromSeries(series.Item1)
-    }
+    // [Fact]
+    // public async Task CreateReadingListsFromSeries_ShouldCreateFromSinglePair()
+    // {
+    //     //await SetupData();
+    //
+    //     var series1 = new SeriesBuilder("Series 1")
+    //         .WithFormat(MangaFormat.Archive)
+    //         .WithVolume(new VolumeBuilder("1")
+    //             .WithChapter(new ChapterBuilder("1")
+    //                 .WithStoryArc("CreateReadingListsFromSeries")
+    //                 .WithStoryArcNumber("1")
+    //                 .Build())
+    //             .WithChapter(new ChapterBuilder("2").Build())
+    //             .Build())
+    //         .Build();
+    //
+    //     _readingListService.CreateReadingListsFromSeries(series.Item1)
+    // }
 
     #endregion
 }

--- a/API.Tests/Services/ReadingListServiceTests.cs
+++ b/API.Tests/Services/ReadingListServiceTests.cs
@@ -1203,11 +1203,68 @@ public class ReadingListServiceTests
 
     #region CreateReadingListsFromSeries
 
-    // [Fact]
-    // public async Task CreateReadingListsFromSeries_ShouldCreateFromSinglePair()
-    // {
-    //
-    // }
+    private async Task<Tuple<Series, Series>> SetupData()
+    {
+        // Setup 2 series, only do this once tho
+        if (await _unitOfWork.SeriesRepository.DoesSeriesNameExistInLibrary("Series 1", 1, MangaFormat.Archive))
+        {
+            return new Tuple<Series, Series>(await _unitOfWork.SeriesRepository.GetFullSeriesForSeriesIdAsync(1),
+                await _unitOfWork.SeriesRepository.GetFullSeriesForSeriesIdAsync(2));
+        }
+
+        var library =
+            await _unitOfWork.LibraryRepository.GetLibraryForIdAsync(1,
+                LibraryIncludes.Series | LibraryIncludes.AppUser);
+        var user = new AppUserBuilder("majora2007", "majora2007@fake.com").Build();
+        library!.AppUsers.Add(user);
+        library.ManageReadingLists = true;
+
+        // Setup the series for CreateReadingListsFromSeries
+        var series1 = new SeriesBuilder("Series 1")
+            .WithFormat(MangaFormat.Archive)
+            .WithVolume(new VolumeBuilder("1")
+                .WithChapter(new ChapterBuilder("1")
+                    .WithStoryArc("CreateReadingListsFromSeries")
+                    .WithStoryArcNumber("1")
+                    .Build())
+                .WithChapter(new ChapterBuilder("2").Build())
+                .Build())
+            .Build();
+
+        var series2 = new SeriesBuilder("Series 2")
+            .WithFormat(MangaFormat.Archive)
+            .WithVolume(new VolumeBuilder(API.Services.Tasks.Scanner.Parser.Parser.DefaultVolume)
+                .WithChapter(new ChapterBuilder("1").Build())
+                .WithChapter(new ChapterBuilder("2").Build())
+                .Build())
+            .Build();
+
+        library!.Series.Add(series1);
+        library!.Series.Add(series2);
+
+        await _unitOfWork.CommitAsync();
+
+        return new Tuple<Series, Series>(series1, series2);
+    }
+
+    [Fact]
+    public async Task CreateReadingListsFromSeries_ShouldCreateFromSinglePair()
+    {
+        //await SetupData();
+
+        var series1 = new SeriesBuilder("Series 1")
+            .WithFormat(MangaFormat.Archive)
+            .WithVolume(new VolumeBuilder("1")
+                .WithChapter(new ChapterBuilder("1")
+                    .WithStoryArc("CreateReadingListsFromSeries")
+                    .WithStoryArcNumber("1")
+                    .Build())
+                .WithChapter(new ChapterBuilder("2").Build())
+                .Build())
+            .Build();
+
+        _readingListService.CreateReadingListsFromSeries(series.Item1)
+    }
 
     #endregion
 }

--- a/API/Data/Repositories/UserRepository.cs
+++ b/API/Data/Repositories/UserRepository.cs
@@ -228,7 +228,7 @@ public class UserRepository : IUserRepository
     public async Task<AppUser> GetDefaultAdminUser()
     {
         return (await _userManager.GetUsersInRoleAsync(PolicyConstants.AdminRole))
-            .OrderByDescending(u => u.Created)
+            .OrderBy(u => u.Created)
             .First();
     }
 

--- a/API/Entities/Metadata/SeriesMetadata.cs
+++ b/API/Entities/Metadata/SeriesMetadata.cs
@@ -13,7 +13,7 @@ public class SeriesMetadata : IHasConcurrencyToken
 
     public string Summary { get; set; } = string.Empty;
 
-    public ICollection<CollectionTag> CollectionTags { get; set; } = null!;
+    public ICollection<CollectionTag> CollectionTags { get; set; } = new List<CollectionTag>();
 
     public ICollection<Genre> Genres { get; set; } = new List<Genre>();
     public ICollection<Tag> Tags { get; set; } = new List<Tag>();

--- a/API/Helpers/Builders/ChapterBuilder.cs
+++ b/API/Helpers/Builders/ChapterBuilder.cs
@@ -17,7 +17,7 @@ public class ChapterBuilder : IEntityBuilder<Chapter>
         {
             Range = string.IsNullOrEmpty(range) ? number : range,
             Title = string.IsNullOrEmpty(range) ? number : range,
-            Number = Services.Tasks.Scanner.Parser.Parser.MinNumberFromRange(number) + string.Empty,
+            Number = Parser.MinNumberFromRange(number) + string.Empty,
             Files = new List<MangaFile>(),
             Pages = 1
         };
@@ -42,9 +42,21 @@ public class ChapterBuilder : IEntityBuilder<Chapter>
         return this;
     }
 
-    private ChapterBuilder WithNumber(string number)
+    public ChapterBuilder WithNumber(string number)
     {
         _chapter.Number = number;
+        return this;
+    }
+
+    public ChapterBuilder WithStoryArc(string arc)
+    {
+        _chapter.StoryArc = arc;
+        return this;
+    }
+
+    public ChapterBuilder WithStoryArcNumber(string number)
+    {
+        _chapter.StoryArcNumber = number;
         return this;
     }
 

--- a/API/Helpers/PersonHelper.cs
+++ b/API/Helpers/PersonHelper.cs
@@ -103,6 +103,7 @@ public static class PersonHelper
         if (string.IsNullOrEmpty(person.Name)) return;
         var existingPerson = metadataPeople.FirstOrDefault(p =>
             p.NormalizedName == person.Name.ToNormalized() && p.Role == person.Role);
+
         if (existingPerson == null)
         {
             metadataPeople.Add(person);

--- a/API/Services/Tasks/Scanner/ProcessSeries.cs
+++ b/API/Services/Tasks/Scanner/ProcessSeries.cs
@@ -836,7 +836,7 @@ public class ProcessSeries : IProcessSeries
         {
             var allPeopleTypeRole = _people.Where(p => p.Role == role).ToList();
             _logger.LogTrace("[UpdatePeople] for {Role} and Names of {Names}", role, names);
-            _logger.LogTrace("[UpdatePeople] for {Role} found {@People}", role, allPeopleTypeRole);
+            _logger.LogTrace("[UpdatePeople] for {Role} found {@People}", role, allPeopleTypeRole.Select(p => new {p.Id, p.Name, SeriesMetadataIds = p.SeriesMetadatas?.Select(m => m.Id).ToList()}));
 
             foreach (var name in names)
             {

--- a/API/Services/Tasks/Scanner/ProcessSeries.cs
+++ b/API/Services/Tasks/Scanner/ProcessSeries.cs
@@ -223,7 +223,7 @@ public class ProcessSeries : IProcessSeries
             _logger.LogError(ex, "[ScannerService] There was an exception updating series for {SeriesName}", series.Name);
         }
 
-        await _metadataService.GenerateCoversForSeries(series, false);
+        await _metadataService.GenerateCoversForSeries(series, (await _unitOfWork.SettingsRepository.GetSettingsDtoAsync()).ConvertCoverToWebP);
         EnqueuePostSeriesProcessTasks(series.LibraryId, series.Id);
     }
 

--- a/API/Services/Tasks/Scanner/ProcessSeries.cs
+++ b/API/Services/Tasks/Scanner/ProcessSeries.cs
@@ -196,8 +196,9 @@ public class ProcessSeries : IProcessSeries
                 {
                     await _unitOfWork.RollbackAsync();
                     _logger.LogCritical(ex,
-                        "[ScannerService] There was an issue writing to the database for series {@SeriesName}",
+                        "[ScannerService] There was an issue writing to the database for series {SeriesName}",
                         series.Name);
+                    _logger.LogTrace("[ScannerService] Full Series Dump: {@Series}", series);
 
                     await _eventHub.SendMessageAsync(MessageFactory.Error,
                         MessageFactory.ErrorEvent($"There was an issue writing to the DB for Series {series}",
@@ -726,7 +727,18 @@ public class ProcessSeries : IProcessSeries
 
         void AddPerson(Person person)
         {
-            PersonHelper.AddPersonIfNotExists(chapter.People, person);
+            // TODO: Temp have code inlined to help debug foreign key constraint issue
+            //PersonHelper.AddPersonIfNotExists(chapter.People, person);
+            if (string.IsNullOrEmpty(person.Name)) return;
+            var existingPerson = chapter.People.FirstOrDefault(p =>
+                p.NormalizedName == person.Name.ToNormalized() && p.Role == person.Role);
+            _logger.LogTrace("[PersonHelper] Attempting to add {@Person} to {FileName} with ChapterID {ChapterId}, adding if not null: {@ExistingPerson}",
+                person, chapter.Files.FirstOrDefault()?.FilePath, chapter.Id, existingPerson);
+
+            if (existingPerson == null)
+            {
+                chapter.People.Add(person);
+            }
         }
 
         void AddGenre(Genre genre, bool newTag)
@@ -823,15 +835,19 @@ public class ProcessSeries : IProcessSeries
         lock (_peopleLock)
         {
             var allPeopleTypeRole = _people.Where(p => p.Role == role).ToList();
+            _logger.LogTrace("[UpdatePeople] for {Role} and Names of {Names}", role, names);
+            _logger.LogTrace("[UpdatePeople] for {Role} found {@People}", role, allPeopleTypeRole);
 
             foreach (var name in names)
             {
                 var normalizedName = name.ToNormalized();
                 var person = allPeopleTypeRole.FirstOrDefault(p =>
                     p.NormalizedName != null && p.NormalizedName.Equals(normalizedName));
+
                 if (person == null)
                 {
                     person = new PersonBuilder(name, role).Build();
+                    _logger.LogTrace("[UpdatePeople] for {Role} no one found, adding to _people", role);
                     _people.Add(person);
                 }
 

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -531,7 +531,7 @@ public class ScannerService : IScannerService
 
         _logger.LogInformation("[ScannerService] Finished file scan in {ScanAndUpdateTime} milliseconds. Updating database", scanElapsedTime);
 
-        var time = DateTime.UtcNow;
+        var time = DateTime.Now;
         foreach (var folderPath in library.Folders)
         {
             folderPath.UpdateLastScanned(time);

--- a/UI/Web/src/app/pipe/time-ago.pipe.ts
+++ b/UI/Web/src/app/pipe/time-ago.pipe.ts
@@ -33,11 +33,12 @@ and modified
 })
 export class TimeAgoPipe implements PipeTransform, OnDestroy {
 
-  private timer: number | null = null;
+	private timer: number | null = null;
 	constructor(private changeDetectorRef: ChangeDetectorRef, private ngZone: NgZone) {}
 	transform(value: string) {
 		this.removeTimer();
 		const d = new Date(value);
+		console.log('date: ', d);
 		const now = new Date();
 		const seconds = Math.round(Math.abs((now.getTime() - d.getTime()) / 1000));
 		const timeToUpdate = (Number.isNaN(seconds)) ? 1000 : this.getSecondsUntilUpdate(seconds) * 1000;
@@ -61,37 +62,37 @@ export class TimeAgoPipe implements PipeTransform, OnDestroy {
 			return '';
 		}
     
-    if (seconds <= 45) {
-			return 'just now';
-		}
-    if (seconds <= 90) {
-			return 'a minute ago';
-		}
-    if (minutes <= 45) {
-			return minutes + ' minutes ago';
-		}
-    if (minutes <= 90) {
-			return 'an hour ago';
-		}
-    if (hours <= 22) {
-			return hours + ' hours ago';
-		}
-    if (hours <= 36) {
-			return 'a day ago';
-		}
-    if (days <= 25) {
-			return days + ' days ago';
-		}
-    if (days <= 45) {
-			return 'a month ago';
-		}
-    if (days <= 345) {
-			return months + ' months ago';
-		}
-    if (days <= 545) {
-			return 'a year ago';
-		}
-    return years + ' years ago';
+		if (seconds <= 45) {
+				return 'just now';
+			}
+		if (seconds <= 90) {
+				return 'a minute ago';
+			}
+		if (minutes <= 45) {
+				return minutes + ' minutes ago';
+			}
+		if (minutes <= 90) {
+				return 'an hour ago';
+			}
+		if (hours <= 22) {
+				return hours + ' hours ago';
+			}
+		if (hours <= 36) {
+				return 'a day ago';
+			}
+		if (days <= 25) {
+				return days + ' days ago';
+			}
+		if (days <= 45) {
+				return 'a month ago';
+			}
+		if (days <= 345) {
+				return months + ' months ago';
+			}
+		if (days <= 545) {
+				return 'a year ago';
+			}
+		return years + ' years ago';
 	}
 
 	ngOnDestroy(): void {

--- a/UI/Web/src/app/reading-list/_modals/edit-reading-list-modal/edit-reading-list-modal.component.html
+++ b/UI/Web/src/app/reading-list/_modals/edit-reading-list-modal/edit-reading-list-modal.component.html
@@ -58,7 +58,7 @@
                                 aria-describedby="starting-year-header">
                                 <div id="inviteForm-validations" class="invalid-feedback" *ngIf="reviewGroup.dirty || reviewGroup.touched">
                                     <div *ngIf="formControl.errors?.min || formControl.errors?.max">
-                                        Must be between 1 and 12 or blank
+                                        Must be greater than 1000, 0 or blank
                                     </div>
                                 </div>
                             </div>
@@ -84,7 +84,7 @@
                                 aria-describedby="ending-year-header">
                                 <div id="inviteForm-validations" class="invalid-feedback" *ngIf="reviewGroup.dirty || reviewGroup.touched">
                                     <div *ngIf="formControl.errors?.min || formControl.errors?.max">
-                                        Must be between 1 and 12 or blank
+                                        Must be greater than 1000, 0 or blank
                                     </div>
                                 </div>
                             </div>
@@ -109,7 +109,7 @@
 </div>
 <div class="modal-footer">
     <button type="button" class="btn btn-secondary" (click)="close()">Close</button>
-    <button type="submit" class="btn btn-primary" [disabled]="!reviewGroup.valid" (click)="save()">Save</button>
+    <button type="submit" class="btn btn-primary" (click)="save()">Save</button>
 </div>
 
 

--- a/UI/Web/src/app/reading-list/_modals/edit-reading-list-modal/edit-reading-list-modal.component.ts
+++ b/UI/Web/src/app/reading-list/_modals/edit-reading-list-modal/edit-reading-list-modal.component.ts
@@ -116,6 +116,8 @@ export class EditReadingListModalComponent implements OnInit, OnDestroy {
 
   updateSelectedIndex(index: number) {
     this.coverImageIndex = index;
+    console.log(this.coverImageIndex)
+    this.cdRef.detectChanges();
   }
 
   updateSelectedImage(url: string) {

--- a/UI/Web/src/app/registration/user-login/user-login.component.html
+++ b/UI/Web/src/app/registration/user-login/user-login.component.html
@@ -12,7 +12,7 @@
                     <div class="mb-2">
                         <label for="password" class="form-label visually-hidden">Password</label>
                         <input class="form-control custom-input" formControlName="password" name="password"
-                         id="password" type="password" ngModel pattern="^.{6,32}$" placeholder="Password">
+                         id="password" type="password" pattern="^.{6,32}$" placeholder="Password">
                         <div id="inviteForm-validations" class="invalid-feedback" *ngIf="loginForm.get('password')?.errors?.pattern"  >
                             <div class="" *ngIf="loginForm.get('password')?.errors?.pattern">
                                 Password must be between 6 and 32 characters in length


### PR DESCRIPTION
# Changed
- Changed: Added extremely verbose TRACE logging for the foreign constraint issue. This should not affect performance or many builds.
- Changed: When is there is a missing pair (aka StoryArc defined but missing number), we would drop the pair. Instead the number will be the last item in the reading list and warnings will be printed as this is likely not the intention. (develop) (Closes #1938 )

# Fixed
- Fixed: Fixed some bad validation messages on Edit Reading List modal  (develop)
- Fixed: Fixed a disabled save button on edit reading list modal which preventing updating cover image (develop)
- Fixed: Fixed a bug where after a series is scanned, generate covers for series didn't respect webp cover generation setting
- Fixed: Fixed library last scan being stored in Utc, but expected server time (Fixes #1935 )
- Fixed: Fixed a bug for reading list generation from ComicInfo where the default admin wasn't being selected correctly. (develop)
- Fixed: Fixed a bug where start and end dates for reading lists were not recalculated after generating/updated from ComicInfo (develop)

