### PR TITLE
More Polish 

### DIFF
--- a/API/Data/Seed.cs
+++ b/API/Data/Seed.cs
@@ -144,4 +144,14 @@ public static class Seed
         }
         await context.SaveChangesAsync();
     }
+
+    // /// <summary>
+    // /// Responsible to copy (not overwrite) a set of favicons that Kavita can't parse from websites.
+    // /// </summary>
+    // /// <param name="directoryService"></param>
+    // /// <returns></returns>
+    // public static Task SeedFavicons(IDirectoryService directoryService)
+    // {
+    //
+    // }
 }

--- a/API/Services/TokenService.cs
+++ b/API/Services/TokenService.cs
@@ -97,7 +97,7 @@ public class TokenService : ITokenService
             }
 
             var validated = await _userManager.VerifyUserTokenAsync(user, TokenOptions.DefaultProvider, RefreshTokenName, request.RefreshToken);
-            if (!validated && tokenContent.ValidTo > DateTime.UtcNow.Add(TimeSpan.FromHours(1)))
+            if (!validated && tokenContent.ValidTo <= DateTime.UtcNow.Add(TimeSpan.FromHours(1)))
             {
                 _logger.LogDebug("[RefreshToken] failed to validate due to invalid refresh token");
                 return null;

--- a/UI/Web/src/app/admin/manage-alerts/manage-alerts.component.html
+++ b/UI/Web/src/app/admin/manage-alerts/manage-alerts.component.html
@@ -1,4 +1,6 @@
-<p>This table contains issues found during scan or reading of your media. This list is non-managed. You can clear it at any time and use Library (Force) Scan to perform analysis.</p>
+<p>This table contains issues found during scan or reading of your media. This list is non-managed.
+  You can clear it at any time and use Library (Force) Scan to perform analysis. A list of some common errors and what
+  they mean can be found on the <a rel="noopener noreferrer" target="_blank" href="https://wiki.kavitareader.com/en/guides/managing-your-files/scanner#media-errors">wiki</a>.</p>
 
 <form [formGroup]="formGroup">
     <div class="row g-0 mb-3">

--- a/openapi.json
+++ b/openapi.json
@@ -7,7 +7,7 @@
       "name": "GPL-3.0",
       "url": "https://github.com/Kareadita/Kavita/blob/develop/LICENSE"
     },
-    "version": "0.7.2.12"
+    "version": "0.7.2.13"
   },
   "servers": [
     {


### PR DESCRIPTION
# Added
- Added: Epubs can now use the refines=file-as to explicitly set sort title, which will override taking from belongs-to-collection or calibre:series
- Added: Weblinks can now fallback to Kavita hosted favicons (on our main site), thus enabling a way for the community to submit ones which Kavita cannot parse that will benefit all installs. 

# Changed
- Changed: Media errors page now has a link to the wiki with common errors and what they mean

# Fixed
- Fixed: Fixed the hack to reduce JWT refresh token expiration (develop)
- Fixed: Fixed a case where favicon downloading wasn't correcting links that started with // (develop)
