### PR TITLE
Fix `GetTagOrCreate_ShouldReturnExistingTag` test

### DIFF
--- a/API.Tests/Services/CollectionTagServiceTests.cs
+++ b/API.Tests/Services/CollectionTagServiceTests.cs
@@ -119,9 +119,10 @@ public class CollectionTagServiceTests : AbstractDbTest
     public async Task GetTagOrCreate_ShouldReturnExistingTag()
     {
         await SeedSeries();
-        var tag = await _service.GetTagOrCreate(1, string.Empty);
+        var tag = await _service.GetTagOrCreate(1, "Some new tag");
         Assert.NotNull(tag);
         Assert.Equal(1, tag.Id);
+        Assert.Equal("Tag 1", tag.Title);
     }
 
     [Fact]


### PR DESCRIPTION
Upon looking at the implementation of `GetTagOrCreate()`, it appears that asserting on `tag.Id` is not enough (introduced in #2318). This is because it doesn't tell us the object was newly created or an existing one. As such, I've added an additional `Assert.Equal` on `tag.Title`. This makes sure that `tag.Title` is equal to an existing tag (that was created during seeding).

# Developer
- Fixed: Fix GetTagOrCreate tests
