### PR TITLE
[BugFix] Fix page turning when dismissing book settings drawer

### DIFF
--- a/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.ts
+++ b/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.ts
@@ -1617,7 +1617,7 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
   // Responsible for handling pagination only
   handleContainerClick(event: MouseEvent) {
 
-    if (this.drawerOpen  || ['action-bar'].some(className => (event.target as Element).classList.contains(className))) {
+    if (this.drawerOpen  || ['action-bar', 'offcanvas-backdrop'].some(className => (event.target as Element).classList.contains(className))) {
       return;
     }
 


### PR DESCRIPTION
# Fixed
- Fixed: Dismissing book settings drawer turns page (Fixes #2430)


# Notes
- Add `'offcanvas-backdrop'` (the dark overlay class used by the drawer) to the ignored class list in `handleContainerClick`
- The `this.drawerOpen` check doesn't work due to the drawer toggle changing to false before `handleContainerClick` processes the event.