### PR TITLE
[epub] Fix turning to page when there's a <link> with no href

### DIFF
--- a/API/Services/BookService.cs
+++ b/API/Services/BookService.cs
@@ -382,7 +382,7 @@ public class BookService : IBookService
             }
         }
 
-        var styleNodes = doc.DocumentNode.SelectNodes("/html/head/link");
+        var styleNodes = doc.DocumentNode.SelectNodes("/html/head/link[@href]");
         if (styleNodes != null)
         {
             foreach (var styleLinks in styleNodes)


### PR DESCRIPTION
# Fixed
- Fixed: Fixed error 'Could not find the appropriate html for that page' when opening a page whose html contains a <link> with no `href` attribute (Fixes #2759)
