### PR TITLE
Downloading Improvments

### DIFF
--- a/Kavita.Common/Kavita.Common.csproj
+++ b/Kavita.Common/Kavita.Common.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net8.0</TargetFramework>
         <Company>kavitareader.com</Company>
         <Product>Kavita</Product>
-        <AssemblyVersion>0.7.12.8</AssemblyVersion>
+        <AssemblyVersion>0.7.13.0</AssemblyVersion>
         <NeutralLanguage>en</NeutralLanguage>
         <TieredPGO>true</TieredPGO>
     </PropertyGroup>

--- a/UI/Web/src/app/user-settings/change-email/change-email.component.html
+++ b/UI/Web/src/app/user-settings/change-email/change-email.component.html
@@ -38,7 +38,7 @@
               </div>
             }
             <div class="mb-3">
-              <label for="email" class="form-label visually-hidden">{{t('email-label')}}</label>
+              <label for="email" class="form-label">{{t('email-label')}}</label>
               <input class="form-control custom-input" type="email" id="email" formControlName="email"
                      [class.is-invalid]="form.get('email')?.invalid && form.get('email')?.touched">
               <div id="email-validations" class="invalid-feedback" *ngIf="form.get('email')?.errors">

--- a/UI/Web/src/app/user-settings/user-preferences/user-preferences.component.ts
+++ b/UI/Web/src/app/user-settings/user-preferences/user-preferences.component.ts
@@ -158,6 +158,7 @@ export class UserPreferencesComponent implements OnInit, OnDestroy {
 
       this.route.fragment.subscribe(frag => {
         const tab = this.tabs.filter(item => item.fragment === frag);
+        console.log('tab: ', tab);
         if (tab.length > 0) {
           this.active = tab[0];
         } else {

--- a/openapi.json
+++ b/openapi.json
@@ -7,7 +7,7 @@
       "name": "GPL-3.0",
       "url": "https://github.com/Kareadita/Kavita/blob/develop/LICENSE"
     },
-    "version": "0.7.12.7"
+    "version": "0.7.13.0"
   },
   "servers": [
     {


### PR DESCRIPTION
A quick and small update for you all with a focus on Kavita+ and a regression that appeared from NetVips, which is responsible for generating cover images, causing black and white covers. 

A word to all Kavita+ users, many of you have user's with AniList tokens that have expired. Your users need to go to User settings > Account and generate a new one to continue scrobbling. Also don't forget to register your discord user id and gain access to the exclusive channels. We have been sharing some of the progress on the big items and I would love more feedback. 

# Added
- Added: Added the ability to delete a library from side nav menu
- Added: (Kavita+) Kavita now alerts the user on visiting their homepage that their AniList token needs rotating to continue scrobbling

# Changed
- Changed: (Kavita+) Kavita will now clear out existing, non-processed scrobbling events when a Series is put on hold.
- Changed: Lots of dependency updates
- Changed: Downloading a Volume (consisting of multiple chapter archives) or a Full Series will not auto extract and re-zip for you.
- Changed: Enhanced the messaging around events widget for downloading/preparing a download.
- Changed: Min length for a user review is now only 5 characters
- Changed: Downloads will download as cbz
- Changed: Under User settings > Account tab, Email and AniList token will now inform user if the email is not validated or if AniList token needs to be regenerated (as they expire every few months)
- Changed: (Kavita+) Kavita will quit faster during scrobbling events whenever rate limit is hit or token is expired.
- Changed: (Kavita+) Switched Kavita to use a new dedicated API to allow data to load on the screen faster and all at once leading to less page shift.
- Changed: (Kavita+) If a license is still on disk, but the subscription is not active, Kavita will not schedule Kavita+ tasks at all.
- Changed: Streamlined some code around downloading for upcoming enhancements
- Changed: Updated dependencies, including NetVips for some regressions around cover generation.
- Changed: Major improvement to messaging when a series collides with another series in a parallel folder to library root. Explicitly give more information.
- Changed: Localization files now have cache busting to help on new releases not reflecting all keys
- Changed: Removed XFrameOptions and replaced with AllowIFraming as true/false. This will control multiple headers for Organizer 
- Changed: Shortened the time in which Kavita will check for an update an inform user. Originally 5-6 hours, now 1-2. We have over 10k users on old installs that haven't updated.

# Fixed
- Fixed: On non-authenticated flows, the nav bar will no longer flash on refresh.
- Fixed: Fixed inablity to right click highlighted text in the book reader
- Fixed: Fixed reading activity graphic not taking the full width like it should
- Fixed: Fixed some spacing on the Continue/Read button on reading list page
- Fixed: Fixed an issue where download indicators on cards would should on different series 
- Fixed: Don't have validations on the login screen
- Fixed: Fixed More in Genre not using a localized string for title
- Fixed: When a series updates to completed and there was a next estimated chapter card, make sure it gets cleared.
- Fixed: Fixed bookmarks having + in the filename when not needed
- Fixed: Fixed bookmarks not showing the download indicator
- Fixed: Fixed bookmarks not showing page count in card
- Fixed: Fixed a bad localization string for chapter actions from within the card detail drawer
- Fixed: Restore PDF layout menu (Thanks @tjarls)
- Fixed: Fixed an issue where tab could flash on user preferences due to some delay waiting for a license check.
- Fixed: Ensure only admins can see files when searching 
- Fixed: Fixed a bug where Edit Series Modal made it look like the language tag was set, but it wasn't 