### PR TITLE
[Docker] Make Kavita executable at Build time instead of Runtime 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
 EXPOSE 5000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ COPY _output/*.tar.gz /files/
 COPY UI/Web/dist /files/wwwroot
 COPY copy_runtime.sh /copy_runtime.sh
 RUN /copy_runtime.sh
+RUN chmod +x /Kavita/Kavita
 
 #Production image
 FROM ubuntu:focal

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,10 +27,8 @@ if [ ! -f "/kavita/config/appsettings.json" ]; then
     fi
 fi
 
-echo "App setting permissions"
+echo "Starting Kavita"
 echo ls -l "/kavita/config/appsettings.json"
-
-chmod +x Kavita
 
 ./Kavita
 


### PR DESCRIPTION
# Fixed
- Fixed: Makes Kavita program and the entrypoint script executable, which removes the need to do that on every startup of the container, additionally is one step closer (still needs other changes) to potentially make the docker image run as rootless. (Fixes: https://github.com/Kareadita/Kavita/issues/1889)
