### PR TITLE
Use new Queryable extension method DoOrderBy() for cleaner code

### DIFF
--- a/API/Data/Repositories/SeriesRepository.cs
+++ b/API/Data/Repositories/SeriesRepository.cs
@@ -903,34 +903,17 @@ public class SeriesRepository : ISeriesRepository
             SortField = SortField.SortName
         };
 
-        if (filter.SortOptions.IsAscending)
+        query = filter.SortOptions.SortField switch
         {
-            query = filter.SortOptions.SortField switch
-            {
-                SortField.SortName => query.OrderBy(s => s.SortName.ToLower()),
-                SortField.CreatedDate => query.OrderBy(s => s.Created),
-                SortField.LastModifiedDate => query.OrderBy(s => s.LastModified),
-                SortField.LastChapterAdded => query.OrderBy(s => s.LastChapterAdded),
-                SortField.TimeToRead => query.OrderBy(s => s.AvgHoursToRead),
-                SortField.ReleaseYear => query.OrderBy(s => s.Metadata.ReleaseYear),
-                SortField.ReadProgress => query.OrderBy(s => s.Progress.Where(p => p.SeriesId == s.Id).Select(p => p.LastModified).Max()),
-                _ => query
-            };
-        }
-        else
-        {
-            query = filter.SortOptions.SortField switch
-            {
-                SortField.SortName => query.OrderByDescending(s => s.SortName.ToLower()),
-                SortField.CreatedDate => query.OrderByDescending(s => s.Created),
-                SortField.LastModifiedDate => query.OrderByDescending(s => s.LastModified),
-                SortField.LastChapterAdded => query.OrderByDescending(s => s.LastChapterAdded),
-                SortField.TimeToRead => query.OrderByDescending(s => s.AvgHoursToRead),
-                SortField.ReleaseYear => query.OrderByDescending(s => s.Metadata.ReleaseYear),
-                SortField.ReadProgress => query.OrderByDescending(s => s.Progress.Where(p => p.SeriesId == s.Id).Select(p => p.LastModified).Max()),
-                _ => query
-            };
-        }
+            SortField.SortName => query.DoOrderBy(s => s.SortName.ToLower(), filter.SortOptions),
+            SortField.CreatedDate => query.DoOrderBy(s => s.Created, filter.SortOptions),
+            SortField.LastModifiedDate => query.DoOrderBy(s => s.LastModified, filter.SortOptions),
+            SortField.LastChapterAdded => query.DoOrderBy(s => s.LastChapterAdded, filter.SortOptions),
+            SortField.TimeToRead => query.DoOrderBy(s => s.AvgHoursToRead, filter.SortOptions),
+            SortField.ReleaseYear => query.DoOrderBy(s => s.Metadata.ReleaseYear, filter.SortOptions),
+            SortField.ReadProgress => query.DoOrderBy(s => s.Progress.Where(p => p.SeriesId == s.Id).Select(p => p.LastModified).Max(), filter.SortOptions),
+            _ => query
+        };
 
         return query.AsSplitQuery();
     }

--- a/API/Extensions/QueryExtensions/Filtering/BookmarkSort.cs
+++ b/API/Extensions/QueryExtensions/Filtering/BookmarkSort.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using API.DTOs.Filtering;
 using API.Entities;
+using API.Extensions.QueryExtensions;
 
 namespace API.Extensions.QueryExtensions.Filtering;
 
@@ -27,34 +28,17 @@ public static class BookmarkSort
             SortField = SortField.SortName
         };
 
-        if (sortOptions.IsAscending)
+        query = sortOptions.SortField switch
         {
-            query = sortOptions.SortField switch
-            {
-                SortField.SortName => query.OrderBy(s => s.Series.SortName.ToLower()),
-                SortField.CreatedDate => query.OrderBy(s => s.Series.Created),
-                SortField.LastModifiedDate => query.OrderBy(s => s.Series.LastModified),
-                SortField.LastChapterAdded => query.OrderBy(s => s.Series.LastChapterAdded),
-                SortField.TimeToRead => query.OrderBy(s => s.Series.AvgHoursToRead),
-                SortField.ReleaseYear => query.OrderBy(s => s.Series.Metadata.ReleaseYear),
-                SortField.ReadProgress => query.OrderBy(s => s.Series.Progress.Where(p => p.SeriesId == s.Series.Id).Select(p => p.LastModified).Max()),
-                _ => query
-            };
-        }
-        else
-        {
-            query = sortOptions.SortField switch
-            {
-                SortField.SortName => query.OrderByDescending(s => s.Series.SortName.ToLower()),
-                SortField.CreatedDate => query.OrderByDescending(s => s.Series.Created),
-                SortField.LastModifiedDate => query.OrderByDescending(s => s.Series.LastModified),
-                SortField.LastChapterAdded => query.OrderByDescending(s => s.Series.LastChapterAdded),
-                SortField.TimeToRead => query.OrderByDescending(s => s.Series.AvgHoursToRead),
-                SortField.ReleaseYear => query.OrderByDescending(s => s.Series.Metadata.ReleaseYear),
-                SortField.ReadProgress => query.OrderByDescending(s => s.Series.Progress.Where(p => p.SeriesId == s.Series.Id).Select(p => p.LastModified).Max()),
-                _ => query
-            };
-        }
+            SortField.SortName => query.DoOrderBy(s => s.Series.SortName.ToLower(), sortOptions),
+            SortField.CreatedDate => query.DoOrderBy(s => s.Series.Created, sortOptions),
+            SortField.LastModifiedDate => query.DoOrderBy(s => s.Series.LastModified, sortOptions),
+            SortField.LastChapterAdded => query.DoOrderBy(s => s.Series.LastChapterAdded, sortOptions),
+            SortField.TimeToRead => query.DoOrderBy(s => s.Series.AvgHoursToRead, sortOptions),
+            SortField.ReleaseYear => query.DoOrderBy(s => s.Series.Metadata.ReleaseYear, sortOptions),
+            SortField.ReadProgress => query.DoOrderBy(s => s.Series.Progress.Where(p => p.SeriesId == s.Series.Id).Select(p => p.LastModified).Max(), sortOptions),
+            _ => query
+        };
 
         return query;
     }

--- a/API/Extensions/QueryExtensions/Filtering/SeriesSort.cs
+++ b/API/Extensions/QueryExtensions/Filtering/SeriesSort.cs
@@ -1,8 +1,7 @@
 ﻿using System.Linq;
 using API.DTOs.Filtering;
 using API.Entities;
-
-namespace API.Extensions.QueryExtensions.Filtering;
+using API.Extensions.QueryExtensions;
 
 public static class SeriesSort
 {
@@ -21,34 +20,17 @@ public static class SeriesSort
             SortField = SortField.SortName
         };
 
-        if (sortOptions.IsAscending)
+        query = sortOptions.SortField switch
         {
-            query = sortOptions.SortField switch
-            {
-                SortField.SortName => query.OrderBy(s => s.SortName.ToLower()),
-                SortField.CreatedDate => query.OrderBy(s => s.Created),
-                SortField.LastModifiedDate => query.OrderBy(s => s.LastModified),
-                SortField.LastChapterAdded => query.OrderBy(s => s.LastChapterAdded),
-                SortField.TimeToRead => query.OrderBy(s => s.AvgHoursToRead),
-                SortField.ReleaseYear => query.OrderBy(s => s.Metadata.ReleaseYear),
-                SortField.ReadProgress => query.OrderBy(s => s.Progress.Where(p => p.SeriesId == s.Id).Select(p => p.LastModified).Max()),
-                _ => query
-            };
-        }
-        else
-        {
-            query = sortOptions.SortField switch
-            {
-                SortField.SortName => query.OrderByDescending(s => s.SortName.ToLower()),
-                SortField.CreatedDate => query.OrderByDescending(s => s.Created),
-                SortField.LastModifiedDate => query.OrderByDescending(s => s.LastModified),
-                SortField.LastChapterAdded => query.OrderByDescending(s => s.LastChapterAdded),
-                SortField.TimeToRead => query.OrderByDescending(s => s.AvgHoursToRead),
-                SortField.ReleaseYear => query.OrderByDescending(s => s.Metadata.ReleaseYear),
-                SortField.ReadProgress => query.OrderByDescending(s => s.Progress.Where(p => p.SeriesId == s.Id).Select(p => p.LastModified).Max()),
-                _ => query
-            };
-        }
+            SortField.SortName => query.DoOrderBy(s => s.SortName.ToLower(), sortOptions),
+            SortField.CreatedDate => query.DoOrderBy(s => s.Created, sortOptions),
+            SortField.LastModifiedDate => query.DoOrderBy(s => s.LastModified, sortOptions),
+            SortField.LastChapterAdded => query.DoOrderBy(s => s.LastChapterAdded, sortOptions),
+            SortField.TimeToRead => query.DoOrderBy(s => s.AvgHoursToRead, sortOptions),
+            SortField.ReleaseYear => query.DoOrderBy(s => s.Metadata.ReleaseYear, sortOptions),
+            SortField.ReadProgress => query.DoOrderBy(s => s.Progress.Where(p => p.SeriesId == s.Id).Select(p => p.LastModified).Max(), sortOptions),
+            _ => query
+        };
 
         return query;
     }

--- a/API/Extensions/QueryExtensions/QueryableExtensions.cs
+++ b/API/Extensions/QueryExtensions/QueryableExtensions.cs
@@ -5,6 +5,7 @@ using System.Linq.Expressions;
 using System.Threading.Tasks;
 using API.Data.Misc;
 using API.Data.Repositories;
+using API.DTOs.Filtering;
 using API.Entities;
 using API.Entities.Enums;
 using API.Entities.Scrobble;
@@ -185,5 +186,17 @@ public static class QueryableExtensions
             ScrobbleEventSortField.IsProcessed => query.OrderBy(s => s.IsProcessed),
             _ => query
         };
+    }
+
+    /// <summary>
+    /// Performs either OrderBy or OrderByDescending on the given query based on the value of SortOptions.IsAscending.
+    /// </summary>
+    /// <param name="query"></param>
+    /// <param name="keySelector"></param>
+    /// <param name="sortOptions"></param>
+    /// <returns></returns>
+    public static IQueryable<T> DoOrderBy<T, TKey>(this IQueryable<T> query, Expression<Func<T, TKey>> keySelector, SortOptions sortOptions)
+    {
+        return sortOptions.IsAscending ? query.OrderBy(keySelector) : query.OrderByDescending(keySelector);
     }
 }


### PR DESCRIPTION
# Developer
- Changed: Refactor SeriesSort and BookmarkSort to use Queryable extension method DoOrderBy() for cleaner code
- Changed: Refactor SeriesRepository.CreateFilteredSearchQueryable() to use Queryable extension method DoOrderBy() for cleaner code