### PR TITLE
fix: silence health checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ EXPOSE 5000
 
 WORKDIR /kavita
 
-HEALTHCHECK --interval=30s --timeout=15s --start-period=30s --retries=3 CMD curl --fail http://localhost:5000/api/health || exit 1
+HEALTHCHECK --interval=30s --timeout=15s --start-period=30s --retries=3 CMD curl -fsS http://localhost:5000/api/health || exit 1
 
 ENV DOTNET_RUNNING_IN_CONTAINER=true
 


### PR DESCRIPTION
# Changed
- Changed: Make health check silent by default (`-s` curl option). They will still output a message in case of error (`-S` curl option)