### PR TITLE
feat: add flat library type

### DIFF
--- a/API/Entities/Enums/LibraryType.cs
+++ b/API/Entities/Enums/LibraryType.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 
 namespace API.Entities.Enums;
 
@@ -24,4 +24,9 @@ public enum LibraryType
     /// </summary>
     [Description("Image")]
     Image = 3,
+    /// <summary>
+    /// Use file name or folder name as series name
+    /// </summary>
+    [Description("Flat")]
+    Flat = 4,
 }

--- a/API/Services/Tasks/Scanner/Parser/DefaultParser.cs
+++ b/API/Services/Tasks/Scanner/Parser/DefaultParser.cs
@@ -46,6 +46,22 @@ public class DefaultParser : IDefaultParser
             Series = string.Empty
         };
 
+        if (type == LibraryType.Flat)
+        {
+            if (Parser.IsImage(filePath))
+            {
+                ret.Series = new FileInfo(filePath).Directory?.Name ?? string.Empty;
+                if(string.IsNullOrEmpty(ret.Series)) throw new InvalidDataException($"Could not parse series from {filePath}");
+            }
+            else
+            {
+                ret.Series = Path.GetFileNameWithoutExtension(filePath);
+            }
+            ret.Volumes = "1";
+            ret.Chapters = Parser.DefaultChapter;
+            return ret;
+        }
+
         // If library type is Image or this is not a cover image in a non-image library, then use dedicated parsing mechanism
         if (type == LibraryType.Image || Parser.IsImage(filePath))
         {

--- a/UI/Web/src/app/_models/library/library.ts
+++ b/UI/Web/src/app/_models/library/library.ts
@@ -4,7 +4,8 @@ export enum LibraryType {
     Manga = 0,
     Comic = 1,
     Book = 2,
-    Images = 3
+    Images = 3,
+    Flat = 4
 }
 
 export interface Library {

--- a/UI/Web/src/app/shared/_services/utility.service.ts
+++ b/UI/Web/src/app/shared/_services/utility.service.ts
@@ -70,6 +70,7 @@ export class UtilityService {
           return this.translocoService.translate('common.issue-hash-num');
         }
         return this.translocoService.translate('common.issue-num') + (includeSpace ? ' ' : '');
+      case LibraryType.Flat:
       case LibraryType.Images:
       case LibraryType.Manga:
         return this.translocoService.translate('common.chapter-num') + (includeSpace ? ' ' : '');

--- a/UI/Web/src/app/sidenav/_components/side-nav/side-nav.component.ts
+++ b/UI/Web/src/app/sidenav/_components/side-nav/side-nav.component.ts
@@ -183,6 +183,7 @@ export class SideNavComponent implements OnInit {
     switch (format) {
       case LibraryType.Book:
         return 'fa-book';
+      case LibraryType.Flat:
       case LibraryType.Comic:
       case LibraryType.Manga:
         return 'fa-book-open';

--- a/openapi.json
+++ b/openapi.json
@@ -7,7 +7,7 @@
       "name": "GPL-3.0",
       "url": "https://github.com/Kareadita/Kavita/blob/develop/LICENSE"
     },
-    "version": "0.7.12.2"
+    "version": "0.7.12.3"
   },
   "servers": [
     {
@@ -2956,7 +2956,8 @@
                     0,
                     1,
                     2,
-                    3
+                    3,
+                    4
                   ],
                   "type": "integer",
                   "format": "int32"
@@ -2968,7 +2969,8 @@
                     0,
                     1,
                     2,
-                    3
+                    3,
+                    4
                   ],
                   "type": "integer",
                   "format": "int32"
@@ -2980,7 +2982,8 @@
                     0,
                     1,
                     2,
-                    3
+                    3,
+                    4
                   ],
                   "type": "integer",
                   "format": "int32"
@@ -13544,7 +13547,8 @@
               0,
               1,
               2,
-              3
+              3,
+              4
             ],
             "type": "integer",
             "format": "int32"
@@ -14136,7 +14140,8 @@
               0,
               1,
               2,
-              3
+              3,
+              4
             ],
             "type": "integer",
             "description": "Library type",
@@ -15639,7 +15644,8 @@
               0,
               1,
               2,
-              3
+              3,
+              4
             ],
             "type": "integer",
             "format": "int32"
@@ -15752,7 +15758,8 @@
               0,
               1,
               2,
-              3
+              3,
+              4
             ],
             "type": "integer",
             "format": "int32"
@@ -16759,7 +16766,8 @@
               0,
               1,
               2,
-              3
+              3,
+              4
             ],
             "type": "integer",
             "format": "int32"
@@ -16811,7 +16819,8 @@
               0,
               1,
               2,
-              3
+              3,
+              4
             ],
             "type": "integer",
             "format": "int32"
@@ -19080,7 +19089,8 @@
               0,
               1,
               2,
-              3
+              3,
+              4
             ],
             "type": "integer",
             "format": "int32"


### PR DESCRIPTION
# Added
- Added: new library type: Flat

For some types like donjinshi and illustration collections, they don't have volumes and chapters, so it doesn't make sense to put them in a folder structure like manga. For this library type, all files will use file name or parent folder name (for loose images) as series name, and they will be assigned a volume number of 1. 