### PR TITLE
Fix StoryArc & StoryArcNumber mismatch

### DIFF
--- a/API/Services/ReadingListService.cs
+++ b/API/Services/ReadingListService.cs
@@ -519,6 +519,14 @@ public class ReadingListService : IReadingListService
         {
             _logger.LogWarning("There is a mismatch on StoryArc and StoryArcNumber for {FileName}. Def", filename);
         }
+        // ensure that both arrays are the same length
+        if (arcNumbers.Length < arcs.Length)
+        {
+            Array.Resize(ref arcNumbers, arcs.Length);
+        } else if (arcs.Length < arcNumbers.Length)
+        {
+            Array.Resize(ref arcs, arcNumbers.Length);
+        }
 
         var maxPairs = Math.Min(arcs.Length, arcNumbers.Length);
         for (var i = 0; i < maxPairs; i++)

--- a/API/Services/ReadingListService.cs
+++ b/API/Services/ReadingListService.cs
@@ -517,27 +517,20 @@ public class ReadingListService : IReadingListService
         var arcNumbers = storyArcNumbers.Split(",", StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
         if (arcNumbers.Count(s => !string.IsNullOrEmpty(s)) != arcs.Length)
         {
-            _logger.LogWarning("There is a mismatch on StoryArc and StoryArcNumber for {FileName}. Def", filename);
-        }
-        // ensure that both arrays are the same length
-        if (arcNumbers.Length < arcs.Length)
-        {
-            Array.Resize(ref arcNumbers, arcs.Length);
-        } else if (arcs.Length < arcNumbers.Length)
-        {
-            Array.Resize(ref arcs, arcNumbers.Length);
+            _logger.LogWarning("There is a mismatch on StoryArc and StoryArcNumber for {FileName}", filename);
         }
 
-        var maxPairs = Math.Min(arcs.Length, arcNumbers.Length);
+        var maxPairs = Math.Max(arcs.Length, arcNumbers.Length);
         for (var i = 0; i < maxPairs; i++)
         {
-            // When there is a mismatch on arcs and arc numbers, then we should default to a high number
-            if (string.IsNullOrEmpty(arcNumbers[i]) && !string.IsNullOrEmpty(arcs[i]))
+            var arcNumber = int.MaxValue.ToString();
+            if (arcNumbers.Length > i)
             {
-                arcNumbers[i] = int.MaxValue.ToString();
+                arcNumber = arcNumbers[i];
             }
-            if (string.IsNullOrEmpty(arcs[i]) || !int.TryParse(arcNumbers[i], out _)) continue;
-            data.Add(new Tuple<string, string>(arcs[i], arcNumbers[i]));
+
+            if (string.IsNullOrEmpty(arcs[i]) || !int.TryParse(arcNumber, out _)) continue;
+            data.Add(new Tuple<string, string>(arcs[i], arcNumber));
         }
 
         return data;

--- a/API/Services/ReadingListService.cs
+++ b/API/Services/ReadingListService.cs
@@ -513,8 +513,8 @@ public class ReadingListService : IReadingListService
         var data = new List<Tuple<string, string>>();
         if (string.IsNullOrEmpty(storyArc)) return data;
 
-        var arcs = storyArc.Split(",");
-        var arcNumbers = storyArcNumbers.Split(",");
+        var arcs = storyArc.Split(",", StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+        var arcNumbers = storyArcNumbers.Split(",", StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
         if (arcNumbers.Count(s => !string.IsNullOrEmpty(s)) != arcs.Length)
         {
             _logger.LogWarning("There is a mismatch on StoryArc and StoryArcNumber for {FileName}. Def", filename);
@@ -537,7 +537,7 @@ public class ReadingListService : IReadingListService
                 arcNumbers[i] = int.MaxValue.ToString();
             }
             if (string.IsNullOrEmpty(arcs[i]) || !int.TryParse(arcNumbers[i], out _)) continue;
-            data.Add(new Tuple<string, string>(arcs[i].Trim(), arcNumbers[i]));
+            data.Add(new Tuple<string, string>(arcs[i], arcNumbers[i]));
         }
 
         return data;

--- a/API/Services/ReadingListService.cs
+++ b/API/Services/ReadingListService.cs
@@ -537,7 +537,7 @@ public class ReadingListService : IReadingListService
                 arcNumbers[i] = int.MaxValue.ToString();
             }
             if (string.IsNullOrEmpty(arcs[i]) || !int.TryParse(arcNumbers[i], out _)) continue;
-            data.Add(new Tuple<string, string>(arcs[i], arcNumbers[i]));
+            data.Add(new Tuple<string, string>(arcs[i].Trim(), arcNumbers[i]));
         }
 
         return data;


### PR DESCRIPTION
# Fixed
- Fixed: Fixed processing logic error that if StoryArcNumber is empty, then multiple StoryArc's are not processed (similar would occur if multiple StoryArcNumber's are present for a single StoryArc).
- Fixed: Fixed inclusion of spaces in multiple StoryArc's due to ', ' as a common CSV format.