### PR TITLE
[skip ci] Fixed: Fix xUnit missing annotation warnings

### DIFF
--- a/API.Tests/Services/ArchiveServiceTests.cs
+++ b/API.Tests/Services/ArchiveServiceTests.cs
@@ -156,7 +156,7 @@ public class ArchiveServiceTests
     }
 
 
-    //[Theory]
+    [Theory(Skip = "No specific reason")]
     //[InlineData("v10.cbz", "v10.expected.png")] // Commented out as these break usually when NetVips is updated
     //[InlineData("v10 - with folder.cbz", "v10 - with folder.expected.png")]
     //[InlineData("v10 - nested folder.cbz", "v10 - nested folder.expected.png")]
@@ -189,7 +189,7 @@ public class ArchiveServiceTests
     }
 
 
-    //[Theory]
+    [Theory(Skip = "No specific reason")]
     //[InlineData("v10.cbz", "v10.expected.png")] // Commented out as these break usually when NetVips is updated
     //[InlineData("v10 - with folder.cbz", "v10 - with folder.expected.png")]
     //[InlineData("v10 - nested folder.cbz", "v10 - nested folder.expected.png")]
@@ -375,7 +375,7 @@ public class ArchiveServiceTests
 
     #region CreateZipForDownload
 
-    //[Fact]
+    [Fact(Skip = "No specific reason")]
     public void CreateZipForDownloadTest()
     {
         var fileSystem = new MockFileSystem();

--- a/API.Tests/Services/ReadingListServiceTests.cs
+++ b/API.Tests/Services/ReadingListServiceTests.cs
@@ -876,6 +876,7 @@ public class ReadingListServiceTests
 
     #region UserHasReadingListAccess
     // TODO: UserHasReadingListAccess tests are unavailable because I can't mock UserManager<AppUser>
+    [Fact(Skip = "Unable to mock UserManager<AppUser>")]
     public async Task UserHasReadingListAccess_ShouldWorkIfTheirList()
     {
         await ResetDb();
@@ -889,7 +890,7 @@ public class ReadingListServiceTests
         Assert.Single(userWithList.ReadingLists);
     }
 
-
+    [Fact(Skip = "Unable to mock UserManager<AppUser>")]
     public async Task UserHasReadingListAccess_ShouldNotWork_IfNotTheirList()
     {
         await ResetDb();
@@ -902,7 +903,7 @@ public class ReadingListServiceTests
         Assert.Null(userWithList);
     }
 
-
+    [Fact(Skip = "Unable to mock UserManager<AppUser>")]
     public async Task UserHasReadingListAccess_ShouldWork_IfNotTheirList_ButUserIsAdmin()
     {
         await ResetDb();


### PR DESCRIPTION
After this change, only two warnings exist related to `Public method 'Dispose' on test class 'X' should be marked as a Fact.`

# Developer
- Fixed: Fix xUnit missing annotation warnings