### PR TITLE
[Bug Fix] Fix dockerfile not copying correct folder to wwwroot 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG TARGETPLATFORM
 #Move the output files to where they need to be
 RUN mkdir /files
 COPY _output/*.tar.gz /files/
-COPY UI/Web/dist /files/wwwroot
+COPY UI/Web/dist/browser /files/wwwroot
 COPY copy_runtime.sh /copy_runtime.sh
 RUN /copy_runtime.sh
 RUN chmod +x /Kavita/Kavita


### PR DESCRIPTION
# Fixed
- Fixed: Fixed a bug where the dockerfile was copying the wrong folder to wwwroot.

After #2422 UI files are saved to dist/browser, dockerfile was not updated to reflect changes. This was causing the docker image to not be able to load the webpage with the error Could not find file '/kavita/wwwroot/index.html'