### PR TITLE
Remove From On Deck

### DIFF
--- a/API/Controllers/SeriesController.cs
+++ b/API/Controllers/SeriesController.cs
@@ -285,6 +285,18 @@ public class SeriesController : BaseApiController
     }
 
     /// <summary>
+    /// Removes a series from displaying on deck until the next read event on that series
+    /// </summary>
+    /// <param name="seriesId"></param>
+    /// <returns></returns>
+    [HttpPost("remove-from-on-deck")]
+    public async Task<ActionResult> RemoveFromOnDeck([FromQuery] int seriesId)
+    {
+        await _unitOfWork.SeriesRepository.RemoveFromOnDeck(seriesId, User.GetUserId());
+        return Ok();
+    }
+
+    /// <summary>
     /// Runs a Cover Image Generation task
     /// </summary>
     /// <param name="refreshSeriesDto"></param>

--- a/API/Controllers/SettingsController.cs
+++ b/API/Controllers/SettingsController.cs
@@ -182,6 +182,24 @@ public class SettingsController : BaseApiController
                 _unitOfWork.SettingsRepository.Update(setting);
             }
 
+            if (setting.Key == ServerSettingKey.OnDeckProgressDays && updateSettingsDto.OnDeckProgressDays + string.Empty != setting.Value)
+            {
+                setting.Value = updateSettingsDto.OnDeckProgressDays + string.Empty;
+                _unitOfWork.SettingsRepository.Update(setting);
+            }
+
+            if (setting.Key == ServerSettingKey.OnDeckUpdateDays && updateSettingsDto.OnDeckUpdateDays + string.Empty != setting.Value)
+            {
+                setting.Value = updateSettingsDto.OnDeckUpdateDays + string.Empty;
+                _unitOfWork.SettingsRepository.Update(setting);
+            }
+
+            if (setting.Key == ServerSettingKey.TaskScan && updateSettingsDto.TaskScan != setting.Value)
+            {
+                setting.Value = updateSettingsDto.TaskScan;
+                _unitOfWork.SettingsRepository.Update(setting);
+            }
+
             if (setting.Key == ServerSettingKey.Port && updateSettingsDto.Port + string.Empty != setting.Value)
             {
                 if (OsInfo.IsDocker) continue;

--- a/API/DTOs/Settings/ServerSettingDTO.cs
+++ b/API/DTOs/Settings/ServerSettingDTO.cs
@@ -76,4 +76,12 @@ public class ServerSettingDto
     /// The size in MB for Caching API data
     /// </summary>
     public long CacheSize { get; set; }
+    /// <summary>
+    /// How many Days since today in the past for reading progress, should content be considered for On Deck, before it gets removed automatically
+    /// </summary>
+    public int OnDeckProgressDays { get; set; }
+    /// <summary>
+    /// How many Days since today in the past for chapter updates, should content be considered for On Deck, before it gets removed automatically
+    /// </summary>
+    public int OnDeckUpdateDays { get; set; }
 }

--- a/API/Data/DataContext.cs
+++ b/API/Data/DataContext.cs
@@ -52,6 +52,7 @@ public sealed class DataContext : IdentityDbContext<AppUser, AppRole, int,
     public DbSet<ScrobbleEvent> ScrobbleEvent { get; set; } = null!;
     public DbSet<ScrobbleError> ScrobbleError { get; set; } = null!;
     public DbSet<ScrobbleHold> ScrobbleHold { get; set; } = null!;
+    public DbSet<AppUserOnDeckRemoval> AppUserOnDeckRemoval { get; set; } = null!;
 
 
     protected override void OnModelCreating(ModelBuilder builder)

--- a/API/Data/Migrations/20230715125951_OnDeckRemoval.Designer.cs
+++ b/API/Data/Migrations/20230715125951_OnDeckRemoval.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using API.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace API.Data.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20230715125951_OnDeckRemoval")]
+    partial class OnDeckRemoval
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "7.0.8");

--- a/API/Data/Migrations/20230715125951_OnDeckRemoval.cs
+++ b/API/Data/Migrations/20230715125951_OnDeckRemoval.cs
@@ -1,0 +1,93 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace API.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class OnDeckRemoval : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Title",
+                table: "ReadingList",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "TEXT",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "NormalizedTitle",
+                table: "ReadingList",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "TEXT",
+                oldNullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "AppUserOnDeckRemoval",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    SeriesId = table.Column<int>(type: "INTEGER", nullable: false),
+                    AppUserId = table.Column<int>(type: "INTEGER", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AppUserOnDeckRemoval", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_AppUserOnDeckRemoval_AspNetUsers_AppUserId",
+                        column: x => x.AppUserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_AppUserOnDeckRemoval_Series_SeriesId",
+                        column: x => x.SeriesId,
+                        principalTable: "Series",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AppUserOnDeckRemoval_AppUserId",
+                table: "AppUserOnDeckRemoval",
+                column: "AppUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AppUserOnDeckRemoval_SeriesId",
+                table: "AppUserOnDeckRemoval",
+                column: "SeriesId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "AppUserOnDeckRemoval");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Title",
+                table: "ReadingList",
+                type: "TEXT",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "TEXT");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "NormalizedTitle",
+                table: "ReadingList",
+                type: "TEXT",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "TEXT");
+        }
+    }
+}

--- a/API/Data/Repositories/SeriesRepository.cs
+++ b/API/Data/Repositories/SeriesRepository.cs
@@ -14,6 +14,7 @@ using API.DTOs.Metadata;
 using API.DTOs.ReadingLists;
 using API.DTOs.Search;
 using API.DTOs.SeriesDetail;
+using API.DTOs.Settings;
 using API.Entities;
 using API.Entities.Enums;
 using API.Entities.Metadata;
@@ -757,8 +758,14 @@ public class SeriesRepository : ISeriesRepository
     /// <returns></returns>
     public async Task<PagedList<SeriesDto>> GetOnDeck(int userId, int libraryId, UserParams userParams, FilterDto filter)
     {
-        var cutoffProgressPoint = DateTime.Now - TimeSpan.FromDays(30);
-        var cutoffLastAddedPoint = DateTime.Now - TimeSpan.FromDays(7);
+        var settings = await _context.ServerSetting
+            .Select(x => x)
+            .AsNoTracking()
+            .ToListAsync();
+        var serverSettings = _mapper.Map<ServerSettingDto>(settings);
+
+        var cutoffProgressPoint = DateTime.Now - TimeSpan.FromDays(serverSettings.OnDeckProgressDays);
+        var cutoffLastAddedPoint = DateTime.Now - TimeSpan.FromDays(serverSettings.OnDeckUpdateDays);
 
         var libraryIds = GetLibraryIdsForUser(userId, libraryId, QueryContext.Dashboard)
             .Where(id => libraryId == 0 || id == libraryId);

--- a/API/Data/Seed.cs
+++ b/API/Data/Seed.cs
@@ -108,6 +108,8 @@ public static class Seed
             new() {Key = ServerSettingKey.HostName, Value = string.Empty},
             new() {Key = ServerSettingKey.EncodeMediaAs, Value = EncodeFormat.PNG.ToString()},
             new() {Key = ServerSettingKey.LicenseKey, Value = string.Empty},
+            new() {Key = ServerSettingKey.OnDeckProgressDays, Value = $"{30}"},
+            new() {Key = ServerSettingKey.OnDeckUpdateDays, Value = $"{7}"},
             new() {
                 Key = ServerSettingKey.CacheSize, Value = Configuration.DefaultCacheMemory + string.Empty
             }, // Not used from DB, but DB is sync with appSettings.json

--- a/API/Entities/AppUser.cs
+++ b/API/Entities/AppUser.cs
@@ -37,6 +37,10 @@ public class AppUser : IdentityUser<int>, IHasConcurrencyToken
     /// </summary>
     public ICollection<Device> Devices { get; set; } = null!;
     /// <summary>
+    /// A list of Series the user doesn't want on deck
+    /// </summary>
+    //public ICollection<Series> OnDeckRemovals { get; set; } = null!;
+    /// <summary>
     /// An API Key to interact with external services, like OPDS
     /// </summary>
     public string? ApiKey { get; set; }

--- a/API/Entities/AppUserOnDeckRemoval.cs
+++ b/API/Entities/AppUserOnDeckRemoval.cs
@@ -1,0 +1,11 @@
+﻿namespace API.Entities;
+
+public class AppUserOnDeckRemoval
+{
+    public int Id { get; set; }
+    public int SeriesId { get; set; }
+    public Series Series { get; set; }
+    public int AppUserId { get; set; }
+    public AppUser AppUser { get; set; }
+
+}

--- a/API/Entities/Enums/ServerSettingKey.cs
+++ b/API/Entities/Enums/ServerSettingKey.cs
@@ -133,5 +133,15 @@ public enum ServerSettingKey
     /// </summary>
     [Description("Cache")]
     CacheSize = 24,
+    /// <summary>
+    /// How many Days since today in the past for reading progress, should content be considered for On Deck, before it gets removed automatically
+    /// </summary>
+    [Description("OnDeckProgressDays")]
+    OnDeckProgressDays = 25,
+    /// <summary>
+    /// How many Days since today in the past for chapter updates, should content be considered for On Deck, before it gets removed automatically
+    /// </summary>
+    [Description("OnDeckUpdateDays")]
+    OnDeckUpdateDays = 26,
 
 }

--- a/API/Helpers/Converters/ServerSettingConverter.cs
+++ b/API/Helpers/Converters/ServerSettingConverter.cs
@@ -73,6 +73,12 @@ public class ServerSettingConverter : ITypeConverter<IEnumerable<ServerSetting>,
                 case ServerSettingKey.CacheSize:
                     destination.CacheSize = long.Parse(row.Value);
                     break;
+                case ServerSettingKey.OnDeckProgressDays:
+                    destination.OnDeckProgressDays = int.Parse(row.Value);
+                    break;
+                case ServerSettingKey.OnDeckUpdateDays:
+                    destination.OnDeckUpdateDays = int.Parse(row.Value);
+                    break;
             }
         }
 

--- a/API/Services/ReaderService.cs
+++ b/API/Services/ReaderService.cs
@@ -262,6 +262,7 @@ public class ReaderService : IReaderService
                     BookScrollId = progressDto.BookScrollId
                 });
                 _unitOfWork.UserRepository.Update(userWithProgress);
+                BackgroundJob.Enqueue(() => _unitOfWork.SeriesRepository.ClearOnDeckRemoval(progressDto.SeriesId, userId));
             }
             else
             {

--- a/UI/Web/src/app/_services/action-factory.service.ts
+++ b/UI/Web/src/app/_services/action-factory.service.ts
@@ -88,6 +88,10 @@ export enum Action {
    * Import some data into Kavita
    */
   Import = 18,
+  /**
+   * Removes the Series from On Deck inclusion
+   */
+  RemoveFromOnDeck = 19,
 }
 
 export interface ActionItem<T> {
@@ -563,9 +567,7 @@ export class ActionFactoryService {
 
   // Checks the whole tree for the action and returns true if it exists
   public hasAction(actions: Array<ActionItem<any>>, action: Action) {
-    var actionFound = false;
-
-    if (actions.length === 0) return actionFound;
+    if (actions.length === 0) return false;
 
     for (let i = 0; i < actions.length; i++)
     {
@@ -573,8 +575,7 @@ export class ActionFactoryService {
       if (this.hasAction(actions[i].children, action)) return true;
     }
 
-
-    return actionFound;
+    return false;
   }
 
 }

--- a/UI/Web/src/app/_services/series.service.ts
+++ b/UI/Web/src/app/_services/series.service.ts
@@ -226,4 +226,8 @@ export class SeriesService {
   getOverallRating(seriesId: number) {
     return this.httpClient.get<Rating>(this.baseUrl + 'rating/overall?seriesId=' + seriesId);
   }
+
+  removeFromOnDeck(seriesId: number) {
+    return this.httpClient.post(this.baseUrl + 'series/remove-from-on-deck?seriesId=' + seriesId, {});
+  }
 }

--- a/UI/Web/src/app/admin/_models/server-settings.ts
+++ b/UI/Web/src/app/admin/_models/server-settings.ts
@@ -18,4 +18,6 @@ export interface ServerSettings {
     enableFolderWatching: boolean;
     hostName: string;
     cacheSize: number;
+    onDeckProgressDays: number;
+    onDeckUpdateDays: number;
 }

--- a/UI/Web/src/app/admin/manage-settings/manage-settings.component.html
+++ b/UI/Web/src/app/admin/manage-settings/manage-settings.component.html
@@ -114,6 +114,38 @@
               </p>
             </ng-container>
           </div>
+          <div class="col-md-4 col-sm-12 pe-2">
+            <label for="on-deck-progress-days" class="form-label">On Deck Last Progress (days)</label>&nbsp;<i class="fa fa-info-circle" placement="right" [ngbTooltip]="onDeckProgressDaysTooltip" role="button" tabindex="0"></i>
+            <ng-template #onDeckProgressDaysTooltip>The number of days since last progress before kicking something off On Deck.</ng-template>
+            <span class="visually-hidden" id="on-deck-progress-days-help">The number of days since last progress before kicking something off On Deck.</span>
+            <input id="on-deck-progress-days" aria-describedby="on-deck-progress-days-help" class="form-control" formControlName="onDeckProgressDays"
+                   type="number" inputmode="numeric" step="1" min="1"
+                   [class.is-invalid]="settingsForm.get('onDeckProgressDays')?.invalid && settingsForm.get('onDeckProgressDays')?.touched">
+            <ng-container *ngIf="settingsForm.get('onDeckProgressDays')?.errors as errors">
+              <p class="invalid-feedback" *ngIf="errors.min">
+                Must be at least 1 day
+              </p>
+              <p class="invalid-feedback" *ngIf="errors.required">
+                This field is required
+              </p>
+            </ng-container>
+          </div>
+          <div class="col-md-4 col-sm-12 pe-2">
+            <label for="on-deck-update-days" class="form-label">On Deck Last Chapter Add (days)</label>&nbsp;<i class="fa fa-info-circle" placement="right" [ngbTooltip]="onDeckUpdateDaysTooltip" role="button" tabindex="0"></i>
+            <ng-template #onDeckUpdateDaysTooltip>The number of days since last chapter was added to include something On Deck.</ng-template>
+            <span class="visually-hidden" id="on-deck-update-days-help">The number of days since last chapter was added to include something On Deck.</span>
+            <input id="on-deck-update-days" aria-describedby="on-deck-update-days-help" class="form-control" formControlName="onDeckUpdateDays"
+                   type="number" inputmode="numeric" step="1" min="1"
+                   [class.is-invalid]="settingsForm.get('onDeckUpdateDays')?.invalid && settingsForm.get('onDeckUpdateDays')?.touched">
+            <ng-container *ngIf="settingsForm.get('onDeckUpdateDays')?.errors as errors">
+              <p class="invalid-feedback" *ngIf="errors.min">
+                Must be at least 1 day
+              </p>
+              <p class="invalid-feedback" *ngIf="errors.required">
+                This field is required
+              </p>
+            </ng-container>
+          </div>
         </div>
 
         <div class="mb-3 mt-3">
@@ -125,7 +157,6 @@
           </div>
         </div>
 
-        <!-- TODO: Move this to Plugins tab once we build out some basic tables -->
         <div class="mb-3">
             <label for="opds" aria-describedby="opds-info" class="form-label">OPDS</label>
             <p class="accent" id="opds-info">OPDS support will allow all users to use OPDS to read and download content from the server.</p>

--- a/UI/Web/src/app/admin/manage-settings/manage-settings.component.ts
+++ b/UI/Web/src/app/admin/manage-settings/manage-settings.component.ts
@@ -25,10 +25,6 @@ export class ManageSettingsComponent implements OnInit {
   taskFrequencies: Array<string> = [];
   logLevels: Array<string> = [];
 
-  get TagBadgeCursor() {
-    return TagBadgeCursor;
-  }
-
   constructor(private settingsService: SettingsService, private toastr: ToastrService,
     private serverService: ServerService) { }
 
@@ -57,6 +53,8 @@ export class ManageSettingsComponent implements OnInit {
       this.settingsForm.addControl('enableFolderWatching', new FormControl(this.serverSettings.enableFolderWatching, [Validators.required]));
       this.settingsForm.addControl('encodeMediaAs', new FormControl(this.serverSettings.encodeMediaAs, []));
       this.settingsForm.addControl('hostName', new FormControl(this.serverSettings.hostName, [Validators.pattern(/^(http:|https:)+[^\s]+[\w]$/)]));
+      this.settingsForm.addControl('onDeckProgressDays', new FormControl(this.serverSettings.onDeckProgressDays, [Validators.required]));
+      this.settingsForm.addControl('onDeckUpdateDays', new FormControl(this.serverSettings.onDeckUpdateDays, [Validators.required]));
 
       this.serverService.getServerInfo().subscribe(info => {
         if (info.isDocker) {
@@ -84,6 +82,8 @@ export class ManageSettingsComponent implements OnInit {
     this.settingsForm.get('encodeMediaAs')?.setValue(this.serverSettings.encodeMediaAs);
     this.settingsForm.get('hostName')?.setValue(this.serverSettings.hostName);
     this.settingsForm.get('cacheSize')?.setValue(this.serverSettings.cacheSize);
+    this.settingsForm.get('onDeckProgressDays')?.setValue(this.serverSettings.onDeckProgressDays);
+    this.settingsForm.get('onDeckUpdateDays')?.setValue(this.serverSettings.onDeckUpdateDays);
     this.settingsForm.markAsPristine();
   }
 

--- a/UI/Web/src/app/cards/series-card/series-card.component.ts
+++ b/UI/Web/src/app/cards/series-card/series-card.component.ts
@@ -8,16 +8,16 @@ import {
   OnInit,
   Output
 } from '@angular/core';
-import { Router } from '@angular/router';
-import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
-import { ToastrService } from 'ngx-toastr';
-import { Series } from 'src/app/_models/series';
-import { ImageService } from 'src/app/_services/image.service';
-import { ActionFactoryService, Action, ActionItem } from 'src/app/_services/action-factory.service';
-import { SeriesService } from 'src/app/_services/series.service';
-import { ActionService } from 'src/app/_services/action.service';
-import { EditSeriesModalComponent } from '../_modals/edit-series-modal/edit-series-modal.component';
-import { RelationKind } from 'src/app/_models/series-detail/relation-kind';
+import {Router} from '@angular/router';
+import {NgbModal} from '@ng-bootstrap/ng-bootstrap';
+import {ToastrService} from 'ngx-toastr';
+import {Series} from 'src/app/_models/series';
+import {ImageService} from 'src/app/_services/image.service';
+import {Action, ActionFactoryService, ActionItem} from 'src/app/_services/action-factory.service';
+import {SeriesService} from 'src/app/_services/series.service';
+import {ActionService} from 'src/app/_services/action.service';
+import {EditSeriesModalComponent} from '../_modals/edit-series-modal/edit-series-modal.component';
+import {RelationKind} from 'src/app/_models/series-detail/relation-kind';
 import {CommonModule} from "@angular/common";
 import {CardItemComponent} from "../card-item/card-item.component";
 import {RelationshipPipe} from "../../pipe/relationship.pipe";
@@ -47,6 +47,10 @@ export class SeriesCardComponent implements OnInit, OnChanges {
    * If the Series has a relationship to display
    */
   @Input() relation: RelationKind | undefined = undefined;
+  /**
+   * When a series card is shown on deck, a special actionable is added to the list
+   */
+  @Input() isOnDeck: boolean = false;
 
   @Output() clicked = new EventEmitter<Series>();
   /**
@@ -79,6 +83,19 @@ export class SeriesCardComponent implements OnInit, OnChanges {
   ngOnChanges(changes: any) {
     if (this.data) {
       this.actions = this.actionFactoryService.getSeriesActions((action: ActionItem<Series>, series: Series) => this.handleSeriesActionCallback(action, series));
+      if (this.isOnDeck) {
+        const othersIndex = this.actions.findIndex(obj => obj.title === 'Others');
+        if (this.actions[othersIndex].children.findIndex(o => o.action === Action.RemoveFromOnDeck) < 0) {
+          this.actions[othersIndex].children.push({
+            action: Action.RemoveFromOnDeck,
+            title: 'Remove From On Deck',
+            callback: (action: ActionItem<Series>, series: Series) => this.handleSeriesActionCallback(action, series),
+            class: 'danger',
+            requiresAdmin: false,
+            children: [],
+          });
+        }
+      }
       this.cdRef.markForCheck();
     }
   }
@@ -124,6 +141,9 @@ export class SeriesCardComponent implements OnInit, OnChanges {
       case Action.SendTo:
         const device = (action._extra!.data as Device);
         this.actionService.sendSeriesToDevice(series.id, device);
+        break;
+      case Action.RemoveFromOnDeck:
+        this.seriesService.removeFromOnDeck(series.id).subscribe(() => this.reload.emit(series.id));
         break;
       default:
         break;

--- a/UI/Web/src/app/dashboard/_components/dashboard.component.html
+++ b/UI/Web/src/app/dashboard/_components/dashboard.component.html
@@ -15,7 +15,8 @@
 
 <app-carousel-reel [items]="inProgress" title="On Deck" (sectionClick)="handleSectionClick($event)">
     <ng-template #carouselItem let-item let-position="idx">
-        <app-series-card [data]="item" [libraryId]="item.libraryId" [suppressLibraryLink]="libraryId !== 0" (reload)="reloadInProgress(item)" (dataChanged)="reloadInProgress($event)"></app-series-card>
+        <app-series-card [data]="item" [libraryId]="item.libraryId" [suppressLibraryLink]="libraryId !== 0" [isOnDeck]="true"
+                         (reload)="reloadInProgress($event)" (dataChanged)="reloadInProgress($event)"></app-series-card>
     </ng-template>
 </app-carousel-reel>
 

--- a/UI/Web/src/app/dashboard/_components/dashboard.component.ts
+++ b/UI/Web/src/app/dashboard/_components/dashboard.component.ts
@@ -120,15 +120,17 @@ export class DashboardComponent implements OnInit {
     this.loadRecentlyAddedSeries();
   }
 
-  reloadInProgress(series: Series | boolean) {
-    if (series === true || series === false) {
-      if (!series) {return;}
-    }
-    // If the update to Series doesn't affect the requirement to be in this stream, then ignore update request
-    const seriesObj = (series as Series);
-    if (seriesObj.pagesRead !== seriesObj.pages && seriesObj.pagesRead !== 0) {
-      return;
-    }
+  reloadInProgress(series: Series | number) {
+    // if (typeof series === 'number') {
+    //   this.loadOnDeck();
+    //   return;
+    // }
+    //
+    // // If the update to Series doesn't affect the requirement to be in this stream, then ignore update request
+    // const seriesObj = (series as Series);
+    // if (seriesObj.pagesRead !== seriesObj.pages && seriesObj.pagesRead !== 0) {
+    //   return;
+    // }
 
     this.loadOnDeck();
   }

--- a/openapi.json
+++ b/openapi.json
@@ -7,7 +7,7 @@
       "name": "GPL-3.0",
       "url": "https://github.com/Kareadita/Kavita/blob/develop/LICENSE"
     },
-    "version": "0.7.4.2"
+    "version": "0.7.4.3"
   },
   "servers": [
     {
@@ -15877,6 +15877,16 @@
             "type": "integer",
             "description": "The size in MB for Caching API data",
             "format": "int64"
+          },
+          "onDeckProgressDays": {
+            "type": "integer",
+            "description": "How many Days since today in the past for reading progress, should content be considered for On Deck, before it gets removed automatically",
+            "format": "int32"
+          },
+          "onDeckUpdateDays": {
+            "type": "integer",
+            "description": "How many Days since today in the past for chapter updates, should content be considered for On Deck, before it gets removed automatically",
+            "format": "int32"
           }
         },
         "additionalProperties": false

--- a/openapi.json
+++ b/openapi.json
@@ -7749,6 +7749,30 @@
         }
       }
     },
+    "/api/Series/remove-from-on-deck": {
+      "post": {
+        "tags": [
+          "Series"
+        ],
+        "summary": "Removes a series from displaying on deck until the next read event on that series",
+        "parameters": [
+          {
+            "name": "seriesId",
+            "in": "query",
+            "description": "",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
     "/api/Series/refresh-metadata": {
       "post": {
         "tags": [


### PR DESCRIPTION
# Added
- Added: Admins can now configure the amount of progress time or last item added range for on deck calculation
- Added: Added the ability for users to remove series from on deck. A series will no longer appear on 'On Deck' until a new chapter is read by that user.

# Changed
- Changed: (Performance) Reduced a DB lookup for many reader based APIs. 

