### PR TITLE
Stability (I hope)

### DIFF
--- a/API.Tests/Services/SeriesServiceTests.cs
+++ b/API.Tests/Services/SeriesServiceTests.cs
@@ -59,8 +59,7 @@ public class SeriesServiceTests : AbstractDbTest
 
         _seriesService = new SeriesService(_unitOfWork, Substitute.For<IEventHub>(),
             Substitute.For<ITaskScheduler>(), Substitute.For<ILogger<SeriesService>>(),
-            Substitute.For<IScrobblingService>(), locService,
-            Substitute.For<IEasyCachingProviderFactory>());
+            Substitute.For<IScrobblingService>(), locService);
     }
     #region Setup
 

--- a/API/API.csproj
+++ b/API/API.csproj
@@ -101,7 +101,7 @@
     </PackageReference>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="8.0.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.3.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.3.1" />
     <PackageReference Include="System.IO.Abstractions" Version="20.0.15" />
     <PackageReference Include="System.Drawing.Common" Version="8.0.1" />
     <PackageReference Include="VersOne.Epub" Version="3.3.1" />

--- a/API/API.csproj
+++ b/API/API.csproj
@@ -68,7 +68,6 @@
     <PackageReference Include="Hangfire" Version="1.8.9" />
     <PackageReference Include="Hangfire.InMemory" Version="0.7.0" />
     <PackageReference Include="Hangfire.MaximumConcurrentExecutions" Version="1.1.0" />
-    <PackageReference Include="Hangfire.MemoryStorage.Core" Version="1.4.0" />
     <PackageReference Include="Hangfire.Storage.SQLite" Version="0.4.0" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.57" />
     <PackageReference Include="MarkdownDeep.NET.Core" Version="1.5.0.4" />

--- a/API/Constants/CacheProfiles.cs
+++ b/API/Constants/CacheProfiles.cs
@@ -15,9 +15,8 @@ public static class EasyCacheProfiles
     /// Cache the libraries on the server
     /// </summary>
     public const string Library = "library";
-    public const string KavitaPlusExternalSeries = "kavita+externalSeries";
     /// <summary>
-    /// Series Detail page for Kavita+ stuff
+    /// External Series metadata for Kavita+ recommendation
     /// </summary>
-    public const string KavitaPlusSeriesDetail = "kavita+seriesDetail";
+    public const string KavitaPlusExternalSeries = "kavita+externalSeries";
 }

--- a/API/Controllers/MetadataController.cs
+++ b/API/Controllers/MetadataController.cs
@@ -195,54 +195,20 @@ public class MetadataController(IUnitOfWork unitOfWork, ILocalizationService loc
     /// </summary>
     /// <remarks>This will hit upstream K+ if the data in local db is 2 weeks old</remarks>
     /// <param name="seriesId"></param>
+    /// <param name="libraryType"></param>
     /// <returns></returns>
     [HttpGet("series-detail-plus")]
-    public async Task<ActionResult<SeriesDetailPlusDto>> GetKavitaPlusSeriesDetailData(int seriesId, LibraryType libraryType, CancellationToken cancellationToken)
+    public async Task<ActionResult<SeriesDetailPlusDto>> GetKavitaPlusSeriesDetailData(int seriesId, LibraryType libraryType)
     {
         var userReviews = (await unitOfWork.UserRepository.GetUserRatingDtosForSeriesAsync(seriesId, User.GetUserId()))
             .Where(r => !string.IsNullOrEmpty(r.Body))
             .OrderByDescending(review => review.Username.Equals(User.GetUsername()) ? 1 : 0)
             .ToList();
 
-        var cacheKey = CacheKey + seriesId;
-        var results = await _cacheProvider.GetAsync<SeriesDetailPlusDto>(cacheKey, cancellationToken);
-        if (results.HasValue)
-        {
-            var cachedResult = results.Value;
-            await PrepareSeriesDetail(userReviews, cachedResult);
-            return cachedResult;
-        }
+        var ret = await metadataService.GetSeriesDetailPlus(seriesId, libraryType);
 
-        SeriesDetailPlusDto? ret = null;
-        if (ExternalMetadataService.IsPlusEligible(libraryType) && await licenseService.HasActiveLicense())
-        {
-            ret = await metadataService.GetSeriesDetailPlus(seriesId);
-        }
-        if (ret == null)
-        {
-            // Cache  an empty result, so we don't constantly hit K+ when we know nothing is going to resolve
-            ret = new SeriesDetailPlusDto()
-            {
-                Reviews = new List<UserReviewDto>(),
-                Recommendations = null,
-                Ratings = null
-            };
-            await _cacheProvider.SetAsync(cacheKey, ret, TimeSpan.FromHours(48), cancellationToken);
-
-            var newCacheResult2 = (await _cacheProvider.GetAsync<SeriesDetailPlusDto>(cacheKey)).Value;
-            await PrepareSeriesDetail(userReviews, newCacheResult2);
-
-            return Ok(newCacheResult2);
-        }
-
-        await _cacheProvider.SetAsync(cacheKey, ret, TimeSpan.FromHours(48), cancellationToken);
-
-        // For some reason if we don't use a different instance, the cache keeps changes made below
-        var newCacheResult = (await _cacheProvider.GetAsync<SeriesDetailPlusDto>(cacheKey, cancellationToken)).Value;
-        await PrepareSeriesDetail(userReviews, newCacheResult);
-
-        return Ok(newCacheResult);
-
+        await PrepareSeriesDetail(userReviews, ret);
+        return Ok(ret);
     }
 
     private async Task PrepareSeriesDetail(List<UserReviewDto> userReviews, SeriesDetailPlusDto ret)

--- a/API/Controllers/MetadataController.cs
+++ b/API/Controllers/MetadataController.cs
@@ -178,10 +178,25 @@ public class MetadataController(IUnitOfWork unitOfWork, ILocalizationService loc
     [HttpGet("chapter-summary")]
     public async Task<ActionResult<string>> GetChapterSummary(int chapterId)
     {
+        // TODO: This doesn't seem used anywhere
         if (chapterId <= 0) return BadRequest(await localizationService.Translate(User.GetUserId(), "chapter-doesnt-exist"));
         var chapter = await unitOfWork.ChapterRepository.GetChapterAsync(chapterId);
         if (chapter == null) return BadRequest(await localizationService.Translate(User.GetUserId(), "chapter-doesnt-exist"));
         return Ok(chapter.Summary);
+    }
+
+    /// <summary>
+    /// If this Series is on Kavita+ Blacklist, removes it. If already cached, invalidates it.
+    /// This then attempts to refresh data from Kavita+ for this series.
+    /// </summary>
+    /// <param name="seriesId"></param>
+    /// <param name="libraryType"></param>
+    /// <returns></returns>
+    [HttpPost("force-refresh")]
+    public async Task<ActionResult> ForceRefresh(int seriesId, LibraryType libraryType)
+    {
+        await metadataService.ForceKavitaPlusRefresh(seriesId, libraryType);
+        return Ok();
     }
 
     /// <summary>

--- a/API/Controllers/MetadataController.cs
+++ b/API/Controllers/MetadataController.cs
@@ -190,12 +190,11 @@ public class MetadataController(IUnitOfWork unitOfWork, ILocalizationService loc
     /// This then attempts to refresh data from Kavita+ for this series.
     /// </summary>
     /// <param name="seriesId"></param>
-    /// <param name="libraryType"></param>
     /// <returns></returns>
     [HttpPost("force-refresh")]
-    public async Task<ActionResult> ForceRefresh(int seriesId, LibraryType libraryType)
+    public async Task<ActionResult> ForceRefresh(int seriesId)
     {
-        await metadataService.ForceKavitaPlusRefresh(seriesId, libraryType);
+        await metadataService.ForceKavitaPlusRefresh(seriesId);
         return Ok();
     }
 

--- a/API/Controllers/ScrobblingController.cs
+++ b/API/Controllers/ScrobblingController.cs
@@ -44,7 +44,7 @@ public class ScrobblingController : BaseApiController
     /// </summary>
     /// <returns></returns>
     [HttpGet("anilist-token")]
-    public async Task<ActionResult> GetAniListToken()
+    public async Task<ActionResult<string>> GetAniListToken()
     {
         var user = await _unitOfWork.UserRepository.GetUserByUsernameAsync(User.GetUsername());
         if (user == null) return Unauthorized();

--- a/API/Controllers/ServerController.cs
+++ b/API/Controllers/ServerController.cs
@@ -270,8 +270,6 @@ public class ServerController : BaseApiController
         _logger.LogInformation("Busting Kavita+ Cache");
         var provider = _cachingProviderFactory.GetCachingProvider(EasyCacheProfiles.KavitaPlusExternalSeries);
         await provider.FlushAsync();
-        provider = _cachingProviderFactory.GetCachingProvider(EasyCacheProfiles.KavitaPlusSeriesDetail);
-        await provider.FlushAsync();
         return Ok();
     }
 

--- a/API/Data/DataContext.cs
+++ b/API/Data/DataContext.cs
@@ -63,6 +63,7 @@ public sealed class DataContext : IdentityDbContext<AppUser, AppRole, int,
     public DbSet<ExternalSeriesMetadata> ExternalSeriesMetadata { get; set; } = null!;
     public DbSet<ExternalRecommendation> ExternalRecommendation { get; set; } = null!;
     public DbSet<ManualMigrationHistory> ManualMigrationHistory { get; set; } = null!;
+    public DbSet<SeriesBlacklist> SeriesBlacklist { get; set; } = null!;
 
 
     protected override void OnModelCreating(ModelBuilder builder)

--- a/API/Data/Migrations/20240204141206_BlackListSeries.Designer.cs
+++ b/API/Data/Migrations/20240204141206_BlackListSeries.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using API.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace API.Data.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20240204141206_BlackListSeries")]
+    partial class BlackListSeries
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "8.0.1");

--- a/API/Data/Migrations/20240204141206_BlackListSeries.cs
+++ b/API/Data/Migrations/20240204141206_BlackListSeries.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace API.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class BlackListSeries : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "LastUpdatedUtc",
+                table: "ExternalSeriesMetadata",
+                newName: "ValidUntilUtc");
+
+            migrationBuilder.CreateTable(
+                name: "SeriesBlacklist",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    SeriesId = table.Column<int>(type: "INTEGER", nullable: false),
+                    LastChecked = table.Column<DateTime>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_SeriesBlacklist", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_SeriesBlacklist_Series_SeriesId",
+                        column: x => x.SeriesId,
+                        principalTable: "Series",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SeriesBlacklist_SeriesId",
+                table: "SeriesBlacklist",
+                column: "SeriesId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "SeriesBlacklist");
+
+            migrationBuilder.RenameColumn(
+                name: "ValidUntilUtc",
+                table: "ExternalSeriesMetadata",
+                newName: "LastUpdatedUtc");
+        }
+    }
+}

--- a/API/Data/Repositories/ExternalSeriesMetadataRepository.cs
+++ b/API/Data/Repositories/ExternalSeriesMetadataRepository.cs
@@ -27,9 +27,11 @@ public interface IExternalSeriesMetadataRepository
     void Remove(IEnumerable<ExternalRating>? ratings);
     void Remove(IEnumerable<ExternalRecommendation>? recommendations);
     Task<ExternalSeriesMetadata?> GetExternalSeriesMetadata(int seriesId);
-    Task<bool> ExternalSeriesMetadataNeedsRefresh(int seriesId, DateTime expireTime);
+    Task<bool> ExternalSeriesMetadataNeedsRefresh(int seriesId);
     Task<SeriesDetailPlusDto> GetSeriesDetailPlusDto(int seriesId);
     Task LinkRecommendationsToSeries(Series series);
+    Task<bool> IsBlacklistedSeries(int seriesId);
+    Task CreateBlacklistedSeries(int seriesId);
 }
 
 public class ExternalSeriesMetadataRepository : IExternalSeriesMetadataRepository
@@ -92,12 +94,12 @@ public class ExternalSeriesMetadataRepository : IExternalSeriesMetadataRepositor
             .FirstOrDefaultAsync();
     }
 
-    public async Task<bool> ExternalSeriesMetadataNeedsRefresh(int seriesId, DateTime expireTime)
+    public async Task<bool> ExternalSeriesMetadataNeedsRefresh(int seriesId)
     {
         var row = await _context.ExternalSeriesMetadata
             .Where(s => s.SeriesId == seriesId)
             .FirstOrDefaultAsync();
-        return row == null || row.LastUpdatedUtc <= expireTime;
+        return row == null || row.ValidUntilUtc <= DateTime.UtcNow;
     }
 
     public async Task<SeriesDetailPlusDto> GetSeriesDetailPlusDto(int seriesId)
@@ -183,5 +185,42 @@ public class ExternalSeriesMetadataRepository : IExternalSeriesMetadataRepositor
         }
 
         await _context.SaveChangesAsync();
+    }
+
+    public Task<bool> IsBlacklistedSeries(int seriesId)
+    {
+        return _context.SeriesBlacklist.AnyAsync(s => s.SeriesId == seriesId);
+    }
+
+    /// <summary>
+    /// Creates a new instance against SeriesId and Saves to the DB
+    /// </summary>
+    /// <param name="seriesId"></param>
+    public async Task CreateBlacklistedSeries(int seriesId)
+    {
+        if (seriesId <= 0) return;
+        await _context.SeriesBlacklist.AddAsync(new SeriesBlacklist()
+        {
+            SeriesId = seriesId
+        });
+        await _context.SaveChangesAsync();
+    }
+
+    /// <summary>
+    /// Removes the Series from Blacklist and Saves to the DB
+    /// </summary>
+    /// <param name="seriesId"></param>
+    public async Task RemoveFromBlacklist(int seriesId)
+    {
+        var seriesBlacklist = await _context.SeriesBlacklist.FirstOrDefaultAsync(sb => sb.SeriesId == seriesId);
+
+        if (seriesBlacklist != null)
+        {
+            // Remove the SeriesBlacklist entity from the context
+            _context.SeriesBlacklist.Remove(seriesBlacklist);
+
+            // Save the changes to the database
+            await _context.SaveChangesAsync();
+        }
     }
 }

--- a/API/Data/Repositories/ExternalSeriesMetadataRepository.cs
+++ b/API/Data/Repositories/ExternalSeriesMetadataRepository.cs
@@ -32,6 +32,7 @@ public interface IExternalSeriesMetadataRepository
     Task LinkRecommendationsToSeries(Series series);
     Task<bool> IsBlacklistedSeries(int seriesId);
     Task CreateBlacklistedSeries(int seriesId);
+    Task RemoveFromBlacklist(int seriesId);
 }
 
 public class ExternalSeriesMetadataRepository : IExternalSeriesMetadataRepository

--- a/API/Data/Repositories/LibraryRepository.cs
+++ b/API/Data/Repositories/LibraryRepository.cs
@@ -43,6 +43,7 @@ public interface ILibraryRepository
     Task<IEnumerable<Library>> GetLibrariesForUserIdAsync(int userId);
     IEnumerable<int> GetLibraryIdsForUserIdAsync(int userId, QueryContext queryContext = QueryContext.None);
     Task<LibraryType> GetLibraryTypeAsync(int libraryId);
+    Task<LibraryType> GetLibraryTypeBySeriesIdAsync(int seriesId);
     Task<IEnumerable<Library>> GetLibraryForIdsAsync(IEnumerable<int> libraryIds, LibraryIncludes includes = LibraryIncludes.None);
     Task<int> GetTotalFiles();
     IEnumerable<JumpKeyDto> GetJumpBarAsync(int libraryId);
@@ -54,6 +55,7 @@ public interface ILibraryRepository
     Task<IList<string>> GetAllCoverImagesAsync();
     Task<IList<Library>> GetAllWithCoversInDifferentEncoding(EncodeFormat encodeFormat);
     Task<bool> GetAllowsScrobblingBySeriesId(int seriesId);
+
 }
 
 public class LibraryRepository : ILibraryRepository
@@ -139,6 +141,14 @@ public class LibraryRepository : ILibraryRepository
             .Where(l => l.Id == libraryId)
             .AsNoTracking()
             .Select(l => l.Type)
+            .FirstAsync();
+    }
+
+    public async Task<LibraryType> GetLibraryTypeBySeriesIdAsync(int seriesId)
+    {
+        return await _context.Series
+            .Where(s => s.Id == seriesId)
+            .Select(s => s.Library.Type)
             .FirstAsync();
     }
 

--- a/API/Entities/Metadata/ExternalSeriesMetadata.cs
+++ b/API/Entities/Metadata/ExternalSeriesMetadata.cs
@@ -29,7 +29,10 @@ public class ExternalSeriesMetadata
     public long MalId { get; set; }
     public string GoogleBooksId { get; set; }
 
-    public DateTime LastUpdatedUtc { get; set; }
+    /// <summary>
+    /// Data is valid until this time
+    /// </summary>
+    public DateTime ValidUntilUtc { get; set; }
 
     public Series Series { get; set; } = null!;
     public int SeriesId { get; set; }

--- a/API/Entities/Metadata/SeriesBlacklist.cs
+++ b/API/Entities/Metadata/SeriesBlacklist.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace API.Entities.Metadata;
+
+/// <summary>
+/// A blacklist of Series for Kavita+
+/// </summary>
+public class SeriesBlacklist
+{
+    public int Id { get; set; }
+    public int SeriesId { get; set; }
+    public Series Series { get; set; }
+    public DateTime LastChecked { get; set; } = DateTime.UtcNow;
+}

--- a/API/Extensions/ApplicationServiceExtensions.cs
+++ b/API/Extensions/ApplicationServiceExtensions.cs
@@ -90,7 +90,7 @@ public static class ApplicationServiceExtensions
 
         services.AddMemoryCache(options =>
         {
-            options.SizeLimit = Configuration.CacheSize * 1024 * 1024; // 50 MB
+            options.SizeLimit = Configuration.CacheSize * 1024 * 1024; // 75 MB
             options.CompactionPercentage = 0.1; // LRU compaction (10%)
         });
 

--- a/API/Extensions/ApplicationServiceExtensions.cs
+++ b/API/Extensions/ApplicationServiceExtensions.cs
@@ -86,7 +86,6 @@ public static class ApplicationServiceExtensions
 
             // KavitaPlus stuff
             options.UseInMemory(EasyCacheProfiles.KavitaPlusExternalSeries);
-            options.UseInMemory(EasyCacheProfiles.KavitaPlusSeriesDetail);
         });
 
         services.AddMemoryCache(options =>

--- a/API/Helpers/LibraryTypeHelper.cs
+++ b/API/Helpers/LibraryTypeHelper.cs
@@ -14,7 +14,6 @@ public static class LibraryTypeHelper
             LibraryType.Manga => MediaFormat.Manga,
             LibraryType.Comic => MediaFormat.Comic,
             LibraryType.Book => MediaFormat.LightNovel,
-            _ => throw new ArgumentOutOfRangeException(nameof(libraryType), libraryType, null)
         };
     }
 }

--- a/API/Services/Plus/ExternalMetadataService.cs
+++ b/API/Services/Plus/ExternalMetadataService.cs
@@ -48,7 +48,8 @@ internal class SeriesDetailPlusApiDto
 public interface IExternalMetadataService
 {
     Task<ExternalSeriesDetailDto?> GetExternalSeriesDetail(int? aniListId, long? malId, int? seriesId);
-    Task<SeriesDetailPlusDto?> GetSeriesDetailPlus(int seriesId);
+    Task<SeriesDetailPlusDto> GetSeriesDetailPlus(int seriesId, LibraryType libraryType);
+    Task BlacklistSeries(int seriesId);
 }
 
 public class ExternalMetadataService : IExternalMetadataService
@@ -56,7 +57,13 @@ public class ExternalMetadataService : IExternalMetadataService
     private readonly IUnitOfWork _unitOfWork;
     private readonly ILogger<ExternalMetadataService> _logger;
     private readonly IMapper _mapper;
-    private readonly TimeSpan _externalSeriesMetadataCache = TimeSpan.FromDays(14);
+    private readonly TimeSpan _externalSeriesMetadataCache = TimeSpan.FromDays(30);
+    private readonly SeriesDetailPlusDto _defaultReturn = new()
+    {
+        Recommendations = null,
+        Ratings = ArraySegment<RatingDto>.Empty,
+        Reviews = ArraySegment<UserReviewDto>.Empty
+    };
 
     public ExternalMetadataService(IUnitOfWork unitOfWork, ILogger<ExternalMetadataService> logger, IMapper mapper)
     {
@@ -68,9 +75,24 @@ public class ExternalMetadataService : IExternalMetadataService
             cli.Settings.HttpClientFactory = new UntrustedCertClientFactory());
     }
 
+    /// <summary>
+    /// Checks if the library type is allowed to interact with Kavita+
+    /// </summary>
+    /// <param name="type"></param>
+    /// <returns></returns>
     public static bool IsPlusEligible(LibraryType type)
     {
         return type != LibraryType.Comic;
+    }
+
+    /// <summary>
+    /// When a series fails to match with Kavita+, the series is then added to a Blacklist so that Kavita isn't spammed constantly
+    /// </summary>
+    /// <param name="seriesId"></param>
+    /// <returns></returns>
+    public Task BlacklistSeries(int seriesId)
+    {
+        throw new NotImplementedException();
     }
 
     /// <summary>
@@ -102,11 +124,15 @@ public class ExternalMetadataService : IExternalMetadataService
     /// </summary>
     /// <param name="seriesId"></param>
     /// <returns></returns>
-    public async Task<SeriesDetailPlusDto?> GetSeriesDetailPlus(int seriesId)
+    public async Task<SeriesDetailPlusDto> GetSeriesDetailPlus(int seriesId, LibraryType libraryType)
     {
+        if (!IsPlusEligible(libraryType)) return _defaultReturn;
+
+        // Check blacklist (bad matches)
+        if (await _unitOfWork.ExternalSeriesMetadataRepository.IsBlacklistedSeries(seriesId)) return _defaultReturn;
+
         var needsRefresh =
-            await _unitOfWork.ExternalSeriesMetadataRepository.ExternalSeriesMetadataNeedsRefresh(seriesId,
-                DateTime.UtcNow.Subtract(_externalSeriesMetadataCache));
+            await _unitOfWork.ExternalSeriesMetadataRepository.ExternalSeriesMetadataNeedsRefresh(seriesId);
 
         if (!needsRefresh)
         {
@@ -116,10 +142,8 @@ public class ExternalMetadataService : IExternalMetadataService
 
         try
         {
-            var series =
-                await _unitOfWork.SeriesRepository.GetSeriesByIdAsync(seriesId,
-                    SeriesIncludes.Metadata | SeriesIncludes.Library | SeriesIncludes.Volumes | SeriesIncludes.Chapters);
-            if (series == null || series.Library.Type == LibraryType.Comic) return null;
+            var data = await _unitOfWork.SeriesRepository.GetPlusSeriesDto(seriesId);
+            if (data == null) return _defaultReturn;
 
             var license = (await _unitOfWork.SettingsRepository.GetSettingAsync(ServerSettingKey.LicenseKey)).Value;
             var result = await (Configuration.KavitaPlusApiUrl + "/api/metadata/v2/series-detail")
@@ -130,12 +154,13 @@ public class ExternalMetadataService : IExternalMetadataService
                 .WithHeader("x-kavita-version", BuildInfo.Version)
                 .WithHeader("Content-Type", "application/json")
                 .WithTimeout(TimeSpan.FromSeconds(Configuration.DefaultTimeOutSecs))
-                .PostJsonAsync(new PlusSeriesDtoBuilder(series).Build())
+                .PostJsonAsync(data)
                 .ReceiveJson<SeriesDetailPlusApiDto>();
 
 
             // Clear out existing results
-            var externalSeriesMetadata = await GetExternalSeriesMetadataForSeries(seriesId, series);
+            var series = await _unitOfWork.SeriesRepository.GetSeriesByIdAsync(seriesId);
+            var externalSeriesMetadata = await GetExternalSeriesMetadataForSeries(seriesId, series!);
             _unitOfWork.ExternalSeriesMetadataRepository.Remove(externalSeriesMetadata.ExternalReviews);
             _unitOfWork.ExternalSeriesMetadataRepository.Remove(externalSeriesMetadata.ExternalRatings);
             _unitOfWork.ExternalSeriesMetadataRepository.Remove(externalSeriesMetadata.ExternalRecommendations);
@@ -157,19 +182,18 @@ public class ExternalMetadataService : IExternalMetadataService
 
             // Recommendations
             externalSeriesMetadata.ExternalRecommendations ??= new List<ExternalRecommendation>();
-            var recs = await ProcessRecommendations(series, result.Recommendations, externalSeriesMetadata);
+            var recs = await ProcessRecommendations(libraryType, result.Recommendations, externalSeriesMetadata);
 
             var extRatings = externalSeriesMetadata.ExternalRatings
                 .Where(r => r.AverageScore > 0)
                 .ToList();
 
-            externalSeriesMetadata.LastUpdatedUtc = DateTime.UtcNow;
+            externalSeriesMetadata.ValidUntilUtc = DateTime.UtcNow.Add(_externalSeriesMetadataCache);
             externalSeriesMetadata.AverageExternalRating = extRatings.Count != 0 ? (int) extRatings
                 .Average(r => r.AverageScore) : 0;
 
             if (result.MalId.HasValue) externalSeriesMetadata.MalId = result.MalId.Value;
             if (result.AniListId.HasValue) externalSeriesMetadata.AniListId = result.AniListId.Value;
-
             await _unitOfWork.CommitAsync();
 
             return new SeriesDetailPlusDto()
@@ -181,9 +205,9 @@ public class ExternalMetadataService : IExternalMetadataService
         }
         catch (FlurlHttpException ex)
         {
-            if (ex.StatusCode == 404)
+            if (ex.StatusCode == 500)
             {
-                return null;
+                return _defaultReturn;
             }
         }
         catch (Exception ex)
@@ -191,7 +215,10 @@ public class ExternalMetadataService : IExternalMetadataService
             _logger.LogError(ex, "An error happened during the request to Kavita+ API");
         }
 
-        return null;
+        // Blacklist the series as it wasn't found in Kavita+
+        await _unitOfWork.ExternalSeriesMetadataRepository.CreateBlacklistedSeries(seriesId);
+
+        return _defaultReturn;
     }
 
 
@@ -200,14 +227,16 @@ public class ExternalMetadataService : IExternalMetadataService
         var externalSeriesMetadata = await _unitOfWork.ExternalSeriesMetadataRepository.GetExternalSeriesMetadata(seriesId);
         if (externalSeriesMetadata != null) return externalSeriesMetadata;
 
-        externalSeriesMetadata = new ExternalSeriesMetadata();
+        externalSeriesMetadata = new ExternalSeriesMetadata()
+        {
+            SeriesId = seriesId,
+        };
         series.ExternalSeriesMetadata = externalSeriesMetadata;
-        externalSeriesMetadata.SeriesId = series.Id;
         _unitOfWork.ExternalSeriesMetadataRepository.Attach(externalSeriesMetadata);
         return externalSeriesMetadata;
     }
 
-    private async Task<RecommendationDto> ProcessRecommendations(Series series, IEnumerable<MediaRecommendationDto> recs,
+    private async Task<RecommendationDto> ProcessRecommendations(LibraryType libraryType, IEnumerable<MediaRecommendationDto> recs,
         ExternalSeriesMetadata externalSeriesMetadata)
     {
         var recDto = new RecommendationDto()
@@ -221,7 +250,7 @@ public class ExternalMetadataService : IExternalMetadataService
         {
             // Find the series based on name and type and that the user has access too
             var seriesForRec = await _unitOfWork.SeriesRepository.GetSeriesDtoByNamesAndMetadataIds(rec.RecommendationNames,
-                series.Library.Type, ScrobblingService.CreateUrl(ScrobblingService.AniListWeblinkWebsite, rec.AniListId),
+                libraryType, ScrobblingService.CreateUrl(ScrobblingService.AniListWeblinkWebsite, rec.AniListId),
                 ScrobblingService.CreateUrl(ScrobblingService.MalWeblinkWebsite, rec.MalId));
 
             if (seriesForRec != null)

--- a/API/Services/Plus/LicenseService.cs
+++ b/API/Services/Plus/LicenseService.cs
@@ -174,6 +174,8 @@ public class LicenseService(
         catch (Exception ex)
         {
             logger.LogError(ex, "There was an issue connecting to Kavita+");
+            await provider.FlushAsync();
+            await provider.SetAsync(CacheKey, false, _licenseCacheTimeout);
         }
 
         return false;

--- a/UI/Web/hash-localization.js
+++ b/UI/Web/hash-localization.js
@@ -17,6 +17,7 @@ const result = {};
 // Remove file if it exists
 const cacheBustingFilePath = './i18n-cache-busting.json';
 if (fs.existsSync(cacheBustingFilePath)) {
+    console.log('Removing existing file')
     fs.unlinkSync(cacheBustingFilePath);
 }
 

--- a/UI/Web/src/app/_services/metadata.service.ts
+++ b/UI/Web/src/app/_services/metadata.service.ts
@@ -33,6 +33,10 @@ export class MetadataService {
     return this.httpClient.get<SeriesDetailPlus | null>(this.baseUrl + 'metadata/series-detail-plus?seriesId=' + seriesId + '&libraryType=' + libraryType);
   }
 
+  forceRefreshFromPlus(seriesId: number) {
+    return this.httpClient.post(this.baseUrl + 'metadata/force-refresh?seriesId=' + seriesId, {});
+  }
+
   getAllAgeRatings(libraries?: Array<number>) {
     let method = 'metadata/age-ratings'
     if (libraries != undefined && libraries.length > 0) {

--- a/UI/Web/src/app/admin/dashboard/dashboard.component.html
+++ b/UI/Web/src/app/admin/dashboard/dashboard.component.html
@@ -35,6 +35,7 @@
           </ng-container>
           <ng-container *ngIf="tab.fragment === TabID.KavitaPlus">
             <p>{{t('kavita+-desc-part-1')}} <a href="https://wiki.kavitareader.com/en/kavita-plus" target="_blank" rel="noreferrer nofollow">{{t('kavita+-desc-part-2')}}</a> {{t('kavita+-desc-part-3')}} <a href="https://wiki.kavitareader.com/en/kavita-plus#faq" target="_blank" rel="noreferrer nofollow">FAQ</a></p>
+            <p>{{t('kavita+-requirement')}} <a [routerLink]="'/announcements'">{{t('kavita+-releases')}}</a></p>
             <app-license></app-license>
           </ng-container>
         </ng-template>

--- a/UI/Web/src/app/admin/manage-system/manage-system.component.html
+++ b/UI/Web/src/app/admin/manage-system/manage-system.component.html
@@ -1,8 +1,8 @@
 <ng-container *transloco="let t; read: 'manage-system'">
   <div class="container-fluid">
-    <h3>{{t('title')}}</h3>
-    <hr/>
+
     <div class="mb-3" *ngIf="serverInfo">
+      <h3>{{t('title')}}</h3>
       <dl>
         <dt>{{t('version-title')}}</dt>
         <dd>{{serverInfo.kavitaVersion}}</dd>
@@ -12,36 +12,43 @@
       </dl>
     </div>
 
-    <h3>{{t('more-info-title')}}</h3>
-    <hr/>
-    <div class="row">
-      <div class="col-4">{{t('home-page-title')}}</div>
-      <div class="col"><a href="https://www.kavitareader.com" target="_blank" rel="noopener noreferrer">kavitareader.com</a></div>
+    <div class="mb-3">
+      <h3>{{t('more-info-title')}}</h3>
+      <div class="row">
+        <div class="col-4">{{t('home-page-title')}}</div>
+        <div class="col"><a href="https://www.kavitareader.com" target="_blank" rel="noopener noreferrer">kavitareader.com</a></div>
+      </div>
+      <div class="row">
+        <div class="col-4">{{t('wiki-title')}}</div>
+        <div class="col"><a href="https://wiki.kavitareader.com" target="_blank" rel="noopener noreferrer">wiki.kavitareader.com</a></div>
+      </div>
+      <div class="row">
+        <div class="col-4">{{t('discord-title')}}</div>
+        <div class="col"><a href="https://discord.gg/b52wT37kt7" target="_blank" rel="noopener noreferrer">discord.gg/b52wT37kt7</a></div>
+      </div>
+      <div class="row">
+        <div class="col-4">{{t('donations-title')}}</div>
+        <div class="col"><a href="https://opencollective.com/kavita" target="_blank" rel="noopener noreferrer">opencollective.com/kavita</a></div>
+      </div>
+      <div class="row">
+        <div class="col-4">{{t('source-title')}}</div>
+        <div class="col"><a href="https://github.com/Kareadita/Kavita" target="_blank" rel="noopener noreferrer">github.com/Kareadita/Kavita</a></div>
+      </div>
+      <div class="row">
+        <div class="col-4">{{t('localization-title')}}</div>
+        <div class="col"><a href="https://hosted.weblate.org/engage/kavita/" target="_blank" rel="noopener noreferrer">Weblate</a><br/></div>
+      </div>
+      <div class="row">
+        <div class="col-4">{{t('feature-request-title')}}</div>
+        <div class="col"><a href="https://github.com/Kareadita/Kavita/discussions/2529" target="_blank" rel="noopener noreferrer">https://github.com/Kareadita/Kavita/discussions/</a><br/></div>
+      </div>
     </div>
-    <div class="row">
-      <div class="col-4">{{t('wiki-title')}}</div>
-      <div class="col"><a href="https://wiki.kavitareader.com" target="_blank" rel="noopener noreferrer">wiki.kavitareader.com</a></div>
+
+    <div class="mb-3">
+      <h3>{{t('updates-title')}}</h3>
+      <app-changelog></app-changelog>
     </div>
-    <div class="row">
-      <div class="col-4">{{t('discord-title')}}</div>
-      <div class="col"><a href="https://discord.gg/b52wT37kt7" target="_blank" rel="noopener noreferrer">discord.gg/b52wT37kt7</a></div>
-    </div>
-    <div class="row">
-      <div class="col-4">{{t('donations-title')}}</div>
-      <div class="col"><a href="https://opencollective.com/kavita" target="_blank" rel="noopener noreferrer">opencollective.com/kavita</a></div>
-    </div>
-    <div class="row">
-      <div class="col-4">{{t('source-title')}}</div>
-      <div class="col"><a href="https://github.com/Kareadita/Kavita" target="_blank" rel="noopener noreferrer">github.com/Kareadita/Kavita</a></div>
-    </div>
-    <div class="row">
-      <div class="col-4">{{t('localization-title')}}</div>
-      <div class="col"><a href="https://hosted.weblate.org/engage/kavita/" target="_blank" rel="noopener noreferrer">Weblate</a><br/></div>
-    </div>
-    <div class="row">
-      <div class="col-4">{{t('feature-request-title')}}</div>
-      <div class="col"><a href="https://github.com/Kareadita/Kavita/discussions/2529" target="_blank" rel="noopener noreferrer">https://github.com/Kareadita/Kavita/discussions/</a><br/></div>
-    </div>
+
   </div>
 
 </ng-container>

--- a/UI/Web/src/app/admin/manage-system/manage-system.component.ts
+++ b/UI/Web/src/app/admin/manage-system/manage-system.component.ts
@@ -3,6 +3,7 @@ import {ServerService} from 'src/app/_services/server.service';
 import {ServerInfoSlim} from '../_models/server-info';
 import {NgIf} from '@angular/common';
 import {TranslocoDirective} from "@ngneat/transloco";
+import {ChangelogComponent} from "../../announcements/_components/changelog/changelog.component";
 
 @Component({
     selector: 'app-manage-system',
@@ -10,7 +11,7 @@ import {TranslocoDirective} from "@ngneat/transloco";
     styleUrls: ['./manage-system.component.scss'],
     standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [NgIf, TranslocoDirective]
+  imports: [NgIf, TranslocoDirective, ChangelogComponent]
 })
 export class ManageSystemComponent implements OnInit {
 

--- a/UI/Web/src/app/admin/manage-tasks-settings/manage-tasks-settings.component.ts
+++ b/UI/Web/src/app/admin/manage-tasks-settings/manage-tasks-settings.component.ts
@@ -55,12 +55,13 @@ export class ManageTasksSettingsComponent implements OnInit {
       api: this.serverService.convertMedia(),
       successMessage: 'convert-media-task-success'
     },
-    {
-      name: 'bust-cache-task',
-      description: 'bust-cache-task-desc',
-      api: this.serverService.bustCache(),
-      successMessage: 'bust-cache-task-success'
-    },
+    // I removed this as it's not really needed given that External Recs are the only thing that fill this cache now
+    // {
+    //   name: 'bust-cache-task',
+    //   description: 'bust-cache-task-desc',
+    //   api: this.serverService.bustCache(),
+    //   successMessage: 'bust-cache-task-success'
+    // },
     {
       name: 'bust-locale-task',
       description: 'bust-locale-task-desc',

--- a/UI/Web/src/app/admin/manage-tasks-settings/manage-tasks-settings.component.ts
+++ b/UI/Web/src/app/admin/manage-tasks-settings/manage-tasks-settings.component.ts
@@ -55,7 +55,7 @@ export class ManageTasksSettingsComponent implements OnInit {
       api: this.serverService.convertMedia(),
       successMessage: 'convert-media-task-success'
     },
-    // I removed this as it's not really needed given that External Recs are the only thing that fill this cache now
+    // I removed this as it's not really needed, given that External Recs are the only thing that fill this cache now
     // {
     //   name: 'bust-cache-task',
     //   description: 'bust-cache-task-desc',

--- a/UI/Web/src/app/announcements/_components/changelog/changelog.component.html
+++ b/UI/Web/src/app/announcements/_components/changelog/changelog.component.html
@@ -9,6 +9,7 @@
       <div class="card w-100 mb-2" style="width: 18rem;">
         <div class="card-body">
           <h4 class="card-title">{{update.updateTitle}}&nbsp;
+            <span class="badge bg-secondary" *ngIf="isNightly(update)">{{t('nightly', {version: update.currentVersion})}}</span>
             <span class="badge bg-secondary" *ngIf="update.updateVersion === update.currentVersion">{{t('installed')}}</span>
             <span class="badge bg-secondary" *ngIf="update.updateVersion > update.currentVersion">{{t('available')}}</span>
           </h4>

--- a/UI/Web/src/app/announcements/_components/changelog/changelog.component.ts
+++ b/UI/Web/src/app/announcements/_components/changelog/changelog.component.ts
@@ -1,29 +1,55 @@
-import { Component, OnInit } from '@angular/core';
-import { UpdateVersionEvent } from 'src/app/_models/events/update-version-event';
-import { ServerService } from 'src/app/_services/server.service';
-import { LoadingComponent } from '../../../shared/loading/loading.component';
-import { ReadMoreComponent } from '../../../shared/read-more/read-more.component';
-import { NgFor, NgIf, DatePipe } from '@angular/common';
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, inject, OnInit} from '@angular/core';
+import {UpdateVersionEvent} from 'src/app/_models/events/update-version-event';
+import {ServerService} from 'src/app/_services/server.service';
+import {LoadingComponent} from '../../../shared/loading/loading.component';
+import {ReadMoreComponent} from '../../../shared/read-more/read-more.component';
+import {DatePipe, NgFor, NgIf} from '@angular/common';
 import {TranslocoDirective} from "@ngneat/transloco";
 
 @Component({
-    selector: 'app-changelog',
-    templateUrl: './changelog.component.html',
-    styleUrls: ['./changelog.component.scss'],
-    standalone: true,
-  imports: [NgFor, NgIf, ReadMoreComponent, LoadingComponent, DatePipe, TranslocoDirective]
+  selector: 'app-changelog',
+  templateUrl: './changelog.component.html',
+  styleUrls: ['./changelog.component.scss'],
+  standalone: true,
+  imports: [NgFor, NgIf, ReadMoreComponent, LoadingComponent, DatePipe, TranslocoDirective],
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ChangelogComponent implements OnInit {
 
+  private readonly serverService = inject(ServerService);
+  private readonly cdRef = inject(ChangeDetectorRef);
   updates: Array<UpdateVersionEvent> = [];
   isLoading: boolean = true;
-
-  constructor(private serverService: ServerService) { }
 
   ngOnInit(): void {
     this.serverService.getChangelog().subscribe(updates => {
       this.updates = updates;
       this.isLoading = false;
+      this.cdRef.markForCheck();
     });
+  }
+
+  isNightly(update: UpdateVersionEvent) {
+    // Split the version numbers into arrays
+    const updateVersionArr = update.updateVersion.split('.');
+    const currentVersionArr = update.currentVersion.split('.');
+
+    // Compare the first three parts of the version numbers
+    for (let i = 0; i < 3; i++) {
+      const updatePart = parseInt(updateVersionArr[i]);
+      const currentPart = parseInt(currentVersionArr[i]);
+
+      // If any part of the update version is less than the corresponding part of the current version, return true
+      if (updatePart < currentPart) {
+        return true;
+      }
+      // If any part of the update version is greater than the corresponding part of the current version, return false
+      else if (updatePart > currentPart) {
+        return false;
+      }
+    }
+
+    // If all parts are equal, compare the length of the version numbers
+    return updateVersionArr.length < currentVersionArr.length;
   }
 }

--- a/UI/Web/src/app/cards/_modals/edit-series-modal/edit-series-modal.component.html
+++ b/UI/Web/src/app/cards/_modals/edit-series-modal/edit-series-modal.component.html
@@ -460,6 +460,10 @@
       <div [ngbNavOutlet]="nav" class="tab-content {{utilityService.getActiveBreakpoint() === Breakpoint.Mobile ? 'mt-3' : 'ms-4 flex-fill'}}"></div>
     </div>
     <div class="modal-footer">
+      @if (accountService.hasValidLicense$ | async) {
+        <button type="button" class="btn btn-light" (click)="forceScan()" position="above"
+                [ngbTooltip]="t('force-refresh-tooltip')">{{t('force-refresh')}}</button>
+      }
       <button type="button" class="btn btn-secondary" (click)="close()">{{t('close')}}</button>
       <button type="submit" class="btn btn-primary" [disabled]="!editSeriesForm.valid" (click)="save()">{{t('save')}}</button>
     </div>

--- a/UI/Web/src/app/cards/_modals/edit-series-modal/edit-series-modal.component.html
+++ b/UI/Web/src/app/cards/_modals/edit-series-modal/edit-series-modal.component.html
@@ -462,7 +462,15 @@
     <div class="modal-footer">
       @if (accountService.hasValidLicense$ | async) {
         <button type="button" class="btn btn-light" (click)="forceScan()" position="above"
-                [ngbTooltip]="t('force-refresh-tooltip')">{{t('force-refresh')}}</button>
+                [ngbTooltip]="t('force-refresh-tooltip')">
+          @if (forceIsLoading) {
+            <div class="spinner-border spinner-border-sm text-primary" role="status">
+              <span class="visually-hidden">loading...</span>
+            </div>
+          } @else {
+            {{t('force-refresh')}}
+          }
+        </button>
       }
       <button type="button" class="btn btn-secondary" (click)="close()">{{t('close')}}</button>
       <button type="submit" class="btn btn-primary" [disabled]="!editSeriesForm.valid" (click)="save()">{{t('save')}}</button>

--- a/UI/Web/src/app/cards/_modals/edit-series-modal/edit-series-modal.component.ts
+++ b/UI/Web/src/app/cards/_modals/edit-series-modal/edit-series-modal.component.ts
@@ -55,6 +55,8 @@ import {TranslocoModule} from "@ngneat/transloco";
 import {TranslocoDatePipe} from "@ngneat/transloco-locale";
 import {UtcToLocalTimePipe} from "../../../_pipes/utc-to-local-time.pipe";
 import {EditListComponent} from "../../../shared/edit-list/edit-list.component";
+import {AccountService} from "../../../_services/account.service";
+import {LibraryType} from "../../../_models/library/library";
 
 enum TabID {
   General = 0,
@@ -112,6 +114,7 @@ export class EditSeriesModalComponent implements OnInit {
   private readonly uploadService = inject(UploadService);
   private readonly metadataService = inject(MetadataService);
   private readonly cdRef = inject(ChangeDetectorRef);
+  public readonly accountService = inject(AccountService);
 
   protected readonly TabID = TabID;
   protected readonly PersonRole = PersonRole;
@@ -503,6 +506,12 @@ export class EditSeriesModalComponent implements OnInit {
 
   close() {
     this.modal.close({success: false, series: undefined, coverImageUpdate: this.coverImageReset});
+  }
+
+  forceScan() {
+    this.metadataService.forceRefreshFromPlus(this.series.id).subscribe(() => {
+
+    });
   }
 
   fetchCollectionTags(filter: string = '') {

--- a/UI/Web/src/app/series-detail/_components/series-detail/series-detail.component.html
+++ b/UI/Web/src/app/series-detail/_components/series-detail/series-detail.component.html
@@ -5,6 +5,7 @@
         <h2 class="title text-break">
           <app-card-actionables (actionHandler)="performAction($event)" [actions]="seriesActions" [labelBy]="series.name" iconClass="fa-ellipsis-v"></app-card-actionables>
           <span>{{series.name}}</span>
+          <app-loading [loading]="isLoadingExtra" [size]="'spinner-border-sm'"></app-loading>
         </h2>
       </ng-container>
       <ng-container subtitle *ngIf="series.localizedName !== series.name">

--- a/UI/Web/src/app/series-detail/_components/series-detail/series-detail.component.html
+++ b/UI/Web/src/app/series-detail/_components/series-detail/series-detail.component.html
@@ -4,8 +4,13 @@
       <ng-container title>
         <h2 class="title text-break">
           <app-card-actionables (actionHandler)="performAction($event)" [actions]="seriesActions" [labelBy]="series.name" iconClass="fa-ellipsis-v"></app-card-actionables>
-          <span>{{series.name}}</span>
-          <app-loading [loading]="isLoadingExtra" [size]="'spinner-border-sm'"></app-loading>
+          <span>{{series.name}}
+            @if(isLoadingExtra || isLoading) {
+              <div class="spinner-border spinner-border-sm text-primary" role="status">
+                <span class="visually-hidden">loading...</span>
+              </div>
+            }
+          </span>
         </h2>
       </ng-container>
       <ng-container subtitle *ngIf="series.localizedName !== series.name">

--- a/UI/Web/src/app/series-detail/_components/series-detail/series-detail.component.ts
+++ b/UI/Web/src/app/series-detail/_components/series-detail/series-detail.component.ts
@@ -48,7 +48,10 @@ import {catchError, forkJoin, Observable, of} from 'rxjs';
 import {map, take} from 'rxjs/operators';
 import {BulkSelectionService} from 'src/app/cards/bulk-selection.service';
 import {CardDetailDrawerComponent} from 'src/app/cards/card-detail-drawer/card-detail-drawer.component';
-import {EditSeriesModalComponent} from 'src/app/cards/_modals/edit-series-modal/edit-series-modal.component';
+import {
+  EditSeriesModalCloseResult,
+  EditSeriesModalComponent
+} from 'src/app/cards/_modals/edit-series-modal/edit-series-modal.component';
 import {TagBadgeCursor} from 'src/app/shared/tag-badge/tag-badge.component';
 import {DownloadEvent, DownloadService} from 'src/app/shared/_services/download.service';
 import {KEY_CODES, UtilityService} from 'src/app/shared/_services/utility.service';
@@ -839,10 +842,10 @@ export class SeriesDetailComponent implements OnInit, AfterContentChecked {
   openEditSeriesModal() {
     const modalRef = this.modalService.open(EditSeriesModalComponent, {  size: 'xl' });
     modalRef.componentInstance.series = this.series;
-    modalRef.closed.subscribe((closeResult: {success: boolean, series: Series, coverImageUpdate: boolean}) => {
+    modalRef.closed.subscribe((closeResult: EditSeriesModalCloseResult) => {
       if (closeResult.success) {
         window.scrollTo(0, 0);
-        this.loadSeries(this.seriesId);
+        this.loadSeries(this.seriesId, closeResult.updateExternal);
       }
 
       if (closeResult.coverImageUpdate) {

--- a/UI/Web/src/app/series-detail/_components/series-detail/series-detail.component.ts
+++ b/UI/Web/src/app/series-detail/_components/series-detail/series-detail.component.ts
@@ -200,6 +200,7 @@ export class SeriesDetailComponent implements OnInit, AfterContentChecked {
   isAdmin = false;
   hasDownloadingRole = false;
   isLoading = true;
+  isLoadingExtra = false;
   showBook = true;
 
   currentlyReadingChapter: Chapter | undefined = undefined;
@@ -708,7 +709,11 @@ export class SeriesDetailComponent implements OnInit, AfterContentChecked {
 
 
   loadPlusMetadata(seriesId: number, libraryType: LibraryType) {
+    this.isLoadingExtra = true;
+    this.cdRef.markForCheck();
     this.metadataService.getSeriesMetadataFromPlus(seriesId, libraryType).subscribe(data => {
+      this.isLoadingExtra = false;
+      this.cdRef.markForCheck();
       if (data === null) return;
 
       // Reviews

--- a/UI/Web/src/app/shared/loading/loading.component.ts
+++ b/UI/Web/src/app/shared/loading/loading.component.ts
@@ -19,6 +19,4 @@ export class LoadingComponent {
    * Uses absolute positioning to ensure it loads over content
    */
   @Input() absolute: boolean = false;
-
-  constructor() { }
 }

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -559,6 +559,7 @@
     "changelog": {
         "installed": "Installed",
         "download": "Download",
+        "nightly": "Nightly: {{version}}",
         "published-label": "Published: ",
         "available": "Available",
         "description": "If you do not see an {{installed}}",
@@ -1231,7 +1232,8 @@
         "donations-title": "Donations:",
         "source-title": "Source:",
         "feature-request-title": "Feature Requests:",
-        "localization-title": "Localizations:"
+        "localization-title": "Localizations:",
+        "updates-title": "Update History"
     },
 
     "manage-tasks-settings": {

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -1720,9 +1720,9 @@
         "chapter-title": "Chapter:",
         "volume-num": "{{common.volume-num}}",
         "highest-count-tooltip": "Highest Count found across all ComicInfo in the Series",
-        "max-issue-tooltip": "Max Issue or Volume field from all ComicInfo in the series"
-
-
+        "max-issue-tooltip": "Max Issue or Volume field from all ComicInfo in the series",
+        "force-refresh": "Force Refresh",
+        "force-refresh-tooltip": "Force refresh external metadata from Kavita+"
     },
 
     "day-breakdown": {

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -1377,7 +1377,9 @@
         "kavita+-tab": "Kavita+",
         "kavita+-desc-part-1": "Kavita+ is a premium subscription service which unlocks features for all users on this Kavita instance. Buy a subscription to unlock ",
         "kavita+-desc-part-2": "premium benefits",
-        "kavita+-desc-part-3": "today!"
+        "kavita+-desc-part-3": "today!",
+        "kavita+-requirement": "Kavita+ is designed to work only with the latest release - 2 versions. Anything outside of that is subject to not working.",
+        "kavita+-releases": "See releases"
     },
 
     "collection-detail": {

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -2064,7 +2064,8 @@
         "smart-filter-updated": "Created/Updated smart filter",
         "external-source-already-exists": "An External Source already exists with the same Name/Host/API Key",
         "anilist-token-expired": "Your AniList token is expired. Scrobbling will no longer process until you re-generate it in User Settings > Account",
-        "collection-tag-deleted": "Collection Tag deleted"
+        "collection-tag-deleted": "Collection Tag deleted",
+        "force-kavita+-refresh-success": "Kavita+ external metadata has been invalidated"
     },
 
     "actionable": {

--- a/openapi.json
+++ b/openapi.json
@@ -3585,6 +3585,7 @@
           {
             "name": "libraryType",
             "in": "query",
+            "description": "",
             "schema": {
               "enum": [
                 0,
@@ -15127,8 +15128,9 @@
             "type": "string",
             "nullable": true
           },
-          "lastUpdatedUtc": {
+          "validUntilUtc": {
             "type": "string",
+            "description": "Data is valid until this time",
             "format": "date-time"
           },
           "series": {

--- a/openapi.json
+++ b/openapi.json
@@ -3580,21 +3580,6 @@
               "type": "integer",
               "format": "int32"
             }
-          },
-          {
-            "name": "libraryType",
-            "in": "query",
-            "description": "",
-            "schema": {
-              "enum": [
-                0,
-                1,
-                2,
-                3
-              ],
-              "type": "integer",
-              "format": "int32"
-            }
           }
         ],
         "responses": {

--- a/openapi.json
+++ b/openapi.json
@@ -7,7 +7,7 @@
       "name": "GPL-3.0",
       "url": "https://github.com/Kareadita/Kavita/blob/develop/LICENSE"
     },
-    "version": "0.7.13.17"
+    "version": "0.7.13.18"
   },
   "servers": [
     {
@@ -7238,7 +7238,24 @@
         "summary": "Get the current user's AniList token",
         "responses": {
           "200": {
-            "description": "Success"
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         }
       }

--- a/openapi.json
+++ b/openapi.json
@@ -3565,6 +3565,45 @@
         }
       }
     },
+    "/api/Metadata/force-refresh": {
+      "post": {
+        "tags": [
+          "Metadata"
+        ],
+        "summary": "If this Series is on Kavita+ Blacklist, removes it. If already cached, invalidates it.\r\nThis then attempts to refresh data from Kavita+ for this series.",
+        "parameters": [
+          {
+            "name": "seriesId",
+            "in": "query",
+            "description": "",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "libraryType",
+            "in": "query",
+            "description": "",
+            "schema": {
+              "enum": [
+                0,
+                1,
+                2,
+                3
+              ],
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
     "/api/Metadata/series-detail-plus": {
       "get": {
         "tags": [

--- a/openapi.json
+++ b/openapi.json
@@ -3576,7 +3576,7 @@
           {
             "name": "seriesId",
             "in": "query",
-            "description": "",
+            "description": "Series Id",
             "schema": {
               "type": "integer",
               "format": "int32"
@@ -3585,7 +3585,7 @@
           {
             "name": "libraryType",
             "in": "query",
-            "description": "",
+            "description": "Library Type",
             "schema": {
               "enum": [
                 0,


### PR DESCRIPTION
In an effort to solve the instability issue, I rewrote a huge part of how the Kavita+ Series Detail API works and expanded it a bit further (what was originally coming in v0.8.x). 

# Added
- Added: (Kavita+) New button in Edit Series modal that allows the series to be invalidated (or removed from blocklist) and force refresh from Kavita+ on next series detail page view.
- Added: Added the changelog to the Admin System tab (in case users don't see it in the announcements page).

# Changed
- Changed: (Kavita+) Series that don't match against Kavita+ will now be stored in a table and not be retried again. 
- Changed: (Kavita+) Removed Bust Kavita+ cache button from Admin -> Tasks screen as it's no longer needed.
- Changed: (Kavita+) Removed the in memory caching that was occurring. I believe this lead to the issues that were being seen due to improperly managing memory. (develop)
- Changed: Changelog now shows if you're on a nightly and which stable it's based off.

