### PR TITLE
Critical Progress Order Fix

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -7,7 +7,7 @@
       "name": "GPL-3.0",
       "url": "https://github.com/Kareadita/Kavita/blob/develop/LICENSE"
     },
-    "version": "0.7.10.20"
+    "version": "0.7.11.0"
   },
   "servers": [
     {


### PR DESCRIPTION
To test this, restore a backup prior to updating then run the cleanup test at night. 

# Fixed
- Fixed: Fixed a critical bug where the cleanup task would break ordering of progress events. This would cause your On Deck to skew. 
