### PR TITLE
Release Bugfixes

### DIFF
--- a/API.Tests/Services/CleanupServiceTests.cs
+++ b/API.Tests/Services/CleanupServiceTests.cs
@@ -514,6 +514,69 @@ public class CleanupServiceTests : AbstractDbTest
     }
     #endregion
 
+
+    #region EnsureChapterProgressIsCapped
+
+    [Fact]
+    public async Task EnsureChapterProgressIsCapped_ShouldNormalizeProgress()
+    {
+        await ResetDb();
+
+        var s = new SeriesBuilder("Test CleanupWantToRead_ShouldRemoveFullyReadSeries")
+            .WithMetadata(new SeriesMetadataBuilder().WithPublicationStatus(PublicationStatus.Completed).Build())
+            .Build();
+
+        s.Library = new LibraryBuilder("Test LIb").Build();
+        var c = new ChapterBuilder("1").WithPages(2).Build();
+        c.UserProgress = new List<AppUserProgress>();
+        s.Volumes = new List<Volume>()
+        {
+            new VolumeBuilder("0").WithChapter(c).Build()
+        };
+        _context.Series.Add(s);
+
+        var user = new AppUser()
+        {
+            UserName = "EnsureChapterProgressIsCapped",
+            Progresses = new List<AppUserProgress>()
+        };
+        _context.AppUser.Add(user);
+
+        await _unitOfWork.CommitAsync();
+
+        await _readerService.MarkChaptersAsRead(user, s.Id, new List<Chapter>() {c});
+        await _unitOfWork.CommitAsync();
+
+        var chapter = await _unitOfWork.ChapterRepository.GetChapterDtoAsync(c.Id);
+        await _unitOfWork.ChapterRepository.AddChapterModifiers(user.Id, chapter);
+
+        Assert.NotNull(chapter);
+        Assert.Equal(2, chapter.PagesRead);
+
+        // Update chapter to have 1 page
+        c.Pages = 1;
+        _unitOfWork.ChapterRepository.Update(c);
+        await _unitOfWork.CommitAsync();
+
+        chapter = await _unitOfWork.ChapterRepository.GetChapterDtoAsync(c.Id);
+        await _unitOfWork.ChapterRepository.AddChapterModifiers(user.Id, chapter);
+        Assert.NotNull(chapter);
+        Assert.Equal(2, chapter.PagesRead);
+        Assert.Equal(1, chapter.Pages);
+
+        var cleanupService = new CleanupService(Substitute.For<ILogger<CleanupService>>(), _unitOfWork,
+            Substitute.For<IEventHub>(),
+            new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), new MockFileSystem()));
+
+        await cleanupService.EnsureChapterProgressIsCapped();
+        chapter = await _unitOfWork.ChapterRepository.GetChapterDtoAsync(c.Id);
+        await _unitOfWork.ChapterRepository.AddChapterModifiers(user.Id, chapter);
+
+        Assert.NotNull(chapter);
+        Assert.Equal(1, chapter.PagesRead);
+    }
+    #endregion
+
     // #region CleanupBookmarks
     //
     // [Fact]

--- a/API.Tests/Services/CleanupServiceTests.cs
+++ b/API.Tests/Services/CleanupServiceTests.cs
@@ -574,6 +574,9 @@ public class CleanupServiceTests : AbstractDbTest
 
         Assert.NotNull(chapter);
         Assert.Equal(1, chapter.PagesRead);
+
+        _context.AppUser.Remove(user);
+        await _unitOfWork.CommitAsync();
     }
     #endregion
 

--- a/API.Tests/Services/ScrobblingServiceTests.cs
+++ b/API.Tests/Services/ScrobblingServiceTests.cs
@@ -1,0 +1,14 @@
+﻿using API.Services.Plus;
+using Xunit;
+
+namespace API.Tests.Services;
+
+public class ScrobblingServiceTests
+{
+    [Theory]
+    [InlineData("https://anilist.co/manga/35851/Byeontaega-Doeja/", 35851)]
+    public void CanParseWeblink(string link, long expectedId)
+    {
+        Assert.Equal(ScrobblingService.ExtractId<long>(link, ScrobblingService.AniListWeblinkWebsite), expectedId);
+    }
+}

--- a/API/Controllers/LibraryController.cs
+++ b/API/Controllers/LibraryController.cs
@@ -425,7 +425,7 @@ public class LibraryController : BaseApiController
     public async Task<ActionResult> UpdateLibrary(UpdateLibraryDto dto)
     {
         var userId = User.GetUserId();
-        var library = await _unitOfWork.LibraryRepository.GetLibraryForIdAsync(dto.Id, LibraryIncludes.Folders | LibraryIncludes.FileTypes);
+        var library = await _unitOfWork.LibraryRepository.GetLibraryForIdAsync(dto.Id, LibraryIncludes.Folders | LibraryIncludes.FileTypes | LibraryIncludes.ExcludePatterns);
         if (library == null) return BadRequest(await _localizationService.Translate(userId, "library-doesnt-exist"));
 
         var newName = dto.Name.Trim();
@@ -453,8 +453,8 @@ public class LibraryController : BaseApiController
             .ToList();
 
         library.LibraryExcludePatterns = dto.ExcludePatterns
-            .Select(t => new LibraryExcludePattern() {Pattern = t, LibraryId = library.Id})
             .Distinct()
+            .Select(t => new LibraryExcludePattern() {Pattern = t, LibraryId = library.Id})
             .ToList();
 
         // Override Scrobbling for Comic libraries since there are no providers to scrobble to

--- a/API/Controllers/ServerController.cs
+++ b/API/Controllers/ServerController.cs
@@ -270,6 +270,8 @@ public class ServerController : BaseApiController
         await provider.FlushAsync();
         provider = _cachingProviderFactory.GetCachingProvider(EasyCacheProfiles.KavitaPlusRatings);
         await provider.FlushAsync();
+        provider = _cachingProviderFactory.GetCachingProvider(EasyCacheProfiles.KavitaPlusExternalSeries);
+        await provider.FlushAsync();
         return Ok();
     }
 

--- a/API/Services/Plus/ScrobblingService.cs
+++ b/API/Services/Plus/ScrobblingService.cs
@@ -714,9 +714,8 @@ public class ScrobblingService : IScrobblingService
                     scrobbleEvent.ProcessDateUtc = DateTime.UtcNow;
                     _unitOfWork.ScrobbleRepository.Update(scrobbleEvent);
                 }
+                await _unitOfWork.CommitAsync();
             }
-
-            await _unitOfWork.CommitAsync();
         }
         catch (FlurlHttpException)
         {

--- a/UI/Web/src/app/book-reader/_components/book-line-overlay/book-line-overlay.component.ts
+++ b/UI/Web/src/app/book-reader/_components/book-line-overlay/book-line-overlay.component.ts
@@ -84,9 +84,11 @@ export class BookLineOverlayComponent implements OnInit {
     const selection = window.getSelection();
     if (!event.target) return;
 
-    if ((!selection || selection.toString().trim() === '' || selection.toString().trim() === this.selectedText)) {
-      event.preventDefault();
-      event.stopPropagation();
+    if ((selection === null || selection === undefined || selection.toString().trim() === '' || selection.toString().trim() === this.selectedText)) {
+      if (this.selectedText !== '') {
+        event.preventDefault();
+        event.stopPropagation();
+      }
       this.reset();
       return;
     }

--- a/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.ts
+++ b/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.ts
@@ -1643,8 +1643,10 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
     if (this.clickToPaginate) {
       if (this.isCursorOverLeftPaginationArea(event)) {
         this.movePage(this.readingDirection === ReadingDirection.LeftToRight ? PAGING_DIRECTION.BACKWARDS : PAGING_DIRECTION.FORWARD);
+        return;
       } else if (this.isCursorOverRightPaginationArea(event)) {
         this.movePage(this.readingDirection === ReadingDirection.LeftToRight ? PAGING_DIRECTION.FORWARD : PAGING_DIRECTION.BACKWARDS)
+        return;
       }
     }
 

--- a/UI/Web/src/app/registration/_components/confirm-email/confirm-email.component.ts
+++ b/UI/Web/src/app/registration/_components/confirm-email/confirm-email.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component } from '@angular/core';
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, OnDestroy} from '@angular/core';
 import { FormControl, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { ToastrService } from 'ngx-toastr';
@@ -9,6 +9,7 @@ import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
 import { NgIf, NgFor, NgTemplateOutlet } from '@angular/common';
 import { SplashContainerComponent } from '../splash-container/splash-container.component';
 import {translate, TranslocoDirective} from "@ngneat/transloco";
+import {take} from "rxjs/operators";
 
 @Component({
     selector: 'app-confirm-email',
@@ -18,7 +19,7 @@ import {translate, TranslocoDirective} from "@ngneat/transloco";
     standalone: true,
   imports: [SplashContainerComponent, NgIf, NgFor, ReactiveFormsModule, NgbTooltip, NgTemplateOutlet, TranslocoDirective]
 })
-export class ConfirmEmailComponent {
+export class ConfirmEmailComponent implements OnDestroy {
   /**
    * Email token used for validating
    */
@@ -53,6 +54,14 @@ export class ConfirmEmailComponent {
       this.token = token!;
       this.registerForm.get('email')?.setValue(email || '');
       this.cdRef.markForCheck();
+  }
+
+  ngOnDestroy() {
+    this.accountService.currentUser$.pipe(take(1)).subscribe(user => {
+      if (user) {
+        this.navService.showSideNav();
+      }
+    });
   }
 
   isNullOrEmpty(v: string | null | undefined) {

--- a/UI/Web/src/app/shared/edit-list/edit-list.component.ts
+++ b/UI/Web/src/app/shared/edit-list/edit-list.component.ts
@@ -68,7 +68,13 @@ export class EditListComponent implements OnInit {
     const tokenToRemove = tokens[index];
 
     this.combinedItems = tokens.filter(t => t != tokenToRemove).join(',');
-    this.form.removeControl('link' + index, {emitEvent: true});
+    for (const [index, [key, value]] of Object.entries(Object.entries(this.form.controls))) {
+      if (key.startsWith('link') && this.form.get(key)?.value === tokenToRemove) {
+        this.form.removeControl('link' + index, {emitEvent: true});
+      }
+    }
+
+
     this.emit();
     this.cdRef.markForCheck();
   }

--- a/UI/Web/src/app/shared/edit-list/edit-list.component.ts
+++ b/UI/Web/src/app/shared/edit-list/edit-list.component.ts
@@ -74,7 +74,6 @@ export class EditListComponent implements OnInit {
       }
     }
 
-
     this.emit();
     this.cdRef.markForCheck();
   }

--- a/UI/Web/src/app/sidenav/_modals/library-settings-modal/library-settings-modal.component.html
+++ b/UI/Web/src/app/sidenav/_modals/library-settings-modal/library-settings-modal.component.html
@@ -115,8 +115,10 @@
                     <div ngbAccordionCollapse>
                       <div ngbAccordionBody>
                         <ng-template>
-                          <span class="mb-2">{{t('exclude-patterns-tooltip')}}<a class="ms-1" href="https://wiki.kavitareader.com/en/guides/managing-your-files/scanner/excluding-files-folders" rel="noopener noreferrer" target="_blank">{{t('help')}}<i class="fa fa-external-link-alt ms-1" aria-hidden="true"></i></a></span>
-                          <app-edit-list [items]="excludePatterns" [label]="t('exclude-patterns-label')" (updateItems)="updateGlobs($event)"></app-edit-list>
+                          <span >{{t('exclude-patterns-tooltip')}}<a class="ms-1" href="https://wiki.kavitareader.com/en/guides/managing-your-files/scanner/excluding-files-folders" rel="noopener noreferrer" target="_blank">{{t('help')}}<i class="fa fa-external-link-alt ms-1" aria-hidden="true"></i></a></span>
+                          <div class="mt-2">
+                            <app-edit-list [items]="excludePatterns" [label]="t('exclude-patterns-label')" (updateItems)="updateGlobs($event)"></app-edit-list>
+                          </div>
                         </ng-template>
                       </div>
                     </div>

--- a/UI/Web/src/app/sidenav/_modals/library-settings-modal/library-settings-modal.component.html
+++ b/UI/Web/src/app/sidenav/_modals/library-settings-modal/library-settings-modal.component.html
@@ -115,8 +115,7 @@
                     <div ngbAccordionCollapse>
                       <div ngbAccordionBody>
                         <ng-template>
-                          <span class="mb-2">{{t('exclude-patterns-tooltip')}}</span>
-                          <a class="ms-1" href="https://wiki.kavitareader.com/en/guides/managing-your-files/scanner/excluding-files-folders" rel="noopener noreferrer" target="_blank">{{t('help')}}<i class="fa fa-external-link-alt ms-1" aria-hidden="true"></i></a>
+                          <span class="mb-2">{{t('exclude-patterns-tooltip')}}<a class="ms-1" href="https://wiki.kavitareader.com/en/guides/managing-your-files/scanner/excluding-files-folders" rel="noopener noreferrer" target="_blank">{{t('help')}}<i class="fa fa-external-link-alt ms-1" aria-hidden="true"></i></a></span>
                           <app-edit-list [items]="excludePatterns" [label]="t('exclude-patterns-label')" (updateItems)="updateGlobs($event)"></app-edit-list>
                         </ng-template>
                       </div>

--- a/UI/Web/src/theme/components/_card.scss
+++ b/UI/Web/src/theme/components/_card.scss
@@ -32,7 +32,7 @@ $image-width: 160px;
 
     .card-title {
         font-size: 13px;
-        width: 130px;
+        width: 140px;
         text-overflow: ellipsis;
         white-space: nowrap;
         overflow: hidden;

--- a/openapi.json
+++ b/openapi.json
@@ -7,7 +7,7 @@
       "name": "GPL-3.0",
       "url": "https://github.com/Kareadita/Kavita/blob/develop/LICENSE"
     },
-    "version": "0.7.10.17"
+    "version": "0.7.10.20"
   },
   "servers": [
     {


### PR DESCRIPTION
# Added
- Added: Added a nightly task (cleanup task) that will ensure all user's progress on a chapter is at max the chapter's pages, in the case it was replaced with one that has less pages. (Closes #2327)

# Changed
- Changed: Adjusted the centering to be better aligned (develop)

# Fixed
- Fixed: (Kavita+) Fixed a bug where if you add and remove a series multiple times from want to read, before scrobbling Kavita identifies the correct end state and scrobbles that, but those other events never got marked as processed.
- Fixed: Fixed an edge case where a logged in user would setup a user account then hit back and their side nav would not restore.
- Fixed: Fixed a bug where exclude patterns weren't removing correctly when there were duplicates and the save on the backend wasn't working correctly (develop)
- Fixed: When busting Kavita+ cache, also bust recommendations
- Fixed: Fixed up book reader showing action bar when paginating (develop)
- Fixed: Fixed up touch/clicks not working in the reader (develop) (Fixes  #2468)

Fixed #2456
