### PR TITLE
More Polish

### DIFF
--- a/API.Tests/Services/ReaderServiceTests.cs
+++ b/API.Tests/Services/ReaderServiceTests.cs
@@ -703,6 +703,37 @@ public class ReaderServiceTests
         Assert.Equal(-1, nextChapter);
     }
 
+    // This is commented out because, while valid, I can't solve how to make this pass (https://github.com/Kareadita/Kavita/issues/2099)
+    // [Fact]
+    // public async Task GetNextChapterIdAsync_ShouldFindNoNextChapterFromLastChapter_NoSpecials_FirstIsVolume()
+    // {
+    //     await ResetDb();
+    //
+    //     var series = new SeriesBuilder("Test")
+    //         .WithVolume(new VolumeBuilder("0")
+    //             .WithMinNumber(0)
+    //             .WithChapter(new ChapterBuilder("1").Build())
+    //             .WithChapter(new ChapterBuilder("2").Build())
+    //             .Build())
+    //         .WithVolume(new VolumeBuilder("1")
+    //             .WithMinNumber(1)
+    //             .WithChapter(new ChapterBuilder("0").Build())
+    //             .Build())
+    //         .Build();
+    //     series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
+    //
+    //     _context.Series.Add(series);
+    //     _context.AppUser.Add(new AppUser()
+    //     {
+    //         UserName = "majora2007"
+    //     });
+    //
+    //     await _context.SaveChangesAsync();
+    //
+    //     var nextChapter = await _readerService.GetNextChapterIdAsync(1, 2, 3, 1);
+    //     Assert.Equal(-1, nextChapter);
+    // }
+
     // This is commented out because, while valid, I can't solve how to make this pass
     // [Fact]
     // public async Task GetNextChapterIdAsync_ShouldFindNoNextChapterFromLastChapter_WithSpecials()

--- a/API/Controllers/MetadataController.cs
+++ b/API/Controllers/MetadataController.cs
@@ -196,7 +196,6 @@ public class MetadataController(IUnitOfWork unitOfWork, ILocalizationService loc
     /// <param name="seriesId"></param>
     /// <returns></returns>
     [HttpGet("series-detail-plus")]
-    [ResponseCache(CacheProfileName = ResponseCacheProfiles.KavitaPlus, VaryByQueryKeys = ["seriesId"])]
     public async Task<ActionResult<SeriesDetailPlusDto>> GetKavitaPlusSeriesDetailData(int seriesId)
     {
         if (!await licenseService.HasActiveLicense())
@@ -225,9 +224,11 @@ public class MetadataController(IUnitOfWork unitOfWork, ILocalizationService loc
         if (ret == null) return Ok(null);
         await _cacheProvider.SetAsync(cacheKey, ret, TimeSpan.FromHours(48));
 
-        await PrepareSeriesDetail(userReviews, ret, user);
+        // For some reason if we don't use a different instance, the cache keeps changes made below
+        var newCacheResult = (await _cacheProvider.GetAsync<SeriesDetailPlusDto>(cacheKey)).Value;
+        await PrepareSeriesDetail(userReviews, newCacheResult, user);
 
-        return Ok(ret);
+        return Ok(newCacheResult);
 
     }
 

--- a/API/Controllers/OPDSController.cs
+++ b/API/Controllers/OPDSController.cs
@@ -1250,7 +1250,7 @@ public class OpdsController : BaseApiController
         if (progress != null)
         {
             link.LastRead = progress.PageNum;
-            link.LastReadDate = progress.LastModifiedUtc;
+            link.LastReadDate = progress.LastModifiedUtc.ToString("o"); // Adhere to ISO 8601
         }
         link.IsPageStream = true;
         return link;

--- a/API/Controllers/PanelsController.cs
+++ b/API/Controllers/PanelsController.cs
@@ -57,7 +57,7 @@ public class PanelsController : BaseApiController
             PageNum = 0,
             ChapterId = chapterId,
             VolumeId = 0,
-            SeriesId = 0
+            SeriesId = 0,
         });
         return Ok(progress);
     }

--- a/API/DTOs/OPDS/FeedLink.cs
+++ b/API/DTOs/OPDS/FeedLink.cs
@@ -39,7 +39,7 @@ public class FeedLink
     /// </summary>
     /// <remarks>Attribute MUST conform Atom's Date construct</remarks>
     [XmlAttribute("lastReadDate", Namespace = "http://vaemendis.net/opds-pse/ns")]
-    public DateTime LastReadDate { get; set; }
+    public string LastReadDate { get; set; }
 
     public bool ShouldSerializeLastReadDate()
     {

--- a/API/DTOs/VolumeDto.cs
+++ b/API/DTOs/VolumeDto.cs
@@ -15,6 +15,11 @@ public class VolumeDto : IHasReadTimeEstimate
     public float MaxNumber { get; set; }
     /// <inheritdoc cref="Volume.Name"/>
     public string Name { get; set; } = default!;
+    /// <summary>
+    /// This will map to MinNumber. Number was removed in v0.7.13.8
+    /// </summary>
+    [Obsolete("Use MinNumber")]
+    public float Number { get; set; }
     public int Pages { get; set; }
     public int PagesRead { get; set; }
     public DateTime LastModifiedUtc { get; set; }

--- a/API/DTOs/VolumeDto.cs
+++ b/API/DTOs/VolumeDto.cs
@@ -16,7 +16,7 @@ public class VolumeDto : IHasReadTimeEstimate
     /// <inheritdoc cref="Volume.Name"/>
     public string Name { get; set; } = default!;
     /// <summary>
-    /// This will map to MinNumber. Number was removed in v0.7.13.8
+    /// This will map to MinNumber. Number was removed in v0.7.13.8/v0.7.14
     /// </summary>
     [Obsolete("Use MinNumber")]
     public float Number { get; set; }

--- a/API/Data/Repositories/ExternalSeriesMetadataRepository.cs
+++ b/API/Data/Repositories/ExternalSeriesMetadataRepository.cs
@@ -122,6 +122,7 @@ public class ExternalSeriesMetadataRepository : IExternalSeriesMetadataRepositor
             externalSeriesRecommendations = seriesDetailDto.ExternalRecommendations
                 .Where(r => r.SeriesId is null or 0)
                 .Select(r => _mapper.Map<ExternalSeriesDto>(r))
+                .DefaultIfEmpty()
                 .ToList();
         }
 
@@ -133,12 +134,17 @@ public class ExternalSeriesMetadataRepository : IExternalSeriesMetadataRepositor
             .OrderBy(s => s.SortName.ToLower())
             .ProjectTo<SeriesDto>(_mapper.ConfigurationProvider)
             .AsNoTracking()
+            .DefaultIfEmpty()
             .ToListAsync();
 
         var seriesDetailPlusDto = new SeriesDetailPlusDto()
         {
-            Ratings = seriesDetailDto.ExternalRatings.Select(r => _mapper.Map<RatingDto>(r)),
-            Reviews = seriesDetailDto.ExternalReviews.OrderByDescending(r => r.Score)
+            Ratings = seriesDetailDto.ExternalRatings
+                .DefaultIfEmpty()
+                .Select(r => _mapper.Map<RatingDto>(r)),
+            Reviews = seriesDetailDto.ExternalReviews
+                .DefaultIfEmpty()
+                .OrderByDescending(r => r.Score)
                 .Select(r =>
                 {
                     var ret = _mapper.Map<UserReviewDto>(r);

--- a/API/Data/Repositories/ExternalSeriesMetadataRepository.cs
+++ b/API/Data/Repositories/ExternalSeriesMetadataRepository.cs
@@ -109,8 +109,6 @@ public class ExternalSeriesMetadataRepository : IExternalSeriesMetadataRepositor
             .Select(l => l.Id)
             .ToListAsync();
 
-        var userRating = await _context.AppUser.GetUserAgeRestriction(user.Id);
-
         var seriesDetailDto = await _context.ExternalSeriesMetadata
             .Where(m => m.SeriesId == seriesId)
             .Include(m => m.ExternalRatings)
@@ -122,21 +120,6 @@ public class ExternalSeriesMetadataRepository : IExternalSeriesMetadataRepositor
         {
             return null; // or handle the case when seriesDetailDto is not found
         }
-
-        // External tables must be reached from SeriesMetadata
-        // var ownedSeriesRecommendations = await _context.ExternalSeriesMetadata
-        //     .Where(s => s.SeriesId == seriesId)
-        //     .Where(series => series.ExternalRecommendations.Any(r => r.SeriesId > 0
-        //                                                              && allowedLibraries.Contains(r.Series.LibraryId)))
-        //     .Select(s => s.Series)
-        //     .RestrictAgainstAgeRestriction(userRating)
-        //     .OrderBy(series => series.SortName.ToLower())
-        //     .ProjectTo<SeriesDto>(_mapper.ConfigurationProvider)
-        //     .ToListAsync();
-
-        // TODO: Instead of selecting from DB, let's just take the existing seriesDetailDto and perform
-        // owned/external on that. Move RestrictAgainstAgeRestriction needs to be in the controller
-
 
         var externalSeriesRecommendations = seriesDetailDto.ExternalRecommendations
             .Where(r => r.SeriesId == null)
@@ -153,15 +136,6 @@ public class ExternalSeriesMetadataRepository : IExternalSeriesMetadataRepositor
             .OrderBy(s => s.SortName.ToLower())
             .ProjectTo<SeriesDto>(_mapper.ConfigurationProvider)
             .ToListAsync();
-
-        // var ownedSeriesRecommendations = await _context.ExternalRecommendation
-        //     .Where(r => r.SeriesId > 0 && allowedLibraries.Contains(r.Series.LibraryId))
-        //     .Join(_context.Series, r => r.SeriesId, s => s.Id, (recommendation, series) => series)
-        //     .RestrictAgainstAgeRestriction(userRating)
-        //     .OrderBy(s => s.SortName.ToLower())
-        //     .ProjectTo<SeriesDto>(_mapper.ConfigurationProvider)
-        //     .AsNoTracking()
-        //     .ToListAsync();
 
         var seriesDetailPlusDto = new SeriesDetailPlusDto()
         {

--- a/API/Entities/Metadata/ExternalReview.cs
+++ b/API/Entities/Metadata/ExternalReview.cs
@@ -25,7 +25,6 @@ public class ExternalReview
     /// Reviewer's username
     /// </summary>
     public string Username { get; set; }
-
     /// <summary>
     /// An Optional Rating coming from the Review
     /// </summary>
@@ -35,6 +34,7 @@ public class ExternalReview
     /// </summary>
     public int Score { get; set; }
     public int TotalVotes { get; set; }
+
 
     public int SeriesId { get; set; }
 

--- a/API/Helpers/AutoMapperProfiles.cs
+++ b/API/Helpers/AutoMapperProfiles.cs
@@ -46,7 +46,8 @@ public class AutoMapperProfiles : Profile
             .ForMember(dest => dest.ChapterId, opt => opt.MapFrom(src => src.Bookmark.ChapterId))
             .ForMember(dest => dest.Series, opt => opt.MapFrom(src => src.Series));
         CreateMap<LibraryDto, Library>();
-        CreateMap<Volume, VolumeDto>();
+        CreateMap<Volume, VolumeDto>()
+            .ForMember(dest => dest.Number, opt => opt.MapFrom(src => src.MinNumber));
         CreateMap<MangaFile, MangaFileDto>();
         CreateMap<Chapter, ChapterDto>();
         CreateMap<Series, SeriesDto>();

--- a/API/Services/Plus/ExternalMetadataService.cs
+++ b/API/Services/Plus/ExternalMetadataService.cs
@@ -132,8 +132,6 @@ public class ExternalMetadataService : IExternalMetadataService
             _unitOfWork.ExternalSeriesMetadataRepository.Remove(externalSeriesMetadata.ExternalRatings);
             _unitOfWork.ExternalSeriesMetadataRepository.Remove(externalSeriesMetadata.ExternalRecommendations);
 
-            await _unitOfWork.CommitAsync();
-
             externalSeriesMetadata.ExternalReviews = result.Reviews.Select(r =>
             {
                 var review = _mapper.Map<ExternalReview>(r);

--- a/API/Services/Plus/ExternalMetadataService.cs
+++ b/API/Services/Plus/ExternalMetadataService.cs
@@ -224,7 +224,7 @@ public class ExternalMetadataService : IExternalMetadataService
                 recDto.OwnedSeries.Add(seriesForRec);
                 externalSeriesMetadata.ExternalRecommendations.Add(new ExternalRecommendation()
                 {
-                    SeriesId = series.Id,
+                    SeriesId = seriesForRec.Id,
                     AniListId = rec.AniListId,
                     MalId = rec.MalId,
                     Name = seriesForRec.Name,

--- a/API/Services/Tasks/Scanner/ProcessSeries.cs
+++ b/API/Services/Tasks/Scanner/ProcessSeries.cs
@@ -127,13 +127,14 @@ public class ProcessSeries : IProcessSeries
             seriesCollisions = seriesCollisions.Where(collision =>
                 collision.Name != firstInfo.Series || collision.LocalizedName != firstInfo.LocalizedSeries).ToList();
 
-            if (seriesCollisions.Any())
+            if (seriesCollisions.Count > 1)
             {
-                var tableRows = seriesCollisions.Select(collision =>
-                    $"<tr><td>Name: {firstInfo.Series}</td><td>Name: {collision.Name}</td></tr>" +
-                    $"<tr><td>Localized: {firstInfo.LocalizedSeries}</td><td>Localized: {collision.LocalizedName}</td></tr>" +
-                    $"<tr><td>Filename: {Parser.Parser.NormalizePath(_directoryService.FileSystem.FileInfo.New(firstInfo.FullFilePath).Directory?.ToString())}</td><td>Filename: {Parser.Parser.NormalizePath(collision.FolderPath)}</td></tr>"
-                );
+                var firstCollision = seriesCollisions[0];
+                var secondCollision = seriesCollisions[1];
+
+                var tableRows = $"<tr><td>Name: {firstCollision.Name}</td><td>Name: {secondCollision.Name}</td></tr>" +
+                                $"<tr><td>Localized: {firstCollision.LocalizedName}</td><td>Localized: {secondCollision.LocalizedName}</td></tr>" +
+                                $"<tr><td>Filename: {Parser.Parser.NormalizePath(firstCollision.FolderPath)}</td><td>Filename: {Parser.Parser.NormalizePath(secondCollision.FolderPath)}</td></tr>";
 
                 var htmlTable = $"<table class='table table-striped'><thead><tr><th>Series 1</th><th>Series 2</th></tr></thead><tbody>{string.Join(string.Empty, tableRows)}</tbody></table>";
 

--- a/UI/Web/src/app/series-detail/_components/series-detail/series-detail.component.ts
+++ b/UI/Web/src/app/series-detail/_components/series-detail/series-detail.component.ts
@@ -704,22 +704,12 @@ export class SeriesDetailComponent implements OnInit, AfterContentChecked {
       this.ratings = [...data.ratings];
 
       // Recommendations
-      data.recommendations.ownedSeries.map(r => {
-        this.seriesService.getMetadata(r.id).subscribe(m => r.summary = m.summary);
-      });
       this.combinedRecs = [...data.recommendations.ownedSeries, ...data.recommendations.externalSeries];
       this.hasRecommendations = this.combinedRecs.length > 0;
 
       this.cdRef.markForCheck();
     });
   }
-  loadReviews() {
-    this.seriesService.getReviews(this.seriesId).subscribe(reviews => {
-      this.reviews = [...reviews];
-      this.cdRef.markForCheck();
-    });
-  }
-
 
   setContinuePoint() {
     this.readerService.hasSeriesProgress(this.seriesId).subscribe(hasProgress => {

--- a/openapi.json
+++ b/openapi.json
@@ -20337,6 +20337,12 @@
             "type": "string",
             "nullable": true
           },
+          "number": {
+            "type": "number",
+            "description": "This will map to MinNumber. Number was removed in v0.7.13.8",
+            "format": "float",
+            "deprecated": true
+          },
           "pages": {
             "type": "integer",
             "format": "int32"

--- a/openapi.json
+++ b/openapi.json
@@ -7,7 +7,7 @@
       "name": "GPL-3.0",
       "url": "https://github.com/Kareadita/Kavita/blob/develop/LICENSE"
     },
-    "version": "0.7.13.9"
+    "version": "0.7.13.10"
   },
   "servers": [
     {


### PR DESCRIPTION
Nightly users, I made massive changes around the local external metadata stuff. If you want to clean out your tables, I would recommend it. 

Tables:
ExternalSeriesMetadata, ExternalReview, ExternalRating, ExternalRecommendation


# Changed
- Changed: Adjusted OPDS-PS lastReadDate to adhere to ISO 8061 as per the spec and what Panels expects for proper sync.

# Fixed
- Fixed: Major refactors to Kavita+ caching (local db) and how it works. Things like recommendations not showing correctly depending on the level of access of the first person to make the call, cache not sending correct data, etc. (develop)
- Fixed: Series detail page was making a ton of api calls that weren't needed.
- Fixed: Fixed an issue when there is a collision between 2 series that share some parts of the same Name/LocalizedName, the correct names should show in the modal. 
- Fixed: Tachiyomi/CDisplayEx now works again (develop)

# API
- Volume Number field is deprecated in favor of MinNumber and MaxNumber (if the volume is a range). You can switch to MinNumber and ignore MaxNumber.
