### PR TITLE
Lots of Bugfixes

### DIFF
--- a/API.Tests/Extensions/SeriesExtensionsTests.cs
+++ b/API.Tests/Extensions/SeriesExtensionsTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using API.Comparators;
 using API.Entities;
@@ -31,7 +32,7 @@ public class SeriesExtensionsTests
 
         foreach (var vol in series.Volumes)
         {
-            vol.CoverImage = vol.Chapters.MinBy(x => double.Parse(x.Number), ChapterSortComparerZeroFirst.Default)?.CoverImage;
+            vol.CoverImage = vol.Chapters.MinBy(x => double.Parse(x.Number, CultureInfo.InvariantCulture), ChapterSortComparerZeroFirst.Default)?.CoverImage;
         }
 
         Assert.Equal("Special 1", series.GetCoverImage());
@@ -66,7 +67,7 @@ public class SeriesExtensionsTests
 
         foreach (var vol in series.Volumes)
         {
-            vol.CoverImage = vol.Chapters.MinBy(x => double.Parse(x.Number), ChapterSortComparerZeroFirst.Default)?.CoverImage;
+            vol.CoverImage = vol.Chapters.MinBy(x => double.Parse(x.Number, CultureInfo.InvariantCulture), ChapterSortComparerZeroFirst.Default)?.CoverImage;
         }
 
         Assert.Equal("Volume 1 Chapter 1", series.GetCoverImage());
@@ -108,7 +109,7 @@ public class SeriesExtensionsTests
 
         foreach (var vol in series.Volumes)
         {
-            vol.CoverImage = vol.Chapters.MinBy(x => double.Parse(x.Number), ChapterSortComparerZeroFirst.Default)?.CoverImage;
+            vol.CoverImage = vol.Chapters.MinBy(x => double.Parse(x.Number, CultureInfo.InvariantCulture), ChapterSortComparerZeroFirst.Default)?.CoverImage;
         }
 
         Assert.Equal("Volume 1 Chapter 1", series.GetCoverImage());
@@ -134,7 +135,7 @@ public class SeriesExtensionsTests
 
         foreach (var vol in series.Volumes)
         {
-            vol.CoverImage = vol.Chapters.MinBy(x => double.Parse(x.Number), ChapterSortComparerZeroFirst.Default)?.CoverImage;
+            vol.CoverImage = vol.Chapters.MinBy(x => double.Parse(x.Number, CultureInfo.InvariantCulture), ChapterSortComparerZeroFirst.Default)?.CoverImage;
         }
 
         Assert.Equal("Special 2", series.GetCoverImage());
@@ -164,7 +165,7 @@ public class SeriesExtensionsTests
 
         foreach (var vol in series.Volumes)
         {
-            vol.CoverImage = vol.Chapters.MinBy(x => double.Parse(x.Number), ChapterSortComparerZeroFirst.Default)?.CoverImage;
+            vol.CoverImage = vol.Chapters.MinBy(x => double.Parse(x.Number, CultureInfo.InvariantCulture), ChapterSortComparerZeroFirst.Default)?.CoverImage;
         }
 
         Assert.Equal("Chapter 2", series.GetCoverImage());
@@ -201,7 +202,7 @@ public class SeriesExtensionsTests
 
         foreach (var vol in series.Volumes)
         {
-            vol.CoverImage = vol.Chapters.MinBy(x => double.Parse(x.Number), ChapterSortComparerZeroFirst.Default)?.CoverImage;
+            vol.CoverImage = vol.Chapters.MinBy(x => double.Parse(x.Number, CultureInfo.InvariantCulture), ChapterSortComparerZeroFirst.Default)?.CoverImage;
         }
 
         Assert.Equal("Volume 1", series.GetCoverImage());
@@ -238,7 +239,7 @@ public class SeriesExtensionsTests
 
         foreach (var vol in series.Volumes)
         {
-            vol.CoverImage = vol.Chapters.MinBy(x => double.Parse(x.Number), ChapterSortComparerZeroFirst.Default)?.CoverImage;
+            vol.CoverImage = vol.Chapters.MinBy(x => double.Parse(x.Number, CultureInfo.InvariantCulture), ChapterSortComparerZeroFirst.Default)?.CoverImage;
         }
 
         Assert.Equal("Volume 1", series.GetCoverImage());
@@ -282,7 +283,7 @@ public class SeriesExtensionsTests
 
         foreach (var vol in series.Volumes)
         {
-            vol.CoverImage = vol.Chapters.MinBy(x => double.Parse(x.Number), ChapterSortComparerZeroFirst.Default)?.CoverImage;
+            vol.CoverImage = vol.Chapters.MinBy(x => double.Parse(x.Number, CultureInfo.InvariantCulture), ChapterSortComparerZeroFirst.Default)?.CoverImage;
         }
 
         Assert.Equal("Volume 1", series.GetCoverImage());
@@ -315,7 +316,7 @@ public class SeriesExtensionsTests
 
         foreach (var vol in series.Volumes)
         {
-            vol.CoverImage = vol.Chapters.MinBy(x => double.Parse(x.Number), ChapterSortComparerZeroFirst.Default)?.CoverImage;
+            vol.CoverImage = vol.Chapters.MinBy(x => double.Parse(x.Number, CultureInfo.InvariantCulture), ChapterSortComparerZeroFirst.Default)?.CoverImage;
         }
 
         Assert.Equal("Chapter 2", series.GetCoverImage());

--- a/API.Tests/Helpers/SmartFilterHelperTests.cs
+++ b/API.Tests/Helpers/SmartFilterHelperTests.cs
@@ -25,7 +25,7 @@ public class SmartFilterHelperTests
 
         var list = filter.Statements.ToList();
         AssertStatementSame(list[2], FilterField.SeriesName, FilterComparison.Matches, "a");
-        AssertStatementSame(list[1], FilterField.AgeRating, FilterComparison.Equal, (int) AgeRating.Unknown + "");
+        AssertStatementSame(list[1], FilterField.AgeRating, FilterComparison.Equal, (int) AgeRating.Unknown + string.Empty);
         AssertStatementSame(list[0], FilterField.Genres, FilterComparison.Contains, "6");
 
     }

--- a/API.Tests/Helpers/SmartFilterHelperTests.cs
+++ b/API.Tests/Helpers/SmartFilterHelperTests.cs
@@ -1,8 +1,11 @@
-﻿using System.Linq;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using API.DTOs.Filtering;
 using API.DTOs.Filtering.v2;
 using API.Entities.Enums;
 using API.Helpers;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities;
 using Xunit;
 
 namespace API.Tests.Helpers;
@@ -13,21 +16,47 @@ public class SmartFilterHelperTests
     public void Test_Decode()
     {
         var encoded = """
-                      stmts=comparison%3D5%26field%3D18%26value%3D6%2Ccomparison%3D0%26field%3D4%26value%3D0%2Ccomparison%3D7%26field%3D1%26value%3Da&sortOptions=sortField=1&isAscending=true&limitTo=0&combination=1
+                      stmts=comparison%3D5%26field%3D18%26value%3D95%2Ccomparison%3D0%26field%3D4%26value%3D0%2Ccomparison%3D7%26field%3D1%26value%3Da&sortOptions=sortField=2&isAscending=false&limitTo=10&combination=1
                       """;
 
         var filter = SmartFilterHelper.Decode(encoded);
 
-        Assert.Equal(0, filter.LimitTo);
-        Assert.Equal(SortField.SortName, filter.SortOptions.SortField);
-        Assert.True(filter.SortOptions.IsAscending);
+        Assert.Equal(10, filter.LimitTo);
+        Assert.Equal(SortField.CreatedDate, filter.SortOptions.SortField);
+        Assert.False(filter.SortOptions.IsAscending);
         Assert.Null(filter.Name);
 
         var list = filter.Statements.ToList();
         AssertStatementSame(list[2], FilterField.SeriesName, FilterComparison.Matches, "a");
         AssertStatementSame(list[1], FilterField.AgeRating, FilterComparison.Equal, (int) AgeRating.Unknown + string.Empty);
-        AssertStatementSame(list[0], FilterField.Genres, FilterComparison.Contains, "6");
+        AssertStatementSame(list[0], FilterField.Genres, FilterComparison.Contains, "95");
+    }
 
+    [Fact]
+    public void Test_Encode()
+    {
+        var filter = new FilterV2Dto()
+        {
+            Name = "Test",
+            SortOptions = new SortOptions() {
+                IsAscending = false,
+                SortField = SortField.CreatedDate
+                },
+            LimitTo = 10,
+            Combination = FilterCombination.And,
+            Statements = new List<FilterStatementDto>()
+            {
+                new FilterStatementDto()
+                {
+                    Comparison = FilterComparison.Equal,
+                    Field = FilterField.AgeRating,
+                    Value = (int) AgeRating.Unknown + string.Empty
+                }
+            }
+        };
+
+        var encodedFilter = SmartFilterHelper.Encode(filter);
+        Assert.Equal("name=Test&stmts=comparison%253D0%252Cfield%253D4%252Cvalue%253D0&sortOptions=sortField%3D2%26isAscending%3DFalse&limitTo=10&combination=1", encodedFilter);
     }
 
     private void AssertStatementSame(FilterStatementDto statement, FilterField field, FilterComparison combination, string value)

--- a/API.Tests/Parser/ParserTest.cs
+++ b/API.Tests/Parser/ParserTest.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Linq;
 using Xunit;
 using static API.Services.Tasks.Scanner.Parser.Parser;
@@ -6,6 +7,14 @@ namespace API.Tests.Parser;
 
 public class ParserTests
 {
+    [Fact]
+    public void ShouldWork()
+    {
+        var s = 6.5f + "";
+        var a = float.Parse(s, CultureInfo.InvariantCulture);
+        Assert.Equal(6.5f, a);
+    }
+
     [Theory]
     [InlineData("Joe Shmo, Green Blue", "Joe Shmo, Green Blue")]
     [InlineData("Shmo, Joe",  "Shmo, Joe")]

--- a/API.Tests/Services/ReaderServiceTests.cs
+++ b/API.Tests/Services/ReaderServiceTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Data.Common;
+using System.Globalization;
 using System.IO.Abstractions.TestingHelpers;
 using System.Linq;
 using System.Threading.Tasks;
@@ -1219,7 +1220,7 @@ public class ReaderServiceTests
 
         var prevChapter = await _readerService.GetPrevChapterIdAsync(1, 2,5, 1);
         var chapterInfoDto = await _unitOfWork.ChapterRepository.GetChapterInfoDtoAsync(prevChapter);
-        Assert.Equal(1, float.Parse(chapterInfoDto.ChapterNumber));
+        Assert.Equal(1, chapterInfoDto.ChapterNumber.AsFloat());
 
         // This is first chapter of first volume
         prevChapter = await _readerService.GetPrevChapterIdAsync(1, 2,4, 1);

--- a/API/Controllers/AccountController.cs
+++ b/API/Controllers/AccountController.cs
@@ -604,7 +604,7 @@ public class AccountController : BaseApiController
 
         // Create a new user
         var user = new AppUserBuilder(dto.Email, dto.Email, await _unitOfWork.SiteThemeRepository.GetDefaultTheme()).Build();
-
+        _unitOfWork.UserRepository.Add(user);
         try
         {
             var result = await _userManager.CreateAsync(user, AccountService.DefaultPassword);

--- a/API/Controllers/ImageController.cs
+++ b/API/Controllers/ImageController.cs
@@ -223,6 +223,7 @@ public class ImageController : BaseApiController
         var userId = await _unitOfWork.UserRepository.GetUserIdByApiKeyAsync(apiKey);
         if (userId == 0) return BadRequest();
         if (string.IsNullOrEmpty(url)) return BadRequest(await _localizationService.Translate(userId, "must-be-defined", "Url"));
+
         var encodeFormat = (await _unitOfWork.SettingsRepository.GetSettingsDtoAsync()).EncodeMediaAs;
 
         // Check if the domain exists

--- a/API/Controllers/LibraryController.cs
+++ b/API/Controllers/LibraryController.cs
@@ -458,6 +458,8 @@ public class LibraryController : BaseApiController
         }
         await _eventHub.SendMessageAsync(MessageFactory.LibraryModified,
             MessageFactory.LibraryModifiedEvent(library.Id, "update"), false);
+        await _eventHub.SendMessageAsync(MessageFactory.SideNavUpdate,
+            MessageFactory.SideNavUpdateEvent(User.GetUserId()), false);
 
         await _libraryCacheProvider.RemoveByPrefixAsync(CacheKey);
 

--- a/API/Controllers/OPDSController.cs
+++ b/API/Controllers/OPDSController.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -775,7 +776,7 @@ public class OpdsController : BaseApiController
         var seriesDetail =  await _seriesService.GetSeriesDetail(seriesId, userId);
         foreach (var volume in seriesDetail.Volumes)
         {
-            var chapters = (await _unitOfWork.ChapterRepository.GetChaptersAsync(volume.Id)).OrderBy(x => double.Parse(x.Number),
+            var chapters = (await _unitOfWork.ChapterRepository.GetChaptersAsync(volume.Id)).OrderBy(x => double.Parse(x.Number, CultureInfo.InvariantCulture),
         _chapterSortComparer);
 
             foreach (var chapter in chapters)
@@ -825,7 +826,7 @@ public class OpdsController : BaseApiController
         var libraryType = await _unitOfWork.LibraryRepository.GetLibraryTypeAsync(series.LibraryId);
         var volume = await _unitOfWork.VolumeRepository.GetVolumeAsync(volumeId);
         var chapters =
-            (await _unitOfWork.ChapterRepository.GetChaptersAsync(volumeId)).OrderBy(x => double.Parse(x.Number),
+            (await _unitOfWork.ChapterRepository.GetChaptersAsync(volumeId)).OrderBy(x => double.Parse(x.Number, CultureInfo.InvariantCulture),
                 _chapterSortComparer);
         var feed = CreateFeed(series.Name + " - Volume " + volume!.Name + $" - {_seriesService.FormatChapterName(userId, libraryType)}s ",
             $"{prefix}{apiKey}/series/{seriesId}/volume/{volumeId}", apiKey, prefix);

--- a/API/Data/Metadata/ComicInfo.cs
+++ b/API/Data/Metadata/ComicInfo.cs
@@ -185,12 +185,12 @@ public class ComicInfo
     {
         try
         {
-            if (float.TryParse(Number, out var chpCount) && chpCount > 0)
+            if (float.TryParse(Number, CultureInfo.InvariantCulture, out var chpCount) && chpCount > 0)
             {
                 return (int) Math.Floor(chpCount);
             }
 
-            if (float.TryParse(Volume, out var volCount) && volCount > 0)
+            if (float.TryParse(Volume, CultureInfo.InvariantCulture, out var volCount) && volCount > 0)
             {
                 return (int) Math.Floor(volCount);
             }

--- a/API/Data/Repositories/UserRepository.cs
+++ b/API/Data/Repositories/UserRepository.cs
@@ -43,12 +43,13 @@ public enum AppUserIncludes
 
 public interface IUserRepository
 {
+    void Add(AppUserBookmark bookmark);
+    void Add(AppUser bookmark);
     void Update(AppUser user);
     void Update(AppUserPreferences preferences);
     void Update(AppUserBookmark bookmark);
     void Update(AppUserDashboardStream stream);
     void Update(AppUserSideNavStream stream);
-    void Add(AppUserBookmark bookmark);
     void Delete(AppUser? user);
     void Delete(AppUserBookmark bookmark);
     void Delete(IEnumerable<AppUserDashboardStream> streams);
@@ -108,6 +109,16 @@ public class UserRepository : IUserRepository
         _mapper = mapper;
     }
 
+    public void Add(AppUserBookmark bookmark)
+    {
+        _context.AppUserBookmark.Add(bookmark);
+    }
+
+    public void Add(AppUser user)
+    {
+        _context.AppUser.Add(user);
+    }
+
     public void Update(AppUser user)
     {
         _context.Entry(user).State = EntityState.Modified;
@@ -131,11 +142,6 @@ public class UserRepository : IUserRepository
     public void Update(AppUserSideNavStream stream)
     {
         _context.Entry(stream).State = EntityState.Modified;
-    }
-
-    public void Add(AppUserBookmark bookmark)
-    {
-        _context.AppUserBookmark.Add(bookmark);
     }
 
     public void Delete(AppUser? user)

--- a/API/Data/UnitOfWork.cs
+++ b/API/Data/UnitOfWork.cs
@@ -5,6 +5,7 @@ using API.Entities;
 using API.Services;
 using AutoMapper;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
 
 namespace API.Data;
 
@@ -117,6 +118,16 @@ public class UnitOfWork : IUnitOfWork
     /// <returns></returns>
     public async Task<bool> RollbackAsync()
     {
+        // foreach (var entry in _context.ChangeTracker.Entries())
+        // {
+        //     switch (entry.State)
+        //     {
+        //         case EntityState.Added:
+        //             entry.State = EntityState.Detached;
+        //             break;
+        //     }
+        // }
+
         try
         {
             await _context.Database.RollbackTransactionAsync();

--- a/API/Data/UnitOfWork.cs
+++ b/API/Data/UnitOfWork.cs
@@ -118,16 +118,6 @@ public class UnitOfWork : IUnitOfWork
     /// <returns></returns>
     public async Task<bool> RollbackAsync()
     {
-        // foreach (var entry in _context.ChangeTracker.Entries())
-        // {
-        //     switch (entry.State)
-        //     {
-        //         case EntityState.Added:
-        //             entry.State = EntityState.Detached;
-        //             break;
-        //     }
-        // }
-
         try
         {
             await _context.Database.RollbackTransactionAsync();

--- a/API/Extensions/ApplicationServiceExtensions.cs
+++ b/API/Extensions/ApplicationServiceExtensions.cs
@@ -107,12 +107,19 @@ public static class ApplicationServiceExtensions
 
     private static void AddSqLite(this IServiceCollection services)
     {
-        services.AddDbContext<DataContext>(options =>
+        services.AddDbContextPool<DataContext>(options =>
         {
             options.UseSqlite("Data source=config/kavita.db");
             options.EnableDetailedErrors();
 
             options.EnableSensitiveDataLogging();
         });
+        // services.AddDbContext<DataContext>(options =>
+        // {
+        //     options.UseSqlite("Data source=config/kavita.db");
+        //     options.EnableDetailedErrors();
+        //
+        //     options.EnableSensitiveDataLogging();
+        // });
     }
 }

--- a/API/Extensions/ApplicationServiceExtensions.cs
+++ b/API/Extensions/ApplicationServiceExtensions.cs
@@ -114,12 +114,5 @@ public static class ApplicationServiceExtensions
 
             options.EnableSensitiveDataLogging();
         });
-        // services.AddDbContext<DataContext>(options =>
-        // {
-        //     options.UseSqlite("Data source=config/kavita.db");
-        //     options.EnableDetailedErrors();
-        //
-        //     options.EnableSensitiveDataLogging();
-        // });
     }
 }

--- a/API/Extensions/SeriesExtensions.cs
+++ b/API/Extensions/SeriesExtensions.cs
@@ -1,5 +1,6 @@
 ﻿#nullable enable
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using API.Comparators;
 using API.Entities;
@@ -24,7 +25,7 @@ public static class SeriesExtensions
         if (firstVolume == null) return null;
 
         var chapters = firstVolume.Chapters
-            .OrderBy(c => double.Parse(c.Number), ChapterSortComparerZeroFirst.Default)
+            .OrderBy(c => c.Number.AsDouble(), ChapterSortComparerZeroFirst.Default)
             .ToList();
 
         if (chapters.Count > 1 && chapters.Exists(c => c.IsSpecial))
@@ -44,9 +45,9 @@ public static class SeriesExtensions
         {
             var looseLeafChapters = volumes.Where(v => $"{v.Number}" == Parser.DefaultVolume)
                 .SelectMany(c => c.Chapters.Where(c => !c.IsSpecial))
-                .OrderBy(c => double.Parse(c.Number), ChapterSortComparerZeroFirst.Default)
+                .OrderBy(c => c.Number.AsDouble(), ChapterSortComparerZeroFirst.Default)
                 .ToList();
-            if (looseLeafChapters.Count > 0 && (1.0f * volumes[0].Number) > float.Parse(looseLeafChapters[0].Number))
+            if (looseLeafChapters.Count > 0 && (1.0f * volumes[0].Number) > looseLeafChapters[0].Number.AsFloat())
             {
                 return looseLeafChapters[0].CoverImage;
             }
@@ -56,7 +57,7 @@ public static class SeriesExtensions
         var firstLooseLeafChapter = volumes
             .Where(v => $"{v.Number}" == Parser.DefaultVolume)
             .SelectMany(v => v.Chapters)
-            .OrderBy(c => double.Parse(c.Number), ChapterSortComparerZeroFirst.Default)
+            .OrderBy(c => c.Number.AsDouble(), ChapterSortComparerZeroFirst.Default)
             .FirstOrDefault(c => !c.IsSpecial);
 
         return firstLooseLeafChapter?.CoverImage ?? firstVolume.CoverImage;

--- a/API/Extensions/StringExtensions.cs
+++ b/API/Extensions/StringExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.RegularExpressions;
+﻿using System.Globalization;
+using System.Text.RegularExpressions;
 
 namespace API.Extensions;
 
@@ -21,5 +22,15 @@ public static class StringExtensions
     {
         if (string.IsNullOrEmpty(value)) return string.Empty;
         return Services.Tasks.Scanner.Parser.Parser.Normalize(value);
+    }
+
+    public static float AsFloat(this string value)
+    {
+        return float.Parse(value, CultureInfo.InvariantCulture);
+    }
+
+    public static double AsDouble(this string value)
+    {
+        return double.Parse(value, CultureInfo.InvariantCulture);
     }
 }

--- a/API/Helpers/Builders/ChapterBuilder.cs
+++ b/API/Helpers/Builders/ChapterBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using API.Entities;
 using API.Entities.Enums;
 using API.Services.Tasks.Scanner.Parser;
@@ -17,7 +18,7 @@ public class ChapterBuilder : IEntityBuilder<Chapter>
         {
             Range = string.IsNullOrEmpty(range) ? number : range,
             Title = string.IsNullOrEmpty(range) ? number : range,
-            Number = Parser.MinNumberFromRange(number) + string.Empty,
+            Number = Parser.MinNumberFromRange(number).ToString(CultureInfo.InvariantCulture),
             Files = new List<MangaFile>(),
             Pages = 1
         };

--- a/API/Helpers/Converters/FilterFieldValueConverter.cs
+++ b/API/Helpers/Converters/FilterFieldValueConverter.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using API.DTOs.Filtering.v2;
 using API.Entities.Enums;
+using API.Extensions;
 
 namespace API.Helpers.Converters;
 
@@ -68,7 +70,7 @@ public static class FilterFieldValueConverter
                 .Select(int.Parse)
                 .ToList(),
             FilterField.WantToRead => bool.Parse(value),
-            FilterField.ReadProgress => float.Parse(value),
+            FilterField.ReadProgress => value.AsFloat(),
             FilterField.ReadingDate => DateTime.Parse(value),
             FilterField.Formats => value.Split(',')
                 .Select(x => (MangaFormat) Enum.Parse(typeof(MangaFormat), x))

--- a/API/Helpers/SmartFilterHelper.cs
+++ b/API/Helpers/SmartFilterHelper.cs
@@ -72,7 +72,7 @@ public static class SmartFilterHelper
 
     private static string EncodeSortOptions(SortOptions sortOptions)
     {
-        return $"sortField={(int) sortOptions.SortField}&isAscending={sortOptions.IsAscending}";
+        return Uri.EscapeDataString($"sortField={(int) sortOptions.SortField}&isAscending={sortOptions.IsAscending}");
     }
 
     private static string EncodeFilterStatementDtos(ICollection<FilterStatementDto> statements)
@@ -90,7 +90,7 @@ public static class SmartFilterHelper
         var encodedField = $"field={(int) statement.Field}";
         var encodedValue = $"value={Uri.EscapeDataString(statement.Value)}";
 
-        return $"{encodedComparison}&{encodedField}&{encodedValue}";
+        return Uri.EscapeDataString($"{encodedComparison},{encodedField},{encodedValue}");
     }
 
     private static List<FilterStatementDto> DecodeFilterStatementDtos(string encodedStatements)
@@ -119,7 +119,7 @@ public static class SmartFilterHelper
 
     private static SortOptions DecodeSortOptions(string encodedSortOptions)
     {
-        string[] parts = encodedSortOptions.Split('&');
+        string[] parts = encodedSortOptions.Split(',');
         var sortFieldPart = parts.FirstOrDefault(part => part.StartsWith("sortField="));
         var isAscendingPart = parts.FirstOrDefault(part => part.StartsWith("isAscending="));
 

--- a/API/Helpers/SmartFilterHelper.cs
+++ b/API/Helpers/SmartFilterHelper.cs
@@ -123,7 +123,7 @@ public static class SmartFilterHelper
         var sortFieldPart = parts.FirstOrDefault(part => part.StartsWith("sortField="));
         var isAscendingPart = parts.FirstOrDefault(part => part.StartsWith("isAscending="));
 
-        var isAscending = isAscendingPart?.Substring(11).Equals("true", StringComparison.OrdinalIgnoreCase) ?? true;
+        var isAscending = isAscendingPart?.Substring(11).Equals("true", StringComparison.OrdinalIgnoreCase) ?? false;
         if (sortFieldPart != null)
         {
             var sortField = Enum.Parse<SortField>(sortFieldPart.Split("=")[1]);

--- a/API/I18N/en.json
+++ b/API/I18N/en.json
@@ -31,6 +31,7 @@
     "password-updated": "Password Updated",
     "forgot-password-generic": "An email will be sent to the email if it exists in our database",
     "not-accessible-password": "Your server is not accessible. The link to reset your password is in the logs",
+    "invalid-email": "The email on file for user is not a valid email. See logs for any links.",
     "not-accessible": "Your server is not accessible externally",
     "email-sent": "Email sent",
     "user-migration-needed": "This user needs to migrate. Have them log out and login to trigger a migration flow",

--- a/API/Services/AccountService.cs
+++ b/API/Services/AccountService.cs
@@ -56,7 +56,8 @@ public class AccountService : IAccountService
     /// <returns></returns>
     public async Task<bool> CheckIfAccessible(HttpRequest request)
     {
-        var host = _environment.IsDevelopment() ? LocalHost : request.Host.ToString();
+        //var host = _environment.IsDevelopment() ? LocalHost : request.Host.ToString();
+        var host =  request.Host.ToString();
         return !string.IsNullOrEmpty((await _unitOfWork.SettingsRepository.GetSettingsDtoAsync()).HostName) || await _emailService.CheckIfAccessible(host);
     }
 

--- a/API/Services/AccountService.cs
+++ b/API/Services/AccountService.cs
@@ -56,8 +56,7 @@ public class AccountService : IAccountService
     /// <returns></returns>
     public async Task<bool> CheckIfAccessible(HttpRequest request)
     {
-        //var host = _environment.IsDevelopment() ? LocalHost : request.Host.ToString();
-        var host =  request.Host.ToString();
+        var host = _environment.IsDevelopment() ? LocalHost : request.Host.ToString();
         return !string.IsNullOrEmpty((await _unitOfWork.SettingsRepository.GetSettingsDtoAsync()).HostName) || await _emailService.CheckIfAccessible(host);
     }
 

--- a/API/Services/BookService.cs
+++ b/API/Services/BookService.cs
@@ -10,6 +10,7 @@ using API.Data.Metadata;
 using API.DTOs.Reader;
 using API.Entities;
 using API.Entities.Enums;
+using API.Extensions;
 using API.Services.Tasks.Scanner.Parser;
 using Docnet.Core;
 using Docnet.Core.Converters;
@@ -490,7 +491,7 @@ public class BookService : IBookService
                 switch (metadataItem.Name)
                 {
                     case "calibre:rating":
-                        info.UserRating = float.Parse(metadataItem.Content);
+                        info.UserRating = metadataItem.Content.AsFloat();
                         break;
                     case "calibre:title_sort":
                         info.TitleSort = metadataItem.Content;

--- a/API/Services/BookService.cs
+++ b/API/Services/BookService.cs
@@ -650,7 +650,7 @@ public class BookService : IBookService
                 return;
             case "ill":
             case "illustrator":
-                info.Letterer += AppendAuthor(person);
+                info.Inker += AppendAuthor(person);
                 return;
             case "clr":
             case "colorist":

--- a/API/Services/DirectoryService.cs
+++ b/API/Services/DirectoryService.cs
@@ -972,9 +972,9 @@ public class DirectoryService : IDirectoryService
             foreach (var file in directory.EnumerateFiles().OrderByNatural(file => file.FullName))
             {
                 if (file.Directory == null) continue;
-                var paddedIndex = Tasks.Scanner.Parser.Parser.PadZeros(directoryIndex + "");
+                var paddedIndex = Tasks.Scanner.Parser.Parser.PadZeros(directoryIndex + string.Empty);
                 // We need to rename the files so that after flattening, they are in the order we found them
-                var newName = $"{paddedIndex}_{Tasks.Scanner.Parser.Parser.PadZeros(fileIndex + "")}{file.Extension}";
+                var newName = $"{paddedIndex}_{Tasks.Scanner.Parser.Parser.PadZeros(fileIndex + string.Empty)}{file.Extension}";
                 var newPath = Path.Join(root.FullName, newName);
                 if (!File.Exists(newPath)) file.MoveTo(newPath);
                 fileIndex++;

--- a/API/Services/EmailService.cs
+++ b/API/Services/EmailService.cs
@@ -138,8 +138,15 @@ public class EmailService : IEmailService
         // This is the only exception for using the default because we need an external service to check if the server is accessible for emails
         try
         {
-            if (IsLocalIpAddress(host)) return false;
-            return await SendEmailWithGet(DefaultApiUrl + "/api/reachable?host=" + host);
+            if (IsLocalIpAddress(host))
+            {
+                _logger.LogDebug("[EmailService] Server is not accessible, using local ip");
+                return false;
+            }
+
+            var url = DefaultApiUrl + "/api/reachable?host=" + host;
+            _logger.LogDebug("[EmailService] Checking if this server is accessible for sending an email to: {Url}", url);
+            return await SendEmailWithGet(url);
         }
         catch (Exception)
         {

--- a/API/Services/EmailService.cs
+++ b/API/Services/EmailService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
@@ -27,6 +28,7 @@ public interface IEmailService
     Task<bool> IsDefaultEmailService();
     Task SendEmailChangeEmail(ConfirmationEmailDto data);
     Task<string?> GetVersion(string emailUrl);
+    bool IsValidEmail(string email);
 }
 
 public class EmailService : IEmailService
@@ -121,6 +123,11 @@ public class EmailService : IEmailService
         }
 
         return null;
+    }
+
+    public bool IsValidEmail(string email)
+    {
+        return new EmailAddressAttribute().IsValid(email);
     }
 
     public async Task SendConfirmationEmail(ConfirmationEmailDto data)

--- a/API/Services/ImageService.cs
+++ b/API/Services/ImageService.cs
@@ -288,7 +288,7 @@ public class ImageService : IImageService
 
             // Create the destination file path
             using var image = Image.PngloadStream(faviconStream);
-            var filename = $"{domain}{encodeFormat.GetExtension()}";
+            var filename = ImageService.GetWebLinkFormat(baseUrl, encodeFormat);
             switch (encodeFormat)
             {
                 case EncodeFormat.PNG:

--- a/API/Services/MediaConversionService.cs
+++ b/API/Services/MediaConversionService.cs
@@ -197,7 +197,7 @@ public class MediaConversionService : IMediaConversionService
         foreach (var volume in nonCustomOrConvertedVolumeCovers)
         {
             if (string.IsNullOrEmpty(volume.CoverImage)) continue;
-            volume.CoverImage = volume.Chapters.MinBy(x => double.Parse(x.Number), ChapterSortComparerZeroFirst.Default)?.CoverImage;
+            volume.CoverImage = volume.Chapters.MinBy(x => x.Number.AsDouble(), ChapterSortComparerZeroFirst.Default)?.CoverImage;
             _unitOfWork.VolumeRepository.Update(volume);
             await _unitOfWork.CommitAsync();
         }

--- a/API/Services/MetadataService.cs
+++ b/API/Services/MetadataService.cs
@@ -107,7 +107,7 @@ public class MetadataService : IMetadataService
 
 
         volume.Chapters ??= new List<Chapter>();
-        var firstChapter = volume.Chapters.MinBy(x => double.Parse(x.Number), ChapterSortComparerZeroFirst.Default);
+        var firstChapter = volume.Chapters.MinBy(x => x.Number.AsDouble(), ChapterSortComparerZeroFirst.Default);
         if (firstChapter == null) return Task.FromResult(false);
 
         volume.CoverImage = firstChapter.CoverImage;

--- a/API/Services/Plus/ScrobblingService.cs
+++ b/API/Services/Plus/ScrobblingService.cs
@@ -526,6 +526,7 @@ public class ScrobblingService : IScrobblingService
             foreach (var series in seriesWithProgress)
             {
                 if (!libAllowsScrobbling[series.LibraryId]) continue;
+                if (series.PagesRead <= 0) continue; // Since we only scrobble when things are higher, we can
                 await ScrobbleReadingUpdate(uId, series.Id);
             }
 

--- a/API/Services/ReaderService.cs
+++ b/API/Services/ReaderService.cs
@@ -245,6 +245,9 @@ public class ReaderService : IReaderService
             var userProgress =
                 await _unitOfWork.AppUserProgressRepository.GetUserProgressAsync(progressDto.ChapterId, userId);
 
+            // Don't create an empty progress record if there isn't any progress. This prevents Last Read date from being updated when
+            // opening a chapter
+            if (userProgress == null && progressDto.PageNum == 0) return true;
 
             if (userProgress == null)
             {

--- a/API/Services/ReadingListService.cs
+++ b/API/Services/ReadingListService.cs
@@ -12,6 +12,7 @@ using API.DTOs.ReadingLists;
 using API.DTOs.ReadingLists.CBL;
 using API.Entities;
 using API.Entities.Enums;
+using API.Extensions;
 using API.Helpers;
 using API.Helpers.Builders;
 using API.Services.Tasks.Scanner.Parser;
@@ -390,7 +391,7 @@ public class ReadingListService : IReadingListService
         var existingChapterExists = readingList.Items.Select(rli => rli.ChapterId).ToHashSet();
         var chaptersForSeries = (await _unitOfWork.ChapterRepository.GetChaptersByIdsAsync(chapterIds, ChapterIncludes.Volumes))
             .OrderBy(c => Parser.MinNumberFromRange(c.Volume.Name))
-            .ThenBy(x => double.Parse(x.Number), _chapterSortComparerForInChapterSorting)
+            .ThenBy(x => x.Number.AsDouble(), _chapterSortComparerForInChapterSorting)
             .ToList();
 
         var index = readingList.Items.Count == 0 ? 0 : lastOrder + 1;

--- a/API/Services/SeriesService.cs
+++ b/API/Services/SeriesService.cs
@@ -85,11 +85,13 @@ public class SeriesService : ISeriesService
 
 
         var allChapters = series.Volumes
-            .SelectMany(v => v.Chapters.OrderBy(c => c.Number.AsFloat(), ChapterSortComparer.Default)).ToList();
-        var minChapter =  allChapters
+            .SelectMany(v => v.Chapters.OrderBy(c => c.Number.AsFloat(), ChapterSortComparer.Default))
+            .ToList();
+        var minChapter = allChapters
             .FirstOrDefault();
 
-        if (minVolumeNumber != null && minChapter != null && float.TryParse(minChapter.Number, CultureInfo.InvariantCulture, out var chapNum) && chapNum >= minVolumeNumber.Number)
+        if (minVolumeNumber != null && minChapter != null && float.TryParse(minChapter.Number, CultureInfo.InvariantCulture, out var chapNum) &&
+            (chapNum >= minVolumeNumber.Number || chapNum == 0))
         {
             return minVolumeNumber.Chapters.MinBy(c => c.Number.AsFloat(), ChapterSortComparer.Default);
         }

--- a/API/Services/SeriesService.cs
+++ b/API/Services/SeriesService.cs
@@ -717,31 +717,6 @@ public class SeriesService : ISeriesService
             ? chapters.Max(c => c.CreatedUtc) + TimeSpan.FromDays(forecastedTimeDifference)
             : (DateTime?)null;
 
-        // if (nextChapterExpected != null && nextChapterExpected < DateTime.UtcNow)
-        // {
-        //     nextChapterExpected = DateTime.UtcNow + TimeSpan.FromDays(forecastedTimeDifference);
-        // }
-        //
-        // var averageTimeDifference = timeDifferences
-        //     .Average(td => td.TotalDays);
-        //
-        //
-        // if (averageTimeDifference == 0)
-        // {
-        //     return _emptyExpectedChapter;
-        // }
-        //
-        //
-        // // Calculate the forecast for when the next chapter is expected
-        // var nextChapterExpected = chapters.Any()
-        //     ? chapters.Max(c => c.CreatedUtc) + TimeSpan.FromDays(averageTimeDifference)
-        //     : (DateTime?) null;
-        //
-        // if (nextChapterExpected != null && nextChapterExpected < DateTime.UtcNow)
-        // {
-        //     nextChapterExpected = DateTime.UtcNow + TimeSpan.FromDays(averageTimeDifference);
-        // }
-
         // For number and volume number, we need the highest chapter, not the latest created
         var lastChapter = chapters.MaxBy(c => float.Parse(c.Number))!;
         float.TryParse(lastChapter.Number, NumberStyles.Number, CultureInfo.InvariantCulture,
@@ -783,9 +758,9 @@ public class SeriesService : ISeriesService
         return result;
     }
 
-    private double ExponentialSmoothing(IEnumerable<double> data, double alpha)
+    private static double ExponentialSmoothing(IList<double> data, double alpha)
     {
-        double forecast = data.First();
+        var forecast = data.First();
 
         foreach (var value in data)
         {

--- a/API/Services/SeriesService.cs
+++ b/API/Services/SeriesService.cs
@@ -759,7 +759,7 @@ public class SeriesService : ISeriesService
 
         if (lastChapterNumber > 0)
         {
-            result.ChapterNumber = lastChapterNumber + 1;
+            result.ChapterNumber = (int) Math.Truncate(lastChapterNumber) + 1;
             result.VolumeNumber = lastChapter.Volume.Number;
             result.Title = series.Library.Type switch
             {

--- a/API/Services/TachiyomiService.cs
+++ b/API/Services/TachiyomiService.cs
@@ -8,6 +8,7 @@ using System.Globalization;
 using System.Linq;
 using API.Comparators;
 using API.Entities;
+using API.Extensions;
 using AutoMapper;
 using Microsoft.Extensions.Logging;
 
@@ -70,7 +71,10 @@ public class TachiyomiService : ITachiyomiService
             var looseLeafChapterVolume = volumes.Find(v => v.Number == 0);
             if (looseLeafChapterVolume == null)
             {
-                var volumeChapter = _mapper.Map<ChapterDto>(volumes.Last().Chapters.OrderBy(c => float.Parse(c.Number), ChapterSortComparerZeroFirst.Default).Last());
+                var volumeChapter = _mapper.Map<ChapterDto>(volumes
+                    .Last().Chapters
+                    .OrderBy(c => c.Number.AsFloat(), ChapterSortComparerZeroFirst.Default)
+                    .Last());
                 if (volumeChapter.Number == "0")
                 {
                     var volume = volumes.First(v => v.Id == volumeChapter.VolumeId);
@@ -88,7 +92,9 @@ public class TachiyomiService : ITachiyomiService
                 };
             }
 
-            var lastChapter = looseLeafChapterVolume.Chapters.OrderBy(c => float.Parse(c.Number), ChapterSortComparer.Default).Last();
+            var lastChapter = looseLeafChapterVolume.Chapters
+                .OrderBy(c => double.Parse(c.Number, CultureInfo.InvariantCulture), ChapterSortComparer.Default)
+                .Last();
             return _mapper.Map<ChapterDto>(lastChapter);
         }
 

--- a/API/Services/Tasks/Metadata/WordCountAnalyzerService.cs
+++ b/API/Services/Tasks/Metadata/WordCountAnalyzerService.cs
@@ -194,7 +194,7 @@ public class WordCountAnalyzerService : IWordCountAnalyzerService
                             _logger.LogError(ex, "There was an error reading an epub file for word count, series skipped");
                             await _eventHub.SendMessageAsync(MessageFactory.Error,
                                 MessageFactory.ErrorEvent("There was an issue counting words on an epub",
-                                    $"{series.Name} - {file}"));
+                                    $"{series.Name} - {file.FilePath}"));
                             return;
                         }
 

--- a/API/Services/Tasks/Scanner/Parser/DefaultParser.cs
+++ b/API/Services/Tasks/Scanner/Parser/DefaultParser.cs
@@ -38,7 +38,7 @@ public class DefaultParser : IDefaultParser
 
         ParserInfo ret;
 
-        if (Parser.IsEpub(filePath))
+        if (Parser.IsEpub(filePath)) // NOTE: Will this ever be called? Because we use ReadingService to handle parse
         {
             ret = new ParserInfo
             {

--- a/API/Services/Tasks/Scanner/Parser/Parser.cs
+++ b/API/Services/Tasks/Scanner/Parser/Parser.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using API.Entities.Enums;
+using API.Extensions;
 
 namespace API.Services.Tasks.Scanner.Parser;
 
@@ -927,7 +928,7 @@ public static class Parser
             }
 
             var tokens = range.Replace("_", string.Empty).Split("-");
-            return tokens.Min(float.Parse);
+            return tokens.Min(t => t.AsFloat());
         }
         catch
         {
@@ -945,7 +946,7 @@ public static class Parser
             }
 
             var tokens = range.Replace("_", string.Empty).Split("-");
-            return tokens.Max(float.Parse);
+            return tokens.Max(t => t.AsFloat());
         }
         catch
         {

--- a/API/Services/Tasks/Scanner/ProcessSeries.cs
+++ b/API/Services/Tasks/Scanner/ProcessSeries.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using API.Data;
@@ -616,7 +617,7 @@ public class ProcessSeries : IProcessSeries
             // Add files
             var specialTreatment = info.IsSpecialInfo();
             AddOrUpdateFileForChapter(chapter, info, forceUpdate);
-            chapter.Number = Parser.Parser.MinNumberFromRange(info.Chapters) + string.Empty;
+            chapter.Number = Parser.Parser.MinNumberFromRange(info.Chapters).ToString(CultureInfo.InvariantCulture);
             chapter.Range = specialTreatment ? info.Filename : info.Chapters;
         }
 

--- a/API/Services/Tasks/Scanner/ProcessSeries.cs
+++ b/API/Services/Tasks/Scanner/ProcessSeries.cs
@@ -21,6 +21,8 @@ using Microsoft.Extensions.Logging;
 
 namespace API.Services.Tasks.Scanner;
 
+#nullable enable
+
 public interface IProcessSeries
 {
     /// <summary>
@@ -208,7 +210,7 @@ public class ProcessSeries : IProcessSeries
                                     .ToList()}));
 
                     await _eventHub.SendMessageAsync(MessageFactory.Error,
-                        MessageFactory.ErrorEvent($"There was an issue writing to the DB for Series {series}",
+                        MessageFactory.ErrorEvent($"There was an issue writing to the DB for Series {series.OriginalName}",
                             ex.Message));
                     return;
                 }
@@ -886,7 +888,7 @@ public class ProcessSeries : IProcessSeries
                 }
             }
 
-            action(genre, newTag);
+            action(genre!, newTag);
         }
     }
 

--- a/UI/Web/package-lock.json
+++ b/UI/Web/package-lock.json
@@ -998,6 +998,7 @@
       "version": "16.2.9",
       "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-16.2.9.tgz",
       "integrity": "sha512-ecH2oOlijJdDqioD9IfgdqJGoRRHI6hAx5rwBxIaYk01ywj13KzvXWPrXbCIupeWtV/XUZUlbwf47nlmL5gxZg==",
+      "dev": true,
       "dependencies": {
         "@babel/core": "7.22.5",
         "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -5897,6 +5898,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -6152,6 +6154,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -6459,6 +6462,7 @@
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
       "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -7638,6 +7642,7 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
@@ -7647,6 +7652,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -8743,6 +8749,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -9566,6 +9573,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -11404,6 +11412,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12744,6 +12753,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -12754,7 +12764,8 @@
     "node_modules/reflect-metadata": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
-      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
+      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==",
+      "dev": true
     },
     "node_modules/regenerate": {
       "version": "1.4.2",
@@ -13190,7 +13201,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/sass": {
       "version": "1.64.1",
@@ -13317,6 +13328,7 @@
       "version": "7.5.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
       "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -13331,6 +13343,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -13341,7 +13354,8 @@
     "node_modules/semver/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/send": {
       "version": "0.18.0",
@@ -14457,6 +14471,7 @@
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
       "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/UI/Web/src/app/_guards/admin.guard.ts
+++ b/UI/Web/src/app/_guards/admin.guard.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { CanActivate } from '@angular/router';
+import {CanActivate, Router} from '@angular/router';
 import { ToastrService } from 'ngx-toastr';
 import { Observable } from 'rxjs';
 import { map, take } from 'rxjs/operators';
@@ -11,10 +11,10 @@ import {TranslocoService} from "@ngneat/transloco";
 })
 export class AdminGuard implements CanActivate {
   constructor(private accountService: AccountService, private toastr: ToastrService,
+              private router: Router,
               private translocoService: TranslocoService) {}
 
   canActivate(): Observable<boolean> {
-    // this automatically subs due to being router guard
     return this.accountService.currentUser$.pipe(take(1),
       map((user) => {
         if (user && this.accountService.hasAdminRole(user)) {
@@ -22,6 +22,7 @@ export class AdminGuard implements CanActivate {
         }
 
         this.toastr.error(this.translocoService.translate('toasts.unauthorized-1'));
+        this.router.navigateByUrl('/libraries');
         return false;
       })
     );

--- a/UI/Web/src/app/_guards/auth.guard.ts
+++ b/UI/Web/src/app/_guards/auth.guard.ts
@@ -22,12 +22,8 @@ export class AuthGuard implements CanActivate {
         if (user) {
           return true;
         }
-        // TODO: Remove the error message stuff here and just redirect them. Don't need to tell them
-        const errorMessage = this.translocoService.translate('toasts.unauthorized-1');
-        const errorMessage2 = this.translocoService.translate('toasts.unauthorized-2');
-        if (this.toastr.toasts.filter(toast => toast.message === errorMessage2 || toast.message === errorMessage).length === 0) {
-          this.toastr.error(errorMessage);
-        }
+
+        console.log('Redirect url: ', window.location.pathname);
         localStorage.setItem(this.urlKey, window.location.pathname);
         this.router.navigateByUrl('/login');
         return false;

--- a/UI/Web/src/app/_guards/auth.guard.ts
+++ b/UI/Web/src/app/_guards/auth.guard.ts
@@ -23,7 +23,6 @@ export class AuthGuard implements CanActivate {
           return true;
         }
 
-        console.log('Redirect url: ', window.location.pathname);
         localStorage.setItem(this.urlKey, window.location.pathname);
         this.router.navigateByUrl('/login');
         return false;

--- a/UI/Web/src/app/cards/_modals/edit-series-modal/edit-series-modal.component.html
+++ b/UI/Web/src/app/cards/_modals/edit-series-modal/edit-series-modal.component.html
@@ -124,9 +124,9 @@
                 <div class="col-md-12">
                   <div class="mb-3">
                     <label for="tags" class="form-label">{{t('tags-label')}}</label>
-                    <app-typeahead (selectedData)="updateTags($event)" [settings]="tagsSettings"
+                    <app-typeahead (selectedData)="updateTags($event);metadata.tagsLocked = true" [settings]="tagsSettings"
                                    [(locked)]="metadata.tagsLocked" (onUnlock)="metadata.tagsLocked = false"
-                                   (newItemAdded)="metadata.tagsLocked = true" (selectedData)="metadata.tagsLocked = true">
+                                   (newItemAdded)="metadata.tagsLocked = true">
                       <ng-template #badgeItem let-item let-position="idx">
                         {{item.title}}
                       </ng-template>

--- a/UI/Web/src/app/cards/_modals/edit-series-modal/edit-series-modal.component.ts
+++ b/UI/Web/src/app/cards/_modals/edit-series-modal/edit-series-modal.component.ts
@@ -368,7 +368,7 @@ export class EditSeriesModalComponent implements OnInit {
       return {id: 0, title: title };
     });
     this.tagsSettings.selectionCompareFn = (a: Tag, b: Tag) => {
-      return a.id == b.id;
+      return a.title.toLowerCase() == b.title.toLowerCase();
     }
     this.tagsSettings.compareFnForAdd = (options: Tag[], filter: string) => {
       return options.filter(m => this.utilityService.filterMatches(m.title, filter));
@@ -398,7 +398,7 @@ export class EditSeriesModalComponent implements OnInit {
       return options.filter(m => this.utilityService.filterMatches(m.title, filter));
     }
     this.genreSettings.selectionCompareFn = (a: Genre, b: Genre) => {
-      return a.title == b.title;
+      return a.title.toLowerCase() == b.title.toLowerCase();
     }
 
     this.genreSettings.addTransformFn = ((title: string) => {

--- a/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.ts
+++ b/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.ts
@@ -1645,6 +1645,7 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       data.emulateBook = modelSettings.emulateBook;
       data.swipeToPaginate = modelSettings.swipeToPaginate;
       data.pageSplitOption = parseInt(modelSettings.pageSplitOption, 10);
+      data.locale = data.locale || 'en';
 
       this.accountService.updatePreferences(data).subscribe(updatedPrefs => {
         this.toastr.success(translate('manga-reader.user-preferences-updated'));

--- a/UI/Web/src/app/registration/user-login/user-login.component.ts
+++ b/UI/Web/src/app/registration/user-login/user-login.component.ts
@@ -92,10 +92,14 @@ export class UserLoginComponent implements OnInit {
 
       // Check if user came here from another url, else send to library route
       const pageResume = localStorage.getItem('kavita--auth-intersection-url');
+      console.log('Redirect Url found: ', pageResume)
       if (pageResume && pageResume !== '/login') {
         localStorage.setItem('kavita--auth-intersection-url', '');
+        const tokens = pageResume.split('/');
+
         this.router.navigateByUrl(pageResume);
       } else {
+        localStorage.setItem('kavita--auth-intersection-url', '');
         this.router.navigateByUrl('/libraries');
       }
       this.isSubmitting = false;

--- a/UI/Web/src/app/registration/user-login/user-login.component.ts
+++ b/UI/Web/src/app/registration/user-login/user-login.component.ts
@@ -53,7 +53,6 @@ export class UserLoginComponent implements OnInit {
       if (user) {
         this.navService.showSideNav();
         this.cdRef.markForCheck();
-        this.router.navigateByUrl('/libraries');
       }
     });
 
@@ -92,11 +91,8 @@ export class UserLoginComponent implements OnInit {
 
       // Check if user came here from another url, else send to library route
       const pageResume = localStorage.getItem('kavita--auth-intersection-url');
-      console.log('Redirect Url found: ', pageResume)
       if (pageResume && pageResume !== '/login') {
         localStorage.setItem('kavita--auth-intersection-url', '');
-        const tokens = pageResume.split('/');
-
         this.router.navigateByUrl(pageResume);
       } else {
         localStorage.setItem('kavita--auth-intersection-url', '');

--- a/UI/Web/src/app/series-detail/_components/series-metadata-detail/series-metadata-detail.component.html
+++ b/UI/Web/src/app/series-detail/_components/series-metadata-detail/series-metadata-detail.component.html
@@ -15,7 +15,7 @@
     <app-metadata-detail [tags]="links" [libraryId]="series.libraryId" [heading]="t('links-title')">
       <ng-template #itemTemplate let-item>
         <a class="col me-1" [href]="item | safeHtml" target="_blank" rel="noopener noreferrer" [title]="item">
-          <img width="24" height="24" class="lazyload img-placeholder"
+          <img width="24" height="24" class="lazyload img-placeholder favicon"
                [src]="imageService.errorWebLinkImage"
                [attr.data-src]="imageService.getWebLinkImage(item)"
                (error)="imageService.updateErroredWebLinkImage($event)"

--- a/UI/Web/src/app/series-detail/_components/series-metadata-detail/series-metadata-detail.component.scss
+++ b/UI/Web/src/app/series-detail/_components/series-metadata-detail/series-metadata-detail.component.scss
@@ -1,0 +1,3 @@
+.favicon {
+  border-radius: 5px;
+}

--- a/UI/Web/src/app/shared/_services/filter-utilities.service.ts
+++ b/UI/Web/src/app/shared/_services/filter-utilities.service.ts
@@ -201,7 +201,7 @@ export class FilterUtilitiesService {
 
         if (sortFieldPart && isAscendingPart) {
             const sortField = parseInt(sortFieldPart.split('=')[1], 10) as SortField;
-            const isAscending = isAscendingPart.split('=')[1] === 'true';
+            const isAscending = isAscendingPart.split('=')[1].toLowerCase() === 'true';
             return {sortField, isAscending};
         }
 

--- a/openapi.json
+++ b/openapi.json
@@ -7,7 +7,7 @@
       "name": "GPL-3.0",
       "url": "https://github.com/Kareadita/Kavita/blob/develop/LICENSE"
     },
-    "version": "0.7.9.2"
+    "version": "0.7.9.3"
   },
   "servers": [
     {


### PR DESCRIPTION
# Changed
- Changed: Tweaked the pooling for DB Connections. This should reduce database is locked and other contention issues. 
- Changed: Don't create a scrobbling event when there is literally no reading progress
- Changed: Favicons on series detail all now have a bit of rounding
- Changed: Epub marc:relators will now map illustrator to Inker instead of Letterer
- Changed: When you are no longer authenticated in the UI, Kavita no longer pops a toasts and just redirects you
- Changed: Email flows will now check the email to see if it's in a valid format. If not, it will skip any email code and let you know that due to not having a valid-looking email, no email is sent and check the logs. 

# Fixed
- Fixed: Fixed a bug where next estimated chapter could have .1, it will always assume a whole number (develop)
- Fixed: Fixed an issue with sort options on a smart filter always choosing desc (develop)
- Fixed: Fixed a bug where Series last read date could be updated just by opening a chapter in the reader (Fixes #2350 )
- Fixed: Fixed an annoying issue where non-English OS Locale's could have weird grouping with chapters that are not whole numbers (Fixes #2339 Fixes #2277 )
- Fixed: Fixed an issue where favicons that have a url starting with www. wasn't properly saving to directory (Fixes #2348 )
- Fixed: Fixed a bug where notification in events widget when there was a problem reading epub word count didn't show the filename like it should have. Same issue with when a Series has an issue, the series name wasn't being shown.  (Fixes #2128 )
- Fixed: Fixed a bug where side nav wasn't refreshing automatically when a user renamed a library (Fixes #2351 )
- Fixed: Fixed a bug where the typeahead in Series Metadata would blank out the field when adding 2 new tags in one go (Fixes #2221 )
- Fixed: Fixed an issue in cover chooser for a volume where the first try it wouldn't save the cover image (Fixes #2229 )
- Fixed: Fixed a bug where the redirection after needing manual authentication wasn't working 
- Fixed: Some users complained that locale was missing when saving preferences from the reader. 
- Fixed: Fixed an edge case where a series of only volumes and a special, the special would be chosen for Series Metadata
- Fixed: Fixed a critical issue where new users weren't able to be created due to a constraint with default streams.