### PR TITLE
Fix Bookmarks don't work in webtoon reading mode 

### DIFF
--- a/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.ts
+++ b/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.ts
@@ -1608,7 +1608,8 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
     if (this.bookmarkMode) return;
 
     const pageNum = this.pageNum;
-    const isDouble = Math.max(this.canvasRenderer.getBookmarkPageCount(), this.singleRenderer.getBookmarkPageCount(),
+    // if canvasRenderer and doubleRenderer is undefined, then we are in webtoon mode
+    const isDouble = this.canvasRenderer !== undefined && this.doubleRenderer !== undefined && Math.max(this.canvasRenderer.getBookmarkPageCount(), this.singleRenderer.getBookmarkPageCount(),
       this.doubleRenderer.getBookmarkPageCount(), this.doubleReverseRenderer.getBookmarkPageCount(), this.doubleNoCoverRenderer.getBookmarkPageCount()) > 1;
 
     if (this.CurrentPageBookmarked) {


### PR DESCRIPTION
# Fixed
- Fixed: Fix the issue where the bookmark action does not work in webtoon mode. (#2501)

This problem is caused by 'canvasRenderer' and 'doubleRendered' being undefined, which leads to an error occurring in the browser when this statement is executed.

result
![圖片](https://github.com/Kareadita/Kavita/assets/30816317/30dbe4bb-02a2-49e3-a0fc-bce521107618)
