### PR TITLE
Feat : add cover display option

### DIFF
--- a/API/Controllers/MetadataController.cs
+++ b/API/Controllers/MetadataController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -197,5 +197,16 @@ public class MetadataController(IUnitOfWork unitOfWork, ILocalizationService loc
 
         return Ok(await metadataService.GetSeriesDetail(User.GetUserId(), seriesId));
 
+    }
+
+    /// <summary>
+    /// Get cover display options
+    /// </summary>
+    /// <returns></returns>
+    [HttpGet("cover-display-options")]
+    public ActionResult<IList<string>> GetCoverDisplayOptions()
+    {
+        var optionStrings = Enum.GetNames(typeof(CoverDisplayOption));
+        return optionStrings.ToList();
     }
 }

--- a/API/DTOs/SeriesMetadataDto.cs
+++ b/API/DTOs/SeriesMetadataDto.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using API.DTOs.CollectionTags;
 using API.DTOs.Metadata;
 using API.Entities.Enums;
@@ -62,6 +62,10 @@ public class SeriesMetadataDto
     /// A comma-separated list of Urls
     /// </summary>
     public string WebLinks { get; set; }
+    /// <summary>
+    /// Series cover display option
+    /// </summary>
+    public CoverDisplayOption CoverDisplayOption { get; set; }
 
     public bool LanguageLocked { get; set; }
     public bool SummaryLocked { get; set; }

--- a/API/Data/DataContext.cs
+++ b/API/Data/DataContext.cs
@@ -137,6 +137,11 @@ public sealed class DataContext : IdentityDbContext<AppUser, AppRole, int,
         builder.Entity<AppUserSideNavStream>()
             .HasIndex(e => e.Visible)
             .IsUnique(false);
+
+        builder.Entity<SeriesMetadata>()
+            .Property(metadata => metadata.CoverDisplayOption)
+            .HasDefaultValue(CoverDisplayOption.Default)
+            .HasConversion<string>();
     }
 
 

--- a/API/Data/Migrations/20240122094835_AddCoverDisplayOption.Designer.cs
+++ b/API/Data/Migrations/20240122094835_AddCoverDisplayOption.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using API.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace API.Data.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20240122094835_AddCoverDisplayOption")]
+    partial class AddCoverDisplayOption
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "8.0.1");

--- a/API/Data/Migrations/20240122094835_AddCoverDisplayOption.cs
+++ b/API/Data/Migrations/20240122094835_AddCoverDisplayOption.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace API.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCoverDisplayOption : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "CoverDisplayOption",
+                table: "SeriesMetadata",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: "Default");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CoverDisplayOption",
+                table: "SeriesMetadata");
+        }
+    }
+}

--- a/API/Entities/Enums/CoverDisplayOption.cs
+++ b/API/Entities/Enums/CoverDisplayOption.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel;
+
+namespace API.Entities.Enums;
+
+public enum CoverDisplayOption
+{
+    [Description("Default")]
+    Default = 0,
+    [Description("Random")]
+    Random,
+    [Description("Latest Volume")]
+    LatestVolume
+}

--- a/API/Entities/Metadata/SeriesMetadata.cs
+++ b/API/Entities/Metadata/SeriesMetadata.cs
@@ -49,6 +49,10 @@ public class SeriesMetadata : IHasConcurrencyToken
     /// </summary>
     /// <remarks>This is not populated from Chapters of the Series</remarks>
     public string WebLinks { get; set; } = string.Empty;
+    /// <summary>
+    /// Series cover display option
+    /// </summary>
+    public CoverDisplayOption CoverDisplayOption { get; set; }
 
     // Locks
     public bool LanguageLocked { get; set; }

--- a/API/Services/SeriesService.cs
+++ b/API/Services/SeriesService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -163,6 +163,8 @@ public class SeriesService : ISeriesService
                     .Select(s => s.Trim())!
                 );
             }
+
+            series.Metadata.CoverDisplayOption = updateSeriesMetadataDto.SeriesMetadata?.CoverDisplayOption ?? CoverDisplayOption.Default;
 
 
             if (updateSeriesMetadataDto.CollectionTags.Any())

--- a/UI/Web/src/app/_models/metadata/series-metadata.ts
+++ b/UI/Web/src/app/_models/metadata/series-metadata.ts
@@ -30,6 +30,7 @@ export interface SeriesMetadata {
     language: string;
     publicationStatus: PublicationStatus;
     webLinks: string;
+    coverDisplayOption: number;
 
     summaryLocked: boolean;
     genresLocked: boolean;

--- a/UI/Web/src/app/_services/metadata.service.ts
+++ b/UI/Web/src/app/_services/metadata.service.ts
@@ -96,6 +96,10 @@ export class MetadataService {
     return this.httpClient.get<Array<Person>>(this.baseUrl + 'metadata/people-by-role?role=' + role);
   }
 
+  getCoverDisplayOptions(){
+    return this.httpClient.get<Array<string>>(this.baseUrl + 'metadata/cover-display-options');
+  }
+
   createDefaultFilterDto(): SeriesFilterV2 {
     return {
       statements: [] as FilterStatement[],

--- a/UI/Web/src/app/cards/_modals/edit-series-modal/edit-series-modal.component.html
+++ b/UI/Web/src/app/cards/_modals/edit-series-modal/edit-series-modal.component.html
@@ -358,6 +358,12 @@
           <li [ngbNavItem]="tabs[TabID.CoverImage]">
             <a ngbNavLink>{{t(tabs[TabID.CoverImage])}}</a>
             <ng-template ngbNavContent>
+              <form [formGroup]="coverOptionForm" style="margin-bottom: 15px">
+                <label for="cover-display-option-port" class="form-label">Cover Display Options</label>
+                <select id="cover-display-option-port" class="form-select" formControlName="coverDisplayOptionSelected">
+                  <option *ngFor="let option of coverDisplayOptions" [ngValue]="option">{{ option | titlecase }}</option>
+                </select>
+              </form>
               <p class="alert alert-primary" role="alert">
                 {{t('cover-image-description')}}
               </p>

--- a/openapi.json
+++ b/openapi.json
@@ -7,7 +7,7 @@
       "name": "GPL-3.0",
       "url": "https://github.com/Kareadita/Kavita/blob/develop/LICENSE"
     },
-    "version": "0.7.13.0"
+    "version": "0.7.13.1"
   },
   "servers": [
     {
@@ -3599,6 +3599,45 @@
               "text/json": {
                 "schema": {
                   "$ref": "#/components/schemas/SeriesDetailPlusDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/Metadata/cover-display-options": {
+      "get": {
+        "tags": [
+          "Metadata"
+        ],
+        "summary": "Get cover display options",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
                 }
               }
             }
@@ -17896,6 +17935,16 @@
             "description": "A Comma-separated list of strings representing links from the series",
             "nullable": true
           },
+          "coverDisplayOption": {
+            "enum": [
+              0,
+              1,
+              2
+            ],
+            "type": "integer",
+            "description": "Series cover display option",
+            "format": "int32"
+          },
           "languageLocked": {
             "type": "boolean"
           },
@@ -18128,6 +18177,16 @@
             "type": "string",
             "description": "A comma-separated list of Urls",
             "nullable": true
+          },
+          "coverDisplayOption": {
+            "enum": [
+              0,
+              1,
+              2
+            ],
+            "type": "integer",
+            "description": "Series cover display option",
+            "format": "int32"
           },
           "languageLocked": {
             "type": "boolean"


### PR DESCRIPTION
# Added
- Added: Add a feature to change how the series cover is displayed (#2629)

\
Note : this PR will update Database (config/kavita.db)
\
\
Currently, there are three display options available:

1. Default: Shows the default display (usually Volume 1).

2. Random: Displays a random volume cover.

3. LatestVolume: Shows the cover of the latest volume.

Random:
![firefox_hdcoFp2tJS](https://github.com/Kareadita/Kavita/assets/30816317/1639aa77-3d1d-432d-8766-01f5f453a7cc)

LatestVolume:
![firefox_jcUDrL3c3I](https://github.com/Kareadita/Kavita/assets/30816317/e67b4d14-e640-4a5d-94dc-9b7df81f695d)
