### PR TITLE
[skip ci] Reduce warnings during tests

### DIFF
--- a/API.Tests/Helpers/GenreHelperTests.cs
+++ b/API.Tests/Helpers/GenreHelperTests.cs
@@ -92,7 +92,7 @@ public class GenreHelperTests
                 genreRemoved.Add(genre);
             });
 
-        Assert.Equal(1, genreRemoved.Count);
+        Assert.Single(genreRemoved);
     }
 
     [Fact]

--- a/API.Tests/Helpers/PersonHelperTests.cs
+++ b/API.Tests/Helpers/PersonHelperTests.cs
@@ -220,7 +220,7 @@ public class PersonHelperTests
         });
 
         Assert.NotEqual(existingPeople, peopleRemoved);
-        Assert.Equal(1, peopleRemoved.Count);
+        Assert.Single(peopleRemoved);
     }
 
     [Fact]
@@ -238,14 +238,14 @@ public class PersonHelperTests
         });
 
         Assert.NotEqual(existingPeople, peopleRemoved);
-        Assert.Equal(1, peopleRemoved.Count);
+        Assert.Single(peopleRemoved);
 
         PersonHelper.RemovePeople(existingPeople, new[] {"Joe Shmo"}, PersonRole.CoverArtist, person =>
         {
             peopleRemoved.Add(person);
         });
 
-        Assert.Equal(0, existingPeople.Count);
+        Assert.Empty(existingPeople);
         Assert.Equal(2, peopleRemoved.Count);
     }
 

--- a/API.Tests/Helpers/TagHelperTests.cs
+++ b/API.Tests/Helpers/TagHelperTests.cs
@@ -29,7 +29,7 @@ public class TagHelperTests
 
         });
 
-        Assert.Equal(1, tagAdded.Count);
+        Assert.Single(tagAdded);
         Assert.Equal(4, allTags.Count);
     }
 
@@ -100,7 +100,7 @@ public class TagHelperTests
                 tagRemoved.Add(tag);
             });
 
-        Assert.Equal(1, tagRemoved.Count);
+        Assert.Single(tagRemoved);
     }
 
     [Fact]

--- a/API.Tests/Parser/ComicParserTests.cs
+++ b/API.Tests/Parser/ComicParserTests.cs
@@ -115,7 +115,6 @@ public class ComicParserTests
     [InlineData("Batgirl Vol.2000 #57 (December, 2004)", "2000")]
     [InlineData("Batgirl V2000 #57", "2000")]
     [InlineData("Fables 021 (2004) (Digital) (Nahga-Empire).cbr", "0")]
-    [InlineData("Cyberpunk 2077 - Trauma Team 04.cbz", "0")]
     [InlineData("2000 AD 0366 [1984-04-28] (flopbie)", "0")]
     [InlineData("Daredevil - v6 - 10 - (2019)", "6")]
     [InlineData("Daredevil - v6.5", "6.5")]

--- a/API.Tests/Repository/SeriesRepositoryTests.cs
+++ b/API.Tests/Repository/SeriesRepositoryTests.cs
@@ -20,11 +20,13 @@ using Xunit;
 
 namespace API.Tests.Repository;
 
+#nullable enable
+
 public class SeriesRepositoryTests
 {
     private readonly IUnitOfWork _unitOfWork;
 
-    private readonly DbConnection _connection;
+    private readonly DbConnection? _connection;
     private readonly DataContext _context;
 
     private const string CacheDirectory = "C:/kavita/config/cache/";

--- a/API.Tests/Services/BookmarkServiceTests.cs
+++ b/API.Tests/Services/BookmarkServiceTests.cs
@@ -163,7 +163,7 @@ Substitute.For<IMediaConversionService>());
 
 
         Assert.True(result);
-        Assert.Equal(1, ds.GetFiles(BookmarkDirectory, searchOption:SearchOption.AllDirectories).Count());
+        Assert.Single(ds.GetFiles(BookmarkDirectory, searchOption:SearchOption.AllDirectories));
         Assert.NotNull(await _unitOfWork.UserRepository.GetBookmarkAsync(1));
     }
 
@@ -223,7 +223,7 @@ Substitute.For<IMediaConversionService>());
 
 
         Assert.True(result);
-        Assert.Equal(0, ds.GetFiles(BookmarkDirectory, searchOption:SearchOption.AllDirectories).Count());
+        Assert.Empty(ds.GetFiles(BookmarkDirectory, searchOption:SearchOption.AllDirectories));
         Assert.Null(await _unitOfWork.UserRepository.GetBookmarkAsync(1));
     }
 
@@ -411,7 +411,7 @@ Substitute.For<IMediaConversionService>());
         await _unitOfWork.CommitAsync();
 
 
-        Assert.Equal(1, ds.GetFiles(BookmarkDirectory, searchOption:SearchOption.AllDirectories).Count());
+        Assert.Single(ds.GetFiles(BookmarkDirectory, searchOption:SearchOption.AllDirectories));
         Assert.NotNull(await _unitOfWork.UserRepository.GetBookmarkAsync(1));
     }
 

--- a/API.Tests/Services/CollectionTagServiceTests.cs
+++ b/API.Tests/Services/CollectionTagServiceTests.cs
@@ -85,8 +85,8 @@ public class CollectionTagServiceTests : AbstractDbTest
         await _service.AddTagToSeries(await _unitOfWork.CollectionTagRepository.GetTagAsync(1, CollectionTagIncludes.SeriesMetadata), ids);
 
         var metadatas = await _unitOfWork.SeriesRepository.GetSeriesMetadataForIdsAsync(ids);
-        Assert.True(metadatas.ElementAt(0).CollectionTags.Any(t => t.Title.Equals("Tag 1")));
-        Assert.True(metadatas.ElementAt(1).CollectionTags.Any(t => t.Title.Equals("Tag 1")));
+        Assert.Contains(metadatas.ElementAt(0).CollectionTags, t => t.Title.Equals("Tag 1"));
+        Assert.Contains(metadatas.ElementAt(1).CollectionTags, t => t.Title.Equals("Tag 1"));
     }
 
     [Fact]
@@ -112,7 +112,7 @@ public class CollectionTagServiceTests : AbstractDbTest
         await SeedSeries();
         var tag = await _service.GetTagOrCreate(0, "GetTagOrCreate_ShouldReturnNewTag");
         Assert.NotNull(tag);
-        Assert.NotSame(0, tag.Id);
+        Assert.Equal(0, tag.Id);
     }
 
     [Fact]
@@ -121,7 +121,7 @@ public class CollectionTagServiceTests : AbstractDbTest
         await SeedSeries();
         var tag = await _service.GetTagOrCreate(1, string.Empty);
         Assert.NotNull(tag);
-        Assert.NotSame(1, tag.Id);
+        Assert.Equal(1, tag.Id);
     }
 
     [Fact]

--- a/API.Tests/Services/DirectoryServiceTests.cs
+++ b/API.Tests/Services/DirectoryServiceTests.cs
@@ -61,13 +61,13 @@ public class DirectoryServiceTests
                 API.Services.Tasks.Scanner.Parser.Parser.ImageFileExtensions, _logger);
             Assert.Equal(1, fileCount);
         }
-        catch (Exception ex)
+        catch
         {
             Assert.False(true);
         }
 
 
-        Assert.Equal(1, files.Count);
+        Assert.Single(files);
     }
 
 
@@ -654,7 +654,7 @@ public class DirectoryServiceTests
         fileSystem.AddFile($"{testDirectory}file_0.zip", new MockFileData(""));
 
         var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), fileSystem);
-        Assert.Equal(1, ds.ListDirectory(testDirectory).Count());
+        Assert.Single(ds.ListDirectory(testDirectory));
     }
 
     #endregion
@@ -881,7 +881,7 @@ public class DirectoryServiceTests
 
         var allFiles = ds.ScanFiles("C:/Data/");
 
-        Assert.Equal(0, allFiles.Count);
+        Assert.Empty(allFiles);
 
         return Task.CompletedTask;
     }
@@ -905,7 +905,7 @@ public class DirectoryServiceTests
 
         var allFiles = ds.ScanFiles("C:/Data/");
 
-        Assert.Equal(1, allFiles.Count); // Ignore files are not counted in files, only valid extensions
+        Assert.Single(allFiles); // Ignore files are not counted in files, only valid extensions
 
         return Task.CompletedTask;
     }

--- a/API.Tests/Services/ReadingListServiceTests.cs
+++ b/API.Tests/Services/ReadingListServiceTests.cs
@@ -164,7 +164,7 @@ public class ReadingListServiceTests
         await _readingListService.AddChaptersToReadingList(1, new List<int>() {1}, readingList);
         await _unitOfWork.CommitAsync();
 
-        Assert.Equal(1, readingList.Items.Count);
+        Assert.Single(readingList.Items);
         Assert.Equal(0, readingList.Items.First().Order);
     }
 
@@ -409,7 +409,7 @@ public class ReadingListServiceTests
             ReadingListId = 1, ReadingListItemId = 1
         });
 
-        Assert.Equal(1, readingList.Items.Count);
+        Assert.Single(readingList.Items);
         Assert.Equal(2, readingList.Items.First().ChapterId);
     }
 

--- a/API.Tests/Services/ScannerServiceTests.cs
+++ b/API.Tests/Services/ScannerServiceTests.cs
@@ -35,7 +35,7 @@ public class ScannerServiceTests
                 .Build()
         };
 
-        Assert.Equal(1, ScannerService.FindSeriesNotOnDisk(existingSeries, infos).Count());
+        Assert.Single(ScannerService.FindSeriesNotOnDisk(existingSeries, infos));
     }
 
     [Fact]

--- a/API.Tests/Services/SeriesServiceTests.cs
+++ b/API.Tests/Services/SeriesServiceTests.cs
@@ -305,7 +305,7 @@ public class SeriesServiceTests : AbstractDbTest
         // A book library where all books are Volumes, will show no "chapters" on the UI because it doesn't make sense
         Assert.Empty(detail.Chapters);
 
-        Assert.Equal(1, detail.Volumes.Count());
+        Assert.Single(detail.Volumes);
     }
 
     [Fact]
@@ -527,7 +527,7 @@ public class SeriesServiceTests : AbstractDbTest
 
         var series = await _unitOfWork.SeriesRepository.GetSeriesByIdAsync(1);
         Assert.NotNull(series.Metadata);
-        Assert.True(series.Metadata.Genres.Select(g => g.Title).Contains("New Genre".SentenceCase()));
+        Assert.Contains("New Genre".SentenceCase(), series.Metadata.Genres.Select(g => g.Title));
 
     }
 
@@ -563,10 +563,10 @@ public class SeriesServiceTests : AbstractDbTest
 
         var series = await _unitOfWork.SeriesRepository.GetSeriesByIdAsync(1);
         Assert.NotNull(series.Metadata);
-        Assert.True(series.Metadata.Genres.Select(g => g.Title).Contains("New Genre".SentenceCase()));
+        Assert.Contains("New Genre".SentenceCase(), series.Metadata.Genres.Select(g => g.Title));
         Assert.True(series.Metadata.People.All(g => g.Name is "Joe Shmo" or "Joe Shmo 2"));
-        Assert.True(series.Metadata.Tags.Select(g => g.Title).Contains("New Tag".SentenceCase()));
-        Assert.True(series.Metadata.CollectionTags.Select(g => g.Title).Contains("New Collection"));
+        Assert.Contains("New Tag".SentenceCase(), series.Metadata.Tags.Select(g => g.Title));
+        Assert.Contains("New Collection", series.Metadata.CollectionTags.Select(g => g.Title));
 
     }
 


### PR DESCRIPTION
Reduced warnings during tests, from 30-something to 10.

Some test cases are missing annotations - this had been done previously so the test is skipped.
As such, the remaining warnings relate to missing annotations:
- `X should be marked as a Theory`
- `X should be marked as a Fact`
- `X Test data attribute should only be used on a Theory`

# Developer
- Changed: Reduce warnings during tests 