### PR TITLE
Preparation for Release

### DIFF
--- a/API.Tests/Parser/ParserTest.cs
+++ b/API.Tests/Parser/ParserTest.cs
@@ -225,6 +225,7 @@ public class ParserTests
     [InlineData("@Recently-Snapshot/Love Hina/", true)]
     [InlineData("@recycle/Love Hina/", true)]
     [InlineData("E:/Test/__MACOSX/Love Hina/", true)]
+    [InlineData("E:/Test/.caltrash/Love Hina/", true)]
     public void HasBlacklistedFolderInPathTest(string inputPath, bool expected)
     {
         Assert.Equal(expected, HasBlacklistedFolderInPath(inputPath));

--- a/API/DTOs/ChapterDto.cs
+++ b/API/DTOs/ChapterDto.cs
@@ -45,6 +45,10 @@ public class ChapterDto : IHasReadTimeEstimate, IEntityDate
     /// </summary>
     public DateTime LastReadingProgressUtc { get; set; }
     /// <summary>
+    /// The last time a chapter was read by current authenticated user
+    /// </summary>
+    public DateTime LastReadingProgress { get; set; }
+    /// <summary>
     /// If the Cover Image is locked for this entity
     /// </summary>
     public bool CoverImageLocked { get; set; }

--- a/API/Data/Repositories/ChapterRepository.cs
+++ b/API/Data/Repositories/ChapterRepository.cs
@@ -253,11 +253,13 @@ public class ChapterRepository : IChapterRepository
         {
             chapter.PagesRead = progress.PagesRead ;
             chapter.LastReadingProgressUtc = progress.LastModifiedUtc;
+            chapter.LastReadingProgress = progress.LastModified;
         }
         else
         {
             chapter.PagesRead = 0;
             chapter.LastReadingProgressUtc = DateTime.MinValue;
+            chapter.LastReadingProgress = DateTime.MinValue;
         }
 
         return chapter;

--- a/API/Data/Repositories/VolumeRepository.cs
+++ b/API/Data/Repositories/VolumeRepository.cs
@@ -238,6 +238,7 @@ public class VolumeRepository : IVolumeRepository
                 if (progresses.Count == 0) continue;
                 c.PagesRead = progresses.Sum(p => p.PagesRead);
                 c.LastReadingProgressUtc = progresses.Max(p => p.LastModifiedUtc);
+                c.LastReadingProgress = progresses.Max(p => p.LastModified);
             }
 
             v.PagesRead = userProgress.Where(p => p.VolumeId == v.Id).Sum(p => p.PagesRead);

--- a/API/Services/BookService.cs
+++ b/API/Services/BookService.cs
@@ -645,13 +645,13 @@ public class BookService : IBookService
         return Parser.CleanAuthor(person.Creator) + ",";
     }
 
-    private static (int year, int month, int day) GetPublicationDate(string publicationDate)
+    private static (int year, int month, int day) GetPublicationDate(string? publicationDate)
     {
-        var dateParsed = DateTime.TryParse(publicationDate, out var date);
         var year = 0;
         var month = 0;
         var day = 0;
-        switch (dateParsed)
+        if (string.IsNullOrEmpty(publicationDate)) return (year, month, day);
+        switch (DateTime.TryParse(publicationDate, out var date))
         {
             case true:
                 year = date.Year;

--- a/API/Services/DirectoryService.cs
+++ b/API/Services/DirectoryService.cs
@@ -83,7 +83,7 @@ public class DirectoryService : IDirectoryService
     private const RegexOptions MatchOptions = RegexOptions.Compiled | RegexOptions.IgnoreCase;
 
     private static readonly Regex ExcludeDirectories = new Regex(
-        @"@eaDir|\.DS_Store|\.qpkg|__MACOSX|@Recently-Snapshot|@recycle|\.@__thumb",
+        @"@eaDir|\.DS_Store|\.qpkg|__MACOSX|@Recently-Snapshot|@recycle|\.@__thumb|\.caltrash",
         MatchOptions,
         Tasks.Scanner.Parser.Parser.RegexTimeout);
     private static readonly Regex FileCopyAppend = new Regex(@"\(\d+\)",

--- a/API/Services/Plus/ScrobblingService.cs
+++ b/API/Services/Plus/ScrobblingService.cs
@@ -188,6 +188,7 @@ public class ScrobblingService : IScrobblingService
         if (series == null) throw new KavitaException("Series not found");
         var library = await _unitOfWork.LibraryRepository.GetLibraryForIdAsync(series.LibraryId);
         if (library is not {AllowScrobbling: true}) return;
+        if (library.Type == LibraryType.Comic) return;
 
         var existingEvt = await _unitOfWork.ScrobbleRepository.GetEvent(userId, series.Id,
             ScrobbleEventType.Review);
@@ -232,6 +233,7 @@ public class ScrobblingService : IScrobblingService
         if (series == null) throw new KavitaException("Series not found");
         var library = await _unitOfWork.LibraryRepository.GetLibraryForIdAsync(series.LibraryId);
         if (library is not {AllowScrobbling: true}) return;
+        if (library.Type == LibraryType.Comic) return;
 
         var existingEvt = await _unitOfWork.ScrobbleRepository.GetEvent(userId, series.Id,
             ScrobbleEventType.ScoreUpdated);
@@ -280,6 +282,7 @@ public class ScrobblingService : IScrobblingService
         }
         var library = await _unitOfWork.LibraryRepository.GetLibraryForIdAsync(series.LibraryId);
         if (library is not {AllowScrobbling: true}) return;
+        if (library.Type == LibraryType.Comic) return;
 
         var existingEvt = await _unitOfWork.ScrobbleRepository.GetEvent(userId, series.Id,
             ScrobbleEventType.ChapterRead);
@@ -339,6 +342,7 @@ public class ScrobblingService : IScrobblingService
         if (series == null) throw new KavitaException("Series not found");
         var library = await _unitOfWork.LibraryRepository.GetLibraryForIdAsync(series.LibraryId);
         if (library is not {AllowScrobbling: true}) return;
+        if (library.Type == LibraryType.Comic) return;
 
         var existing = await _unitOfWork.ScrobbleRepository.Exists(userId, series.Id,
             onWantToRead ? ScrobbleEventType.AddWantToRead : ScrobbleEventType.RemoveWantToRead);

--- a/API/Services/ReaderService.cs
+++ b/API/Services/ReaderService.cs
@@ -262,7 +262,6 @@ public class ReaderService : IReaderService
                     BookScrollId = progressDto.BookScrollId
                 });
                 _unitOfWork.UserRepository.Update(userWithProgress);
-                BackgroundJob.Enqueue(() => _unitOfWork.SeriesRepository.ClearOnDeckRemoval(progressDto.SeriesId, userId));
             }
             else
             {
@@ -286,6 +285,8 @@ public class ReaderService : IReaderService
                     // Inform Scrobble service that a chapter is read
                     BackgroundJob.Enqueue(() => _scrobblingService.ScrobbleReadingUpdate(user.Id, progressDto.SeriesId));
                 }
+
+                BackgroundJob.Enqueue(() => _unitOfWork.SeriesRepository.ClearOnDeckRemoval(progressDto.SeriesId, userId));
 
                 return true;
             }

--- a/API/Services/Tasks/Scanner/Parser/Parser.cs
+++ b/API/Services/Tasks/Scanner/Parser/Parser.cs
@@ -995,7 +995,9 @@ public static class Parser
     /// <returns></returns>
     public static bool HasBlacklistedFolderInPath(string path)
     {
-        return path.Contains("__MACOSX") || path.StartsWith("@Recently-Snapshot") || path.StartsWith("@recycle") || path.StartsWith("._") || Path.GetFileName(path).StartsWith("._") || path.Contains(".qpkg");
+        return path.Contains("__MACOSX") || path.StartsWith("@Recently-Snapshot") || path.StartsWith("@recycle")
+               || path.StartsWith("._") || Path.GetFileName(path).StartsWith("._") || path.Contains(".qpkg")
+               || path.Contains(".caltrash");
     }
 
 

--- a/API/Services/Tasks/Scanner/Parser/ParserInfo.cs
+++ b/API/Services/Tasks/Scanner/Parser/ParserInfo.cs
@@ -2,6 +2,7 @@
 using API.Entities.Enums;
 
 namespace API.Services.Tasks.Scanner.Parser;
+#nullable enable
 
 /// <summary>
 /// This represents all parsed information from a single file
@@ -12,7 +13,7 @@ public class ParserInfo
     /// Represents the parsed chapters from a file. By default, will be 0 which means nothing could be parsed.
     /// <remarks>The chapters can only be a single float or a range of float ie) 1-2. Mainly floats should be multiples of 0.5 representing specials</remarks>
     /// </summary>
-    public string Chapters { get; set; } = "";
+    public string Chapters { get; set; } = string.Empty;
     /// <summary>
     /// Represents the parsed series from the file or folder
     /// </summary>
@@ -31,17 +32,17 @@ public class ParserInfo
     /// <example>Beastars Vol 3-4 will map to "3-4"</example>
     /// <remarks>The volumes can only be a single int or a range of ints ie) 1-2. Float based volumes are not supported.</remarks>
     /// </summary>
-    public string Volumes { get; set; } = "";
+    public string Volumes { get; set; } = string.Empty;
     /// <summary>
     /// Filename of the underlying file
     /// <example>Beastars v01 (digital).cbz</example>
     /// </summary>
-    public string Filename { get; init; } = "";
+    public string Filename { get; init; } = string.Empty;
     /// <summary>
     /// Full filepath of the underlying file
     /// <example>C:/Manga/Beastars v01 (digital).cbz</example>
     /// </summary>
-    public string FullFilePath { get; set; } = "";
+    public string FullFilePath { get; set; } = string.Empty;
 
     /// <summary>
     /// <see cref="MangaFormat"/> that represents the type of the file
@@ -53,7 +54,7 @@ public class ParserInfo
     /// This can potentially story things like "Omnibus, Color, Full Contact Edition, Extra, Final, etc"
     /// </summary>
     /// <remarks>Not Used in Database</remarks>
-    public string Edition { get; set; } = "";
+    public string Edition { get; set; } = string.Empty;
 
     /// <summary>
     /// If the file contains no volume/chapter information or contains Special Keywords <see cref="Parser.MangaSpecialRegex"/>
@@ -72,7 +73,7 @@ public class ParserInfo
     /// <returns></returns>
     public bool IsSpecialInfo()
     {
-        return (IsSpecial || (Volumes == "0" && Chapters == "0"));
+        return (IsSpecial || (Volumes == Parser.DefaultVolume && Chapters == Parser.DefaultChapter));
     }
 
     /// <summary>
@@ -89,8 +90,8 @@ public class ParserInfo
     public void Merge(ParserInfo? info2)
     {
         if (info2 == null) return;
-        Chapters = string.IsNullOrEmpty(Chapters) || Chapters == "0" ? info2.Chapters: Chapters;
-        Volumes = string.IsNullOrEmpty(Volumes) || Volumes == "0" ? info2.Volumes : Volumes;
+        Chapters = string.IsNullOrEmpty(Chapters) || Chapters == Parser.DefaultChapter ? info2.Chapters: Chapters;
+        Volumes = string.IsNullOrEmpty(Volumes) || Volumes == Parser.DefaultVolume ? info2.Volumes : Volumes;
         Edition = string.IsNullOrEmpty(Edition) ? info2.Edition : Edition;
         Title = string.IsNullOrEmpty(Title) ? info2.Title : Title;
         Series = string.IsNullOrEmpty(Series) ? info2.Series : Series;

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -164,7 +164,7 @@ public class ScannerService : IScannerService
 
         var libraries = (await _unitOfWork.LibraryRepository.GetLibraryDtosAsync()).ToList();
         var libraryFolders = libraries.SelectMany(l => l.Folders);
-        var libraryFolder = libraryFolders.Select(Scanner.Parser.Parser.NormalizePath).SingleOrDefault(f => f.Contains(parentDirectory));
+        var libraryFolder = libraryFolders.Select(Scanner.Parser.Parser.NormalizePath).FirstOrDefault(f => f.Contains(parentDirectory));
 
         if (string.IsNullOrEmpty(libraryFolder)) return;
         var library = libraries.Find(l => l.Folders.Select(Parser.NormalizePath).Contains(libraryFolder));

--- a/Kavita.Common/Configuration.cs
+++ b/Kavita.Common/Configuration.cs
@@ -284,7 +284,7 @@ public static class Configuration
             var json = File.ReadAllText(filePath);
             var jsonObj = JsonSerializer.Deserialize<AppSettings>(json);
 
-            return jsonObj.Cache;
+            return jsonObj.Cache == 0 ? DefaultCacheMemory : jsonObj.Cache;
         }
         catch (Exception ex)
         {
@@ -324,13 +324,13 @@ public static class Configuration
     {
         public string TokenKey { get; set; }
         // ReSharper disable once MemberHidesStaticFromOuterClass
-        public int Port { get; set; }
+        public int Port { get; set; } = DefaultHttpPort;
         // ReSharper disable once MemberHidesStaticFromOuterClass
         public string IpAddresses { get; set; } = string.Empty;
         // ReSharper disable once MemberHidesStaticFromOuterClass
         public string BaseUrl { get; set; }
         // ReSharper disable once MemberHidesStaticFromOuterClass
-        public long Cache { get; set; }
+        public long Cache { get; set; } = DefaultCacheMemory;
         // ReSharper disable once MemberHidesStaticFromOuterClass
         public string XFrameOrigins { get; set; } = DefaultXFrameOptions;
     }

--- a/Kavita.Common/HashUtil.cs
+++ b/Kavita.Common/HashUtil.cs
@@ -64,8 +64,7 @@ public static class HashUtil
                 }
                 linux.AddMotherboardSerialNumber();
             })
-            .OnMac(mac => mac
-                .AddSystemDriveSerialNumber())
+            .OnMac(mac => mac.AddSystemDriveSerialNumber())
             .ToString();
         return CalculateCrc(seed);
     }

--- a/UI/Web/src/app/_models/chapter.ts
+++ b/UI/Web/src/app/_models/chapter.ts
@@ -26,7 +26,7 @@ export interface Chapter {
      * Actual name of the Chapter if populated in underlying metadata
      */
     titleName: string;
-    /** 
+    /**
      * Summary for the chapter
      */
     summary?: string;
@@ -43,4 +43,5 @@ export interface Chapter {
     volumeTitle?: string;
     webLinks: string;
     isbn: string;
+    lastReadingProgress: string;
 }

--- a/UI/Web/src/app/cards/entity-info-cards/entity-info-cards.component.html
+++ b/UI/Web/src/app/cards/entity-info-cards/entity-info-cards.component.html
@@ -94,5 +94,14 @@
                 </app-icon-and-title>
             </div>
         </ng-container>
+
+        <ng-container *ngIf="(chapter.lastReadingProgress | date: 'shortDate') !== '1/1/01'">
+          <div class="vr d-none d-lg-block m-2"></div>
+          <div class="col-auto">
+            <app-icon-and-title label="Last Read" [clickable]="false" fontClasses="fa-regular fa-clock" title="{{chapter.lastReadingProgress | date: 'medium'}}">
+              {{chapter.lastReadingProgress | date: 'shortDate'}}
+            </app-icon-and-title>
+          </div>
+        </ng-container>
     </ng-container>
 </div>

--- a/UI/Web/src/app/cards/entity-info-cards/entity-info-cards.component.ts
+++ b/UI/Web/src/app/cards/entity-info-cards/entity-info-cards.component.ts
@@ -1,5 +1,11 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnDestroy, OnInit, inject } from '@angular/core';
-import { Subject } from 'rxjs';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  Input,
+  OnInit,
+  inject,
+} from '@angular/core';
 import { UtilityService } from 'src/app/shared/_services/utility.service';
 import { Chapter } from 'src/app/_models/chapter';
 import { ChapterMetadata } from 'src/app/_models/metadata/chapter-metadata';
@@ -26,7 +32,7 @@ import {AgeRatingPipe} from "../../pipe/age-rating.pipe";
   styleUrls: ['./entity-info-cards.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class EntityInfoCardsComponent implements OnInit, OnDestroy {
+export class EntityInfoCardsComponent implements OnInit {
 
   @Input({required: true}) entity!: Volume | Chapter;
   /**
@@ -49,7 +55,6 @@ export class EntityInfoCardsComponent implements OnInit, OnDestroy {
   readingTime: HourEstimateRange = {maxHours: 1, minHours: 1, avgHours: 1};
   size: number = 0;
 
-  private readonly onDestroy: Subject<void> = new Subject();
   imageService = inject(ImageService);
 
   get LibraryType() {
@@ -68,6 +73,8 @@ export class EntityInfoCardsComponent implements OnInit, OnDestroy {
     if (this.chapter.webLinks === '') return [];
     return this.chapter.webLinks.split(',');
   }
+
+
 
   constructor(private utilityService: UtilityService, private seriesService: SeriesService, private readonly cdRef: ChangeDetectorRef) {}
 
@@ -119,8 +126,8 @@ export class EntityInfoCardsComponent implements OnInit, OnDestroy {
     this.cdRef.markForCheck();
   }
 
-  ngOnDestroy(): void {
-    this.onDestroy.next();
-    this.onDestroy.complete();
+  getTimezone(timezone: string): string {
+    const localDate = new Date(timezone);
+    return localDate.toLocaleString('en-US', { timeZoneName: 'short' }).split(' ')[3];
   }
 }

--- a/UI/Web/src/app/dashboard/_components/dashboard.component.ts
+++ b/UI/Web/src/app/dashboard/_components/dashboard.component.ts
@@ -121,17 +121,6 @@ export class DashboardComponent implements OnInit {
   }
 
   reloadInProgress(series: Series | number) {
-    // if (typeof series === 'number') {
-    //   this.loadOnDeck();
-    //   return;
-    // }
-    //
-    // // If the update to Series doesn't affect the requirement to be in this stream, then ignore update request
-    // const seriesObj = (series as Series);
-    // if (seriesObj.pagesRead !== seriesObj.pages && seriesObj.pagesRead !== 0) {
-    //   return;
-    // }
-
     this.loadOnDeck();
   }
 

--- a/openapi.json
+++ b/openapi.json
@@ -7,7 +7,7 @@
       "name": "GPL-3.0",
       "url": "https://github.com/Kareadita/Kavita/blob/develop/LICENSE"
     },
-    "version": "0.7.4.3"
+    "version": "0.7.4.4"
   },
   "servers": [
     {

--- a/openapi.json
+++ b/openapi.json
@@ -11740,6 +11740,11 @@
             "description": "The last time a chapter was read by current authenticated user",
             "format": "date-time"
           },
+          "lastReadingProgress": {
+            "type": "string",
+            "description": "The last time a chapter was read by current authenticated user",
+            "format": "date-time"
+          },
           "coverImageLocked": {
             "type": "boolean",
             "description": "If the Cover Image is locked for this entity"


### PR DESCRIPTION

Kavita+ will only scrobble the highest volume/chapter number now. So instead of always overriding what's in AniList, Kavita+ will ensure we are only setting a higher number. This is live for all installs now (Closes #2122 Closes #2123 )

# Added
- Added: Added the ability to see the last reading date for a volume or chapter in the details drawer. Hover over the clock to get the full timestamp.

# Changed
- Changed: (Kavita+) Don't allow Comic Libraries to do any scrobbling as there aren't any Comic Scrobbling providers yet
- Changed: A series will be included in on deck again after any reading progress, as epubs are usually just one file (develop)
- Changed: Ignore .caltrash folders during scan for users that use Calibre's managed directory as library folder (Closes #2132 )

# Fixed
- Fixed: Fixed a bug where if you have multiple libraries pointing to the same folder (for whatever reason), the Scan Folder api could be rejected.
- Fixed: Handle more appropriately if the publication date from an epub is empty to avoid a bad parse error
- Fixed: Fixed up the defaulting code for cache size
