### PR TITLE
[skip ci] Update en.json to include additional information about folder monitoring only triggering every 10 minutes

### DIFF
--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -1129,7 +1129,7 @@
         "opds-tooltip": "OPDS support will allow all users to use OPDS to read and download content from the server.",
         "enable-opds": "Enable OPDS",
         "folder-watching-label": "Folder Watching",
-        "folder-watching-tooltip": "Allows Kavita to monitor Library Folders to detect changes and invoke scanning on those changes. This allows content to be updated without manually invoking scans or waiting for nightly scans.",
+        "folder-watching-tooltip": "Allows Kavita to monitor Library Folders to detect changes and invoke scanning on those changes. This allows content to be updated without manually invoking scans or waiting for nightly scans. Will always wait 10 minutes before triggering scan.",
         "enable-folder-watching": "Enable Folder Watching",
 
 


### PR DESCRIPTION
# Changed
- Changed: Update `folder-watching-tooltip` to have the info about scans only occurring once every 10 minutes to make it more clear to users.

