### PR TITLE
v0.7.10 - Bugfixes

### DIFF
--- a/Kavita.Common/Kavita.Common.csproj
+++ b/Kavita.Common/Kavita.Common.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net7.0</TargetFramework>
         <Company>kavitareader.com</Company>
         <Product>Kavita</Product>
-        <AssemblyVersion>0.7.9.5</AssemblyVersion>
+        <AssemblyVersion>0.7.10.0</AssemblyVersion>
         <NeutralLanguage>en</NeutralLanguage>
         <TieredPGO>true</TieredPGO>
     </PropertyGroup>


### PR DESCRIPTION
Another release so soon? Unfortunately, a critical bug was found from v0.7.9 which prevented inviting new users to Kavita servers which means I had to cut the release short. This release is mainly bug fixes, but there is one new feature for you, which so far from testing is pretty cool.

This release adds a new feature called Next Estimated Chapter. By using the underlying volumes and chapters in a Series and when Kavita Scanned them, as long as there is enough information and the Series is On Going or Ended, Kavita will calculate when the next chapter/volume should be available to read. The dates are of course estimated and from testing and a lot of math, I believe I've accounted for the different acquisition methods to predict a pretty close date. I am also exploring potentially expanding this to provide more accurate dates from external metadata via Kavita+. 

This release also adds some changes to how Kavita talks to the DB to help with some contention. Please raise an issue if you're suddenly seeing issues in day to day use. 

I will likely continue v0.7.11 with more bugfixes, as I've let them build up due to building out such big features. 

**Note: There was a build pipeline issue and docker users on the Stable were shipped an early version of the Next Expected Chapter. This release has completely different code**

# Added
- Added: Added a button in Tasks to bust locale cache, which can sometimes get stuck
- Added: Added a new chapter/volume card (list view not implemented yet) for Series that are On Going or Ended, that uses the delta times between each chapter being added to estimate when the next chapter should be available on the server.

# Changed
- Changed: When testing email service, when successful, it will return the version number back to you. Email version will not show when using default mailer.
- Changed: Tweaked the pooling for DB Connections. This should reduce database is locked and other contention issues.
- Changed: Don't create a scrobbling event when there is literally no reading progress
- Changed: Favicons on series detail all now have a bit of rounding
- Changed: Epub marc:relators will now map illustrator to Inker instead of Letterer
- Changed: When you are no longer authenticated in the UI, Kavita no longer pops a toasts and just redirects you
- Changed: Email flows will now check the email to see if it's in a valid format. If not, it will skip any email code and let you know that due to not having a valid-looking email, no email is sent and check the logs.
- Changed: Tweaked the wording for invite user modal.
- Changed: After inviting a user, the invite modal will hide the instructions from the pre-invite step.
- Changed: (Kavita+) If scrobbling a series that is already completed in AniList and Kavita is not completed, Kavita+ will no longer update the status to in progress. 
- Changed: Updated Translations

# Fixed
- Fixed: Fixed a bug where a Ended series could get flagged as Completed Publication Status
- Fixed: Fixed an issue where sorting by Last Read progress could incorrectly order the series if another user had recently read that Series.
- that Series.
- Fixed: Fixed an issue where Smart Filters that had a value with a space would resume as a Smart Filter with +, thus breaking the filter.
- Fixed: Fixed an issue where table of contents in dark mode in the pdf reader wouldn't be readable 
- Fixed: Fixed a bug where the filter wouldn't reflect the correct sorting icon when loading a smart filter
- Fixed: Fixed an issue where email links could generate with // in them
- Fixed: Don't allow the scanner to accept any themes with a space in their filename
- Fixed: When saving an email url, ensure ending / is removed
- Fixed: Fixed a parsing issue on non-English systems where ComicInfo had a , instead of a . 
- Fixed: Fixed a bug where Series last read date could be updated just by opening a chapter in the reader
- Fixed: Fixed an annoying issue where non-English OS Locale's could have weird grouping with chapters that are not whole numbers
- Fixed: Fixed an issue where favicons that have a url starting with [www](http://www/). wasn't properly saving to directory
- Fixed: Fixed a bug where notification in events widget when there was a problem reading epub word count didn't show the filename like it should have. Same issue with when a Series has an issue, the series name wasn't being shown.
- Fixed: Fixed a bug where side nav wasn't refreshing automatically when a user renamed a library
- Fixed: Fixed a bug where the typeahead in Series Metadata would blank out the field when adding 2 new tags in one go 
- Fixed: Fixed an issue in cover chooser for a volume where the first try it wouldn't save the cover image 
- Fixed: Fixed a bug where the redirection after needing manual authentication wasn't working
- Fixed: Some users complained that locale was missing when saving preferences from the reader.
- Fixed: Fixed an edge case where a series of only volumes and a special, the special would be chosen for Series Metadata
- Fixed: Fixed a critical issue where new users weren't able to be created due to a constraint with default streams.
- Fixed: Fixed some bad series name parsing with pure Korean filenames.
- Fixed: Fixed up some minor styling issues on the admin dashboard.

# Removed
- Removed: Removed a bunch of migrations from v0.7.2 through v0.7.6