### PR TITLE
More Fixes

### DIFF
--- a/API.Benchmark/ArchiveServiceBenchmark.cs
+++ b/API.Benchmark/ArchiveServiceBenchmark.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using API.Services;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Order;
+using EasyCaching.Core;
 using NSubstitute;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Formats.Png;
@@ -31,7 +32,7 @@ public class ArchiveServiceBenchmark
     public ArchiveServiceBenchmark()
     {
         _directoryService = new DirectoryService(null, new FileSystem());
-        _imageService = new ImageService(null, _directoryService);
+        _imageService = new ImageService(null, _directoryService, Substitute.For<IEasyCachingProviderFactory>());
         _archiveService = new ArchiveService(new NullLogger<ArchiveService>(), _directoryService, _imageService, Substitute.For<IMediaErrorService>());
     }
 

--- a/API.Tests/Parser/MangaParserTests.cs
+++ b/API.Tests/Parser/MangaParserTests.cs
@@ -197,6 +197,7 @@ public class MangaParserTests
     [InlineData("Esquire 6권 2021년 10월호", "Esquire")]
     [InlineData("Accel World: Vol 1", "Accel World")]
     [InlineData("Accel World Chapter 001 Volume 002", "Accel World")]
+    [InlineData("Bleach 001-003", "Bleach")]
     public void ParseSeriesTest(string filename, string expected)
     {
         Assert.Equal(expected, API.Services.Tasks.Scanner.Parser.Parser.ParseSeries(filename));
@@ -281,6 +282,7 @@ public class MangaParserTests
     [InlineData("Манга 2 Глава", "2")]
     [InlineData("Манга Том 1 2 Глава", "2")]
     [InlineData("Accel World Chapter 001 Volume 002", "1")]
+    [InlineData("Bleach 001-003", "1-3")]
     public void ParseChaptersTest(string filename, string expected)
     {
         Assert.Equal(expected, API.Services.Tasks.Scanner.Parser.Parser.ParseChapter(filename));

--- a/API.Tests/Services/ArchiveServiceTests.cs
+++ b/API.Tests/Services/ArchiveServiceTests.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using API.Archive;
 using API.Entities.Enums;
 using API.Services;
+using EasyCaching.Core;
 using Microsoft.Extensions.Logging;
 using NetVips;
 using NSubstitute;
@@ -28,7 +29,7 @@ public class ArchiveServiceTests
     {
         _testOutputHelper = testOutputHelper;
         _archiveService = new ArchiveService(_logger, _directoryService,
-            new ImageService(Substitute.For<ILogger<ImageService>>(), _directoryService),
+            new ImageService(Substitute.For<ILogger<ImageService>>(), _directoryService, Substitute.For<IEasyCachingProviderFactory>()),
             Substitute.For<IMediaErrorService>());
     }
 
@@ -166,7 +167,7 @@ public class ArchiveServiceTests
     public void GetCoverImage_Default_Test(string inputFile, string expectedOutputFile)
     {
         var ds = Substitute.For<DirectoryService>(_directoryServiceLogger, new FileSystem());
-        var imageService = new ImageService(Substitute.For<ILogger<ImageService>>(), ds);
+        var imageService = new ImageService(Substitute.For<ILogger<ImageService>>(), ds, Substitute.For<IEasyCachingProviderFactory>());
         var archiveService =  Substitute.For<ArchiveService>(_logger, ds, imageService, Substitute.For<IMediaErrorService>());
 
         var testDirectory = Path.GetFullPath(Path.Join(Directory.GetCurrentDirectory(), "../../../Services/Test Data/ArchiveService/CoverImages"));
@@ -197,7 +198,7 @@ public class ArchiveServiceTests
     [InlineData("sorting.zip", "sorting.expected.png")]
     public void GetCoverImage_SharpCompress_Test(string inputFile, string expectedOutputFile)
     {
-        var imageService = new ImageService(Substitute.For<ILogger<ImageService>>(), _directoryService);
+        var imageService = new ImageService(Substitute.For<ILogger<ImageService>>(), _directoryService, Substitute.For<IEasyCachingProviderFactory>());
         var archiveService =  Substitute.For<ArchiveService>(_logger,
             new DirectoryService(_directoryServiceLogger, new FileSystem()), imageService,
             Substitute.For<IMediaErrorService>());

--- a/API.Tests/Services/BookServiceTests.cs
+++ b/API.Tests/Services/BookServiceTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO;
 using System.IO.Abstractions;
 using API.Services;
+using EasyCaching.Core;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using Xunit;
@@ -16,7 +17,7 @@ public class BookServiceTests
     {
         var directoryService = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), new FileSystem());
         _bookService = new BookService(_logger, directoryService,
-            new ImageService(Substitute.For<ILogger<ImageService>>(), directoryService)
+            new ImageService(Substitute.For<ILogger<ImageService>>(), directoryService, Substitute.For<IEasyCachingProviderFactory>())
             , Substitute.For<IMediaErrorService>());
     }
 

--- a/API/API.csproj
+++ b/API/API.csproj
@@ -56,6 +56,7 @@
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
     <PackageReference Include="CsvHelper" Version="30.0.1" />
     <PackageReference Include="Docnet.Core" Version="2.4.0-alpha.4" />
+    <PackageReference Include="EasyCaching.InMemory" Version="1.9.0" />
     <PackageReference Include="ExCSS" Version="4.1.0" />
     <PackageReference Include="Flurl" Version="3.0.7" />
     <PackageReference Include="Flurl.Http" Version="3.2.4" />

--- a/API/Controllers/DownloadController.cs
+++ b/API/Controllers/DownloadController.cs
@@ -117,7 +117,7 @@ public class DownloadController : BaseApiController
     private ActionResult GetFirstFileDownload(IEnumerable<MangaFile> files)
     {
         var (zipFile, contentType, fileDownloadName) = _downloadService.GetFirstFileDownload(files);
-        return PhysicalFile(zipFile, contentType, fileDownloadName, true);
+        return PhysicalFile(zipFile, contentType, System.Web.HttpUtility.UrlEncode(fileDownloadName), true);
     }
 
     /// <summary>
@@ -163,7 +163,7 @@ public class DownloadController : BaseApiController
             await _eventHub.SendMessageAsync(MessageFactory.NotificationProgress,
                 MessageFactory.DownloadProgressEvent(User.GetUsername(),
                     Path.GetFileNameWithoutExtension(downloadName), 1F, "ended"));
-            return PhysicalFile(filePath, DefaultContentType, downloadName, true);
+            return PhysicalFile(filePath, DefaultContentType, System.Web.HttpUtility.UrlEncode(downloadName), true);
         }
         catch (Exception ex)
         {
@@ -220,7 +220,7 @@ public class DownloadController : BaseApiController
             MessageFactory.DownloadProgressEvent(username, Path.GetFileNameWithoutExtension(filename), 1F));
 
 
-        return PhysicalFile(filePath, DefaultContentType, filename, true);
+        return PhysicalFile(filePath, DefaultContentType, System.Web.HttpUtility.UrlEncode(filename), true);
     }
 
 }

--- a/API/Controllers/ServerController.cs
+++ b/API/Controllers/ServerController.cs
@@ -150,7 +150,8 @@ public class ServerController : BaseApiController
         try
         {
             var zipPath =  _archiveService.CreateZipForDownload(files, "logs");
-            return PhysicalFile(zipPath, "application/zip", Path.GetFileName(zipPath), true);
+            return PhysicalFile(zipPath, "application/zip",
+                System.Web.HttpUtility.UrlEncode(Path.GetFileName(zipPath)), true);
         }
         catch (KavitaException ex)
         {

--- a/API/Controllers/SettingsController.cs
+++ b/API/Controllers/SettingsController.cs
@@ -214,7 +214,14 @@ public class SettingsController : BaseApiController
                     ? $"{path}/"
                     : path;
                 setting.Value = path;
-                Configuration.BaseUrl = updateSettingsDto.BaseUrl;
+                try
+                {
+                    Configuration.BaseUrl = updateSettingsDto.BaseUrl;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Could not set base url. Give this exception to majora2007");
+                }
                 _unitOfWork.SettingsRepository.Update(setting);
             }
 

--- a/API/Controllers/UsersController.cs
+++ b/API/Controllers/UsersController.cs
@@ -33,6 +33,9 @@ public class UsersController : BaseApiController
         var user = await _unitOfWork.UserRepository.GetUserByUsernameAsync(username);
         _unitOfWork.UserRepository.Delete(user);
 
+        //(TODO: After updating a role or removing a user, delete their token)
+        // await _userManager.RemoveAuthenticationTokenAsync(user, TokenOptions.DefaultProvider, RefreshTokenName);
+
         if (await _unitOfWork.CommitAsync()) return Ok();
 
         return BadRequest("Could not delete the user.");

--- a/API/Data/Metadata/ComicInfo.cs
+++ b/API/Data/Metadata/ComicInfo.cs
@@ -153,7 +153,7 @@ public class ComicInfo
         info.CoverArtist = Services.Tasks.Scanner.Parser.Parser.CleanAuthor(info.CoverArtist);
 
         // We need to convert GTIN to ISBN
-        if (!string.IsNullOrEmpty(info.GTIN) && ArticleNumberHelper.IsValidGtin(info.GTIN))
+        if (!string.IsNullOrEmpty(info.GTIN))
         {
             // This is likely a valid ISBN
             if (info.GTIN[0] == '0')
@@ -163,9 +163,10 @@ public class ComicInfo
                 {
                     info.Isbn = potentialISBN;
                 }
-
+            } else if (ArticleNumberHelper.IsValidIsbn10(info.GTIN) || ArticleNumberHelper.IsValidIsbn13(info.GTIN))
+            {
+                info.Isbn = info.GTIN;
             }
-
         }
     }
 

--- a/API/Extensions/ApplicationServiceExtensions.cs
+++ b/API/Extensions/ApplicationServiceExtensions.cs
@@ -22,9 +22,7 @@ public static class ApplicationServiceExtensions
         services.AddAutoMapper(typeof(AutoMapperProfiles).Assembly);
 
         services.AddScoped<IUnitOfWork, UnitOfWork>();
-        services.AddScoped<IDirectoryService, DirectoryService>();
         services.AddScoped<ITokenService, TokenService>();
-        services.AddScoped<IFileSystem, FileSystem>();
         services.AddScoped<IFileService, FileService>();
         services.AddScoped<ICacheHelper, CacheHelper>();
 
@@ -35,7 +33,6 @@ public static class ApplicationServiceExtensions
         services.AddScoped<IBackupService, BackupService>();
         services.AddScoped<ICleanupService, CleanupService>();
         services.AddScoped<IBookService, BookService>();
-        services.AddScoped<IImageService, ImageService>();
         services.AddScoped<IVersionUpdaterService, VersionUpdaterService>();
         services.AddScoped<IDownloadService, DownloadService>();
         services.AddScoped<IReaderService, ReaderService>();
@@ -59,11 +56,20 @@ public static class ApplicationServiceExtensions
         services.AddScoped<ITachiyomiService, TachiyomiService>();
         services.AddScoped<ICollectionTagService, CollectionTagService>();
 
-        services.AddScoped<IPresenceTracker, PresenceTracker>();
+        services.AddScoped<IFileSystem, FileSystem>();
+        services.AddScoped<IDirectoryService, DirectoryService>();
         services.AddScoped<IEventHub, EventHub>();
+        services.AddScoped<IPresenceTracker, PresenceTracker>();
+
+        services.AddScoped<IImageService, ImageService>();
 
         services.AddSqLite(env);
         services.AddSignalR(opt => opt.EnableDetailedErrors = true);
+
+        services.AddEasyCaching(options =>
+        {
+            options.UseInMemory("favicon");
+        });
     }
 
     private static void AddSqLite(this IServiceCollection services, IHostEnvironment env)

--- a/API/Services/BookService.cs
+++ b/API/Services/BookService.cs
@@ -437,6 +437,7 @@ public class BookService : IBookService
 
             foreach (var identifier in epubBook.Schema.Package.Metadata.Identifiers.Where(id => id.Scheme.Equals("ISBN")))
             {
+                if (string.IsNullOrEmpty(identifier.Identifier)) continue;
                 var isbn = identifier.Identifier.Replace("urn:isbn:", string.Empty).Replace("isbn:", string.Empty);
                 if (!ArticleNumberHelper.IsValidIsbn10(isbn) && !ArticleNumberHelper.IsValidIsbn13(isbn))
                 {

--- a/API/Services/BookService.cs
+++ b/API/Services/BookService.cs
@@ -437,8 +437,12 @@ public class BookService : IBookService
 
             foreach (var identifier in epubBook.Schema.Package.Metadata.Identifiers.Where(id => id.Scheme.Equals("ISBN")))
             {
-                var isbn = identifier.Identifier.Replace("urn:isbn:", string.Empty);
-                if (!ArticleNumberHelper.IsValidIsbn10(isbn) && !ArticleNumberHelper.IsValidIsbn13(isbn)) continue;
+                var isbn = identifier.Identifier.Replace("urn:isbn:", string.Empty).Replace("isbn:", string.Empty);
+                if (!ArticleNumberHelper.IsValidIsbn10(isbn) && !ArticleNumberHelper.IsValidIsbn13(isbn))
+                {
+                    _logger.LogDebug("[BookService] {File} has invalid ISBN number", filePath);
+                    continue;
+                }
                 info.Isbn = isbn;
                 break;
             }

--- a/API/Services/ImageService.cs
+++ b/API/Services/ImageService.cs
@@ -221,7 +221,7 @@ public class ImageService : IImageService
             var pngLinks = htmlDocument.DocumentNode.Descendants("link")
                 .Where(link => ValidIconRelations.Contains(link.GetAttributeValue("rel", string.Empty)))
                 .Select(link => link.GetAttributeValue("href", string.Empty))
-                .Where(href => href.EndsWith(".png") || href.EndsWith(".PNG"))
+                .Where(href => href.Split("?")[0].EndsWith(".png", StringComparison.InvariantCultureIgnoreCase))
                 .ToList();
 
             if (pngLinks == null)

--- a/API/Services/ImageService.cs
+++ b/API/Services/ImageService.cs
@@ -80,7 +80,8 @@ public class ImageService : IImageService
     private static readonly string[] ValidIconRelations = {
         "icon",
         "apple-touch-icon",
-        "apple-touch-icon-precomposed"
+        "apple-touch-icon-precomposed",
+        "apple-touch-icon icon-precomposed" // ComicVine has it combined
     };
 
     /// <summary>

--- a/API/Services/ReadingListService.cs
+++ b/API/Services/ReadingListService.cs
@@ -496,12 +496,13 @@ public class ReadingListService : IReadingListService
                 }
 
                 readingList.Items = items;
+
+                if (!_unitOfWork.HasChanges()) continue;
+
                 await CalculateReadingListAgeRating(readingList);
-                if (_unitOfWork.HasChanges())
-                {
-                    await _unitOfWork.CommitAsync();
-                }
-                await CalculateStartAndEndDates(await _unitOfWork.ReadingListRepository.GetReadingListByTitleAsync(arcPair.Item1, user.Id, ReadingListIncludes.Items | ReadingListIncludes.ItemChapter));
+                await _unitOfWork.CommitAsync(); // TODO: See if we can avoid this extra commit by reworking bottom logic
+                await CalculateStartAndEndDates(await _unitOfWork.ReadingListRepository.GetReadingListByTitleAsync(arcPair.Item1,
+                    user.Id, ReadingListIncludes.Items | ReadingListIncludes.ItemChapter));
                 await _unitOfWork.CommitAsync();
             }
         }

--- a/API/Services/Tasks/Scanner/Parser/Parser.cs
+++ b/API/Services/Tasks/Scanner/Parser/Parser.cs
@@ -323,7 +323,7 @@ public static class Parser
             MatchOptions, RegexTimeout),
         // [BAA]_Darker_than_Black_Omake-1, Bleach 001-002, Kodoja #001 (March 2016)
         new Regex(
-            @"^(?!Vol)(?<Series>.+?)(-|_|\s|#)\d+(-\d+)?",
+            @"^(?!Vol)(?!Chapter)(?<Series>.+?)(-|_|\s|#)\d+(-\d+)?",
             MatchOptions, RegexTimeout),
         // Baketeriya ch01-05.zip, Akiiro Bousou Biyori - 01.jpg, Beelzebub_172_RHS.zip, Cynthia the Mission 29.rar, A Compendium of Ghosts - 031 - The Third Story_ Part 12 (Digital) (Cobalt001)
         new Regex(

--- a/API/Services/Tasks/Scanner/Parser/Parser.cs
+++ b/API/Services/Tasks/Scanner/Parser/Parser.cs
@@ -321,13 +321,9 @@ public static class Parser
         new Regex(
             @"(?<Series>.*)( ?- ?)Ch\.\d+-?\d*",
             MatchOptions, RegexTimeout),
-        // [BAA]_Darker_than_Black_Omake-1.zip
+        // [BAA]_Darker_than_Black_Omake-1, Bleach 001-002, Kodoja #001 (March 2016)
         new Regex(
-            @"^(?!Vol)(?<Series>.*)(-)\d+-?\d*", // This catches a lot of stuff ^(?!Vol)(?<Series>.*)( |_)(\d+)
-            MatchOptions, RegexTimeout),
-        // Kodoja #001 (March 2016)
-        new Regex(
-            @"(?<Series>.*)(\s|_|-)#",
+            @"^(?!Vol)(?<Series>.+?)(-|_|\s|#)\d+(-\d+)?",
             MatchOptions, RegexTimeout),
         // Baketeriya ch01-05.zip, Akiiro Bousou Biyori - 01.jpg, Beelzebub_172_RHS.zip, Cynthia the Mission 29.rar, A Compendium of Ghosts - 031 - The Third Story_ Part 12 (Digital) (Cobalt001)
         new Regex(

--- a/API/Services/Tasks/Scanner/ProcessSeries.cs
+++ b/API/Services/Tasks/Scanner/ProcessSeries.cs
@@ -346,6 +346,8 @@ public class ProcessSeries : IProcessSeries
         }
 
 
+        #region People
+
         // Handle People
         foreach (var chapter in chapters)
         {
@@ -489,6 +491,8 @@ public class ProcessSeries : IProcessSeries
                         break;
                 }
             });
+
+        #endregion
 
     }
 

--- a/API/Services/Tasks/StatsService.cs
+++ b/API/Services/Tasks/StatsService.cs
@@ -34,7 +34,7 @@ public class StatsService : IStatsService
     private readonly IUnitOfWork _unitOfWork;
     private readonly DataContext _context;
     private readonly IStatisticService _statisticService;
-    private const string ApiUrl = "http://localhost:5003";
+    private const string ApiUrl = "https://stats.kavitareader.com";
 
     public StatsService(ILogger<StatsService> logger, IUnitOfWork unitOfWork, DataContext context, IStatisticService statisticService)
     {

--- a/API/Services/TokenService.cs
+++ b/API/Services/TokenService.cs
@@ -90,12 +90,12 @@ public class TokenService : ITokenService
                 Token = await CreateToken(user),
                 RefreshToken = await CreateRefreshToken(user)
             };
-        } catch (SecurityTokenExpiredException)
+        } catch (SecurityTokenExpiredException ex)
         {
             // Handle expired token
             return null;
         }
-        catch (Exception)
+        catch (Exception ex)
         {
             // Handle other exceptions
             return null;

--- a/API/config/appsettings.Development.json
+++ b/API/config/appsettings.Development.json
@@ -2,5 +2,5 @@
   "TokenKey": "super secret unguessable key that is longer because we require it",
   "Port": 5000,
   "IpAddresses": "",
-  "BaseUrl": "/joe/"
+  "BaseUrl": "/"
 }

--- a/UI/Web/src/app/admin/manage-alerts/manage-alerts.component.html
+++ b/UI/Web/src/app/admin/manage-alerts/manage-alerts.component.html
@@ -2,14 +2,12 @@
 
 <form [formGroup]="formGroup">
     <div class="row g-0 mb-3">
-        <div class="col-md-10">
+        <div class="col-md-12">
             <label for="filter" class="visually-hidden">Filter</label>
             <div class="input-group">
                 <input id="filter" type="text" class="form-control" placeholder="Filter" formControlName="filter" />
+                <button class="btn btn-primary" type="button" (click)="clear()">Clear Alerts</button>
             </div>
-        </div>
-        <div class="col-md-2">
-            <button class="btn btn-primary mb-2" (click)="clear()">Clear Alerts</button>
         </div>
     </div>
 </form>

--- a/UI/Web/src/app/admin/manage-alerts/manage-alerts.component.html
+++ b/UI/Web/src/app/admin/manage-alerts/manage-alerts.component.html
@@ -1,6 +1,18 @@
 <p>This table contains issues found during scan or reading of your media. This list is non-managed. You can clear it at any time and use Library (Force) Scan to perform analysis.</p>
 
-<button class="btn btn-primary mb-2" (click)="clear()">Clear Alerts</button>
+<form [formGroup]="formGroup">
+    <div class="row g-0 mb-3">
+        <div class="col-md-10">
+            <label for="filter" class="visually-hidden">Filter</label>
+            <div class="input-group">
+                <input id="filter" type="text" class="form-control" placeholder="Filter" formControlName="filter" />
+            </div>
+        </div>
+        <div class="col-md-2">
+            <button class="btn btn-primary mb-2" (click)="clear()">Clear Alerts</button>
+        </div>
+    </div>
+</form>
 <table class="table table-light table-hover table-sm table-hover">
     <thead #header>
         <tr>
@@ -20,20 +32,22 @@
     </thead>
     <tbody #container>
         <tr *ngIf="isLoading"><td colspan="4" style="text-align: center;"><app-loading [loading]="isLoading"></app-loading></td></tr>
-        <tr *ngIf="data.length === 0 && !isLoading"><td colspan="4" style="text-align: center;">No issues</td></tr>
-        <tr *ngFor="let item of data; index as i">
-            <td>
-              {{item.extension}}
-            </td>
-            <td>
-              {{item.filePath}}
-            </td>
-            <td>
-              {{item.comment}}
-            </td>
-            <td>
-              {{item.details}}
-            </td>
-        </tr>
+        <ng-container *ngIf="data | filter: filterList as filteredData">
+            <tr *ngIf="filteredData.length === 0 && !isLoading"><td colspan="4" style="text-align: center;">No issues</td></tr>
+            <tr *ngFor="let item of filteredData; index as i">
+                <td>
+                {{item.extension}}
+                </td>
+                <td>
+                {{item.filePath}}
+                </td>
+                <td>
+                {{item.comment}}
+                </td>
+                <td>
+                {{item.details}}
+                </td>
+            </tr>
+        </ng-container>
     </tbody>
 </table>

--- a/UI/Web/src/app/admin/manage-alerts/manage-alerts.component.ts
+++ b/UI/Web/src/app/admin/manage-alerts/manage-alerts.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, OnInit, QueryList, ViewChildren, inject } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, OnInit, Output, QueryList, ViewChildren, inject } from '@angular/core';
 import { BehaviorSubject, Observable, Subject, combineLatest, filter, map, shareReplay, takeUntil } from 'rxjs';
 import { SortEvent, SortableHeader, compare } from 'src/app/_single-module/table/_directives/sortable-header.directive';
 import { KavitaMediaError } from '../_models/media-error';
@@ -13,6 +13,7 @@ import { EVENTS, MessageHubService } from 'src/app/_services/message-hub.service
 })
 export class ManageAlertsComponent implements OnInit {
 
+  @Output() alertCount = new EventEmitter<number>();
   @ViewChildren(SortableHeader<KavitaMediaError>) headers!: QueryList<SortableHeader<KavitaMediaError>>;
   private readonly serverService = inject(ServerService); 
   private readonly messageHub = inject(MessageHubService); 
@@ -63,8 +64,7 @@ export class ManageAlertsComponent implements OnInit {
     this.serverService.getMediaErrors().subscribe(d => {
       this.data = d;
       this.isLoading = false;
-      console.log(this.data)
-      console.log(this.isLoading)
+      this.alertCount.emit(d.length);
       this.cdRef.detectChanges();
     });
   }

--- a/UI/Web/src/app/admin/manage-alerts/manage-alerts.component.ts
+++ b/UI/Web/src/app/admin/manage-alerts/manage-alerts.component.ts
@@ -4,6 +4,7 @@ import { SortEvent, SortableHeader, compare } from 'src/app/_single-module/table
 import { KavitaMediaError } from '../_models/media-error';
 import { ServerService } from 'src/app/_services/server.service';
 import { EVENTS, MessageHubService } from 'src/app/_services/message-hub.service';
+import { FormControl, FormGroup } from '@angular/forms';
 
 @Component({
   selector: 'app-manage-alerts',
@@ -26,6 +27,9 @@ export class ManageAlertsComponent implements OnInit {
 
   data: Array<KavitaMediaError> = [];
   isLoading = true;
+  formGroup = new FormGroup({
+    filter: new FormControl('', [])
+  });
   
 
   constructor() {}
@@ -71,5 +75,10 @@ export class ManageAlertsComponent implements OnInit {
 
   clear() {
     this.serverService.clearMediaAlerts().subscribe(_ => this.loadData());
+  }
+
+  filterList = (listItem: KavitaMediaError) => {
+    const query = (this.formGroup.get('filter')?.value || '').toLowerCase();
+    return listItem.comment.toLowerCase().indexOf(query) >= 0 || listItem.filePath.toLowerCase().indexOf(query) >= 0 || listItem.details.indexOf(query) >= 0;
   }
 }

--- a/UI/Web/src/app/admin/manage-media-settings/manage-media-settings.component.html
+++ b/UI/Web/src/app/admin/manage-media-settings/manage-media-settings.component.html
@@ -37,13 +37,13 @@
         </div>
     </form>
 
-    <ngb-accordion #a="ngbAccordion">
+    <ngb-accordion #a="ngbAccordion" [destroyOnHide]="false">
         <ngb-panel>
             <ng-template ngbPanelTitle>
-                Media Issues
+                Media Issues <span class="ms-1" *ngIf="alertCount > 0">({{alertCount}})</span>
             </ng-template>
             <ng-template ngbPanelContent>
-                <app-manage-alerts></app-manage-alerts>
+                <app-manage-alerts (alertCount)="alertCount = $event"></app-manage-alerts>
             </ng-template>
         </ngb-panel>
     </ngb-accordion>

--- a/UI/Web/src/app/admin/manage-media-settings/manage-media-settings.component.ts
+++ b/UI/Web/src/app/admin/manage-media-settings/manage-media-settings.component.ts
@@ -18,6 +18,8 @@ export class ManageMediaSettingsComponent implements OnInit {
   serverSettings!: ServerSettings;
   settingsForm: FormGroup = new FormGroup({});
 
+  alertCount: number = 0;
+
   get EncodeFormats() { return EncodeFormats; }
   
   constructor(private settingsService: SettingsService, private toastr: ToastrService, private modalService: NgbModal, ) { }

--- a/UI/Web/src/app/shared/_services/download.service.ts
+++ b/UI/Web/src/app/shared/_services/download.service.ts
@@ -55,6 +55,7 @@ export class DownloadService {
   private downloadsSource: BehaviorSubject<DownloadEvent[]> = new BehaviorSubject<DownloadEvent[]>([]);
   public activeDownloads$ = this.downloadsSource.asObservable();
 
+
   constructor(private httpClient: HttpClient, private confirmService: ConfirmService, 
     @Inject(SAVER) private save: Saver, private accountService: AccountService) { }
 
@@ -159,7 +160,7 @@ export class DownloadService {
     ).pipe(
       throttleTime(DEBOUNCE_TIME, asyncScheduler, { leading: true, trailing: true }), 
       download((blob, filename) => {
-        this.save(blob, filename);
+        this.save(blob, decodeURIComponent(filename));
       }),
       tap((d) => this.updateDownloadState(d, downloadType, subtitle)),
       finalize(() => this.finalizeDownloadState(downloadType, subtitle))
@@ -174,7 +175,7 @@ export class DownloadService {
             ).pipe(
               throttleTime(DEBOUNCE_TIME, asyncScheduler, { leading: true, trailing: true }), 
               download((blob, filename) => {
-                this.save(blob, filename);
+                this.save(blob, decodeURIComponent(filename));
               }),
               tap((d) => this.updateDownloadState(d, downloadType, subtitle)),
               finalize(() => this.finalizeDownloadState(downloadType, subtitle))
@@ -213,7 +214,7 @@ export class DownloadService {
         ).pipe(
           throttleTime(DEBOUNCE_TIME, asyncScheduler, { leading: true, trailing: true }), 
           download((blob, filename) => {
-            this.save(blob, filename);
+            this.save(blob, decodeURIComponent(filename));
           }),
           tap((d) => this.updateDownloadState(d, downloadType, subtitle)),
           finalize(() => this.finalizeDownloadState(downloadType, subtitle))
@@ -228,7 +229,7 @@ export class DownloadService {
             ).pipe(
               throttleTime(DEBOUNCE_TIME, asyncScheduler, { leading: true, trailing: true }), 
               download((blob, filename) => {
-                this.save(blob, filename);
+                this.save(blob, decodeURIComponent(filename));
               }),
               tap((d) => this.updateDownloadState(d, downloadType, subtitle)),
               finalize(() => this.finalizeDownloadState(downloadType, subtitle))
@@ -248,7 +249,7 @@ export class DownloadService {
             ).pipe(
               throttleTime(DEBOUNCE_TIME, asyncScheduler, { leading: true, trailing: true }), 
               download((blob, filename) => {
-                this.save(blob, filename);
+                this.save(blob, decodeURIComponent(filename));
               }),
               tap((d) => this.updateDownloadState(d, downloadType, subtitle)),
               finalize(() => this.finalizeDownloadState(downloadType, subtitle))

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,6 +27,9 @@ if [ ! -f "/kavita/config/appsettings.json" ]; then
     fi
 fi
 
+echo "App setting permissions"
+echo ls -l "/kavita/config/appsettings.json"
+
 chmod +x Kavita
 
 ./Kavita

--- a/openapi.json
+++ b/openapi.json
@@ -7,7 +7,7 @@
       "name": "GPL-3.0",
       "url": "https://github.com/Kareadita/Kavita/blob/develop/LICENSE"
     },
-    "version": "0.7.2.6"
+    "version": "0.7.2.7"
   },
   "servers": [
     {


### PR DESCRIPTION
# Changed
- Changed: From ComicInfo.xml, when parsing the GTIN, allow anything in there, but only save valid ISBN-10 and ISBN-13 numbers to Kavita. (develop)
- Changed: Show the count of Media Issues even before you expand the accordion (develop)
- Changed: Added filtering to the Media Issues table (develop)
- Changed: Expanded icon parsing code to fix ComicVine (develop)
- Changed: When trying to download favicons, only try once, and after failure, don't retry until server restart (develop)

# Fixed
- Fixed: Strip just 'isbn:' from epub isbns  (develop)
- Fixed: Fixed a bug where Kavita couldn't parse Series name when there was no volume/chapter keywords and a chapter range (ie Series 001-003) (Fixes #1975 )
- Fixed: Encode filenames before sending them to the UI for downloading (Fixes #1958 )
- Fixed: Added support to parse ComicInfo.xml when they have empty single tags (Fixes #1981 )
- Fixed: Fixed the stats url being incorrect (develop)