### PR TITLE
Next Estimated Chapter

### DIFF
--- a/API/Controllers/FilterController.cs
+++ b/API/Controllers/FilterController.cs
@@ -46,8 +46,6 @@ public class FilterController : BaseApiController
             return BadRequest("You cannot use the name of a system provided stream");
         }
 
-        // I might just want to use DashboardStream instead of a separate entity. It will drastically simplify implementation
-
         var existingFilter =
             user.SmartFilters.FirstOrDefault(f => f.Name.Equals(dto.Name, StringComparison.InvariantCultureIgnoreCase));
         if (existingFilter != null)

--- a/API/Controllers/SeriesController.cs
+++ b/API/Controllers/SeriesController.cs
@@ -610,4 +610,18 @@ public class SeriesController : BaseApiController
         }
     }
 
+    /// <summary>
+    /// Based on the delta times between when chapters are added, for series that are not Completed/Cancelled/Hiatus, forecast the next
+    /// date when it will be available.
+    /// </summary>
+    /// <param name="seriesId"></param>
+    /// <returns></returns>
+    [HttpGet("next-expected")]
+    public async Task<ActionResult<NextExpectedChapterDto>> GetNextExpectedChapter(int seriesId)
+    {
+        var userId = User.GetUserId();
+
+        return Ok(await _seriesService.GetEstimatedChapterCreationDate(seriesId, userId));
+    }
+
 }

--- a/API/DTOs/Filtering/v2/FilterField.cs
+++ b/API/DTOs/Filtering/v2/FilterField.cs
@@ -44,6 +44,6 @@ public enum FilterField
     /// <summary>
     /// Last time User Read
     /// </summary>
-    ReadingDate = 27
+    ReadingDate = 27,
 
 }

--- a/API/DTOs/SeriesDetail/NextExpectedChapterDto.cs
+++ b/API/DTOs/SeriesDetail/NextExpectedChapterDto.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace API.DTOs.SeriesDetail;
+
+public class NextExpectedChapterDto
+{
+    public float ChapterNumber { get; set; }
+    public int VolumeNumber { get; set; }
+    /// <summary>
+    /// Null if not applicable
+    /// </summary>
+    public DateTime? ExpectedDate { get; set; }
+    /// <summary>
+    /// The localized title to render on the card
+    /// </summary>
+    public string Title { get; set; }
+}

--- a/API/DTOs/SeriesDetail/SeriesDetailDto.cs
+++ b/API/DTOs/SeriesDetail/SeriesDetailDto.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 
 namespace API.DTOs.SeriesDetail;
+#nullable enable
 
 /// <summary>
 /// This is a special DTO for a UI page in Kavita. This performs sorting and grouping and returns exactly what UI requires for layout.
@@ -32,5 +33,4 @@ public class SeriesDetailDto
     /// How many chapters are there
     /// </summary>
     public int TotalCount { get; set; }
-
 }

--- a/API/Data/Metadata/ComicInfo.cs
+++ b/API/Data/Metadata/ComicInfo.cs
@@ -185,7 +185,7 @@ public class ComicInfo
 
             if (float.TryParse(Volume, out var volCount) && volCount > 0)
             {
-                return Math.Max(Count, (int) Math.Floor(volCount));
+                return (int) Math.Floor(volCount);
             }
         }
         catch (Exception)

--- a/API/Data/Metadata/ComicInfo.cs
+++ b/API/Data/Metadata/ComicInfo.cs
@@ -176,13 +176,21 @@ public class ComicInfo
     /// <returns></returns>
     public int CalculatedCount()
     {
-        if (!string.IsNullOrEmpty(Number) && float.Parse(Number) > 0)
+        try
         {
-            return (int) Math.Floor(float.Parse(Number));
+            if (float.TryParse(Number, out var chpCount) && chpCount > 0)
+            {
+                return (int) Math.Floor(chpCount);
+            }
+
+            if (float.TryParse(Volume, out var volCount) && volCount > 0)
+            {
+                return Math.Max(Count, (int) Math.Floor(volCount));
+            }
         }
-        if (!string.IsNullOrEmpty(Volume) && float.Parse(Volume) > 0)
+        catch (Exception)
         {
-            return Math.Max(Count, (int) Math.Floor(float.Parse(Volume)));
+            return 0;
         }
 
         return 0;

--- a/API/Data/Metadata/ComicInfo.cs
+++ b/API/Data/Metadata/ComicInfo.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Globalization;
 using System.Linq;
+using System.Threading;
 using API.Entities;
 using API.Entities.Enums;
 using API.Services;
@@ -167,6 +169,12 @@ public class ComicInfo
             {
                 info.Isbn = info.GTIN;
             }
+        }
+
+        if (!string.IsNullOrEmpty(info.Number))
+        {
+            float.TryParse(info.Number, NumberStyles.Any, Thread.CurrentThread.CurrentCulture, out var number);
+            info.Number = $"{number}";
         }
     }
 

--- a/API/Data/Metadata/ComicInfo.cs
+++ b/API/Data/Metadata/ComicInfo.cs
@@ -173,8 +173,7 @@ public class ComicInfo
 
         if (!string.IsNullOrEmpty(info.Number))
         {
-            float.TryParse(info.Number, NumberStyles.Any, Thread.CurrentThread.CurrentCulture, out var number);
-            info.Number = $"{number}";
+            info.Number = info.Number.Replace(",", "."); // Corrective measure for non English OSes
         }
     }
 

--- a/API/Data/Repositories/AppUserProgressRepository.cs
+++ b/API/Data/Repositories/AppUserProgressRepository.cs
@@ -205,5 +205,4 @@ public class AppUserProgressRepository : IAppUserProgressRepository
             .Where(p => p.ChapterId == chapterId && p.AppUserId == userId)
             .FirstOrDefaultAsync();
     }
-    #nullable disable
 }

--- a/API/Data/Repositories/ChapterRepository.cs
+++ b/API/Data/Repositories/ChapterRepository.cs
@@ -40,6 +40,7 @@ public interface IChapterRepository
     Task<IList<Chapter>> GetAllChaptersWithCoversInDifferentEncoding(EncodeFormat format);
     Task<IEnumerable<string>> GetCoverImagesForLockedChaptersAsync();
     Task<ChapterDto> AddChapterModifiers(int userId, ChapterDto chapter);
+    IEnumerable<Chapter> GetChaptersForSeries(int seriesId);
 }
 public class ChapterRepository : IChapterRepository
 {
@@ -263,5 +264,13 @@ public class ChapterRepository : IChapterRepository
         }
 
         return chapter;
+    }
+
+    public IEnumerable<Chapter> GetChaptersForSeries(int seriesId)
+    {
+        return _context.Chapter
+            .Where(c => c.Volume.SeriesId == seriesId)
+            .Include(c => c.Volume)
+            .AsEnumerable();
     }
 }

--- a/API/Data/Repositories/SeriesRepository.cs
+++ b/API/Data/Repositories/SeriesRepository.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -457,6 +458,12 @@ public class SeriesRepository : ISeriesRepository
         return result;
     }
 
+    /// <summary>
+    /// Includes Progress for the user
+    /// </summary>
+    /// <param name="seriesId"></param>
+    /// <param name="userId"></param>
+    /// <returns></returns>
     public async Task<SeriesDto?> GetSeriesDtoByIdAsync(int seriesId, int userId)
     {
         var series = await _context.Series.Where(x => x.Id == seriesId)
@@ -1975,4 +1982,5 @@ public class SeriesRepository : ISeriesRepository
             .IsRestricted(queryContext)
             .Select(lib => lib.Id);
     }
+
 }

--- a/API/Data/Repositories/SeriesRepository.cs
+++ b/API/Data/Repositories/SeriesRepository.cs
@@ -966,7 +966,7 @@ public class SeriesRepository : ISeriesRepository
 
 
         return ApplyLimit(query
-            .Sort(filter.SortOptions)
+            .Sort(userId, filter.SortOptions)
             .AsSplitQuery(), filter.LimitTo);
     }
 
@@ -1119,7 +1119,7 @@ public class SeriesRepository : ISeriesRepository
                                                || EF.Functions.Like(s.LocalizedName!, $"%{filter.SeriesNameQuery}%"))
             .Where(s => userLibraries.Contains(s.LibraryId)
                         && formats.Contains(s.Format))
-            .Sort(filter.SortOptions)
+            .Sort(userId, filter.SortOptions)
             .AsNoTracking();
 
         return query.AsSplitQuery();

--- a/API/Data/Repositories/SeriesRepository.cs
+++ b/API/Data/Repositories/SeriesRepository.cs
@@ -347,9 +347,9 @@ public class SeriesRepository : ISeriesRepository
             .Where(l => libraryIds.Contains(l.Id))
             .Where(l => EF.Functions.Like(l.Name, $"%{searchQuery}%"))
             .IsRestricted(QueryContext.Search)
-            .OrderBy(l => l.Name.ToLower())
             .AsSplitQuery()
             .Take(maxRecords)
+            .OrderBy(l => l.Name.ToLower())
             .ProjectTo<LibraryDto>(_mapper.ConfigurationProvider)
             .ToListAsync();
 
@@ -366,10 +366,10 @@ public class SeriesRepository : ISeriesRepository
                          || (hasYearInQuery && s.Metadata.ReleaseYear == yearComparison))
             .RestrictAgainstAgeRestriction(userRating)
             .Include(s => s.Library)
-            .OrderBy(s => s.SortName!.ToLower())
             .AsNoTracking()
             .AsSplitQuery()
             .Take(maxRecords)
+            .OrderBy(s => s.SortName!.ToLower())
             .ProjectTo<SearchResultDto>(_mapper.ConfigurationProvider)
             .AsEnumerable();
 
@@ -379,6 +379,7 @@ public class SeriesRepository : ISeriesRepository
             .RestrictAgainstAgeRestriction(userRating)
             .AsSplitQuery()
             .Take(maxRecords)
+            .OrderBy(r => r.NormalizedTitle)
             .ProjectTo<ReadingListDto>(_mapper.ConfigurationProvider)
             .ToListAsync();
 
@@ -399,8 +400,9 @@ public class SeriesRepository : ISeriesRepository
             .Where(sm => seriesIds.Contains(sm.SeriesId))
             .SelectMany(sm => sm.People.Where(t => t.Name != null && EF.Functions.Like(t.Name, $"%{searchQuery}%")))
             .AsSplitQuery()
-            .Take(maxRecords)
             .Distinct()
+            .Take(maxRecords)
+            .OrderBy(p => p.NormalizedName)
             .ProjectTo<PersonDto>(_mapper.ConfigurationProvider)
             .ToListAsync();
 
@@ -408,9 +410,9 @@ public class SeriesRepository : ISeriesRepository
             .Where(sm => seriesIds.Contains(sm.SeriesId))
             .SelectMany(sm => sm.Genres.Where(t => EF.Functions.Like(t.Title, $"%{searchQuery}%")))
             .AsSplitQuery()
-            .OrderBy(t => t.NormalizedTitle)
             .Distinct()
             .Take(maxRecords)
+            .OrderBy(t => t.NormalizedTitle)
             .ProjectTo<GenreTagDto>(_mapper.ConfigurationProvider)
             .ToListAsync();
 
@@ -418,9 +420,9 @@ public class SeriesRepository : ISeriesRepository
             .Where(sm => seriesIds.Contains(sm.SeriesId))
             .SelectMany(sm => sm.Tags.Where(t => EF.Functions.Like(t.Title, $"%{searchQuery}%")))
             .AsSplitQuery()
-            .OrderBy(t => t.NormalizedTitle)
             .Distinct()
             .Take(maxRecords)
+            .OrderBy(t => t.NormalizedTitle)
             .ProjectTo<TagDto>(_mapper.ConfigurationProvider)
             .ToListAsync();
 
@@ -435,6 +437,7 @@ public class SeriesRepository : ISeriesRepository
             .Where(m => EF.Functions.Like(m.FilePath, $"%{searchQuery}%") && fileIds.Contains(m.Id))
             .AsSplitQuery()
             .Take(maxRecords)
+            .OrderBy(f => f.FilePath)
             .ProjectTo<MangaFileDto>(_mapper.ConfigurationProvider)
             .ToListAsync();
 
@@ -447,6 +450,7 @@ public class SeriesRepository : ISeriesRepository
             .Where(c => c.Files.All(f => fileIds.Contains(f.Id)))
             .AsSplitQuery()
             .Take(maxRecords)
+            .OrderBy(c => c.TitleName)
             .ProjectTo<ChapterDto>(_mapper.ConfigurationProvider)
             .ToListAsync();
 

--- a/API/Data/UnitOfWork.cs
+++ b/API/Data/UnitOfWork.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using API.Data.Repositories;
 using API.Entities;
+using API.Services;
 using AutoMapper;
 using Microsoft.AspNetCore.Identity;
 
@@ -40,6 +41,7 @@ public class UnitOfWork : IUnitOfWork
     private readonly DataContext _context;
     private readonly IMapper _mapper;
     private readonly UserManager<AppUser> _userManager;
+    private readonly ILocalizationService _localizationService;
 
     public UnitOfWork(DataContext context, IMapper mapper, UserManager<AppUser> userManager)
     {

--- a/API/Data/UnitOfWork.cs
+++ b/API/Data/UnitOfWork.cs
@@ -101,6 +101,16 @@ public class UnitOfWork : IUnitOfWork
         return _context.ChangeTracker.HasChanges();
     }
 
+    public async Task BeginTransactionAsync()
+    {
+        await _context.Database.BeginTransactionAsync();
+    }
+
+    public async Task CommitTransactionAsync()
+    {
+        await _context.Database.CommitTransactionAsync();
+    }
+
     /// <summary>
     /// Rollback transaction
     /// </summary>

--- a/API/Entities/Chapter.cs
+++ b/API/Entities/Chapter.cs
@@ -67,13 +67,13 @@ public class Chapter : IEntityDate, IHasReadTimeEstimate
     /// </summary>
     public string? Language { get; set; }
     /// <summary>
-    /// Total number of issues or volumes in the series
+    /// Total number of issues or volumes in the series. This is straight from ComicInfo
     /// </summary>
-    /// <remarks>Users may use Volume count or issue count. Kavita performs some light logic to help Count match up with TotalCount</remarks>
     public int TotalCount { get; set; } = 0;
     /// <summary>
     /// Number of the Total Count (progress the Series is complete)
     /// </summary>
+    /// <remarks>This is either the highest of ComicInfo Count field and (nonparsed volume/chapter number)</remarks>
     public int Count { get; set; } = 0;
     /// <summary>
     /// SeriesGroup tag in ComicInfo

--- a/API/Entities/Metadata/SeriesMetadata.cs
+++ b/API/Entities/Metadata/SeriesMetadata.cs
@@ -36,7 +36,7 @@ public class SeriesMetadata : IHasConcurrencyToken
     /// </summary>
     public string Language { get; set; } = string.Empty;
     /// <summary>
-    /// Total number of issues/volumes in the series
+    /// Total expected number of issues/volumes in the series from ComicInfo.xml
     /// </summary>
     public int TotalCount { get; set; } = 0;
     /// <summary>

--- a/API/Extensions/QueryExtensions/Filtering/SeriesSort.cs
+++ b/API/Extensions/QueryExtensions/Filtering/SeriesSort.cs
@@ -11,7 +11,7 @@ public static class SeriesSort
     /// <param name="query"></param>
     /// <param name="sortOptions"></param>
     /// <returns></returns>
-    public static IQueryable<Series> Sort(this IQueryable<Series> query, SortOptions? sortOptions)
+    public static IQueryable<Series> Sort(this IQueryable<Series> query, int userId, SortOptions? sortOptions)
     {
         // If no sort options, default to using SortName
         sortOptions ??= new SortOptions()
@@ -28,7 +28,9 @@ public static class SeriesSort
             SortField.LastChapterAdded => query.DoOrderBy(s => s.LastChapterAdded, sortOptions),
             SortField.TimeToRead => query.DoOrderBy(s => s.AvgHoursToRead, sortOptions),
             SortField.ReleaseYear => query.DoOrderBy(s => s.Metadata.ReleaseYear, sortOptions),
-            SortField.ReadProgress => query.DoOrderBy(s => s.Progress.Where(p => p.SeriesId == s.Id).Select(p => p.LastModified).Max(), sortOptions),
+            SortField.ReadProgress => query.DoOrderBy(s => s.Progress.Where(p => p.SeriesId == s.Id && p.AppUserId == userId)
+                .Select(p => p.LastModified)
+                .Max(), sortOptions),
             _ => query
         };
 

--- a/API/Helpers/SmartFilterHelper.cs
+++ b/API/Helpers/SmartFilterHelper.cs
@@ -80,7 +80,7 @@ public static class SmartFilterHelper
         if (statements == null || statements.Count == 0)
             return string.Empty;
 
-        var encodedStatements = StatementsKey + HttpUtility.UrlEncode(string.Join(",", statements.Select(EncodeFilterStatementDto)));
+        var encodedStatements = StatementsKey + Uri.EscapeDataString(string.Join(",", statements.Select(EncodeFilterStatementDto)));
         return encodedStatements;
     }
 
@@ -88,7 +88,7 @@ public static class SmartFilterHelper
     {
         var encodedComparison = $"comparison={(int) statement.Comparison}";
         var encodedField = $"field={(int) statement.Field}";
-        var encodedValue = $"value={HttpUtility.UrlEncode(statement.Value)}";
+        var encodedValue = $"value={Uri.EscapeDataString(statement.Value)}";
 
         return $"{encodedComparison}&{encodedField}&{encodedValue}";
     }

--- a/API/Services/BookService.cs
+++ b/API/Services/BookService.cs
@@ -1026,9 +1026,11 @@ public class BookService : IBookService
 
         if (chaptersList.Count != 0) return chaptersList;
         // Generate from TOC from links (any point past this, Kavita is generating as a TOC doesn't exist)
-        var tocPage = book.Content.Html.Local.Select(s => s.Key).FirstOrDefault(k => k.Equals("TOC.XHTML", StringComparison.InvariantCultureIgnoreCase) ||
+        var tocPage = book.Content.Html.Local.Select(s => s.Key)
+            .FirstOrDefault(k => k.Equals("TOC.XHTML", StringComparison.InvariantCultureIgnoreCase) ||
             k.Equals("NAVIGATION.XHTML", StringComparison.InvariantCultureIgnoreCase));
         if (string.IsNullOrEmpty(tocPage)) return chaptersList;
+
 
         // Find all anchor tags, for each anchor we get inner text, to lower then title case on UI. Get href and generate page content
         if (!book.Content.Html.TryGetLocalFileRefByKey(tocPage, out var file)) return chaptersList;
@@ -1036,6 +1038,14 @@ public class BookService : IBookService
 
         var doc = new HtmlDocument();
         doc.LoadHtml(content);
+
+        // TODO: We may want to check if there is a toc.ncs file to better handle nested toc
+        // We could do a fallback first with ol/lis
+        //var sections = doc.DocumentNode.SelectNodes("//ol");
+        //if (sections == null)
+
+
+
         var anchors = doc.DocumentNode.SelectNodes("//a");
         if (anchors == null) return chaptersList;
 

--- a/API/Services/Plus/ScrobblingService.cs
+++ b/API/Services/Plus/ScrobblingService.cs
@@ -206,8 +206,7 @@ public class ScrobblingService : IScrobblingService
             ScrobbleEventType.Review);
         if (existingEvt is {IsProcessed: false})
         {
-            _logger.LogDebug("Overriding scrobble event for {Series} from Review {Tagline}/{Body} -> {UpdatedTagline}{UpdatedBody}",
-                existingEvt.Series.Name, existingEvt.ReviewTitle, existingEvt.ReviewBody, reviewTitle, reviewBody);
+            _logger.LogDebug("Overriding Review scrobble event for {Series}", existingEvt.Series.Name);
             existingEvt.ReviewBody = reviewBody;
             existingEvt.ReviewTitle = reviewTitle;
             _unitOfWork.ScrobbleRepository.Update(existingEvt);

--- a/API/Services/SeriesService.cs
+++ b/API/Services/SeriesService.cs
@@ -702,7 +702,7 @@ public class SeriesService : ISeriesService
             ChapterNumber = 0,
             VolumeNumber = 0,
             ExpectedDate = nextChapterExpected,
-            Title = ""
+            Title = string.Empty
         };
 
         if (lastChapterNumber > 0)
@@ -723,7 +723,8 @@ public class SeriesService : ISeriesService
         else
         {
             result.VolumeNumber = lastChapter.VolumeNumber + 1;
-            result.Title = "Volume " + result.ChapterNumber;
+            result.Title = await _localizationService.Translate(userId, "vol-num",
+                new object[] {result.VolumeNumber});
         }
 
 

--- a/API/Services/Tasks/Scanner/ProcessSeries.cs
+++ b/API/Services/Tasks/Scanner/ProcessSeries.cs
@@ -288,19 +288,16 @@ public class ProcessSeries : IProcessSeries
         series.Metadata.TotalCount = chapters.Max(chapter => chapter.TotalCount);
         // The actual number of count's defined across all chapter's metadata
         series.Metadata.MaxCount = chapters.Max(chapter => chapter.Count);
-        // To not have to rely completely on ComicInfo, try to parse out if the series is complete by checking parsed filenames as well.
-        if (series.Metadata.MaxCount != series.Metadata.TotalCount)
-        {
-            var maxVolume = series.Volumes.Max(v => (int) Parser.Parser.MaxNumberFromRange(v.Name));
-            var maxChapter = chapters.Max(c => (int) Parser.Parser.MaxNumberFromRange(c.Range));
-            if (maxVolume == series.Metadata.TotalCount) series.Metadata.MaxCount = maxVolume;
-            else if (maxChapter == series.Metadata.TotalCount) series.Metadata.MaxCount = maxChapter;
-        }
+
+        var maxVolume = series.Volumes.Max(v => (int) Parser.Parser.MaxNumberFromRange(v.Name));
+        var maxChapter = chapters.Max(c => (int) Parser.Parser.MaxNumberFromRange(c.Range));
+        var maxActual = Math.Max(maxVolume, maxChapter);
+
+        series.Metadata.MaxCount = maxActual;
 
 
         if (!series.Metadata.PublicationStatusLocked)
         {
-            // TODO: MOve this into a Helper so that we can test it
             series.Metadata.PublicationStatus = PublicationStatus.OnGoing;
             if (series.Metadata.MaxCount >= series.Metadata.TotalCount && series.Metadata.TotalCount > 0)
             {

--- a/API/Services/Tasks/Scanner/ProcessSeries.cs
+++ b/API/Services/Tasks/Scanner/ProcessSeries.cs
@@ -300,6 +300,7 @@ public class ProcessSeries : IProcessSeries
 
         if (!series.Metadata.PublicationStatusLocked)
         {
+            // TODO: MOve this into a Helper so that we can test it
             series.Metadata.PublicationStatus = PublicationStatus.OnGoing;
             if (series.Metadata.MaxCount >= series.Metadata.TotalCount && series.Metadata.TotalCount > 0)
             {

--- a/UI/Web/src/app/_models/series-detail/next-expected-chapter.ts
+++ b/UI/Web/src/app/_models/series-detail/next-expected-chapter.ts
@@ -1,0 +1,10 @@
+export interface NextExpectedChapter {
+    volumeNumber: number;
+    chapterNumber: number;
+    expectedDate: string | null;
+    title: string;
+    /**
+     * Not real, used for some type stuff with app-card
+     */
+    id: number;
+}

--- a/UI/Web/src/app/_services/image.service.ts
+++ b/UI/Web/src/app/_services/image.service.ts
@@ -17,6 +17,7 @@ export class ImageService {
   public errorImage = 'assets/images/error-placeholder2.dark-min.png';
   public resetCoverImage = 'assets/images/image-reset-cover-min.png';
   public errorWebLinkImage = 'assets/images/broken-white-32x32.png';
+  public nextChapterImage = 'assets/images/image-placeholder.dark-min.png'
 
   constructor(private accountService: AccountService, private themeService: ThemeService) {
     this.themeService.currentTheme$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(theme => {

--- a/UI/Web/src/app/_services/series.service.ts
+++ b/UI/Web/src/app/_services/series.service.ts
@@ -21,6 +21,7 @@ import {UserReview} from "../_single-module/review-card/user-review";
 import {Rating} from "../_models/rating";
 import {Recommendation} from "../_models/series-detail/recommendation";
 import {ExternalSeriesDetail} from "../_models/series-detail/external-series-detail";
+import {NextExpectedChapter} from "../_models/series-detail/next-expected-chapter";
 
 @Injectable({
   providedIn: 'root'
@@ -231,6 +232,10 @@ export class SeriesService {
 
   getExternalSeriesDetails(aniListId?: number, malId?: number, seriesId?: number) {
     return this.httpClient.get<ExternalSeriesDetail>(this.baseUrl + 'series/external-series-detail?aniListId=' + (aniListId || 0) + '&malId=' + (malId || 0) + '&seriesId=' + (seriesId || 0));
+  }
+
+  getNextExpectedChapterDate(seriesId: number) {
+    return this.httpClient.get<NextExpectedChapter>(this.baseUrl + 'series/next-expected?seriesId=' + seriesId);
   }
 
 }

--- a/UI/Web/src/app/admin/manage-tasks-settings/manage-tasks-settings.component.ts
+++ b/UI/Web/src/app/admin/manage-tasks-settings/manage-tasks-settings.component.ts
@@ -57,6 +57,17 @@ export class ManageTasksSettingsComponent implements OnInit {
       successMessage: 'bust-cache-task-success'
     },
     {
+      name: 'bust-locale-task',
+      description: 'bust-locale-task-desc',
+      api: defer(() => {
+        localStorage.removeItem('@transloco/translations/timestamp');
+        localStorage.removeItem('@transloco/translations');
+        localStorage.removeItem('translocoLang');
+        return of();
+      }),
+      successMessage: 'bust-locale-task-success',
+    },
+    {
       name: 'clear-reading-cache-task',
       description: 'clear-reading-cache-task-desc',
       api: this.serverService.clearCache(),

--- a/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.scss
+++ b/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.scss
@@ -324,6 +324,7 @@ $action-bar-height: 38px;
     color: $primary-color;
 }
 
+$pagination-color: transparent;
 
 
 .right {
@@ -332,7 +333,7 @@ $action-bar-height: 38px;
     top: $action-bar-height;
     width: 20vw;
     z-index: 3;
-    background: transparent;
+    background: $pagination-color;
     border-color: transparent;
     border: none !important;
     opacity: 0;
@@ -354,7 +355,7 @@ $action-bar-height: 38px;
     top: $action-bar-height;
     width: 18%;
     z-index: 3;
-    background: transparent;
+    background: $pagination-color;
     border-color: transparent;
     border: none !important;
     opacity: 0;
@@ -374,7 +375,7 @@ $action-bar-height: 38px;
     left: 0px;
     top: $action-bar-height;
     width: 20vw;
-    background: transparent;
+    background: $pagination-color;
     border-color: transparent;
     border: none !important;
     z-index: 3;

--- a/UI/Web/src/app/cards/card-item/card-item.component.html
+++ b/UI/Web/src/app/cards/card-item/card-item.component.html
@@ -34,7 +34,7 @@
         <span class="badge bg-primary">{{count}}</span>
       </div>
       <div class="card-overlay"></div>
-      <div class="overlay-information" *ngIf="overlayInformation !== '' ||  overlayInformation !== undefined">
+      <div class="overlay-information {{centerOverlay ? 'overlay-information--centered' : ''}}" *ngIf="overlayInformation !== '' ||  overlayInformation !== undefined">
         <div class="position-relative">
           <span class="card-title library mx-auto" style="width: auto;" [ngbTooltip]="overlayInformation" placement="top">{{overlayInformation}}</span>
         </div>

--- a/UI/Web/src/app/cards/card-item/card-item.component.scss
+++ b/UI/Web/src/app/cards/card-item/card-item.component.scss
@@ -77,7 +77,7 @@ $image-width: 160px;
     position: absolute;
     top: 0;
     width: 158px;
-    
+
 }
 
 .not-read-badge {
@@ -111,6 +111,8 @@ $image-width: 160px;
     }
 }
 
+
+
 .overlay-information {
     position: absolute;
     top: 5px;
@@ -118,13 +120,18 @@ $image-width: 160px;
     border-radius: 15px;
     padding: 0 10px;
     background-color: var(--card-bg-color);
+
+    &.overlay-information--centered {
+        top: 95px;
+        left: 36px;
+    }
 }
 
 .overlay {
     height: $image-height;
     border-top-left-radius: 4px;
     border-top-right-radius: 4px;
-    
+
     &:hover {
         visibility: visible;
 
@@ -138,11 +145,11 @@ $image-width: 160px;
             z-index: 100;
         }
     }
-    
+
     .overlay-item {
         visibility: hidden;
     }
-    
+
     z-index: 10;
 
     .count {

--- a/UI/Web/src/app/pdf-reader/_components/pdf-reader/pdf-reader.component.scss
+++ b/UI/Web/src/app/pdf-reader/_components/pdf-reader/pdf-reader.component.scss
@@ -3,13 +3,18 @@
 }
 
 .book-title {
-    margin: 8px 0 4px !important;   
+    margin: 8px 0 4px !important;
 }
 
 // Override since it's not coming from library
 ::ng-deep #presentationMode {
     margin: 3px 0 4px !important;
 }
+
+::ng-deep .dark > ngx-extended-pdf-viewer .treeItem>a {
+    color: lightblue !important;
+}
+
 
 .progress-container {
     width: 100%;

--- a/UI/Web/src/app/series-detail/_components/series-detail/series-detail.component.html
+++ b/UI/Web/src/app/series-detail/_components/series-detail/series-detail.component.html
@@ -157,6 +157,7 @@
                                      [selected]="bulkSelectionService.isCardSelected('chapter', scroll.viewPortInfo.startIndexWithBuffer + idx)" [allowSelection]="true"></app-card-item>
                     </ng-template>
                   </ng-container>
+                  <ng-container [ngTemplateOutlet]="estimatedNextCard" [ngTemplateOutletContext]="{tabId: TabID.Storyline}"></ng-container>
                 </div>
               </ng-container>
               <ng-template #storylineListLayout>
@@ -203,6 +204,7 @@
                                    [selected]="bulkSelectionService.isCardSelected('volume', scroll.viewPortInfo.startIndexWithBuffer + idx)" [allowSelection]="true">
                     </app-card-item>
                   </ng-container>
+                  <ng-container [ngTemplateOutlet]="estimatedNextCard" [ngTemplateOutletContext]="{tabId: TabID.Volumes}"></ng-container>
                 </div>
               </ng-container>
               <ng-template #volumeListLayout>
@@ -240,6 +242,7 @@
                       </ng-container>
                     </app-card-item>
                   </div>
+                  <ng-container [ngTemplateOutlet]="estimatedNextCard" [ngTemplateOutletContext]="{tabId: TabID.Chapters}"></ng-container>
                 </div>
               </ng-container>
               <ng-template #chapterListLayout>
@@ -354,5 +357,26 @@
 
     <app-loading [loading]="isLoading"></app-loading>
   </div>
+  <ng-template #estimatedNextCard let-tabId="tabId">
+    <ng-container *ngIf="nextExpectedChapter">
+      <ng-container [ngSwitch]="tabId">
+        <ng-container *ngSwitchCase="TabID.Volumes">
+          <app-card-item *ngIf="nextExpectedChapter.volumeNumber > 0 && nextExpectedChapter.chapterNumber === 0" class="col-auto mt-2 mb-2" [entity]="nextExpectedChapter" ></app-card-item>
+        </ng-container>
+        <ng-container *ngSwitchCase="TabID.Chapters">
+          <app-card-item class="col-auto mt-2 mb-2" [entity]="nextExpectedChapter" ></app-card-item>
+        </ng-container>
+        <ng-container *ngSwitchCase="TabID.Storyline">
+          <app-card-item class="col-auto mt-2 mb-2" [entity]="nextExpectedChapter" ></app-card-item>
+        </ng-container>
+      </ng-container>
+<!--      <ng-container *ngIf="tabId === TabID.Volumes && nextExpectedChapter.volumeNumber > 0 && nextExpectedChapter.chapterNumber === 0">-->
+<!--        <app-card-item class="col-auto mt-2 mb-2" [entity]="nextExpectedChapter" ></app-card-item>-->
+<!--      </ng-container>-->
+<!--      <ng-container *ngIf="tabId === TabID.Storyline || tabId === TabID.Chapters && nextExpectedChapter.chapterNumber !== 0">-->
+<!--        <app-card-item class="col-auto mt-2 mb-2" [entity]="nextExpectedChapter" ></app-card-item>-->
+<!--      </ng-container>-->
+    </ng-container>
+  </ng-template>
 
 </ng-container>

--- a/UI/Web/src/app/series-detail/_components/series-detail/series-detail.component.ts
+++ b/UI/Web/src/app/series-detail/_components/series-detail/series-detail.component.ts
@@ -1,4 +1,4 @@
-import { DOCUMENT, NgIf, NgStyle, NgFor, DecimalPipe } from '@angular/common';
+import {DecimalPipe, DOCUMENT, NgFor, NgIf, NgStyle, NgSwitch, NgSwitchCase, NgTemplateOutlet} from '@angular/common';
 import {
   AfterContentChecked,
   ChangeDetectionStrategy,
@@ -12,17 +12,31 @@ import {
   OnInit,
   ViewChild
 } from '@angular/core';
-import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import {FormControl, FormGroup, ReactiveFormsModule} from '@angular/forms';
 import {Title} from '@angular/platform-browser';
 import {ActivatedRoute, Router} from '@angular/router';
-import { NgbModal, NgbNavChangeEvent, NgbOffcanvas, NgbTooltip, NgbProgressbar, NgbDropdown, NgbDropdownToggle, NgbDropdownMenu, NgbDropdownItem, NgbNav, NgbNavItem, NgbNavLink, NgbNavContent, NgbNavOutlet } from '@ng-bootstrap/ng-bootstrap';
+import {
+  NgbDropdown,
+  NgbDropdownItem,
+  NgbDropdownMenu,
+  NgbDropdownToggle,
+  NgbModal,
+  NgbNav,
+  NgbNavChangeEvent,
+  NgbNavContent,
+  NgbNavItem,
+  NgbNavLink,
+  NgbNavOutlet,
+  NgbOffcanvas,
+  NgbProgressbar,
+  NgbTooltip
+} from '@ng-bootstrap/ng-bootstrap';
 import {ToastrService} from 'ngx-toastr';
 import {catchError, forkJoin, of} from 'rxjs';
 import {take} from 'rxjs/operators';
 import {BulkSelectionService} from 'src/app/cards/bulk-selection.service';
 import {CardDetailDrawerComponent} from 'src/app/cards/card-detail-drawer/card-detail-drawer.component';
 import {EditSeriesModalComponent} from 'src/app/cards/_modals/edit-series-modal/edit-series-modal.component';
-import {ConfirmService} from 'src/app/shared/confirm.service';
 import {TagBadgeCursor} from 'src/app/shared/tag-badge/tag-badge.component';
 import {DownloadService} from 'src/app/shared/_services/download.service';
 import {KEY_CODES, UtilityService} from 'src/app/shared/_services/utility.service';
@@ -54,27 +68,30 @@ import {ReviewSeriesModalComponent} from '../../../_single-module/review-series-
 import {PageLayoutMode} from 'src/app/_models/page-layout-mode';
 import {takeUntilDestroyed} from "@angular/core/rxjs-interop";
 import {UserReview} from "../../../_single-module/review-card/user-review";
-import { LoadingComponent } from '../../../shared/loading/loading.component';
-import { ExternalListItemComponent } from '../../../cards/external-list-item/external-list-item.component';
-import { ExternalSeriesCardComponent } from '../../../cards/external-series-card/external-series-card.component';
-import { SeriesCardComponent } from '../../../cards/series-card/series-card.component';
-import { EntityTitleComponent } from '../../../cards/entity-title/entity-title.component';
-import { ListItemComponent } from '../../../cards/list-item/list-item.component';
-import { CardItemComponent } from '../../../cards/card-item/card-item.component';
-import { VirtualScrollerModule } from '@iharbeck/ngx-virtual-scroller';
-import { BulkOperationsComponent } from '../../../cards/bulk-operations/bulk-operations.component';
-import { ReviewCardComponent } from '../../../_single-module/review-card/review-card.component';
-import { CarouselReelComponent } from '../../../carousel/_components/carousel-reel/carousel-reel.component';
-import { SeriesMetadataDetailComponent } from '../series-metadata-detail/series-metadata-detail.component';
-import { ImageComponent } from '../../../shared/image/image.component';
-import { TagBadgeComponent } from '../../../shared/tag-badge/tag-badge.component';
-import { SideNavCompanionBarComponent } from '../../../sidenav/_components/side-nav-companion-bar/side-nav-companion-bar.component';
+import {LoadingComponent} from '../../../shared/loading/loading.component';
+import {ExternalListItemComponent} from '../../../cards/external-list-item/external-list-item.component';
+import {ExternalSeriesCardComponent} from '../../../cards/external-series-card/external-series-card.component';
+import {SeriesCardComponent} from '../../../cards/series-card/series-card.component';
+import {EntityTitleComponent} from '../../../cards/entity-title/entity-title.component';
+import {ListItemComponent} from '../../../cards/list-item/list-item.component';
+import {CardItemComponent} from '../../../cards/card-item/card-item.component';
+import {VirtualScrollerModule} from '@iharbeck/ngx-virtual-scroller';
+import {BulkOperationsComponent} from '../../../cards/bulk-operations/bulk-operations.component';
+import {ReviewCardComponent} from '../../../_single-module/review-card/review-card.component';
+import {CarouselReelComponent} from '../../../carousel/_components/carousel-reel/carousel-reel.component';
+import {SeriesMetadataDetailComponent} from '../series-metadata-detail/series-metadata-detail.component';
+import {ImageComponent} from '../../../shared/image/image.component';
+import {TagBadgeComponent} from '../../../shared/tag-badge/tag-badge.component';
+import {
+  SideNavCompanionBarComponent
+} from '../../../sidenav/_components/side-nav-companion-bar/side-nav-companion-bar.component';
 import {TranslocoDirective, TranslocoService} from "@ngneat/transloco";
 import {CardActionablesComponent} from "../../../_single-module/card-actionables/card-actionables.component";
 import {ExternalSeries} from "../../../_models/series-detail/external-series";
 import {
   SeriesPreviewDrawerComponent
 } from "../../../_single-module/series-preview-drawer/series-preview-drawer.component";
+import {PublicationStatus} from "../../../_models/metadata/publication-status";
 
 interface RelatedSeriesPair {
   series: Series;
@@ -102,7 +119,7 @@ interface StoryLineItem {
     styleUrls: ['./series-detail.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush,
     standalone: true,
-  imports: [NgIf, SideNavCompanionBarComponent, CardActionablesComponent, ReactiveFormsModule, NgStyle, TagBadgeComponent, ImageComponent, NgbTooltip, NgbProgressbar, NgbDropdown, NgbDropdownToggle, NgbDropdownMenu, NgbDropdownItem, SeriesMetadataDetailComponent, CarouselReelComponent, ReviewCardComponent, BulkOperationsComponent, NgbNav, NgbNavItem, NgbNavLink, NgbNavContent, VirtualScrollerModule, NgFor, CardItemComponent, ListItemComponent, EntityTitleComponent, SeriesCardComponent, ExternalSeriesCardComponent, ExternalListItemComponent, NgbNavOutlet, LoadingComponent, DecimalPipe, TranslocoDirective]
+  imports: [NgIf, SideNavCompanionBarComponent, CardActionablesComponent, ReactiveFormsModule, NgStyle, TagBadgeComponent, ImageComponent, NgbTooltip, NgbProgressbar, NgbDropdown, NgbDropdownToggle, NgbDropdownMenu, NgbDropdownItem, SeriesMetadataDetailComponent, CarouselReelComponent, ReviewCardComponent, BulkOperationsComponent, NgbNav, NgbNavItem, NgbNavLink, NgbNavContent, VirtualScrollerModule, NgFor, CardItemComponent, ListItemComponent, EntityTitleComponent, SeriesCardComponent, ExternalSeriesCardComponent, ExternalListItemComponent, NgbNavOutlet, LoadingComponent, DecimalPipe, TranslocoDirective, NgTemplateOutlet, NgSwitch, NgSwitchCase]
 })
 export class SeriesDetailComponent implements OnInit, AfterContentChecked {
 
@@ -149,6 +166,8 @@ export class SeriesDetailComponent implements OnInit, AfterContentChecked {
    */
   seriesImage: string = '';
   downloadInProgress: boolean = false;
+
+  nextExpectedChapter: any | undefined;
 
   /**
    * Track by function for Volume to tell when to refresh card data
@@ -293,7 +312,7 @@ export class SeriesDetailComponent implements OnInit, AfterContentChecked {
               public utilityService: UtilityService, private toastr: ToastrService,
               private accountService: AccountService, public imageService: ImageService,
               private actionFactoryService: ActionFactoryService, private libraryService: LibraryService,
-              private confirmService: ConfirmService, private titleService: Title,
+              private titleService: Title,
               private downloadService: DownloadService, private actionService: ActionService,
               private messageHub: MessageHubService, private readingListService: ReadingListService,
               public navService: NavService,
@@ -501,6 +520,14 @@ export class SeriesDetailComponent implements OnInit, AfterContentChecked {
     this.seriesService.getMetadata(seriesId).subscribe(metadata => {
       this.seriesMetadata = metadata;
       this.cdRef.markForCheck();
+
+      if (![PublicationStatus.Ended, PublicationStatus.OnGoing].includes(this.seriesMetadata.publicationStatus)) return;
+      this.seriesService.getNextExpectedChapterDate(seriesId).subscribe(date => {
+        if (date == null || date.expectedDate === null) return;
+
+        this.nextExpectedChapter = date;
+        this.cdRef.markForCheck();
+      })
     });
 
     this.seriesService.isWantToRead(seriesId).subscribe(isWantToRead => {

--- a/UI/Web/src/app/user-settings/change-email/change-email.component.ts
+++ b/UI/Web/src/app/user-settings/change-email/change-email.component.ts
@@ -64,7 +64,7 @@ export class ChangeEmailComponent implements OnInit {
         if (updateEmailResponse.hadNoExistingEmail) {
           this.toastr.success(translate('toasts.email-sent-to-no-existing', {email: model.email}));
         } else {
-          this.toastr.success(translate('toasts.email-send-to'));
+          this.toastr.success(translate('toasts.email-sent-to'));
         }
       } else {
         this.toastr.success(translate('toasts.change-email-private'));

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -1191,6 +1191,10 @@
         "bust-cache-task-desc": "Busts the Kavita+ Cache - should only be used when debugging bad matches.",
         "bust-cache-task-success": "Kavita+ Cache busted",
 
+        "bust-locale-task": "Bust Locale Cache",
+        "bust-locale-task-desc": "Busts the Locale Cache. This can fix issues with strings not showing correctly after an update",
+        "bust-locale-task-success": "Locale Cache busted",
+
         "clear-reading-cache-task": "Clear Reading Cache",
         "clear-reading-cache-task-desc": "Clears cached files for reading. Useful when you've just updated a file that you were previously reading within the last 24 hours.",
         "clear-reading-cache-task-success": "Cache has been cleared",

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -897,7 +897,6 @@
 
     "card-item": {
         "cannot-read": "Cannot Read"
-
     },
 
     "chapter-metadata-detail": {

--- a/openapi.json
+++ b/openapi.json
@@ -9071,6 +9071,47 @@
         }
       }
     },
+    "/api/Series/next-expected": {
+      "get": {
+        "tags": [
+          "Series"
+        ],
+        "summary": "Based on the delta times between when chapters are added, for series that are not Completed/Cancelled/Hiatus, forecast the next\r\ndate when it will be available.",
+        "parameters": [
+          {
+            "name": "seriesId",
+            "in": "query",
+            "description": "",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/NextExpectedChapterDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NextExpectedChapterDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NextExpectedChapterDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/Server/clear-cache": {
       "post": {
         "tags": [
@@ -15632,6 +15673,31 @@
           },
           "password": {
             "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "NextExpectedChapterDto": {
+        "type": "object",
+        "properties": {
+          "chapterNumber": {
+            "type": "number",
+            "format": "float"
+          },
+          "volumeNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "expectedDate": {
+            "type": "string",
+            "description": "Null if not applicable",
+            "format": "date-time",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "description": "The localized title to render on the card",
             "nullable": true
           }
         },

--- a/openapi.json
+++ b/openapi.json
@@ -7,7 +7,7 @@
       "name": "GPL-3.0",
       "url": "https://github.com/Kareadita/Kavita/blob/develop/LICENSE"
     },
-    "version": "0.7.8.15"
+    "version": "0.7.9.0"
   },
   "servers": [
     {

--- a/openapi.json
+++ b/openapi.json
@@ -13389,7 +13389,7 @@
           },
           "totalCount": {
             "type": "integer",
-            "description": "Total number of issues or volumes in the series",
+            "description": "Total number of issues or volumes in the series. This is straight from ComicInfo",
             "format": "int32"
           },
           "count": {
@@ -17244,7 +17244,7 @@
           },
           "totalCount": {
             "type": "integer",
-            "description": "Total number of issues/volumes in the series",
+            "description": "Total expected number of issues/volumes in the series from ComicInfo.xml",
             "format": "int32"
           },
           "maxCount": {


### PR DESCRIPTION
# Added
- Added: Added a button in Tasks to bust locale cache, which can sometimes get stuck
- Added: Added a new chapter/volume card (list view not implemented yet) for Series that are On Going or Ended, that uses the delta times between each chapter being added to estimate when the next chapter should be available on the server. 

# Fixed
- Fixed: Fixed a bug where a Ended series could get flagged as Completed Publication Status
- Fixed: Fixed an issue where sorting by Last Read progress could incorrectly order the series if another user had recently read that Series. 
- Fixed: Fixed an issue where Smart Filters that had a value with a space would resume as a Smart Filter with +, thus breaking the filter. 
- Fixed: Fixed an issue where table of contents in dark mode in the pdf reader wouldn't be readable (Fixes #2340 )
