### PR TITLE
Correct not-read badge position

### DIFF
--- a/UI/Web/src/app/cards/list-item/list-item.component.scss
+++ b/UI/Web/src/app/cards/list-item/list-item.component.scss
@@ -29,7 +29,7 @@ $image-width: 160px;
 .not-read-badge {
     position: absolute;
     top: 8px;
-    left: 108px;
+    left: 110px;
     width: 0;
     height: 0;
     border-style: solid;


### PR DESCRIPTION
# Fixed
- Fixed: Fixed the not-read badge not being flush against the edge of the book cover in list-item page.

Before:
![image](https://github.com/Hobogrammer/Kavita/assets/1426720/295eba59-9d2e-443b-86b3-83928e287fdc)

After:
![image](https://github.com/Hobogrammer/Kavita/assets/1426720/94291297-447e-457f-9550-012014285277)

