### PR TITLE
v0.7.6 - Personal Table of Contents + Rating Overhaul

### DIFF
--- a/Kavita.Common/Kavita.Common.csproj
+++ b/Kavita.Common/Kavita.Common.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net7.0</TargetFramework>
         <Company>kavitareader.com</Company>
         <Product>Kavita</Product>
-        <AssemblyVersion>0.7.5.8</AssemblyVersion>
+        <AssemblyVersion>0.7.6.0</AssemblyVersion>
         <NeutralLanguage>en</NeutralLanguage>
         <TieredPGO>true</TieredPGO>
     </PropertyGroup>


### PR DESCRIPTION
v0.7.6 is here with a small feature enhancement of your own personal table of contents (named bookmarks for epub reader). I often find myself reading cooking books and while there is an official ToC, I often want to bookmark my favorite recipies with my own description. Well, now I can. This small feature opens up a lot of architecture for future epub related work. Do note this is not possible in the pdf reader. It has become clear that the current offerings for pdf reader is not flexible enough for the work I want to do and I have started planning a revamp of all things pdf within Kavita.

This release also adds Google Book rating support for Kavita+ users. While Google Books is not ideal, it is something and from internal testing, there is value add. I have found some other platforms and will be working to find some value add from them if possible. 

Lastly, ratings have been overhauled to allow half stars. You can now go from 0-5 with step increments of 0.5. For Kavita+ users, scrobbling is already aware of mapping to your target AniList rating scheme, so no change there. You can now also rate a series as 0 stars (but you should likely just delete the series). Series without a rating with show as N/A. This change should allow for more expressive ratings. 

In other news, Localization support is in progress. I've already worked on it for 50 hours and it looks like I have 50 hours more just to get the English foundation implemented. So let's expect v0.7.7 to be just localization. 

# Added
- Added: Added Personal Table of Contents (called Bookmarks on epub). The idea is that sometimes you want to bookmark certain parts of pages to get back to quickly later. This mechanism will allow you to do that without having to edit the underlying ToC. This is only available on epub currently. PDF Reader is planned.
- Added: (Kavita+) Google Play ratings will now show on normal books
- Added: (Kavita+) Added the ability to see the Series the Rating is matched with.  You will see an Entry in the tooltip of the rating.
- Added: New css variable --rating-star-color

# Changed
- Changed: Changed Kavita+ Payment link to support Google Pay
- Changed: Added a button to update modal to show how to update for those unaware
- Changed: Darkened the link text color on tables to make it more readable
- Changed: (Kavita+) When scrobbling, send the first and last times the series was read by the user. This will ensure a better completion and start data in AniList (this will not overwrite existing data)
- Changed: Updated the icons for MAL and AniList under rating icons to look cleaner.
- Changed: Moved the nightly backup job (if nightly) to 2am to prevent contention with other nightly maintenance items that might lock the db and prevent a copy from being made
- Changed: When calculating overall average rating of server, if only review is yours, don't include it.
- Changed: When calculating overall average rating of server, scale to percentage (* 20) to match all other rating scales.
- Changed: Ratings can now be decimals from 0-5 with a step of 0.5.
- Changed: Series without any rating will now show N/A to indicate the user hasn't added a rating yet. 0% now means the series is that bad.
- Changed: When calculating overall rating for a series from within the Server, don't include series that have not been rated
- Changed: List item cards on desktop will now show more properties, like size, weblinks, etc
- Changed: List items on series detail will now show Characters and Tags on desktop. These properties are helpful for more H related content.

# Fixed
- Fixed: Fixed default token key not being long enough and Kavita not auto-generating it (this may impact Kavita+ user's fingerprint. Just contact me for a reset)
- Fixed: Fixed duplicate events occurring on newly added series from a scan
- Fixed: Somehow the version update checker wasn't hooked up, it's back. It checks on startup and every 4-6 hours randomly.
- Fixed: Fixed backups not backing up favicons in the correct folder
- Fixed: Fixed the bookmark overlay on mobile to work with touch events. Since suppressing the native control, Kavita has a copy for the highlighted selection.
- Fixed: Fixed side nav on mobile without donate link not fully covering the height of the screen when no donation link is present
- Fixed: Only trigger the task conversion warning on Media screen if you've touched the appropriate control.
- Fixed: Fixed a bug where bookmark directory wasn't able to be changed.
- Fixed: Fixed a bug where see More wouldn't show if there were just characters due to missing that check. 
- Fixed: (Kavita+) If a chapter has a range 1-6 and is fully read, when calculating highest chapter for Scrobbling, use the 6.
- Fixed: Fixed a number of additional network calls occurring from editing series metadata
- Fixed: Don't try to backup the DB if it doesn't exist. This will stop errors in log on first start.
- Fixed: Fixed a bug where reading progress wouldn't add a series back onto On Deck

# Removed
- Removed: Removed manual Migrate Series Relations migration from v0.7 release (5 releases ago)
