### PR TITLE
Background Prefetching for Kavita+

### DIFF
--- a/API.Tests/Helpers/RateLimiterTests.cs
+++ b/API.Tests/Helpers/RateLimiterTests.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using API.Helpers;
+using Xunit;
+
+namespace API.Tests.Helpers;
+
+public class RateLimiterTests
+{
+    [Fact]
+    public void AcquireTokens_Successful()
+    {
+        // Arrange
+        var limiter = new RateLimiter(3, TimeSpan.FromSeconds(1));
+
+        // Act & Assert
+        Assert.True(limiter.TryAcquire("test_key"));
+        Assert.True(limiter.TryAcquire("test_key"));
+        Assert.True(limiter.TryAcquire("test_key"));
+    }
+
+    [Fact]
+    public void AcquireTokens_ExceedLimit()
+    {
+        // Arrange
+        var limiter = new RateLimiter(2, TimeSpan.FromSeconds(10), false);
+
+        // Act
+        limiter.TryAcquire("test_key");
+        limiter.TryAcquire("test_key");
+
+        // Assert
+        Assert.False(limiter.TryAcquire("test_key"));
+    }
+
+    [Fact]
+    public void AcquireTokens_Refill()
+    {
+        // Arrange
+        var limiter = new RateLimiter(2, TimeSpan.FromSeconds(1));
+
+        // Act
+        limiter.TryAcquire("test_key");
+        limiter.TryAcquire("test_key");
+
+        // Wait for refill
+        System.Threading.Thread.Sleep(1100);
+
+        // Assert
+        Assert.True(limiter.TryAcquire("test_key"));
+    }
+
+    [Fact]
+    public void AcquireTokens_Refill_WithOff()
+    {
+        // Arrange
+        var limiter = new RateLimiter(2, TimeSpan.FromSeconds(10), false);
+
+        // Act
+        limiter.TryAcquire("test_key");
+        limiter.TryAcquire("test_key");
+
+        // Wait for refill
+        System.Threading.Thread.Sleep(2100);
+
+        // Assert
+        Assert.False(limiter.TryAcquire("test_key"));
+    }
+
+    [Fact]
+    public void AcquireTokens_MultipleKeys()
+    {
+        // Arrange
+        var limiter = new RateLimiter(2, TimeSpan.FromSeconds(1));
+
+        // Act & Assert
+        Assert.True(limiter.TryAcquire("key1"));
+        Assert.True(limiter.TryAcquire("key2"));
+    }
+}

--- a/API.Tests/Services/SeriesServiceTests.cs
+++ b/API.Tests/Services/SeriesServiceTests.cs
@@ -1392,4 +1392,96 @@ public class SeriesServiceTests : AbstractDbTest
     }
 
     #endregion
+
+    #region DeleteMultipleSeries
+
+    [Fact]
+    public async Task DeleteMultipleSeries_ShouldDeleteSeries()
+    {
+        await ResetDb();
+        var lib1 = new LibraryBuilder("Test LIb")
+            .WithSeries(new SeriesBuilder("Test Series")
+                .WithMetadata(new SeriesMetadata()
+                {
+                    AgeRating = AgeRating.Everyone
+                })
+                .WithVolume(new VolumeBuilder("0")
+                    .WithChapter(new ChapterBuilder("1").WithFile(
+                        new MangaFileBuilder($"{DataDirectory}1.zip", MangaFormat.Archive)
+                            .WithPages(1)
+                            .Build()
+                    ).Build())
+                    .Build())
+                .Build())
+            .WithSeries(new SeriesBuilder("Test Series Prequels").Build())
+            .WithSeries(new SeriesBuilder("Test Series Sequels").Build())
+            .WithAppUser(new AppUserBuilder("majora2007", string.Empty).Build())
+            .Build();
+        _context.Library.Add(lib1);
+
+        var lib2 = new LibraryBuilder("Test LIb 2", LibraryType.Book)
+            .WithSeries(new SeriesBuilder("Test Series 2").Build())
+            .WithSeries(new SeriesBuilder("Test Series Prequels 2").Build())
+            .WithSeries(new SeriesBuilder("Test Series Prequels 2").Build())// TODO: Is this a bug
+            .WithAppUser(new AppUserBuilder("majora2007", string.Empty).Build())
+            .Build();
+        _context.Library.Add(lib2);
+
+        await _context.SaveChangesAsync();
+
+        var series1 = await _unitOfWork.SeriesRepository.GetSeriesByIdAsync(1,
+            SeriesIncludes.Related | SeriesIncludes.ExternalRatings);
+        // Add relations
+        var addRelationDto = CreateRelationsDto(series1);
+        addRelationDto.Adaptations.Add(4); // cross library link
+        await _seriesService.UpdateRelatedSeries(addRelationDto);
+
+
+        // Setup External Metadata stuff
+        series1.ExternalSeriesMetadata ??= new ExternalSeriesMetadata();
+        series1.ExternalSeriesMetadata.ExternalRatings = new List<ExternalRating>()
+        {
+            new ExternalRating()
+            {
+                SeriesId = 1,
+                Provider = ScrobbleProvider.Mal,
+                AverageScore = 1
+            }
+        };
+        series1.ExternalSeriesMetadata.ExternalRecommendations = new List<ExternalRecommendation>()
+        {
+            new ExternalRecommendation()
+            {
+                SeriesId = 2,
+                Name = "Series 2",
+                Url = "",
+                CoverUrl = ""
+            },
+            new ExternalRecommendation()
+            {
+                SeriesId = 0, // Causes a FK constraint
+                Name = "Series 2",
+                Url = "",
+                CoverUrl = ""
+            }
+        };
+        series1.ExternalSeriesMetadata.ExternalReviews = new List<ExternalReview>()
+        {
+            new ExternalReview()
+            {
+                Body = "",
+                Provider = ScrobbleProvider.Mal,
+                BodyJustText = ""
+            }
+        };
+
+        await _context.SaveChangesAsync();
+
+        // Ensure we can delete the series
+        Assert.True(await _seriesService.DeleteMultipleSeries(new[] {1, 2}));
+        Assert.Null(await _unitOfWork.SeriesRepository.GetSeriesByIdAsync(1));
+        Assert.Null(await _unitOfWork.SeriesRepository.GetSeriesByIdAsync(2));
+    }
+
+    #endregion
 }

--- a/API/Controllers/DeviceController.cs
+++ b/API/Controllers/DeviceController.cs
@@ -103,7 +103,7 @@ public class DeviceController : BaseApiController
         if (dto.ChapterIds.Any(i => i < 0)) return BadRequest(await _localizationService.Translate(User.GetUserId(), "greater-0", "ChapterIds"));
         if (dto.DeviceId < 0) return BadRequest(await _localizationService.Translate(User.GetUserId(), "greater-0", "DeviceId"));
 
-        var isEmailSetup = (await _unitOfWork.SettingsRepository.GetSettingsDtoAsync()).IsEmailSetup();
+        var isEmailSetup = (await _unitOfWork.SettingsRepository.GetSettingsDtoAsync()).IsEmailSetupForSendToDevice();
         if (!isEmailSetup)
             return BadRequest(await _localizationService.Translate(User.GetUserId(), "send-to-kavita-email"));
 
@@ -142,7 +142,7 @@ public class DeviceController : BaseApiController
         if (dto.SeriesId <= 0) return BadRequest(await _localizationService.Translate(User.GetUserId(), "greater-0", "SeriesId"));
         if (dto.DeviceId < 0) return BadRequest(await _localizationService.Translate(User.GetUserId(), "greater-0", "DeviceId"));
 
-        var isEmailSetup = (await _unitOfWork.SettingsRepository.GetSettingsDtoAsync()).IsEmailSetup();
+        var isEmailSetup = (await _unitOfWork.SettingsRepository.GetSettingsDtoAsync()).IsEmailSetupForSendToDevice();
         if (!isEmailSetup)
             return BadRequest(await _localizationService.Translate(User.GetUserId(), "send-to-kavita-email"));
 

--- a/API/Controllers/SeriesController.cs
+++ b/API/Controllers/SeriesController.cs
@@ -122,6 +122,11 @@ public class SeriesController : BaseApiController
         return Ok(series);
     }
 
+    /// <summary>
+    /// Deletes a series from Kavita
+    /// </summary>
+    /// <param name="seriesId"></param>
+    /// <returns>If the series was deleted or not</returns>
     [Authorize(Policy = "RequireAdminRole")]
     [HttpDelete("{seriesId}")]
     public async Task<ActionResult<bool>> DeleteSeries(int seriesId)
@@ -139,7 +144,7 @@ public class SeriesController : BaseApiController
         var username = User.GetUsername();
         _logger.LogInformation("Series {@SeriesId} is being deleted by {UserName}", dto.SeriesIds, username);
 
-        if (await _seriesService.DeleteMultipleSeries(dto.SeriesIds)) return Ok();
+        if (await _seriesService.DeleteMultipleSeries(dto.SeriesIds)) return Ok(true);
 
         return BadRequest(await _localizationService.Translate(User.GetUserId(), "generic-series-delete"));
     }

--- a/API/DTOs/Settings/ServerSettingDTO.cs
+++ b/API/DTOs/Settings/ServerSettingDTO.cs
@@ -95,9 +95,18 @@ public class ServerSettingDto
     /// <returns></returns>
     public bool IsEmailSetup()
     {
-        //return false;
         return !string.IsNullOrEmpty(SmtpConfig.Host)
                && !string.IsNullOrEmpty(SmtpConfig.UserName)
                && !string.IsNullOrEmpty(HostName);
+    }
+
+    /// <summary>
+    /// Are at least some basics filled in, but not hostname as not required for Send to Device
+    /// </summary>
+    /// <returns></returns>
+    public bool IsEmailSetupForSendToDevice()
+    {
+        return !string.IsNullOrEmpty(SmtpConfig.Host)
+               && !string.IsNullOrEmpty(SmtpConfig.UserName);
     }
 }

--- a/API/Data/DataContext.cs
+++ b/API/Data/DataContext.cs
@@ -143,6 +143,12 @@ public sealed class DataContext : IdentityDbContext<AppUser, AppRole, int,
         builder.Entity<AppUserSideNavStream>()
             .HasIndex(e => e.Visible)
             .IsUnique(false);
+
+        builder.Entity<ExternalSeriesMetadata>()
+            .HasOne(em => em.Series)
+            .WithOne(s => s.ExternalSeriesMetadata)
+            .HasForeignKey<ExternalSeriesMetadata>(em => em.SeriesId)
+            .OnDelete(DeleteBehavior.Cascade);
     }
 
     #nullable enable

--- a/API/Data/Migrations/20240209224347_DBTweaks.Designer.cs
+++ b/API/Data/Migrations/20240209224347_DBTweaks.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using API.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace API.Data.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20240209224347_DBTweaks")]
+    partial class DBTweaks
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "8.0.1");

--- a/API/Data/Migrations/20240209224347_DBTweaks.cs
+++ b/API/Data/Migrations/20240209224347_DBTweaks.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace API.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class DBTweaks : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_ExternalRecommendation_Series_SeriesId",
+                table: "ExternalRecommendation");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddForeignKey(
+                name: "FK_ExternalRecommendation_Series_SeriesId",
+                table: "ExternalRecommendation",
+                column: "SeriesId",
+                principalTable: "Series",
+                principalColumn: "Id");
+        }
+    }
+}

--- a/API/Data/Repositories/ExternalSeriesMetadataRepository.cs
+++ b/API/Data/Repositories/ExternalSeriesMetadataRepository.cs
@@ -19,6 +19,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 
 namespace API.Data.Repositories;
+#nullable enable
 
 public interface IExternalSeriesMetadataRepository
 {
@@ -28,6 +29,7 @@ public interface IExternalSeriesMetadataRepository
     void Remove(IEnumerable<ExternalReview>? reviews);
     void Remove(IEnumerable<ExternalRating>? ratings);
     void Remove(IEnumerable<ExternalRecommendation>? recommendations);
+    void Remove(ExternalSeriesMetadata metadata);
     Task<ExternalSeriesMetadata?> GetExternalSeriesMetadata(int seriesId);
     Task<bool> ExternalSeriesMetadataNeedsRefresh(int seriesId);
     Task<SeriesDetailPlusDto> GetSeriesDetailPlusDto(int seriesId);
@@ -70,16 +72,22 @@ public class ExternalSeriesMetadataRepository : IExternalSeriesMetadataRepositor
         _context.ExternalReview.RemoveRange(reviews);
     }
 
-    public void Remove(IEnumerable<ExternalRating> ratings)
+    public void Remove(IEnumerable<ExternalRating>? ratings)
     {
         if (ratings == null) return;
         _context.ExternalRating.RemoveRange(ratings);
     }
 
-    public void Remove(IEnumerable<ExternalRecommendation> recommendations)
+    public void Remove(IEnumerable<ExternalRecommendation>? recommendations)
     {
         if (recommendations == null) return;
         _context.ExternalRecommendation.RemoveRange(recommendations);
+    }
+
+    public void Remove(ExternalSeriesMetadata? metadata)
+    {
+        if (metadata == null) return;
+        _context.ExternalSeriesMetadata.Remove(metadata);
     }
 
     /// <summary>

--- a/API/Data/Repositories/LibraryRepository.cs
+++ b/API/Data/Repositories/LibraryRepository.cs
@@ -56,6 +56,7 @@ public interface ILibraryRepository
     Task<IList<Library>> GetAllWithCoversInDifferentEncoding(EncodeFormat encodeFormat);
     Task<bool> GetAllowsScrobblingBySeriesId(int seriesId);
 
+    Task<IDictionary<int, LibraryType>> GetLibraryTypesBySeriesIdsAsync(IList<int> seriesIds);
 }
 
 public class LibraryRepository : ILibraryRepository
@@ -351,5 +352,17 @@ public class LibraryRepository : ILibraryRepository
         return await _context.Series.Where(s => s.Id == seriesId)
             .Select(s => s.Library.AllowScrobbling)
             .SingleOrDefaultAsync();
+    }
+
+    public async Task<IDictionary<int, LibraryType>> GetLibraryTypesBySeriesIdsAsync(IList<int> seriesIds)
+    {
+        return await _context.Series
+            .Where(series => seriesIds.Contains(series.Id))
+            .Select(series => new
+            {
+                series.Id,
+                series.Library.Type
+            })
+            .ToDictionaryAsync(entity => entity.Id, entity => entity.Type);
     }
 }

--- a/API/Data/Repositories/SeriesRepository.cs
+++ b/API/Data/Repositories/SeriesRepository.cs
@@ -49,6 +49,7 @@ public enum SeriesIncludes
     ExternalReviews = 64,
     ExternalRatings = 128,
     ExternalRecommendations = 256,
+    ExternalMetadata = 512
 
 }
 
@@ -551,7 +552,7 @@ public class SeriesRepository : ISeriesRepository
     }
 
     /// <summary>
-    /// Returns Volumes, Metadata, and Collection Tags
+    /// Returns Full Series including all external links
     /// </summary>
     /// <param name="seriesIds"></param>
     /// <returns></returns>
@@ -559,9 +560,20 @@ public class SeriesRepository : ISeriesRepository
     {
         return await _context.Series
             .Include(s => s.Volumes)
+            .Include(s => s.Relations)
             .Include(s => s.Metadata)
             .ThenInclude(m => m.CollectionTags)
-            .Include(s => s.Relations)
+
+
+            .Include(s => s.ExternalSeriesMetadata)
+
+            .Include(s => s.ExternalSeriesMetadata)
+            .ThenInclude(e => e.ExternalRatings)
+            .Include(s => s.ExternalSeriesMetadata)
+            .ThenInclude(e => e.ExternalReviews)
+            .Include(s => s.ExternalSeriesMetadata)
+            .ThenInclude(e => e.ExternalRecommendations)
+
             .Where(s => seriesIds.Contains(s.Id))
             .AsSplitQuery()
             .ToListAsync();

--- a/API/Data/Seed.cs
+++ b/API/Data/Seed.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;

--- a/API/Entities/Metadata/ExternalRecommendation.cs
+++ b/API/Entities/Metadata/ExternalRecommendation.cs
@@ -1,8 +1,11 @@
 ﻿using System.Collections.Generic;
 using API.Services.Plus;
+using Microsoft.EntityFrameworkCore;
+
 
 namespace API.Entities.Metadata;
 
+[Index(nameof(SeriesId), IsUnique = false)]
 public class ExternalRecommendation
 {
     public int Id { get; set; }
@@ -19,7 +22,7 @@ public class ExternalRecommendation
     /// When null, represents an external series. When set, it is a Series
     /// </summary>
     public int? SeriesId { get; set; }
-    public virtual Series Series { get; set; }
+    //public virtual Series? Series { get; set; }
 
     // Relationships
     public ICollection<ExternalSeriesMetadata> ExternalSeriesMetadatas { get; set; } = null!;

--- a/API/Extensions/QueryExtensions/IncludesExtensions.cs
+++ b/API/Extensions/QueryExtensions/IncludesExtensions.cs
@@ -80,6 +80,12 @@ public static class IncludesExtensions
                 .ThenInclude(s => s.ExternalRatings);
         }
 
+        if (includeFlags.HasFlag(SeriesIncludes.ExternalMetadata))
+        {
+            query = query
+                .Include(s => s.ExternalSeriesMetadata);
+        }
+
         if (includeFlags.HasFlag(SeriesIncludes.ExternalRecommendations))
         {
             query = query

--- a/API/Helpers/RateLimiter.cs
+++ b/API/Helpers/RateLimiter.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace API.Helpers;
+
+public class RateLimiter(int maxRequests, TimeSpan duration, bool refillBetween = true)
+{
+    private readonly Dictionary<string, (int Tokens, DateTime LastRefill)> _tokenBuckets = new();
+    private readonly object _lock = new();
+
+    public bool TryAcquire(string key)
+    {
+        lock (_lock)
+        {
+            if (!_tokenBuckets.TryGetValue(key, out var bucket))
+            {
+                bucket = (Tokens: maxRequests, LastRefill: DateTime.UtcNow);
+                _tokenBuckets[key] = bucket;
+            }
+
+            RefillTokens(key);
+
+            lock (_lock)
+            {
+
+                if (_tokenBuckets[key].Tokens > 0)
+                {
+                    _tokenBuckets[key] = (Tokens: _tokenBuckets[key].Tokens - 1, LastRefill: _tokenBuckets[key].LastRefill);
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+
+    private void RefillTokens(string key)
+    {
+        lock (_lock)
+        {
+            var now = DateTime.UtcNow;
+            var timeSinceLastRefill = now - _tokenBuckets[key].LastRefill;
+            var tokensToAdd = (int) (timeSinceLastRefill.TotalSeconds / duration.TotalSeconds);
+
+            // Refill the bucket if the elapsed time is greater than or equal to the duration
+            if (timeSinceLastRefill >= duration)
+            {
+                _tokenBuckets[key] = (Tokens: maxRequests, LastRefill: now);
+                Console.WriteLine($"Tokens Refilled to Max: {maxRequests}");
+            }
+            else if (tokensToAdd > 0 && refillBetween)
+            {
+                _tokenBuckets[key] = (Tokens: Math.Min(maxRequests, _tokenBuckets[key].Tokens + tokensToAdd), LastRefill: now);
+                Console.WriteLine($"Tokens Refilled: {_tokenBuckets[key].Tokens}");
+            }
+        }
+    }
+}
+

--- a/API/Services/DeviceService.cs
+++ b/API/Services/DeviceService.cs
@@ -126,6 +126,7 @@ public class DeviceService : IDeviceService
         device.UpdateLastUsed();
         _unitOfWork.DeviceRepository.Update(device);
         await _unitOfWork.CommitAsync();
+
         var success = await _emailService.SendFilesToEmail(new SendToDto()
         {
             DestinationEmail = device.EmailAddress!,

--- a/API/Services/EmailService.cs
+++ b/API/Services/EmailService.cs
@@ -224,7 +224,7 @@ public class EmailService : IEmailService
     public async Task<bool> SendFilesToEmail(SendToDto data)
     {
         var serverSetting = await _unitOfWork.SettingsRepository.GetSettingsDtoAsync();
-        if (!serverSetting.IsEmailSetup()) return false;
+        if (!serverSetting.IsEmailSetupForSendToDevice()) return false;
 
         var emailOptions = new EmailOptionsDto()
         {

--- a/API/Services/Plus/ExternalMetadataService.cs
+++ b/API/Services/Plus/ExternalMetadataService.cs
@@ -13,6 +13,7 @@ using API.Entities;
 using API.Entities.Enums;
 using API.Entities.Metadata;
 using API.Extensions;
+using API.Helpers;
 using AutoMapper;
 using Flurl.Http;
 using Hangfire;
@@ -76,6 +77,8 @@ public class ExternalMetadataService : IExternalMetadataService
         Ratings = ArraySegment<RatingDto>.Empty,
         Reviews = ArraySegment<UserReviewDto>.Empty
     };
+    // Allow 50 requests per 24 hours
+    private static readonly RateLimiter _rateLimiter = new RateLimiter(10, TimeSpan.FromMinutes(10), false);
 
     public ExternalMetadataService(IUnitOfWork unitOfWork, ILogger<ExternalMetadataService> logger, IMapper mapper, ILicenseService licenseService)
     {
@@ -83,7 +86,6 @@ public class ExternalMetadataService : IExternalMetadataService
         _logger = logger;
         _mapper = mapper;
         _licenseService = licenseService;
-
 
 
         FlurlHttp.ConfigureClient(Configuration.KavitaPlusApiUrl, cli =>
@@ -145,13 +147,31 @@ public class ExternalMetadataService : IExternalMetadataService
         await _unitOfWork.CommitAsync();
     }
 
-    [DisableConcurrentExecution(60 * 60 * 60)]
-    [AutomaticRetry(Attempts = 3, OnAttemptsExceeded = AttemptsExceededAction.Delete)]
-    public Task GetNewSeriesData(int seriesId, LibraryType libraryType)
+    /// <summary>
+    /// Fetches data from Kavita+
+    /// </summary>
+    /// <param name="seriesId"></param>
+    /// <param name="libraryType"></param>
+    public async Task GetNewSeriesData(int seriesId, LibraryType libraryType)
     {
-        // TODO: Implement this task
-        if (!IsPlusEligible(libraryType)) return Task.CompletedTask;
-        return Task.CompletedTask;
+        // TODO: I need this to only allow this to be called 50 times per 24 hours
+        if (!IsPlusEligible(libraryType)) return;
+
+        // Generate key based on seriesId and libraryType or any unique identifier for the request
+        // Check if the request is allowed based on the rate limit
+        if (!_rateLimiter.TryAcquire(string.Empty))
+        {
+            // Request not allowed due to rate limit
+            _logger.LogDebug("Rate Limit hit for Kavita+ prefetch");
+            return;
+        }
+
+        _logger.LogDebug("Prefetching Kavita+ data for Series {SeriesId}", seriesId);
+        // Prefetch SeriesDetail data
+        await GetSeriesDetailPlus(seriesId, libraryType);
+
+        // TODO: Fetch Series Metadata
+
     }
 
     /// <summary>

--- a/API/Services/Plus/ExternalMetadataService.cs
+++ b/API/Services/Plus/ExternalMetadataService.cs
@@ -78,7 +78,7 @@ public class ExternalMetadataService : IExternalMetadataService
         Reviews = ArraySegment<UserReviewDto>.Empty
     };
     // Allow 50 requests per 24 hours
-    private static readonly RateLimiter RateLimiter = new RateLimiter(10, TimeSpan.FromMinutes(10), false);
+    private static readonly RateLimiter RateLimiter = new RateLimiter(50, TimeSpan.FromHours(12), false);
 
     public ExternalMetadataService(IUnitOfWork unitOfWork, ILogger<ExternalMetadataService> logger, IMapper mapper, ILicenseService licenseService)
     {
@@ -122,7 +122,7 @@ public class ExternalMetadataService : IExternalMetadataService
         foreach (var seriesId in ids)
         {
             var libraryType = libTypes[seriesId];
-            await GetSeriesDetailPlus(seriesId, libraryType);
+            await GetNewSeriesData(seriesId, libraryType);
             await Task.Delay(1500);
             count++;
         }

--- a/API/Services/Plus/ExternalMetadataService.cs
+++ b/API/Services/Plus/ExternalMetadataService.cs
@@ -78,7 +78,7 @@ public class ExternalMetadataService : IExternalMetadataService
         Reviews = ArraySegment<UserReviewDto>.Empty
     };
     // Allow 50 requests per 24 hours
-    private static readonly RateLimiter _rateLimiter = new RateLimiter(10, TimeSpan.FromMinutes(10), false);
+    private static readonly RateLimiter RateLimiter = new RateLimiter(10, TimeSpan.FromMinutes(10), false);
 
     public ExternalMetadataService(IUnitOfWork unitOfWork, ILogger<ExternalMetadataService> logger, IMapper mapper, ILicenseService licenseService)
     {
@@ -154,12 +154,11 @@ public class ExternalMetadataService : IExternalMetadataService
     /// <param name="libraryType"></param>
     public async Task GetNewSeriesData(int seriesId, LibraryType libraryType)
     {
-        // TODO: I need this to only allow this to be called 50 times per 24 hours
         if (!IsPlusEligible(libraryType)) return;
 
         // Generate key based on seriesId and libraryType or any unique identifier for the request
         // Check if the request is allowed based on the rate limit
-        if (!_rateLimiter.TryAcquire(string.Empty))
+        if (!RateLimiter.TryAcquire(string.Empty))
         {
             // Request not allowed due to rate limit
             _logger.LogDebug("Rate Limit hit for Kavita+ prefetch");

--- a/API/Services/Plus/ExternalMetadataService.cs
+++ b/API/Services/Plus/ExternalMetadataService.cs
@@ -114,17 +114,17 @@ public class ExternalMetadataService : IExternalMetadataService
         var ids = await _unitOfWork.ExternalSeriesMetadataRepository.GetAllSeriesIdsWithoutMetadata(25);
         if (ids.Count == 0) return;
 
-        _logger.LogInformation("Started Refreshing {Count} series data from Kavita+", ids.Count);
+        _logger.LogInformation("[Kavita+ Data Refresh] Started Refreshing {Count} series data from Kavita+", ids.Count);
         var count = 0;
+        var libTypes = await _unitOfWork.LibraryRepository.GetLibraryTypesBySeriesIdsAsync(ids);
         foreach (var seriesId in ids)
         {
-            // TODO: Rewrite this so it's streamlined and not multiple DB calls
-            var libraryType = await _unitOfWork.LibraryRepository.GetLibraryTypeBySeriesIdAsync(seriesId);
+            var libraryType = libTypes[seriesId];
             await GetSeriesDetailPlus(seriesId, libraryType);
             await Task.Delay(1500);
             count++;
         }
-        _logger.LogInformation("Finished Refreshing {Count} series data from Kavita+", count);
+        _logger.LogInformation("[Kavita+ Data Refresh] Finished Refreshing {Count} series data from Kavita+", count);
     }
 
     /// <summary>

--- a/API/Services/TaskScheduler.cs
+++ b/API/Services/TaskScheduler.cs
@@ -182,10 +182,10 @@ public class TaskScheduler : ITaskScheduler
         RecurringJob.AddOrUpdate(ProcessProcessedScrobblingEventsId, () => _scrobblingService.ClearProcessedEvents(),
             Cron.Daily, RecurringJobOptions);
 
-        // Backfilling/Freshening Reviews/Rating/Recommendations (TODO: This will come in v0.8.x)
-        // RecurringJob.AddOrUpdate(KavitaPlusDataRefreshId,
-        //     () => _externalMetadataService.FetchExternalDataTask(), Cron.Hourly(Rnd.Next(0, 59)),
-        //     RecurringJobOptions);
+        // Backfilling/Freshening Reviews/Rating/Recommendations
+        RecurringJob.AddOrUpdate(KavitaPlusDataRefreshId,
+            () => _externalMetadataService.FetchExternalDataTask(), Cron.Daily(Rnd.Next(1, 4)),
+            RecurringJobOptions);
     }
 
     #region StatsTasks

--- a/Kavita.Common/Kavita.Common.csproj
+++ b/Kavita.Common/Kavita.Common.csproj
@@ -19,5 +19,6 @@
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
+      <PackageReference Include="xunit.assert" Version="2.6.6" />
     </ItemGroup>
 </Project>

--- a/Kavita.Common/Kavita.Common.csproj
+++ b/Kavita.Common/Kavita.Common.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net8.0</TargetFramework>
         <Company>kavitareader.com</Company>
         <Product>Kavita</Product>
-        <AssemblyVersion>0.8.0.1</AssemblyVersion>
+        <AssemblyVersion>0.7.14.1</AssemblyVersion>
         <NeutralLanguage>en</NeutralLanguage>
         <TieredPGO>true</TieredPGO>
     </PropertyGroup>

--- a/UI/Web/src/app/_services/action.service.ts
+++ b/UI/Web/src/app/_services/action.service.ts
@@ -552,11 +552,9 @@ export class ActionService implements OnDestroy {
   }
 
   /**
-   * Mark all chapters and the volumes as Read. All volumes and chapters must belong to a series
-   * @param seriesId Series Id
-   * @param volumes Volumes, should have id, chapters and pagesRead populated
-   * @param chapters? Chapters, should have id
-   * @param callback Optional callback to perform actions after API completes
+   * Deletes all series
+   * @param seriesIds - List of series
+   * @param callback - Optional callback once complete
    */
    async deleteMultipleSeries(seriesIds: Array<Series>, callback?: BooleanActionCallback) {
     if (!await this.confirmService.confirm(translate('toasts.confirm-delete-multiple-series', {count: seriesIds.length}))) {
@@ -565,11 +563,15 @@ export class ActionService implements OnDestroy {
       }
       return;
     }
-    this.seriesService.deleteMultipleSeries(seriesIds.map(s => s.id)).pipe(take(1)).subscribe(() => {
-      this.toastr.success(translate('toasts.series-deleted'));
+    this.seriesService.deleteMultipleSeries(seriesIds.map(s => s.id)).pipe(take(1)).subscribe(res => {
+      if (res) {
+        this.toastr.success(translate('toasts.series-deleted'));
+      } else {
+        this.toastr.error(translate('errors.generic'));
+      }
 
       if (callback) {
-        callback(true);
+        callback(res);
       }
     });
   }
@@ -584,7 +586,12 @@ export class ActionService implements OnDestroy {
 
     this.seriesService.delete(series.id).subscribe((res: boolean) => {
       if (callback) {
-        this.toastr.success(translate('toasts.series-deleted'));
+        if (res) {
+          this.toastr.success(translate('toasts.series-deleted'));
+        } else {
+          this.toastr.error(translate('errors.generic'));
+        }
+
         callback(res);
       }
     });

--- a/UI/Web/src/app/_services/series.service.ts
+++ b/UI/Web/src/app/_services/series.service.ts
@@ -80,11 +80,11 @@ export class SeriesService {
   }
 
   delete(seriesId: number) {
-    return this.httpClient.delete<boolean>(this.baseUrl + 'series/' + seriesId);
+    return this.httpClient.delete<string>(this.baseUrl + 'series/' + seriesId, TextResonse).pipe(map(s => s === "true"));
   }
 
   deleteMultipleSeries(seriesIds: Array<number>) {
-    return this.httpClient.post<boolean>(this.baseUrl + 'series/delete-multiple', {seriesIds});
+    return this.httpClient.post<string>(this.baseUrl + 'series/delete-multiple', {seriesIds}, TextResonse).pipe(map(s => s === "true"));
   }
 
   updateRating(seriesId: number, userRating: number) {

--- a/UI/Web/src/app/admin/manage-email-settings/manage-email-settings.component.ts
+++ b/UI/Web/src/app/admin/manage-email-settings/manage-email-settings.component.ts
@@ -15,8 +15,6 @@ import {NgForOf, NgIf, NgTemplateOutlet, TitleCasePipe} from '@angular/common';
 import {translate, TranslocoModule} from "@ngneat/transloco";
 import {SafeHtmlPipe} from "../../_pipes/safe-html.pipe";
 import {ManageAlertsComponent} from "../manage-alerts/manage-alerts.component";
-import {takeUntilDestroyed} from "@angular/core/rxjs-interop";
-import {filter} from "rxjs/operators";
 
 @Component({
     selector: 'app-manage-email-settings',

--- a/UI/Web/src/app/carousel/_components/carousel-reel/carousel-reel.component.html
+++ b/UI/Web/src/app/carousel/_components/carousel-reel/carousel-reel.component.html
@@ -8,8 +8,8 @@
           <i *ngIf="iconClasses !== ''" class="{{iconClasses}} title-icon ms-1" aria-hidden="true"></i>
         </h3>
         <div class="float-end" *ngIf="swiper">
-          <button class="btn btn-icon" [disabled]="swiper.isBeginning" (click)="prevPage()"><i class="fa fa-angle-left" aria-hidden="true"></i><span class="visually-hidden">{{t('prev-items')}}</span></button>
-          <button class="btn btn-icon" [disabled]="swiper.isEnd" (click)="nextPage()"><i class="fa fa-angle-right" aria-hidden="true"></i><span class="visually-hidden">{{t('next-items')}}</span></button>
+          <button class="btn btn-icon carousel-btn" [disabled]="swiper.isBeginning" (click)="prevPage()"><i class="fa fa-angle-left" aria-hidden="true"></i><span class="visually-hidden">{{t('prev-items')}}</span></button>
+          <button class="btn btn-icon carousel-btn" [disabled]="swiper.isEnd" (click)="nextPage()"><i class="fa fa-angle-right" aria-hidden="true"></i><span class="visually-hidden">{{t('next-items')}}</span></button>
         </div>
       </div>
       @if (items.length > 0) {

--- a/UI/Web/src/app/carousel/_components/carousel-reel/carousel-reel.component.scss
+++ b/UI/Web/src/app/carousel/_components/carousel-reel/carousel-reel.component.scss
@@ -21,6 +21,10 @@
     .non-selectable {
         cursor: default;
     }
+
+  .carousel-btn > i {
+    color: var(--carousel-btn-color);
+  }
 }
 
 

--- a/UI/Web/src/app/series-detail/_components/external-rating/external-rating.component.scss
+++ b/UI/Web/src/app/series-detail/_components/external-rating/external-rating.component.scss
@@ -3,11 +3,15 @@
     padding-right: 0px;
 }
 
+.badge {
+  color: var(--badge-text-color);
+}
+
 .sm-popover {
   width: 150px;
 
   > .popover-body {
-    padding-top: 0px;
+    padding-top: 10px;
   }
 }
 
@@ -15,7 +19,7 @@
   width: 214px;
 
   > .popover-body {
-    padding-top: 0px;
+    padding-top: 10px;
   }
 }
 
@@ -23,7 +27,7 @@
   width: 320px;
 
   > .popover-body {
-    padding-top: 0px;
+    padding-top: 10px;
   }
 }
 

--- a/UI/Web/src/app/shared/_services/download.service.ts
+++ b/UI/Web/src/app/shared/_services/download.service.ts
@@ -12,7 +12,7 @@ import {
   tap,
   finalize,
   of,
-  filter, Subject,
+  filter,
 } from 'rxjs';
 import { download, Download } from '../_models/download';
 import { PageBookmark } from 'src/app/_models/readers/page-bookmark';
@@ -71,6 +71,10 @@ export class DownloadService {
    * Size in bytes in which to inform the user for confirmation before download starts. Defaults to 100 MB.
    */
   public SIZE_WARNING = 104_857_600;
+  /**
+   * Sie in bytes in which to inform the user that anything above may fail on iOS due to device limits. (200MB)
+   */
+  private IOS_SIZE_WARNING = 209_715_200;
 
   private downloadsSource: BehaviorSubject<DownloadEvent[]> = new BehaviorSubject<DownloadEvent[]>([]);
   /**
@@ -290,41 +294,18 @@ export class DownloadService {
 
   private downloadChapter(chapter: Chapter) {
     return this.downloadEntity(chapter);
-
-    // const downloadType = 'chapter';
-    // const subtitle = this.downloadSubtitle(downloadType, chapter);
-    // return this.httpClient.get(this.baseUrl + 'download/chapter?chapterId=' + chapter.id,
-    //             {observe: 'events', responseType: 'blob', reportProgress: true}
-    //     ).pipe(
-    //       throttleTime(DEBOUNCE_TIME, asyncScheduler, { leading: true, trailing: true }),
-    //       download((blob, filename) => {
-    //         this.save(blob, decodeURIComponent(filename));
-    //       }),
-    //       tap((d) => this.updateDownloadState(d, downloadType, subtitle, chapter.id)),
-    //       finalize(() => this.finalizeDownloadState(downloadType, subtitle))
-    //     );
   }
 
   private downloadVolume(volume: Volume) {
     return this.downloadEntity(volume);
-    // const downloadType = 'volume';
-    // const subtitle = this.downloadSubtitle(downloadType, volume);
-    // return this.httpClient.get(this.baseUrl + 'download/volume?volumeId=' + volume.id,
-    //                   {observe: 'events', responseType: 'blob', reportProgress: true}
-    //         ).pipe(
-    //           throttleTime(DEBOUNCE_TIME, asyncScheduler, { leading: true, trailing: true }),
-    //           download((blob, filename) => {
-    //             this.save(blob, decodeURIComponent(filename));
-    //           }),
-    //           tap((d) => this.updateDownloadState(d, downloadType, subtitle, volume.id)),
-    //           finalize(() => this.finalizeDownloadState(downloadType, subtitle))
-    //         );
   }
 
   private async confirmSize(size: number, entityType: DownloadEntityType) {
+    const showIosWarning = size > this.IOS_SIZE_WARNING && /iPad|iPhone|iPod/.test(navigator.userAgent);
     return (size < this.SIZE_WARNING ||
       await this.confirmService.confirm(translate('toasts.confirm-download-size',
-        {entityType: translate('entity-type.' + entityType), size: bytesPipe.transform(size)})));
+        {entityType: translate('entity-type.' + entityType), size: bytesPipe.transform(size)})
+      + (!showIosWarning ? '' : '<br/><br/>' + translate('toasts.confirm-download-size-ios'))));
   }
 
   private downloadBookmarks(bookmarks: PageBookmark[]) {

--- a/UI/Web/src/app/sidenav/_components/side-nav-item/side-nav-item.component.scss
+++ b/UI/Web/src/app/sidenav/_components/side-nav-item/side-nav-item.component.scss
@@ -100,7 +100,7 @@
 
 a {
     text-decoration: none;
-    color: var(--side-nav-color);
+    color: var(--side-nav-text-color);
 }
 
 @media (max-width: 576px) {

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -2060,6 +2060,7 @@
         "confirm-library-delete": "Are you sure you want to delete the {{name}} library? You cannot undo this action.",
         "confirm-library-type-change": "Changing library type will trigger a new scan with different parsing rules and may lead to series being re-created and hence you may loose progress and bookmarks. You should backup before you do this. Are you sure you want to continue?",
         "confirm-download-size": "The {{entityType}} is {{size}}. Are you sure you want to continue?",
+        "confirm-download-size-ios": "Warning! The file may not download on your iOS device. iOS has arbitrary limits past 200MB.",
         "list-doesnt-exist": "This list doesn't exist",
         "confirm-delete-smart-filter": "Are you sure you want to delete this Smart Filter?",
         "smart-filter-deleted": "Smart Filter Deleted",

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -2060,7 +2060,7 @@
         "confirm-library-delete": "Are you sure you want to delete the {{name}} library? You cannot undo this action.",
         "confirm-library-type-change": "Changing library type will trigger a new scan with different parsing rules and may lead to series being re-created and hence you may loose progress and bookmarks. You should backup before you do this. Are you sure you want to continue?",
         "confirm-download-size": "The {{entityType}} is {{size}}. Are you sure you want to continue?",
-        "confirm-download-size-ios": "Warning! The file may not download on your iOS device. iOS has arbitrary limits past 200MB.",
+        "confirm-download-size-ios": "iOS has issues downloading files that are larger than 200MB, this download might not complete.",
         "list-doesnt-exist": "This list doesn't exist",
         "confirm-delete-smart-filter": "Are you sure you want to delete this Smart Filter?",
         "smart-filter-deleted": "Smart Filter Deleted",

--- a/UI/Web/src/theme/themes/dark.scss
+++ b/UI/Web/src/theme/themes/dark.scss
@@ -110,7 +110,7 @@
     --side-nav-mobile-box-shadow: 3px 0em 5px 10em rgb(0 0 0 / 50%);
     --side-nav-hover-text-color: white;
     --side-nav-hover-bg-color: black;
-    --side-nav-color: white;
+    --side-nav-text-color: white;
     --side-nav-border-radius: 5px;
     --side-nav-border: none;
     --side-nav-border-closed: none;
@@ -228,6 +228,7 @@
     --carousel-header-text-color: var(--body-text-color);
     --carousel-header-text-decoration: none;
     --carousel-hover-header-text-decoration: none;
+    --carousel-btn-color: var(--body-text-color);
 
     /** Drawer */
     --drawer-bg-color: #292929;
@@ -259,4 +260,7 @@
     /** Rating Star Color **/
     --rating-star-color: var(--primary-color);
 
-  }
+    /** Badge **/
+    --badge-text-color: var(--bs-badge-color);
+
+}

--- a/UI/Web/src/theme/themes/e-ink.scss
+++ b/UI/Web/src/theme/themes/e-ink.scss
@@ -72,7 +72,7 @@
   --side-nav-mobile-box-shadow: 3px 0em 5px 10em rgb(0 0 0 / 50%);
   --side-nav-hover-text-color: white;
   --side-nav-hover-bg-color: black;
-  --side-nav-color: black;
+  --side-nav-text-color: black;
   --side-nav-border-radius: 5px;
   --side-nav-border: none;
   --side-nav-border-closed: none;

--- a/UI/Web/src/theme/themes/light.scss
+++ b/UI/Web/src/theme/themes/light.scss
@@ -10,7 +10,7 @@
     --body-text-color: #efefef;
     --btn-icon-filter: invert(1) grayscale(100%) brightness(200%);
     --primary-color-scrollbar: rgba(74,198,148,0.75);
-    
+
 
     /* Navbar */
     --navbar-bg-color: black;
@@ -100,7 +100,7 @@
     --side-nav-mobile-box-shadow: 3px 0em 5px 10em rgb(0 0 0 / 50%);
     --side-nav-hover-text-color: white;
     --side-nav-hover-bg-color: black;
-    --side-nav-color: white;
+    --side-nav-text-color: white;
     --side-nav-border-radius: 5px;
     --side-nav-border: none;
     --side-nav-border-closed: none;

--- a/openapi.json
+++ b/openapi.json
@@ -8001,10 +8001,12 @@
         "tags": [
           "Series"
         ],
+        "summary": "Deletes a series from Kavita",
         "parameters": [
           {
             "name": "seriesId",
             "in": "path",
+            "description": "",
             "required": true,
             "schema": {
               "type": "integer",
@@ -14982,9 +14984,6 @@
             "description": "When null, represents an external series. When set, it is a Series",
             "format": "int32",
             "nullable": true
-          },
-          "series": {
-            "$ref": "#/components/schemas/Series"
           },
           "externalSeriesMetadatas": {
             "type": "array",

--- a/openapi.json
+++ b/openapi.json
@@ -7,7 +7,7 @@
       "name": "GPL-3.0",
       "url": "https://github.com/Kareadita/Kavita/blob/develop/LICENSE"
     },
-    "version": "0.8.0.0"
+    "version": "0.8.0.1"
   },
   "servers": [
     {

--- a/openapi.json
+++ b/openapi.json
@@ -7,7 +7,7 @@
       "name": "GPL-3.0",
       "url": "https://github.com/Kareadita/Kavita/blob/develop/LICENSE"
     },
-    "version": "0.8.0.1"
+    "version": "0.7.14.1"
   },
   "servers": [
     {


### PR DESCRIPTION
Note that I bumped the release wrong for the first nightly. I will be removing that individual nightly from the docker repository. 

# Added
- Added: (Kavita+) Implemented a background prefetch task that will slowly refresh series from Kavita+ (reviews, recs, ratings). 
- Added: (Kavita+) Kavita will now prefetch data from Kavita+ on new series. This and the prefetch background task is limited to 50 series per 12 hours. Loading on-demand will still work as normal and is not restricted. 

# Changed
- Changed: Allow users to send files to their devices without having host name set for Email settings
- Changed: (Theme) side-nav-color is now side-nav-text-color
- Changed: (Theme) Added carousel-btn-color (for carousel buttons) and badge-text-color (for badge text)
- Changed: The release number has been corrected back to 0.7.14.x. The 0.8.0.x bump happens after the stable.
- Changed: When iOS users are trying to download files greater than 200MB, they will be given an additional warning that iOS may fail to download due to arbitrary limits each device has. 

# Fixed
- Fixed: Fixed an issue around being able to delete series with external recommendations. 
- Fixed: Fixed up the delete series flow so that the boolean returned is used in the UI to pop the correct toaster.
