### PR TITLE
v0.7.11.2 - Hotfix 2

### DIFF
--- a/Kavita.Common/Kavita.Common.csproj
+++ b/Kavita.Common/Kavita.Common.csproj
@@ -19,5 +19,4 @@
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
     </ItemGroup>
-
 </Project>


### PR DESCRIPTION
Unfortunately a few more bugs surfaced after the last hotfix, one being a problem with extracting weblink id's for Kavita+ matching along with an annoying bug with side nav being wiped out for fresh install admins. This is the last release for the year.

## Remember to use the new [Docker Central Repo](https://hub.docker.com/r/jvmilazz0/kavita)! Updates are not going to the old one. 

# Changed
- Changed: Backups now show the version of Kavita in the filename
- Changed: Moved some cleanup tasks within another task to ensure everything is processed at the same time.
- Changed: Changed the readme to point to the correct type of projects.
- Changed: (Kavita+) When sending requests to Kavita+, MangaDex Ids will be sent as well to prepare for a potential enhancement next year.

# Fixed
- Fixed: Fixed unneeded slowness in the image api as some debug code got left in there
- Fixed: Fixed invalid date showing on tasks screen
- Fixed: Fixed a long standing parser bug where series would parse as Love Hina Vol. 30 Chapter 22 when the file was Love Hina Vol. 30 Chapter 22 - Vol 30 Omakes
- Fixed: (Kavita+) Fixed a bug where Kavita+ wasn't being sent the ids from Weblinks
- Fixed: Fixed a loader showing on the webtoon reader when it shouldn't have
- Fixed: Fixed a critical issue where fresh installs that invite a user have their own admin account's side nav and dashboard streams wiped out
- Fixed: Fixed a bug where Smart filters would always evaluate to descending sort
- Fixed: Fixed a bug where some progress bars wouldn't report series progress correctly

# Known Issue
- Some users on iOS are reporting issues with the webtoon reader. I spent a week working with one user but unfortunately unable to reproduce. I will look into buying an iOS device next year. 
