### PR TITLE
Hotfix Prep

### DIFF
--- a/API.Tests/Helpers/SmartFilterHelperTests.cs
+++ b/API.Tests/Helpers/SmartFilterHelperTests.cs
@@ -45,6 +45,17 @@ public class SmartFilterHelperTests
     }
 
     [Fact]
+    public void Test_Decode2()
+    {
+        const string encoded = """
+                               name=Test%202&stmts=comparison%253D10%25C2%25A6field%253D1%25C2%25A6value%253DA%EF%BF%BDcomparison%253D0%25C2%25A6field%253D19%25C2%25A6value%253D11&sortOptions=sortField%3D1%C2%A6isAscending%3DTrue&limitTo=0&combination=1
+                               """;
+
+        var filter = SmartFilterHelper.Decode(encoded);
+        Assert.True(filter.SortOptions.IsAscending);
+    }
+
+    [Fact]
     public void Test_EncodeDecode()
     {
         var filter = new FilterV2Dto()

--- a/API.Tests/Parser/MangaParserTests.cs
+++ b/API.Tests/Parser/MangaParserTests.cs
@@ -83,6 +83,7 @@ public class MangaParserTests
     [InlineData("시즌34삽화2", "34")]
     [InlineData("Accel World Chapter 001 Volume 002", "2")]
     [InlineData("Accel World Volume 2", "2")]
+    [InlineData("Nagasarete Airantou - Vol. 30 Ch. 187.5 - Vol.31 Omake", "30")]
     public void ParseVolumeTest(string filename, string expected)
     {
         Assert.Equal(expected, API.Services.Tasks.Scanner.Parser.Parser.ParseVolume(filename));
@@ -204,6 +205,7 @@ public class MangaParserTests
     [InlineData("죠시라쿠! 2년 후 1권", "죠시라쿠! 2년 후")]
     [InlineData("test 2 years 1권", "test 2 years")]
     [InlineData("test 2 years 1화", "test 2 years")]
+    [InlineData("Nagasarete Airantou - Vol. 30 Ch. 187.5 - Vol.30 Omake", "Nagasarete Airantou")]
     public void ParseSeriesTest(string filename, string expected)
     {
         Assert.Equal(expected, API.Services.Tasks.Scanner.Parser.Parser.ParseSeries(filename));

--- a/API.Tests/Services/ScrobblingServiceTests.cs
+++ b/API.Tests/Services/ScrobblingServiceTests.cs
@@ -2,6 +2,7 @@
 using Xunit;
 
 namespace API.Tests.Services;
+#nullable enable
 
 public class ScrobblingServiceTests
 {

--- a/API.Tests/Services/ScrobblingServiceTests.cs
+++ b/API.Tests/Services/ScrobblingServiceTests.cs
@@ -9,8 +9,15 @@ public class ScrobblingServiceTests
     [InlineData("https://anilist.co/manga/35851/Byeontaega-Doeja/", 35851)]
     [InlineData("https://anilist.co/manga/30105", 30105)]
     [InlineData("https://anilist.co/manga/30105/Kekkaishi/", 30105)]
-    public void CanParseWeblink(string link, long expectedId)
+    public void CanParseWeblink_AniList(string link, long expectedId)
     {
         Assert.Equal(ScrobblingService.ExtractId<long>(link, ScrobblingService.AniListWeblinkWebsite), expectedId);
+    }
+
+    [Theory]
+    [InlineData("https://mangadex.org/title/316d3d09-bb83-49da-9d90-11dc7ce40967/honzuki-no-gekokujou-shisho-ni-naru-tame-ni-wa-shudan-wo-erandeiraremasen-dai-3-bu-ryouchi-ni-hon-o", "316d3d09-bb83-49da-9d90-11dc7ce40967")]
+    public void CanParseWeblink_MangaDex(string link, string expectedId)
+    {
+        Assert.Equal(ScrobblingService.ExtractId<string?>(link, ScrobblingService.MangaDexWeblinkWebsite), expectedId);
     }
 }

--- a/API.Tests/Services/ScrobblingServiceTests.cs
+++ b/API.Tests/Services/ScrobblingServiceTests.cs
@@ -7,6 +7,8 @@ public class ScrobblingServiceTests
 {
     [Theory]
     [InlineData("https://anilist.co/manga/35851/Byeontaega-Doeja/", 35851)]
+    [InlineData("https://anilist.co/manga/30105", 30105)]
+    [InlineData("https://anilist.co/manga/30105/Kekkaishi/", 30105)]
     public void CanParseWeblink(string link, long expectedId)
     {
         Assert.Equal(ScrobblingService.ExtractId<long>(link, ScrobblingService.AniListWeblinkWebsite), expectedId);

--- a/API.Tests/Services/ScrobblingServiceTests.cs
+++ b/API.Tests/Services/ScrobblingServiceTests.cs
@@ -10,9 +10,9 @@ public class ScrobblingServiceTests
     [InlineData("https://anilist.co/manga/35851/Byeontaega-Doeja/", 35851)]
     [InlineData("https://anilist.co/manga/30105", 30105)]
     [InlineData("https://anilist.co/manga/30105/Kekkaishi/", 30105)]
-    public void CanParseWeblink_AniList(string link, long expectedId)
+    public void CanParseWeblink_AniList(string link, int? expectedId)
     {
-        Assert.Equal(ScrobblingService.ExtractId<long>(link, ScrobblingService.AniListWeblinkWebsite), expectedId);
+        Assert.Equal(ScrobblingService.ExtractId<int?>(link, ScrobblingService.AniListWeblinkWebsite), expectedId);
     }
 
     [Theory]

--- a/API/Controllers/AccountController.cs
+++ b/API/Controllers/AccountController.cs
@@ -595,7 +595,7 @@ public class AccountController : BaseApiController
         if (string.IsNullOrEmpty(dto.Email))
             return BadRequest(await _localizationService.Translate(userId, "invalid-payload"));
 
-        _logger.LogInformation("{User} is inviting {Email} to the server", User.GetUsername(), dto.Email);
+        _logger.LogInformation("{User} is inviting {Email} to the server", adminUser.UserName, dto.Email);
 
         // Check if there is an existing invite
         var emailValidationErrors = await _accountService.ValidateEmail(dto.Email);
@@ -701,7 +701,7 @@ public class AccountController : BaseApiController
                 BackgroundJob.Enqueue(() => _emailService.SendConfirmationEmail(new ConfirmationEmailDto()
                 {
                     EmailAddress = dto.Email,
-                    InvitingUser = User.GetUsername(),
+                    InvitingUser = adminUser.UserName,
                     ServerConfirmationLink = emailLink
                 }));
             }

--- a/API/Controllers/ReaderController.cs
+++ b/API/Controllers/ReaderController.cs
@@ -115,10 +115,6 @@ public class ReaderController : BaseApiController
 
         try
         {
-            if (new Random().Next(1, 10) > 5)
-            {
-                await Task.Delay(1000);
-            }
             var chapter = await _cacheService.Ensure(chapterId, extractPdf);
             if (chapter == null) return NoContent();
             _logger.LogInformation("Fetching Page {PageNum} on Chapter {ChapterId}", page, chapterId);

--- a/API/Data/Seed.cs
+++ b/API/Data/Seed.cs
@@ -76,48 +76,42 @@ public static class Seed
             },
         }.ToArray());
 
-    public static readonly ImmutableArray<AppUserSideNavStream> DefaultSideNavStreams = ImmutableArray.Create(new[]
+    public static readonly ImmutableArray<AppUserSideNavStream> DefaultSideNavStreams = ImmutableArray.Create(
+        new AppUserSideNavStream()
     {
-        new AppUserSideNavStream()
-        {
-            Name = "want-to-read",
-            StreamType = SideNavStreamType.WantToRead,
-            Order = 1,
-            IsProvided = true,
-            Visible = true
-        },
-        new AppUserSideNavStream()
-        {
-            Name = "collections",
-            StreamType = SideNavStreamType.Collections,
-            Order = 2,
-            IsProvided = true,
-            Visible = true
-        },
-        new AppUserSideNavStream()
-        {
-            Name = "reading-lists",
-            StreamType = SideNavStreamType.ReadingLists,
-            Order = 3,
-            IsProvided = true,
-            Visible = true
-        },
-        new AppUserSideNavStream()
-        {
-            Name = "bookmarks",
-            StreamType = SideNavStreamType.Bookmarks,
-            Order = 4,
-            IsProvided = true,
-            Visible = true
-        },
-        new AppUserSideNavStream()
-        {
-            Name = "all-series",
-            StreamType = SideNavStreamType.AllSeries,
-            Order = 5,
-            IsProvided = true,
-            Visible = true
-        }
+        Name = "want-to-read",
+        StreamType = SideNavStreamType.WantToRead,
+        Order = 1,
+        IsProvided = true,
+        Visible = true
+    }, new AppUserSideNavStream()
+    {
+        Name = "collections",
+        StreamType = SideNavStreamType.Collections,
+        Order = 2,
+        IsProvided = true,
+        Visible = true
+    }, new AppUserSideNavStream()
+    {
+        Name = "reading-lists",
+        StreamType = SideNavStreamType.ReadingLists,
+        Order = 3,
+        IsProvided = true,
+        Visible = true
+    }, new AppUserSideNavStream()
+    {
+        Name = "bookmarks",
+        StreamType = SideNavStreamType.Bookmarks,
+        Order = 4,
+        IsProvided = true,
+        Visible = true
+    }, new AppUserSideNavStream()
+    {
+        Name = "all-series",
+        StreamType = SideNavStreamType.AllSeries,
+        Order = 5,
+        IsProvided = true,
+        Visible = true
     });
 
 

--- a/API/Helpers/AutoMapperProfiles.cs
+++ b/API/Helpers/AutoMapperProfiles.cs
@@ -240,9 +240,10 @@ public class AutoMapperProfiles : Profile
 
         CreateMap<AppUserSmartFilter, SmartFilterDto>();
         CreateMap<AppUserDashboardStream, DashboardStreamDto>();
-        // CreateMap<AppUserDashboardStream, DashboardStreamDto>()
-        //     .ForMember(dest => dest.SmartFilterEncoded,
-        //         opt => opt.MapFrom(src => src.SmartFilter));
+
+        // This is for cloning to ensure the records don't get overwritten when setting from SeedData
+        CreateMap<AppUserDashboardStream, AppUserDashboardStream>();
+        CreateMap<AppUserSideNavStream, AppUserSideNavStream>();
 
     }
 }

--- a/API/Helpers/Builders/PlusSeriesDtoBuilder.cs
+++ b/API/Helpers/Builders/PlusSeriesDtoBuilder.cs
@@ -27,6 +27,8 @@ public class PlusSeriesDtoBuilder : IEntityBuilder<PlusSeriesDto>
                 ScrobblingService.MalWeblinkWebsite),
             GoogleBooksId = ScrobblingService.ExtractId<string?>(series.Metadata.WebLinks,
                 ScrobblingService.GoogleBooksWeblinkWebsite),
+            MangaDexId = ScrobblingService.ExtractId<string?>(series.Metadata.WebLinks,
+                ScrobblingService.MangaDexWeblinkWebsite),
             VolumeCount = series.Volumes.Count,
             ChapterCount = series.Volumes.SelectMany(v => v.Chapters).Count(c => !c.IsSpecial),
             Year = series.Metadata.ReleaseYear

--- a/API/Helpers/SmartFilterHelper.cs
+++ b/API/Helpers/SmartFilterHelper.cs
@@ -133,7 +133,7 @@ public static class SmartFilterHelper
         var sortFieldPart = parts.FirstOrDefault(part => part.StartsWith(SortFieldKey));
         var isAscendingPart = parts.FirstOrDefault(part => part.StartsWith(IsAscendingKey));
 
-        var isAscending = isAscendingPart?.Substring(11).Equals("true", StringComparison.OrdinalIgnoreCase) ?? false;
+        var isAscending = isAscendingPart?.Trim().Replace(IsAscendingKey, string.Empty).Equals("true", StringComparison.OrdinalIgnoreCase) ?? false;
         if (sortFieldPart == null)
         {
             return new SortOptions();

--- a/API/Services/Plus/RecommendationService.cs
+++ b/API/Services/Plus/RecommendationService.cs
@@ -25,6 +25,7 @@ public record PlusSeriesDto
     public int? AniListId { get; set; }
     public long? MalId { get; set; }
     public string? GoogleBooksId { get; set; }
+    public string? MangaDexId { get; set; }
     public string SeriesName { get; set; }
     public string? AltSeriesName { get; set; }
     public MediaFormat MediaFormat { get; set; }

--- a/API/Services/Plus/ScrobblingService.cs
+++ b/API/Services/Plus/ScrobblingService.cs
@@ -829,12 +829,12 @@ public class ScrobblingService : IScrobblingService
             if (!webLink.StartsWith(website)) continue;
             var tokens = webLink.Split(website)[1].Split('/');
             var value = tokens[index];
-            if (typeof(T) == typeof(int))
+            if (typeof(T) == typeof(int?))
             {
                 if (int.TryParse(value, out var intValue))
                     return (T)(object)intValue;
             }
-            else if (typeof(T) == typeof(long))
+            else if (typeof(T) == typeof(long?))
             {
                 if (long.TryParse(value, out var longValue))
                     return (T)(object)longValue;

--- a/API/Services/Plus/ScrobblingService.cs
+++ b/API/Services/Plus/ScrobblingService.cs
@@ -67,13 +67,14 @@ public class ScrobblingService : IScrobblingService
     public const string AniListWeblinkWebsite = "https://anilist.co/manga/";
     public const string MalWeblinkWebsite = "https://myanimelist.net/manga/";
     public const string GoogleBooksWeblinkWebsite = "https://books.google.com/books?id=";
+    public const string MangaDexWeblinkWebsite = "https://mangadex.org/title/";
 
     private static readonly IDictionary<string, int> WeblinkExtractionMap = new Dictionary<string, int>()
     {
         {AniListWeblinkWebsite, 0},
         {MalWeblinkWebsite, 0},
         {GoogleBooksWeblinkWebsite, 0},
-
+        {MangaDexWeblinkWebsite, 0},
     };
 
     private const int ScrobbleSleepTime = 700; // We can likely tie this to AniList's 90 rate / min ((60 * 1000) / 90)

--- a/API/Services/TaskScheduler.cs
+++ b/API/Services/TaskScheduler.cs
@@ -34,7 +34,6 @@ public interface ITaskScheduler
     void ScanSiteThemes();
     void CovertAllCoversToEncoding();
     Task CleanupDbEntries();
-    Task ScrobbleUpdates(int userId);
 
 }
 public class TaskScheduler : ITaskScheduler
@@ -141,7 +140,6 @@ public class TaskScheduler : ITaskScheduler
         }
 
         RecurringJob.AddOrUpdate(CleanupTaskId, () => _cleanupService.Cleanup(), Cron.Daily, RecurringJobOptions);
-        RecurringJob.AddOrUpdate(CleanupDbTaskId, () => _cleanupService.CleanupDbEntries(), Cron.Daily, RecurringJobOptions);
         RecurringJob.AddOrUpdate(RemoveFromWantToReadTaskId, () => _cleanupService.CleanupWantToRead(), Cron.Daily, RecurringJobOptions);
         RecurringJob.AddOrUpdate(UpdateYearlyStatsTaskId, () => _statisticService.UpdateServerStatistics(), Cron.Monthly, RecurringJobOptions);
 
@@ -270,16 +268,6 @@ public class TaskScheduler : ITaskScheduler
     public async Task CleanupDbEntries()
     {
         await _cleanupService.CleanupDbEntries();
-    }
-
-    /// <summary>
-    /// TODO: Remove this for Release
-    /// </summary>
-    /// <returns></returns>
-    public async Task ScrobbleUpdates(int userId)
-    {
-        if (!await _licenseService.HasActiveLicense()) return;
-        BackgroundJob.Enqueue(() => _scrobblingService.ProcessUpdatesSinceLastSync());
     }
 
     /// <summary>

--- a/API/Services/Tasks/BackupService.cs
+++ b/API/Services/Tasks/BackupService.cs
@@ -9,6 +9,7 @@ using API.Entities.Enums;
 using API.Logging;
 using API.SignalR;
 using Hangfire;
+using Kavita.Common.EnvironmentInfo;
 using Microsoft.Extensions.Logging;
 
 namespace API.Services.Tasks;
@@ -91,7 +92,7 @@ public class BackupService : IBackupService
         await SendProgress(0.1F, "Copying core files");
 
         var dateString = $"{DateTime.UtcNow.ToShortDateString()}_{DateTime.UtcNow.ToLongTimeString()}".Replace("/", "_").Replace(":", "_");
-        var zipPath = _directoryService.FileSystem.Path.Join(backupDirectory, $"kavita_backup_{dateString}.zip");
+        var zipPath = _directoryService.FileSystem.Path.Join(backupDirectory, $"kavita_backup_{dateString}_v{BuildInfo.Version}.zip");
 
         if (File.Exists(zipPath))
         {

--- a/API/Services/Tasks/CleanupService.cs
+++ b/API/Services/Tasks/CleanupService.cs
@@ -92,6 +92,8 @@ public class CleanupService : ICleanupService
         await CleanupLogs();
         await SendProgress(0.9F, "Cleaning progress events that exceed 100%");
         await EnsureChapterProgressIsCapped();
+        await SendProgress(0.95F, "Cleaning abandoned database rows");
+        await CleanupDbEntries();
         await SendProgress(1F, "Cleanup finished");
         _logger.LogInformation("Cleanup finished");
     }

--- a/API/Services/Tasks/Scanner/Parser/Parser.cs
+++ b/API/Services/Tasks/Scanner/Parser/Parser.cs
@@ -109,9 +109,9 @@ public static class Parser
         new Regex(
             @"(?<Series>.*)(\b|_)v(?<Volume>\d+-?\d+)( |_)",
             MatchOptions, RegexTimeout),
-        // NEEDLESS_Vol.4_-Simeon_6_v2[SugoiSugoi].rar
+        // Nagasarete Airantou - Vol. 30 Ch. 187.5 - Vol.31 Omake
         new Regex(
-            @"(?<Series>.*)(\b|_)(?!\[)(vol\.?)(?<Volume>\d+(-\d+)?)(?!\])",
+            @"^(?<Series>.+?)(\s*Chapter\s*\d+)?(\s|_|\-\s)+(Vol(ume)?\.?(\s|_)?)(?<Volume>\d+(\.\d+)?)(.+?|$)",
             MatchOptions, RegexTimeout),
         // Historys Strongest Disciple Kenichi_v11_c90-98.zip or Dance in the Vampire Bund v16-17
         new Regex(
@@ -137,6 +137,7 @@ public static class Parser
         new Regex(
             @"(vol_)(?<Volume>\d+(\.\d)?)",
             MatchOptions, RegexTimeout),
+
         // Chinese Volume: 第n卷 -> Volume n, 第n册 -> Volume n, 幽游白书完全版 第03卷 天下 or 阿衰online 第1册
         new Regex(
             @"第(?<Volume>\d+)(卷|册)",

--- a/API/Services/Tasks/Scanner/Parser/Parser.cs
+++ b/API/Services/Tasks/Scanner/Parser/Parser.cs
@@ -197,16 +197,17 @@ public static class Parser
         new Regex(
             @"(?<Series>.*)(\b|_|-|\s)(?:sp)\d",
             MatchOptions, RegexTimeout),
-        // [SugoiSugoi]_NEEDLESS_Vol.2_-_Disk_The_Informant_5_[ENG].rar, Yuusha Ga Shinda! - Vol.tbd Chapter 27.001 V2 Infection ①.cbz
-        new Regex(
-            @"^(?<Series>.*)( |_)Vol\.?(\d+|tbd)",
-            MatchOptions, RegexTimeout),
         // Mad Chimera World - Volume 005 - Chapter 026.cbz (couldn't figure out how to get Volume negative lookaround working on below regex),
         // The Duke of Death and His Black Maid - Vol. 04 Ch. 054.5 - V4 Omake
         new Regex(
             @"(?<Series>.+?)(\s|_|-)+(?:Vol(ume|\.)?(\s|_|-)+\d+)(\s|_|-)+(?:(Ch|Chapter|Ch)\.?)(\s|_|-)+(?<Chapter>\d+)",
             MatchOptions,
             RegexTimeout),
+        // [SugoiSugoi]_NEEDLESS_Vol.2_-_Disk_The_Informant_5_[ENG].rar, Yuusha Ga Shinda! - Vol.tbd Chapter 27.001 V2 Infection ①.cbz,
+        // Nagasarete Airantou - Vol. 30 Ch. 187.5 - Vol.30 Omake
+        new Regex(
+            @"^(?<Series>.+?)(\s*Chapter\s*\d+)?(\s|_|\-\s)+Vol(ume)?\.?(\d+|tbd|\s\d).+?",
+            MatchOptions, RegexTimeout),
         // Ichiban_Ushiro_no_Daimaou_v04_ch34_[VISCANS].zip, VanDread-v01-c01.zip
         new Regex(
             @"(?<Series>.*)(\b|_)v(?<Volume>\d+-?\d*)(\s|_|-)",
@@ -233,6 +234,7 @@ public static class Parser
             @"(?<Series>.+?):?(\s|\b|_|-)Chapter(\s|\b|_|-)\d+(\s|\b|_|-)(vol)(ume)",
             MatchOptions,
             RegexTimeout),
+
         // [xPearse] Kyochuu Rettou Volume 1 [English] [Manga] [Volume Scans]
         new Regex(
             @"(?<Series>.+?):? (\b|_|-)(vol)(ume)",

--- a/Kavita.Common/Kavita.Common.csproj
+++ b/Kavita.Common/Kavita.Common.csproj
@@ -20,5 +20,4 @@
       </PackageReference>
     </ItemGroup>
 
-
 </Project>

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ install methods and platforms.
 **Note: Kavita is under heavy development and is being updated all the time, so the tag for bleeding edge builds is `:nightly`. The `:latest` tag will be the latest stable release.**
 
 ## Feature Requests
-Got a great idea? Throw it up on our [Feature Request site](https://feats.kavitareader.com/) or vote on another idea. Please check the [Project Board](https://github.com/Kareadita/Kavita/projects) first for a list of planned features before you submit an idea.
+Got a great idea? Throw it up on our [Feature Request site](https://feats.kavitareader.com/) or vote on another idea. Please check the [Project Board](https://github.com/Kareadita/Kavita/projects?type=classic) first for a list of planned features before you submit an idea.
 
 ## Notice
 Kavita is being actively developed and should be considered beta software until the 1.0 release.

--- a/UI/Web/src/app/_pipes/utc-to-local-time.pipe.ts
+++ b/UI/Web/src/app/_pipes/utc-to-local-time.pipe.ts
@@ -15,7 +15,8 @@ type UtcToLocalTimeFormat = 'full' | 'short' | 'shortDate' | 'shortTime';
 })
 export class UtcToLocalTimePipe implements PipeTransform {
 
-  transform(utcDate: string, format: UtcToLocalTimeFormat = 'short'): string {
+  transform(utcDate: string | undefined | null, format: UtcToLocalTimeFormat = 'short'): string {
+    if (utcDate === undefined || utcDate === null) return '';
     const browserLanguage = navigator.language;
     const dateTime = DateTime.fromISO(utcDate, { zone: 'utc' }).toLocal().setLocale(browserLanguage);
 

--- a/UI/Web/src/app/admin/manage-tasks-settings/manage-tasks-settings.component.html
+++ b/UI/Web/src/app/admin/manage-tasks-settings/manage-tasks-settings.component.html
@@ -58,7 +58,9 @@
           <td>
             {{task.title | titlecase}}
           </td>
-          <td>{{task.lastExecutionUtc | utcToLocalTime | defaultValue }}</td>
+          <td>
+            {{task.lastExecutionUtc | utcToLocalTime | defaultValue }}
+          </td>
           <td>{{task.cron}}</td>
         </tr>
         </tbody>

--- a/UI/Web/src/app/cards/list-item/list-item.component.html
+++ b/UI/Web/src/app/cards/list-item/list-item.component.html
@@ -7,7 +7,7 @@
             <app-download-indicator [download$]="download$"></app-download-indicator>
         </span>
       <div class="progress-banner" *ngIf="pagesRead < totalPages && totalPages > 0 && pagesRead !== totalPages"
-           ngbTooltip="{{(pagesRead / totalPages) * 100 | number:'1.0-1'}}% Read">
+           ngbTooltip="{{(pagesRead / totalPages) | number:'1.0-1'}}% Read">
         <p><ngb-progressbar type="primary" height="5px" [value]="pagesRead" [max]="totalPages"></ngb-progressbar></p>
       </div>
     </div>

--- a/UI/Web/src/app/cards/list-item/list-item.component.html
+++ b/UI/Web/src/app/cards/list-item/list-item.component.html
@@ -7,7 +7,7 @@
             <app-download-indicator [download$]="download$"></app-download-indicator>
         </span>
       <div class="progress-banner" *ngIf="pagesRead < totalPages && totalPages > 0 && pagesRead !== totalPages"
-           ngbTooltip="{{(pagesRead / totalPages) | number:'1.0-1'}}% Read">
+           ngbTooltip="{{(pagesRead / totalPages) * 100 | number:'1.0-1'}}% Read">
         <p><ngb-progressbar type="primary" height="5px" [value]="pagesRead" [max]="totalPages"></ngb-progressbar></p>
       </div>
     </div>

--- a/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.html
+++ b/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.html
@@ -36,7 +36,7 @@
         </div>
       </div>
     </div>
-    <app-loading [loading]="isLoading || !(currentImage$ | async)?.complete" [absolute]="true"></app-loading>
+    <app-loading [loading]="isLoading || (!(currentImage$ | async)?.complete && this.readerMode !== ReaderMode.Webtoon)" [absolute]="true"></app-loading>
     <div class="reading-area"
          ngSwipe (swipeEnd)="onSwipeEnd($event)" (swipeMove)="onSwipeMove($event)"
          [ngStyle]="{'background-color': backgroundColor, 'height': readerMode === ReaderMode.Webtoon ? 'inherit' : 'calc(var(--vh)*100)'}" #readingArea>

--- a/UI/Web/src/app/series-detail/_components/series-detail/series-detail.component.html
+++ b/UI/Web/src/app/series-detail/_components/series-detail/series-detail.component.html
@@ -51,7 +51,7 @@
         </div>
         <app-image height="100%" maxHeight="400px" objectFit="contain" background="none" [imageUrl]="seriesImage"></app-image>
         <ng-container *ngIf="series.pagesRead < series.pages && hasReadingProgress && currentlyReadingChapter && !currentlyReadingChapter.isSpecial">
-          <div class="progress-banner" ngbTooltip="{{(series.pagesRead / series.pages) | number:'1.0-1'}}% Read">
+          <div class="progress-banner" ngbTooltip="{{(series.pagesRead / series.pages) * 100 | number:'1.0-1'}}% Read">
             <ngb-progressbar type="primary" height="5px" [value]="series.pagesRead" [max]="series.pages"></ngb-progressbar>
           </div>
           <div class="under-image">

--- a/openapi.json
+++ b/openapi.json
@@ -7,7 +7,7 @@
       "name": "GPL-3.0",
       "url": "https://github.com/Kareadita/Kavita/blob/develop/LICENSE"
     },
-    "version": "0.7.11.0"
+    "version": "0.7.11.1"
   },
   "servers": [
     {


### PR DESCRIPTION
# Changed
- Changed: Backups now show the version of Kavita in the filename
- Changed: Moved some cleanup tasks within another task to ensure everything is processed at the same time.
- Changed: Changed the readme to point to the correct type of projects.
- Changed: When sending requests to Kavita+, MangaDex Ids will be sent as well to prepare for a potential enhancement next year.

# Fixed
- Fixed: Fixed unneeded slowness in the image api as some debug code got left in there
- Fixed: Fixed invalid date showing on tasks screen
- Fixed: Fixed a long standing parser bug where series would parse as Love Hina Vol. 30 Chapter 22 when the file was Love Hina Vol. 30 Chapter 22 - Vol 30 Omakes
- Fixed: Fixed a bug where Kavita+ wasn't being sent the ids from Weblinks
- Fixed: Fixed a loader showing on the webtoon reader when it shouldn't have (Fixes #2489 )
- Fixed: Fixed a critical issue where fresh installs that invite a user have their own admin account's side nav and dashboard streams wiped out (Fixes #2453 )
- Fixed: Fixed a bug where Smart filters would always evaluate to descending sort (Fixes #2481)
- Fixed: Fixed a bug where some progress bars wouldn't report series progress correctly (Fixes #2380 )

