### PR TITLE
[skip ci] Fixed: Fix the problem of not being able to open the API project in Visual Studio.

### DIFF
--- a/API/API.csproj
+++ b/API/API.csproj
@@ -190,7 +190,7 @@
 
   <ItemGroup>
     <Folder Include="config\themes" />
-    <Folder Include="I18N\**" />
+    <None Include="I18N\**" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Fixed
- Fix the problem of not being able to open the API project in Visual Studio.
  > This problem is caused by I18N containing only JSON files, but in the .csproj file, those files are added as a folder.

This problem can also be observed in the Rider IDE
before:
![圖片](https://github.com/Kareadita/Kavita/assets/30816317/7e134709-117d-4d8e-a055-22afab32962c)
after:
![圖片](https://github.com/Kareadita/Kavita/assets/30816317/7b8ad955-1e1f-41c7-9ed5-1ee6b2cb1189)
