### PR TITLE
[BugFix] Fix clicking on book-line-overlay turning pages

### DIFF
--- a/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.ts
+++ b/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.ts
@@ -1633,7 +1633,7 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
   // Responsible for handling pagination only
   handleContainerClick(event: MouseEvent) {
 
-    if (this.drawerOpen  || ['action-bar', 'offcanvas-backdrop'].some(className => (event.target as Element).classList.contains(className))) {
+    if (this.drawerOpen || ['action-bar', 'offcanvas-backdrop', 'justify-content-between'].some(className => (event.target as Element).classList.contains(className))) {
       return;
     }
 


### PR DESCRIPTION
Quick fix for the book-line-overlay turning pages. Some time should probably be dedicated later to making tap pagination work correctly without having to blacklist classes.

# Fixed
- Fixed: Fix clicking on book-line-overlay turning pages (Fixes #2463)

