### PR TITLE
Fix bug where `Parser.NormalizePath()` did not normalise `\` in Unix-based operating systems

### DIFF
--- a/API/Services/Tasks/Scanner/Parser/Parser.cs
+++ b/API/Services/Tasks/Scanner/Parser/Parser.cs
@@ -1043,7 +1043,7 @@ public static class Parser
     /// <returns></returns>
     public static string NormalizePath(string? path)
     {
-        return string.IsNullOrEmpty(path) ? string.Empty : path.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+        return string.IsNullOrEmpty(path) ? string.Empty : path.Replace('\\', Path.AltDirectorySeparatorChar)
             .Replace(@"//", Path.AltDirectorySeparatorChar + string.Empty);
     }
 


### PR DESCRIPTION
# Fixed
- Fixed: Fix bug where `Parser.NormalizePath()` did not normalise `\` in Unix-based operating systems. (Fixes #2311)
