### PR TITLE
Nightly Issues (2)

### DIFF
--- a/API/Services/Plus/ScrobblingService.cs
+++ b/API/Services/Plus/ScrobblingService.cs
@@ -643,6 +643,7 @@ public class ScrobblingService : IScrobblingService
             .Concat(addToWantToRead.Select(r => r.AppUser))
             .Concat(removeWantToRead.Select(r => r.AppUser))
             .Concat(ratingEvents.Select(r => r.AppUser))
+            .Where(user => !string.IsNullOrEmpty(user.AniListAccessToken))
             .DistinctBy(u => u.Id)
             .ToList();
         foreach (var user in usersToScrobble)
@@ -886,6 +887,7 @@ public class ScrobblingService : IScrobblingService
 
     private async Task<int> SetAndCheckRateLimit(IDictionary<int, int> userRateLimits, AppUser user, string license)
     {
+        if (string.IsNullOrEmpty(user.AniListAccessToken)) return 0;
         try
         {
             if (!userRateLimits.ContainsKey(user.Id))

--- a/UI/Web/hash-localization.js
+++ b/UI/Web/hash-localization.js
@@ -15,7 +15,13 @@ function generateChecksum(str, algorithm, encoding) {
 const result = {};
 
 glob.sync(`${jsonFilesDir}**/*.json`).forEach(path => {
-    const [_, lang] = path.split('dist\\browser\\assets\\langs\\');
+    console.log('Calculating hash for ', path);
+    let tokens = path.split('dist\\browser\\assets\\langs\\');
+    if (tokens.length === 1) {
+        tokens = path.split('dist/browser/assets/langs/');
+    }
+    const lang = tokens[1];
+    console.log('Language: ', lang);
     const content = fs.readFileSync(path, { encoding: 'utf-8' });
     result[lang.replace('.json', '')] = generateChecksum(content);
 });


### PR DESCRIPTION
# Changed
- Changed: Updated dependencies, including NetVips for some regressions around cover generation.
- Changed: Major improvement to messaging when a series collides with another series in a parallel folder to library root. Explicitly give more information.
- Changed: Localization files now have cache busting to help on new releases not reflecting all keys
- Changed: Removed XFrameOptions and replaced with AllowIFraming as true/false. This will control multiple headers for Organizer (Fixes #2509)

# Fixed
- Fixed: Fixed a few issues that cropped up from last nightly (develop)
- Fixed: Fixed a bad error message for when a series isn't found on Kavita+ (via new api) (develop)
- Fixed: Fixed an issue where tab could flash on user preferences due to some delay waiting for a license check.
- Fixed: Ensure only admins can see files when searching (Fixes #2603)

