### PR TITLE
v0.7.14 - iOS Webtoon Fixes, Built-in Email, and a new Wiki!

### DIFF
--- a/Kavita.Common/Kavita.Common.csproj
+++ b/Kavita.Common/Kavita.Common.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net8.0</TargetFramework>
         <Company>kavitareader.com</Company>
         <Product>Kavita</Product>
-        <AssemblyVersion>0.7.13.23</AssemblyVersion>
+        <AssemblyVersion>0.7.14.0</AssemblyVersion>
         <NeutralLanguage>en</NeutralLanguage>
         <TieredPGO>true</TieredPGO>
     </PropertyGroup>

--- a/openapi.json
+++ b/openapi.json
@@ -7,7 +7,7 @@
       "name": "GPL-3.0",
       "url": "https://github.com/Kareadita/Kavita/blob/develop/LICENSE"
     },
-    "version": "0.7.13.22"
+    "version": "0.7.14.0"
   },
   "servers": [
     {


### PR DESCRIPTION
A small on the surface, large under the hood release for everyone. This release first off fixes the webtoon reader for our iOS users. Many have validated and want to thank the community for helping me test and @thundernerd for doing some basic POC to help me drive it home. In addition to this, Want to Read had a critical bug in the architecture (that somehow slipped noticed for over a year now) where if one user adds a series to want to read, then another does, it will override the other. And lastly, for Kavita+ users, this is foundational release for the upcoming Basic Metadata feature. All data, like reviews, recommendations, and ratings are now stored in your DB. This leads to very quick response times and sets up the system for future data synchronization. 

Another big feature in this release is KavitaEmail is no longer required for those that want to use email (and me hosting an email service for everyone is no more). All email settings are built into the application and this has allowed me to streamline how Kavita works around email. Before, it was a mess of having to call an external system, check if the system was accessible externally, etc. Now, you MUST setup a host name (reverse proxy domain) and the email settings to use any email functionality. Due to this, all the flows got polished and should be much more consistent for users. 

Lastly, while it looks so small, it was over 3K lines of code, but volume numbers are now float-based, meaning if a volume is < 1, it will now properly show on book library series detail page. In addition to this, Omnibus (Volume 1-2) is now much better supported and Kavita+ will get Volume 2 when you read an Omnibus vs Volume 1 previously.

That wraps the v0.7.x series of releases. Next release series (v0.8.x) will be focusing mainly on the new Magazine library type, PDF parsing enhancements, and likely the new comic library.

### New Wiki
Lastly I want to call out a massive thanks to @DieselTech who has been leading a redesign of our wiki. Safe to say, at least 100 hours have been poured into re-organizing and updating a ton of the content from our old wiki into a brand new system. It looks slick and should be much easier to understand and search against. While we aren't yet ready to roll out, be on the look out next release for the full release. For those that want a sneak peak, you can check it out [here](https://wiki2.kavitareader.com).

### Old Email Service
As mentioned, this release contains built-in email functionality. The old emailer will remain on for 1 week after this release to give time for people to update. If you are stuck on an old version, please reach out so we can help understand why and get you updated. 

### Kavita+
Kavita+ is designed to work with the latest - 2 releases. If you are further than that out of date, it may no longer work appropriately. It is important to stay up to date.

# Added
- Added: Added limited parsing support for c01-c04. Normally, c01-04 is used. 
- Added: Admins can now write custom cron notation for Scans, Backup, and Cleanup tasks. Cleanup cannot be disabled as it is required for Kavita to function smoothly. Ideal to always leave at midnight.
- Added: (Kavita+) New filter for Average Rating. This will allow you to filter on series that have an external average rating. Note: This only applies to series that have metadata pulled down from Kavita+.
- Added: (Kavita+) Kavita will now store Kavita+ external ratings, reviews, and recommendations in your Database. This will increase performance and lays the foundation for the upcoming basic metadata from Kavita+. Data is refreshed ad-hoc after 2 weeks and cached in memory for 48 hours. 
- Added: (Kavita+) New button in Edit Series modal that allows the series to be invalidated (or removed from blocklist) and force refresh from Kavita+ on next series detail page view.
- Added: (Kavita+) User's can now see error messages and a different icon on Scrobbling History when a series fails to scrobble.
- Added: (Kavita+) Sort by Average Rating
- Added: Added a new role that makes a user account read only. This means they cannot change anything themselves (Age Restriction, Email, Password, Forgot Password, API Key). This is not intended for users to use, but for the demo instance.
- Added: Added a popup that will tell users that are over 3 releases behind to update. 
- Added: New setting in Email settings to let you use Customized Template files. If this is true, Kavita will pick templates from config/templates rather than internal storage. Fallback is available. You then own the onset to stay up to date with email template changes.
- Added: Added back the ability to delete your own review
- Added: Added the ability to delete collection tags via actionables on collection detail page. 
- Added: Added buttons that allows users to quickly autofill gmail/outlook email settings
- Added: Added the changelog to the Admin System tab (in case users don't see it in the announcements page).



# Changed
- Changed: (Kavita+) Changed how Series Detail api works to drastically reduce memory needs
- Changed: (Kavita+) Removed Bust Kavita+ cache button from Admin -> Tasks screen as it's no longer needed.
- Changed: (Kavita+) Series that don't match against Kavita+ will now be stored in a table and not be retried again.
- Changed: (Kavita+) When scrobbling, check if a series is blacklisted or not before trying. When an unknown series comes back, add it to the blacklist (so we don't waste time trying when it will never match)
- Changed: Updated system tab with a link to localization and new feature request site
- Changed: Massive refactor to change how Volume numbers are represented within Kavita to support volumes that are < 1 on the UI. This means 0.5 books will now work going forward.
- Changed: Lots of autocomplete hints added to help password managers and browsers autofill login/registration/passwords.
- Changed: Adjusted OPDS-PS lastReadDate to adhere to ISO 8061 as per the spec and what Panels expects for proper sync.
- Changed: Supressed image requests on the logs as they are quite noisy
- Changed: Hostname setting is in general admin settings as well as email, as it's not 100% tied to email functionality
- Changed: Kavita will now confirm before you delete a device
- Changed: Email is now baked into Kavita. If email is not setup then all flows will now just work. The extra security measures will only work with email being setup (and HostName set). Kavita will no longer try to identify if the server is accessible externally. You will have to set HostName and setup the emailer going forward.
- Changed: Series detail title (series title) now shows a loading indicator showcasing all the important apis that are loading
- Changed: If Kavita+ license check throws an exception, just assume license is invalid and let the scheduled task check again (or the user manually)
- Changed: Changelog now shows if you're on a nightly and which stable it's based off.
- Changed: Split the main email template into base.html and fixed some bad closing tags. This should make customizing email templates easier.
- Changed: Removed the up/down arrow keys on webtoon reader moving full pages. Use up/down for scroll and space for a bit at a time. 
- Changed: Updated the Kavita templates to be more modern (in terms of the code) and easier to customize.

# Fixed
- Fixed: Fixed UI not being able to render search for non-admin users 
- Fixed: Remove from On Deck wasn't refreshing the dashboard
- Fixed: Fixed up the display and logic around when there is a series collision, to help the user understand more
- Fixed: Fixed a bug where the UI filter could send out of date information to the backend which threw an error.
- Fixed: (Kavita+) Fixed a bug where external reviews would show as local
- Fixed: Fixed webtoon reader being unusable on iOS (Thanks @thundernerd for the help)
- Fixed: Series detail page was making a ton of api calls that weren't needed.
- Fixed: Fixed a bug where scrobbling tab could duplicate
- Fixed: Fixed a bunch of warnings about ordering and take with search queries
- Fixed: Want to Read had a critical issue where a user could undo your want to read.
- Fixed: Fixed bulk select of chapters leaving the last one off.
- Fixed: On non-authenticated flows, the nav bar will no longer flash on refresh.
- Fixed: Fixed inability to right click highlighted text in the book reader 
- Fixed: Fixed reading activity graphic not taking the full width like it should
- Fixed: Fixed some spacing on the Continue/Read button on reading list page
- Fixed: Fixed an issue where download indicators on cards would should on different series 
- Fixed: Don't have validations on the login screen
- Fixed: Support for the 'pageNumber' parameter in OPDS API smart-filter/{Id}.  (Thanks @charles7668 )
- Fixed: Fixed and polished a lot of the email flows.
- Fixed: Fixed a bug where send to device didn't properly send the correct end event
- Fixed: LSIO dockers weren't properly recognized as Docker, Kavita now checks for LSIO_FIRST_PARTY environment variable 
- Fixed: Fixed an issue with // being generated for some invite links (
- Fixed: Fixed an issue where a new library could render as blank in the UI 
- Fixed: Fixed an issue when creating a new library, that new library wouldn't be included in folder watching
- Fixed: Fixed a bad encoding of dates for lastReadDate on OPDS-PS streams. Panels has already updated implemenation to help progress sync work more smoothly.
- Fixed: Fixed a bug where non Kavita+ users wouldn't see reviews.
- Fixed: Handled a rare case where a cover image wouldn't exist when creating a merged image for a reading list/collection.
- Fixed: Fixed a bad comparison on code that pushes update notification users to admins. 
- Fixed: Fixed an issue where continue point for a totally unread series would start on the special and not chapter 1.
- Fixed: Fixed an issue in webtoon reader where it would load the next chapter and be all black.

# API
- Volume Number field is deprecated in favor of MinNumber and MaxNumber (if the volume is a range). You can switch to MinNumber and ignore MaxNumber. (Volume Number will not be removed for at least 6 months to give time for apps to update)