### PR TITLE
v0.7.11.1 - Hotfix

### DIFF
--- a/Kavita.Common/Kavita.Common.csproj
+++ b/Kavita.Common/Kavita.Common.csproj
@@ -20,5 +20,4 @@
       </PackageReference>
     </ItemGroup>
 
-
 </Project>


### PR DESCRIPTION
An unfortunate bug slipped in last minute with the release which would cause LastModified fields to be updated at night when a cleanup task ran to cap progress to 100% (in cases where a user reads 10 pages, swaps the file for one with only 8 pages). 

This hotfix will fix that skewing, however, it is likely the task has already ran. You can restore your DB backup from prior to updating (Dec 3rd). 

I'm sorry about the data loss.

# Fixed
- Fixed: Fixed a critical bug where the cleanup task would break ordering of progress events. This would cause your On Deck to skew.