### PR TITLE
Read Only Accounts

### DIFF
--- a/API.Tests/Services/ReaderServiceTests.cs
+++ b/API.Tests/Services/ReaderServiceTests.cs
@@ -382,6 +382,41 @@ public class ReaderServiceTests
         Assert.Equal("2", actualChapter.Range);
     }
 
+    //[Fact]
+    public async Task GetNextChapterIdAsync_ShouldGetNextVolume_WhenUsingRanges()
+    {
+        // V1 -> V2
+        await ResetDb();
+
+        var series = new SeriesBuilder("Test")
+            .WithVolume(new VolumeBuilder("1-2")
+                .WithNumber(1)
+                .WithChapter(new ChapterBuilder("1").Build())
+                .WithChapter(new ChapterBuilder("2").Build())
+                .Build())
+
+            .WithVolume(new VolumeBuilder("3-4")
+                .WithNumber(2)
+                .WithChapter(new ChapterBuilder("21").Build())
+                .WithChapter(new ChapterBuilder("22").Build())
+                .Build())
+            .Build();
+        series.Library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+
+        _context.Series.Add(series);
+
+        _context.AppUser.Add(new AppUser()
+        {
+            UserName = "majora2007"
+        });
+
+        await _context.SaveChangesAsync();
+
+        var nextChapter = await _readerService.GetNextChapterIdAsync(1, 1, 1, 1);
+        var actualChapter = await _unitOfWork.ChapterRepository.GetChapterAsync(nextChapter);
+        Assert.Equal("3-4", actualChapter.Range);
+    }
+
     [Fact]
     public async Task GetNextChapterIdAsync_ShouldGetNextVolume_OnlyFloats()
     {

--- a/API/Constants/PolicyConstants.cs
+++ b/API/Constants/PolicyConstants.cs
@@ -35,7 +35,13 @@ public static class PolicyConstants
     /// Used to give a user ability to Login to their account
     /// </summary>
     public const string LoginRole = "Login";
+    /// <summary>
+    /// Restricts the ability to manage their account without an admin
+    /// </summary>
+    /// <remarks>This is used explicitly for Demo Server. Not sure why it would be used in another fashion</remarks>
+    public const string ReadOnlyRole = "Read Only";
+
 
     public static readonly ImmutableArray<string> ValidRoles =
-        ImmutableArray.Create(AdminRole, PlebRole, DownloadRole, ChangePasswordRole, BookmarkRole, ChangeRestrictionRole, LoginRole);
+        ImmutableArray.Create(AdminRole, PlebRole, DownloadRole, ChangePasswordRole, BookmarkRole, ChangeRestrictionRole, LoginRole, ReadOnlyRole);
 }

--- a/API/Controllers/SettingsController.cs
+++ b/API/Controllers/SettingsController.cs
@@ -128,7 +128,7 @@ public class SettingsController : BaseApiController
     /// Is the minimum information setup for Email to work
     /// </summary>
     /// <returns></returns>
-    [Authorize]
+    [Authorize(Policy = "RequireAdminRole")]
     [HttpGet("is-email-setup")]
     public async Task<ActionResult<bool>> IsEmailSetup()
     {

--- a/API/Entities/Volume.cs
+++ b/API/Entities/Volume.cs
@@ -8,7 +8,7 @@ public class Volume : IEntityDate, IHasReadTimeEstimate
 {
     public int Id { get; set; }
     /// <summary>
-    /// A String representation of the volume number. Allows for floats.
+    /// A String representation of the volume number. Allows for floats. Can also include a range (1-2).
     /// </summary>
     /// <remarks>For Books with Series_index, this will map to the Series Index.</remarks>
     public required string Name { get; set; }

--- a/API/Services/AccountService.cs
+++ b/API/Services/AccountService.cs
@@ -26,7 +26,7 @@ public interface IAccountService
     Task<IEnumerable<ApiException>> ValidateEmail(string email);
     Task<bool> HasBookmarkPermission(AppUser? user);
     Task<bool> HasDownloadPermission(AppUser? user);
-    Task<bool> HasChangeRestrictionRole(AppUser? user);
+    Task<bool> CanChangeAgeRestriction(AppUser? user);
 }
 
 public class AccountService : IAccountService
@@ -128,14 +128,15 @@ public class AccountService : IAccountService
     }
 
     /// <summary>
-    /// Does the user have Change Restriction permission or admin rights
+    /// Does the user have Change Restriction permission or admin rights and not Read Only
     /// </summary>
     /// <param name="user"></param>
     /// <returns></returns>
-    public async Task<bool> HasChangeRestrictionRole(AppUser? user)
+    public async Task<bool> CanChangeAgeRestriction(AppUser? user)
     {
         if (user == null) return false;
         var roles = await _userManager.GetRolesAsync(user);
+        if (roles.Contains(PolicyConstants.ReadOnlyRole)) return false;
         return roles.Contains(PolicyConstants.ChangePasswordRole) || roles.Contains(PolicyConstants.AdminRole);
     }
 

--- a/UI/Web/src/app/_services/account.service.ts
+++ b/UI/Web/src/app/_services/account.service.ts
@@ -20,7 +20,8 @@ export enum Role {
   ChangePassword = 'Change Password',
   Bookmark = 'Bookmark',
   Download = 'Download',
-  ChangeRestriction = 'Change Restriction'
+  ChangeRestriction = 'Change Restriction',
+  ReadOnly = 'Read Only'
 }
 
 @Injectable({
@@ -78,6 +79,10 @@ export class AccountService {
 
   hasBookmarkRole(user: User) {
     return user && user.roles.includes(Role.Bookmark);
+  }
+
+  hasReadOnlyRole(user: User) {
+    return user && user.roles.includes(Role.ReadOnly);
   }
 
   getRoles() {

--- a/UI/Web/src/app/app.component.ts
+++ b/UI/Web/src/app/app.component.ts
@@ -1,6 +1,6 @@
 import {ChangeDetectorRef, Component, DestroyRef, HostListener, inject, Inject, OnInit} from '@angular/core';
 import {NavigationStart, Router, RouterOutlet} from '@angular/router';
-import {map, shareReplay, take} from 'rxjs/operators';
+import {map, shareReplay, take, tap} from 'rxjs/operators';
 import { AccountService } from './_services/account.service';
 import { LibraryService } from './_services/library.service';
 import { NavService } from './_services/nav.service';
@@ -67,8 +67,21 @@ export class AppComponent implements OnInit {
 
       });
 
+    // Every hour, have the UI check for an update. People seriously stay out of date
+    // interval(60 * 60 * 1000) // 60 minutes in milliseconds
+    //   .pipe(
+    //     switchMap(() => this.accountService.currentUser$),
+    //     filter(u => u !== undefined && this.accountService.hasAdminRole(u)),
+    //     switchMap(_ => this.serverService.checkForUpdates())
+    //   )
+    //   .subscribe();
 
-    this.transitionState$ = this.accountService.currentUser$.pipe(map((user) => {
+
+    this.transitionState$ = this.accountService.currentUser$.pipe(
+      tap(user => {
+
+      }),
+      map((user) => {
       if (!user) return false;
       return user.preferences.noTransitions;
     }), takeUntilDestroyed(this.destroyRef));

--- a/UI/Web/src/app/user-settings/api-key/api-key.component.ts
+++ b/UI/Web/src/app/user-settings/api-key/api-key.component.ts
@@ -26,23 +26,27 @@ import {translate, TranslocoDirective} from "@ngneat/transloco";
 })
 export class ApiKeyComponent implements OnInit {
 
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly confirmService = inject(ConfirmService);
+  private readonly accountService = inject(AccountService);
+  private readonly toastr = inject(ToastrService);
+  private readonly clipboard = inject(Clipboard);
+  private readonly cdRef = inject(ChangeDetectorRef);
+
   @Input() title: string = 'API Key';
   @Input() showRefresh: boolean = true;
   @Input() transform: (val: string) => string = (val: string) => val;
   @Input() tooltipText: string = '';
   @Input() hideData = true;
   @ViewChild('apiKey') inputElem!: ElementRef;
-  key: string = '';
-  private readonly destroyRef = inject(DestroyRef);
 
+  key: string = '';
   isDataHidden: boolean = this.hideData;
 
   get InputType() {
     return (this.hideData && this.isDataHidden) ? 'password' : 'text';
   }
 
-  constructor(private confirmService: ConfirmService, private accountService: AccountService, private toastr: ToastrService, private clipboard: Clipboard,
-              private readonly cdRef: ChangeDetectorRef) { }
 
   ngOnInit(): void {
     this.accountService.currentUser$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(user => {
@@ -52,6 +56,8 @@ export class ApiKeyComponent implements OnInit {
       } else {
         key = translate('api-key.no-key');
       }
+
+      this.showRefresh = !this.accountService.hasReadOnlyRole(user!);
 
       if (this.transform != undefined) {
         this.key = this.transform(key);

--- a/UI/Web/src/app/user-settings/change-age-restriction/change-age-restriction.component.html
+++ b/UI/Web/src/app/user-settings/change-age-restriction/change-age-restriction.component.html
@@ -5,7 +5,7 @@
         <div class="container-fluid row mb-2">
           <div class="col-10 col-sm-11"><h4 id="age-restriction">{{t('age-restriction-label')}}</h4></div>
           <div class="col-1 text-end">
-            <button class="btn btn-primary btn-sm" (click)="toggleViewMode()" *ngIf="(hasChangeAgeRestrictionAbility | async)">{{isViewMode ? t('edit') : t('cancel')}}</button>
+            <button class="btn btn-primary btn-sm" (click)="toggleViewMode()" [disabled]="!(hasChangeAgeRestrictionAbility | async)">{{isViewMode ? t('edit') : t('cancel')}}</button>
           </div>
         </div>
       </div>

--- a/UI/Web/src/app/user-settings/change-age-restriction/change-age-restriction.component.ts
+++ b/UI/Web/src/app/user-settings/change-age-restriction/change-age-restriction.component.ts
@@ -50,7 +50,7 @@ export class ChangeAgeRestrictionComponent implements OnInit {
     });
 
     this.hasChangeAgeRestrictionAbility = this.accountService.currentUser$.pipe(takeUntilDestroyed(this.destroyRef), shareReplay(), map(user => {
-      return user !== undefined && (!this.accountService.hasAdminRole(user) && this.accountService.hasChangeAgeRestrictionRole(user));
+      return user !== undefined && !this.accountService.hasReadOnlyRole(user) && (!this.accountService.hasAdminRole(user) && this.accountService.hasChangeAgeRestrictionRole(user));
     }));
     this.cdRef.markForCheck();
   }

--- a/UI/Web/src/app/user-settings/change-email/change-email.component.html
+++ b/UI/Web/src/app/user-settings/change-email/change-email.component.html
@@ -15,7 +15,7 @@
             </h4>
           </div>
           <div class="col-1 text-end">
-            <button class="btn btn-primary btn-sm" (click)="toggleViewMode()">{{isViewMode ? 'Edit' : 'Cancel'}}</button>
+            <button class="btn btn-primary btn-sm" (click)="toggleViewMode()" [disabled]="!canEdit">{{isViewMode ? t('edit') : t('cancel')}}</button>
           </div>
         </div>
       </div>

--- a/UI/Web/src/app/user-settings/change-email/change-email.component.ts
+++ b/UI/Web/src/app/user-settings/change-email/change-email.component.ts
@@ -29,6 +29,7 @@ export class ChangeEmailComponent implements OnInit {
   emailLink: string = '';
   emailConfirmed: boolean = true;
   hasValidEmail: boolean = true;
+  canEdit: boolean = false;
 
 
   public get email() { return this.form.get('email'); }
@@ -38,8 +39,9 @@ export class ChangeEmailComponent implements OnInit {
   constructor(public accountService: AccountService, private toastr: ToastrService, private readonly cdRef: ChangeDetectorRef) { }
 
   ngOnInit(): void {
-    this.accountService.currentUser$.pipe(takeUntilDestroyed(this.destroyRef), shareReplay(), take(1)).subscribe(user => {
+    this.accountService.currentUser$.pipe(takeUntilDestroyed(this.destroyRef), shareReplay()).subscribe(user => {
       this.user = user;
+      this.canEdit = !this.accountService.hasReadOnlyRole(user!);
       this.form.addControl('email', new FormControl(user?.email, [Validators.required, Validators.email]));
       this.form.addControl('password', new FormControl('', [Validators.required]));
       this.cdRef.markForCheck();

--- a/UI/Web/src/app/user-settings/change-password/change-password.component.html
+++ b/UI/Web/src/app/user-settings/change-password/change-password.component.html
@@ -5,7 +5,7 @@
         <div class="container-fluid row mb-2">
           <div class="col-10 col-sm-11"><h4>{{t('password-label')}}</h4></div>
           <div class="col-1 text-end">
-            <button class="btn btn-primary btn-sm" (click)="toggleViewMode()" *ngIf="(hasChangePasswordAbility | async)">{{isViewMode ? t('edit') : t('cancel')}}</button>
+            <button class="btn btn-primary btn-sm" (click)="toggleViewMode()" [disabled]="!(hasChangePasswordAbility | async)">{{isViewMode ? t('edit') : t('cancel')}}</button>
           </div>
         </div>
       </div>

--- a/UI/Web/src/app/user-settings/change-password/change-password.component.ts
+++ b/UI/Web/src/app/user-settings/change-password/change-password.component.ts
@@ -44,13 +44,13 @@ export class ChangePasswordComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
 
-    this.accountService.currentUser$.pipe(takeUntilDestroyed(this.destroyRef), shareReplay(), take(1)).subscribe(user => {
+    this.accountService.currentUser$.pipe(takeUntilDestroyed(this.destroyRef), shareReplay()).subscribe(user => {
       this.user = user;
       this.cdRef.markForCheck();
     });
 
     this.hasChangePasswordAbility = this.accountService.currentUser$.pipe(takeUntilDestroyed(this.destroyRef), shareReplay(), map(user => {
-      return user !== undefined && (this.accountService.hasAdminRole(user) || this.accountService.hasChangePasswordRole(user));
+      return user !== undefined && !this.accountService.hasReadOnlyRole(user) && (this.accountService.hasAdminRole(user) || this.accountService.hasChangePasswordRole(user));
     }));
     this.cdRef.markForCheck();
 

--- a/UI/Web/src/app/user-settings/user-preferences/user-preferences.component.ts
+++ b/UI/Web/src/app/user-settings/user-preferences/user-preferences.component.ts
@@ -9,7 +9,7 @@ import {
 } from '@angular/core';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { ToastrService } from 'ngx-toastr';
-import { take } from 'rxjs/operators';
+import {take, tap} from 'rxjs/operators';
 import { Title } from '@angular/platform-browser';
 import {
   readingDirections,
@@ -129,7 +129,7 @@ export class UserPreferencesComponent implements OnInit, OnDestroy {
   opdsUrl: string = '';
   makeUrl: (val: string) => string = (val: string) => { return this.opdsUrl; };
   hasActiveLicense = false;
-
+  canEdit = true;
 
 
 
@@ -142,6 +142,11 @@ export class UserPreferencesComponent implements OnInit, OnDestroy {
       this.cdRef.markForCheck();
     });
 
+    this.settingsService.getOpdsEnabled().subscribe(res => {
+      this.opdsEnabled = res;
+      this.cdRef.markForCheck();
+    });
+
     this.localizationService.getLocales().subscribe(res => {
       this.locales = res;
       this.cdRef.markForCheck();
@@ -149,7 +154,7 @@ export class UserPreferencesComponent implements OnInit, OnDestroy {
 
 
 
-    this.accountService.hasValidLicense$.pipe(take(1), takeUntilDestroyed(this.destroyRef)).subscribe(res => {
+    this.accountService.hasValidLicense$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(res => {
       if (res) {
         this.tabs.push({title: 'scrobbling-tab', fragment: FragmentID.Scrobbling});
         this.hasActiveLicense = true;
@@ -169,10 +174,7 @@ export class UserPreferencesComponent implements OnInit, OnDestroy {
     });
 
 
-    this.settingsService.getOpdsEnabled().subscribe(res => {
-      this.opdsEnabled = res;
-      this.cdRef.markForCheck();
-    });
+
   }
 
   ngOnInit(): void {

--- a/openapi.json
+++ b/openapi.json
@@ -7,7 +7,7 @@
       "name": "GPL-3.0",
       "url": "https://github.com/Kareadita/Kavita/blob/develop/LICENSE"
     },
-    "version": "0.7.13.5"
+    "version": "0.7.13.6"
   },
   "servers": [
     {
@@ -9560,37 +9560,6 @@
         }
       }
     },
-    "/api/Server/accessible": {
-      "get": {
-        "tags": [
-          "Server"
-        ],
-        "summary": "Is this server accessible to the outside net",
-        "description": "If the instance has the HostName set, this will return true whether or not it is accessible externally",
-        "responses": {
-          "200": {
-            "description": "Success",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "boolean"
-                }
-              },
-              "application/json": {
-                "schema": {
-                  "type": "boolean"
-                }
-              },
-              "text/json": {
-                "schema": {
-                  "type": "boolean"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/api/Server/jobs": {
       "get": {
         "tags": [
@@ -10109,6 +10078,36 @@
               "text/json": {
                 "schema": {
                   "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/Settings/test-email-url": {
+      "post": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Sends a test email to see if email settings are hooked up correctly",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/EmailTestResultDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EmailTestResultDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EmailTestResultDto"
                 }
               }
             }
@@ -14764,6 +14763,24 @@
           }
         },
         "additionalProperties": false
+      },
+      "EmailTestResultDto": {
+        "type": "object",
+        "properties": {
+          "successful": {
+            "type": "boolean"
+          },
+          "errorMessage": {
+            "type": "string",
+            "nullable": true
+          },
+          "emailAddress": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Represents if Test Email Service URL was successful or not and if any error occured"
       },
       "ExternalRating": {
         "type": "object",

--- a/openapi.json
+++ b/openapi.json
@@ -20239,7 +20239,7 @@
           },
           "name": {
             "type": "string",
-            "description": "A String representation of the volume number. Allows for floats.",
+            "description": "A String representation of the volume number. Allows for floats. Can also include a range (1-2).",
             "nullable": true
           },
           "number": {


### PR DESCRIPTION
# Added
- Added: Added a new role that makes a user account read only. This means they cannot change anything themselves (Age Restriction, Email, Password, Forgot Password, API Key). This is not intended for users to use, but for the demo instance. 
