### PR TITLE
Scanner Tech Debt

### DIFF
--- a/API.Tests/Helpers/GenreHelperTests.cs
+++ b/API.Tests/Helpers/GenreHelperTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using API.Data;
 using API.Entities;
+using API.Extensions;
 using API.Helpers;
 using API.Helpers.Builders;
 using Xunit;
@@ -12,42 +13,51 @@ public class GenreHelperTests
     [Fact]
     public void UpdateGenre_ShouldAddNewGenre()
     {
-        var allGenres = new List<Genre>
+        var allGenres = new Dictionary<string, Genre>
         {
-            new GenreBuilder("Action").Build(),
-            new GenreBuilder("action").Build(),
-            new GenreBuilder("Sci-fi").Build(),
+            {"Action".ToNormalized(), new GenreBuilder("Action").Build()},
+            {"Sci-fi".ToNormalized(), new GenreBuilder("Sci-fi").Build()}
         };
         var genreAdded = new List<Genre>();
+        var addedCount = 0;
 
-        GenreHelper.UpdateGenre(allGenres, new[] {"Action", "Adventure"}, genre =>
+        GenreHelper.UpdateGenre(allGenres, new[] {"Action", "Adventure"}, (genre, isNew) =>
         {
+            if (isNew)
+            {
+                addedCount++;
+            }
             genreAdded.Add(genre);
         });
 
         Assert.Equal(2, genreAdded.Count);
-        Assert.Equal(4, allGenres.Count);
+        Assert.Equal(1, addedCount);
+        Assert.Equal(3, allGenres.Count);
     }
 
     [Fact]
     public void UpdateGenre_ShouldNotAddDuplicateGenre()
     {
-        var allGenres = new List<Genre>
+        var allGenres = new Dictionary<string, Genre>
         {
-            new GenreBuilder("Action").Build(),
-            new GenreBuilder("action").Build(),
-            new GenreBuilder("Sci-fi").Build(),
-
+            {"Action".ToNormalized(), new GenreBuilder("Action").Build()},
+            {"Sci-fi".ToNormalized(), new GenreBuilder("Sci-fi").Build()}
         };
         var genreAdded = new List<Genre>();
+        var addedCount = 0;
 
-        GenreHelper.UpdateGenre(allGenres, new[] {"Action", "Scifi"}, genre =>
+        GenreHelper.UpdateGenre(allGenres, new[] {"Action", "Scifi"}, (genre, isNew) =>
         {
+            if (isNew)
+            {
+                addedCount++;
+            }
             genreAdded.Add(genre);
         });
 
-        Assert.Equal(3, allGenres.Count);
+        Assert.Equal(0, addedCount);
         Assert.Equal(2, genreAdded.Count);
+        Assert.Equal(2, allGenres.Count);
     }
 
     [Fact]

--- a/API.Tests/Helpers/TagHelperTests.cs
+++ b/API.Tests/Helpers/TagHelperTests.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using API.Data;
 using API.Entities;
+using API.Extensions;
 using API.Helpers;
 using API.Helpers.Builders;
 using Xunit;
@@ -12,50 +14,50 @@ public class TagHelperTests
     [Fact]
     public void UpdateTag_ShouldAddNewTag()
     {
-        var allTags = new List<Tag>
+        var allTags = new Dictionary<string, Tag>
         {
-            new TagBuilder("Action").Build(),
-            new TagBuilder("action").Build(),
-            new TagBuilder("Sci-fi").Build(),
+            {"Action".ToNormalized(), new TagBuilder("Action").Build()},
+            {"Sci-fi".ToNormalized(), new TagBuilder("Sci-fi").Build()}
         };
-        var tagAdded = new List<Tag>();
+        var tagCalled = new List<Tag>();
+        var addedCount = 0;
 
         TagHelper.UpdateTag(allTags, new[] {"Action", "Adventure"}, (tag, added) =>
         {
             if (added)
             {
-                tagAdded.Add(tag);
+                addedCount++;
             }
-
+            tagCalled.Add(tag);
         });
 
-        Assert.Single(tagAdded);
-        Assert.Equal(4, allTags.Count);
+        Assert.Equal(1, addedCount);
+        Assert.Equal(2, tagCalled.Count());
+        Assert.Equal(3, allTags.Count);
     }
 
     [Fact]
     public void UpdateTag_ShouldNotAddDuplicateTag()
     {
-        var allTags = new List<Tag>
+        var allTags = new Dictionary<string, Tag>
         {
-            new TagBuilder("Action").Build(),
-            new TagBuilder("action").Build(),
-            new TagBuilder("Sci-fi").Build(),
-
+            {"Action".ToNormalized(), new TagBuilder("Action").Build()},
+            {"Sci-fi".ToNormalized(), new TagBuilder("Sci-fi").Build()}
         };
-        var tagAdded = new List<Tag>();
+        var tagCalled = new List<Tag>();
+        var addedCount = 0;
 
         TagHelper.UpdateTag(allTags, new[] {"Action", "Scifi"}, (tag, added) =>
         {
             if (added)
             {
-                tagAdded.Add(tag);
+                addedCount++;
             }
-            TagHelper.AddTagIfNotExists(allTags, tag);
+            tagCalled.Add(tag);
         });
 
-        Assert.Equal(3, allTags.Count);
-        Assert.Empty(tagAdded);
+        Assert.Equal(2, allTags.Count);
+        Assert.Equal(0, addedCount);
     }
 
     [Fact]

--- a/API.Tests/Services/ParseScannedFilesTests.cs
+++ b/API.Tests/Services/ParseScannedFilesTests.cs
@@ -65,6 +65,7 @@ internal class MockReadingItemService : IReadingItemService
     }
 }
 
+// TODO: Move this to an AbstractDbTest
 public class ParseScannedFilesTests
 {
     private readonly ILogger<ParseScannedFiles> _logger = Substitute.For<ILogger<ParseScannedFiles>>();

--- a/API/Controllers/LicenseController.cs
+++ b/API/Controllers/LicenseController.cs
@@ -32,7 +32,11 @@ public class LicenseController(
     public async Task<ActionResult<bool>> HasValidLicense(bool forceCheck = false)
     {
         var result = await licenseService.HasActiveLicense(forceCheck);
-        await taskScheduler.ScheduleKavitaPlusTasks();
+        if (result)
+        {
+            await taskScheduler.ScheduleKavitaPlusTasks();
+        }
+
         return Ok(result);
     }
 

--- a/API/Data/Metadata/ComicInfo.cs
+++ b/API/Data/Metadata/ComicInfo.cs
@@ -177,7 +177,12 @@ public class ComicInfo
 
         if (!string.IsNullOrEmpty(info.Number))
         {
-            info.Number = info.Number.Replace(",", "."); // Corrective measure for non English OSes
+            info.Number = info.Number.Trim().Replace(",", "."); // Corrective measure for non English OSes
+        }
+
+        if (!string.IsNullOrEmpty(info.Volume))
+        {
+            info.Volume = info.Volume.Trim();
         }
     }
 

--- a/API/Data/Repositories/ExternalSeriesMetadataRepository.cs
+++ b/API/Data/Repositories/ExternalSeriesMetadataRepository.cs
@@ -34,6 +34,7 @@ public interface IExternalSeriesMetadataRepository
     Task<bool> ExternalSeriesMetadataNeedsRefresh(int seriesId);
     Task<SeriesDetailPlusDto> GetSeriesDetailPlusDto(int seriesId);
     Task LinkRecommendationsToSeries(Series series);
+    Task LinkRecommendationsToSeries(int seriesId);
     Task<bool> IsBlacklistedSeries(int seriesId);
     Task CreateBlacklistedSeries(int seriesId, bool saveChanges = true);
     Task RemoveFromBlacklist(int seriesId);
@@ -177,6 +178,13 @@ public class ExternalSeriesMetadataRepository : IExternalSeriesMetadataRepositor
         };
 
         return seriesDetailPlusDto;
+    }
+
+    public async Task LinkRecommendationsToSeries(int seriesId)
+    {
+        var series = await _context.Series.Where(s => s.Id == seriesId).AsNoTracking().SingleOrDefaultAsync();
+        if (series == null) return;
+        await LinkRecommendationsToSeries(series);
     }
 
     /// <summary>

--- a/API/Entities/Series.cs
+++ b/API/Entities/Series.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using API.Entities.Enums;
 using API.Entities.Interfaces;
 using API.Entities.Metadata;
+using API.Services.Tasks.Scanner.Parser;
 
 namespace API.Entities;
 

--- a/API/Extensions/ApplicationServiceExtensions.cs
+++ b/API/Extensions/ApplicationServiceExtensions.cs
@@ -60,6 +60,7 @@ public static class ApplicationServiceExtensions
         services.AddScoped<ILibraryWatcher, LibraryWatcher>();
         services.AddScoped<ITachiyomiService, TachiyomiService>();
         services.AddScoped<ICollectionTagService, CollectionTagService>();
+        services.AddScoped<ITagManagerService, TagManagerService>();
 
         services.AddScoped<IFileSystem, FileSystem>();
         services.AddScoped<IDirectoryService, DirectoryService>();

--- a/API/Helpers/GenreHelper.cs
+++ b/API/Helpers/GenreHelper.cs
@@ -67,6 +67,7 @@ public static class GenreHelper
     public static void UpdateGenreList(ICollection<GenreTagDto>? tags, Series series,
         IReadOnlyCollection<Genre> allTags, Action<Genre> handleAdd, Action onModified)
     {
+        // TODO: Write some unit tests
         if (tags == null) return;
         var isModified = false;
         // I want a union of these 2 lists. Return only elements that are in both lists, but the list types are different

--- a/API/Helpers/GenreHelper.cs
+++ b/API/Helpers/GenreHelper.cs
@@ -12,24 +12,27 @@ namespace API.Helpers;
 
 public static class GenreHelper
 {
-    public static void UpdateGenre(ICollection<Genre> allGenres, IEnumerable<string> names, Action<Genre> action)
+
+    public static void UpdateGenre(Dictionary<string, Genre> allGenres,
+        IEnumerable<string> names, Action<Genre, bool> action)
     {
         foreach (var name in names)
         {
             var normalizedName = name.ToNormalized();
             if (string.IsNullOrEmpty(normalizedName)) continue;
 
-            var genre = allGenres.FirstOrDefault(p => p.NormalizedTitle != null && p.NormalizedTitle.Equals(normalizedName));
-            if (genre == null)
+            if (allGenres.TryGetValue(normalizedName, out var genre))
+            {
+                action(genre, false);
+            }
+            else
             {
                 genre = new GenreBuilder(name).Build();
-                allGenres.Add(genre);
+                allGenres.Add(normalizedName, genre);
+                action(genre, true);
             }
-
-            action(genre);
         }
     }
-
 
     public static void KeepOnlySameGenreBetweenLists(ICollection<Genre> existingGenres, ICollection<Genre> removeAllExcept, Action<Genre>? action = null)
     {

--- a/API/Helpers/GenreHelper.cs
+++ b/API/Helpers/GenreHelper.cs
@@ -16,9 +16,9 @@ public static class GenreHelper
     {
         foreach (var name in names)
         {
-            if (string.IsNullOrEmpty(name.Trim())) continue;
-
             var normalizedName = name.ToNormalized();
+            if (string.IsNullOrEmpty(normalizedName)) continue;
+
             var genre = allGenres.FirstOrDefault(p => p.NormalizedTitle != null && p.NormalizedTitle.Equals(normalizedName));
             if (genre == null)
             {

--- a/API/Helpers/PersonHelper.cs
+++ b/API/Helpers/PersonHelper.cs
@@ -12,6 +12,7 @@ namespace API.Helpers;
 
 public static class PersonHelper
 {
+
     /// <summary>
     /// Given a list of all existing people, this will check the new names and roles and if it doesn't exist in allPeople, will create and
     /// add an entry. For each person in name, the callback will be executed.
@@ -24,7 +25,6 @@ public static class PersonHelper
     /// <param name="action"></param>
     public static void UpdatePeople(ICollection<Person> allPeople, IEnumerable<string> names, PersonRole role, Action<Person> action)
     {
-        // TODO: Validate if we need this, not used
         var allPeopleTypeRole = allPeople.Where(p => p.Role == role).ToList();
 
         foreach (var name in names)

--- a/API/Helpers/TagHelper.cs
+++ b/API/Helpers/TagHelper.cs
@@ -21,6 +21,7 @@ public static class TagHelper
     /// <param name="action">Callback for every item. Will give said item back and a bool if item was added</param>
     public static void UpdateTag(ICollection<Tag> allTags, IEnumerable<string> names, Action<Tag, bool> action)
     {
+
         foreach (var name in names)
         {
             if (string.IsNullOrEmpty(name.Trim())) continue;
@@ -28,16 +29,16 @@ public static class TagHelper
             var added = false;
             var normalizedName = name.ToNormalized();
 
-            var genre = allTags.FirstOrDefault(p =>
+            var tag = allTags.FirstOrDefault(p =>
                 p.NormalizedTitle.Equals(normalizedName));
-            if (genre == null)
+            if (tag == null)
             {
                 added = true;
-                genre = new TagBuilder(name).Build();
-                allTags.Add(genre);
+                tag = new TagBuilder(name).Build();
+                allTags.Add(tag);
             }
 
-            action(genre, added);
+            action(tag, added);
         }
     }
 

--- a/API/Helpers/TagHelper.cs
+++ b/API/Helpers/TagHelper.cs
@@ -1,41 +1,34 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using API.Data;
 using API.DTOs.Metadata;
 using API.Entities;
 using API.Extensions;
 using API.Helpers.Builders;
+using API.Services.Tasks.Scanner.Parser;
 
 namespace API.Helpers;
 #nullable enable
 
 public static class TagHelper
 {
-    /// <summary>
-    ///
-    /// </summary>
-    /// <param name="allTags"></param>
-    /// <param name="names"></param>
-    /// <param name="action">Callback for every item. Will give said item back and a bool if item was added</param>
-    public static void UpdateTag(ICollection<Tag> allTags, IEnumerable<string> names, Action<Tag, bool> action)
+    public static void UpdateTag(Dictionary<string, Tag> allTags, IEnumerable<string> names, Action<Tag, bool> action)
     {
-
         foreach (var name in names)
         {
             if (string.IsNullOrEmpty(name.Trim())) continue;
 
-            var added = false;
             var normalizedName = name.ToNormalized();
+            allTags.TryGetValue(normalizedName, out var tag);
 
-            var tag = allTags.FirstOrDefault(p =>
-                p.NormalizedTitle.Equals(normalizedName));
+            var added = tag == null;
             if (tag == null)
             {
-                added = true;
                 tag = new TagBuilder(name).Build();
-                allTags.Add(tag);
+                allTags.Add(normalizedName, tag);
             }
 
             action(tag, added);
@@ -79,6 +72,22 @@ public static class TagHelper
             metadataTags.Add(tag);
         }
     }
+
+    public static IList<string> GetTagValues(string comicInfoTagSeparatedByComma)
+    {
+        // TODO: Unit tests needed
+        if (string.IsNullOrEmpty(comicInfoTagSeparatedByComma))
+        {
+            return ImmutableList<string>.Empty;
+        }
+
+        return comicInfoTagSeparatedByComma.Split(",")
+            .Select(s => s.Trim())
+            .DistinctBy(Parser.Normalize)
+            .ToList();
+    }
+
+
 
     /// <summary>
     /// Remove tags on a list

--- a/API/Services/Plus/ExternalMetadataService.cs
+++ b/API/Services/Plus/ExternalMetadataService.cs
@@ -162,7 +162,7 @@ public class ExternalMetadataService : IExternalMetadataService
         if (!RateLimiter.TryAcquire(string.Empty))
         {
             // Request not allowed due to rate limit
-            _logger.LogDebug("Rate Limit hit for Kavita+ prefetch"); // TODO: This will call even if we don't have a license.
+            _logger.LogDebug("Rate Limit hit for Kavita+ prefetch");
             return;
         }
 

--- a/API/Services/Plus/ExternalMetadataService.cs
+++ b/API/Services/Plus/ExternalMetadataService.cs
@@ -155,13 +155,14 @@ public class ExternalMetadataService : IExternalMetadataService
     public async Task GetNewSeriesData(int seriesId, LibraryType libraryType)
     {
         if (!IsPlusEligible(libraryType)) return;
+        if (!await _licenseService.HasActiveLicense()) return;
 
         // Generate key based on seriesId and libraryType or any unique identifier for the request
         // Check if the request is allowed based on the rate limit
         if (!RateLimiter.TryAcquire(string.Empty))
         {
             // Request not allowed due to rate limit
-            _logger.LogDebug("Rate Limit hit for Kavita+ prefetch");
+            _logger.LogDebug("Rate Limit hit for Kavita+ prefetch"); // TODO: This will call even if we don't have a license.
             return;
         }
 

--- a/API/Services/Plus/ExternalMetadataService.cs
+++ b/API/Services/Plus/ExternalMetadataService.cs
@@ -70,7 +70,7 @@ public class ExternalMetadataService : IExternalMetadataService
     private readonly IMapper _mapper;
     private readonly ILicenseService _licenseService;
     private readonly TimeSpan _externalSeriesMetadataCache = TimeSpan.FromDays(30);
-    public static readonly ImmutableArray<LibraryType> NonEligibleLibraryTypes = ImmutableArray.Create<LibraryType>(LibraryType.Comic, LibraryType.Book);
+    public static readonly ImmutableArray<LibraryType> NonEligibleLibraryTypes = ImmutableArray.Create<LibraryType>(LibraryType.Comic, LibraryType.Book, LibraryType.Image, LibraryType.ComicVine);
     private readonly SeriesDetailPlusDto _defaultReturn = new()
     {
         Recommendations = null,

--- a/API/Services/ReadingListService.cs
+++ b/API/Services/ReadingListService.cs
@@ -46,6 +46,8 @@ public interface IReadingListService
     /// <param name="library"></param>
     /// <returns></returns>
     Task CreateReadingListsFromSeries(Series series, Library library);
+
+    Task CreateReadingListsFromSeries(int libraryId, int seriesId);
 }
 
 /// <summary>
@@ -405,6 +407,20 @@ public class ReadingListService : IReadingListService
         await CalculateReadingListAgeRating(readingList, new []{ seriesId });
 
         return index > lastOrder + 1;
+    }
+
+    /// <summary>
+    /// Create Reading lists from a Series
+    /// </summary>
+    /// <remarks>Execute this from Hangfire</remarks>
+    /// <param name="libraryId"></param>
+    /// <param name="seriesId"></param>
+    public async Task CreateReadingListsFromSeries(int libraryId, int seriesId)
+    {
+        var series = await _unitOfWork.SeriesRepository.GetFullSeriesForSeriesIdAsync(seriesId);
+        var library = await _unitOfWork.LibraryRepository.GetLibraryForIdAsync(libraryId);
+        if (series == null || library == null) return;
+        await CreateReadingListsFromSeries(series, library);
     }
 
     public async Task CreateReadingListsFromSeries(Series series, Library library)

--- a/API/Services/TaskScheduler.cs
+++ b/API/Services/TaskScheduler.cs
@@ -334,7 +334,7 @@ public class TaskScheduler : ITaskScheduler
         }
 
         _logger.LogInformation("Enqueuing library scan for: {LibraryId}", libraryId);
-        BackgroundJob.Enqueue(() => _scannerService.ScanLibrary(libraryId, force));
+        BackgroundJob.Enqueue(() => _scannerService.ScanLibrary(libraryId, force, true));
         // When we do a scan, force cache to re-unpack in case page numbers change
         BackgroundJob.Enqueue(() => _cleanupService.CleanupCacheAndTempDirectories());
     }
@@ -428,8 +428,14 @@ public class TaskScheduler : ITaskScheduler
     public static bool HasScanTaskRunningForLibrary(int libraryId, bool checkRunningJobs = true)
     {
         return
-            HasAlreadyEnqueuedTask(ScannerService.Name, "ScanLibrary", new object[] {libraryId, true}, ScanQueue, checkRunningJobs) ||
-            HasAlreadyEnqueuedTask(ScannerService.Name, "ScanLibrary", new object[] {libraryId, false}, ScanQueue, checkRunningJobs);
+            HasAlreadyEnqueuedTask(ScannerService.Name, "ScanLibrary", new object[] {libraryId, true, true}, ScanQueue,
+                checkRunningJobs) ||
+            HasAlreadyEnqueuedTask(ScannerService.Name, "ScanLibrary", new object[] {libraryId, false, true}, ScanQueue,
+                checkRunningJobs) ||
+            HasAlreadyEnqueuedTask(ScannerService.Name, "ScanLibrary", new object[] {libraryId, true, false}, ScanQueue,
+                checkRunningJobs) ||
+            HasAlreadyEnqueuedTask(ScannerService.Name, "ScanLibrary", new object[] {libraryId, false, false}, ScanQueue,
+                checkRunningJobs);
     }
 
     /// <summary>

--- a/API/Services/TaskScheduler.cs
+++ b/API/Services/TaskScheduler.cs
@@ -386,7 +386,7 @@ public class TaskScheduler : ITaskScheduler
         }
         if (RunningAnyTasksByMethod(ScanTasks, ScanQueue))
         {
-            // BUG: This can end up triggering a ton of scan series calls
+            // BUG: This can end up triggering a ton of scan series calls (but i haven't seen in practice)
             _logger.LogInformation("A Scan is already running, rescheduling ScanSeries in 10 minutes");
             BackgroundJob.Schedule(() => ScanSeries(libraryId, seriesId, forceUpdate), TimeSpan.FromMinutes(10));
             return;

--- a/API/Services/TaskScheduler.cs
+++ b/API/Services/TaskScheduler.cs
@@ -328,7 +328,7 @@ public class TaskScheduler : ITaskScheduler
         }
         if (RunningAnyTasksByMethod(ScanTasks, ScanQueue))
         {
-            _logger.LogInformation("A Library Scan is already running, rescheduling ScanLibrary in 3 hours");
+            _logger.LogInformation("A Scan is already running, rescheduling ScanLibrary in 3 hours");
             BackgroundJob.Schedule(() => ScanLibrary(libraryId, force), TimeSpan.FromHours(3));
             return;
         }

--- a/API/Services/Tasks/Scanner/ParseScannedFiles.cs
+++ b/API/Services/Tasks/Scanner/ParseScannedFiles.cs
@@ -341,9 +341,6 @@ public class ParseScannedFiles
                         }
                     }
 
-                    // I think we can do a bit of work here and streamline this to still use scanResult
-                    //var processedSeries = new List<ScanResult>(); // NOTE: I need to figure out if I do this in the nested loop or bring it out
-
                     foreach (var series in scannedSeries.Keys)
                     {
                         if (scannedSeries[series].Count <= 0) continue;

--- a/API/Services/Tasks/Scanner/ParseScannedFiles.cs
+++ b/API/Services/Tasks/Scanner/ParseScannedFiles.cs
@@ -300,12 +300,11 @@ public class ParseScannedFiles
     /// <param name="folders"></param>
     /// <param name="isLibraryScan">If true, does a directory scan first (resulting in folders being tackled in parallel), else does an immediate scan files</param>
     /// <param name="seriesPaths">A map of Series names -> existing folder paths to handle skipping folders</param>
-    /// <param name="processSeriesInfos">Action which returns if the folder was skipped and the infos from said folder</param>
     /// <param name="forceCheck">Defaults to false</param>
     /// <returns></returns>
     public async Task<IList<ScannedSeriesResult>> ScanLibrariesForSeries(Library library,
         IEnumerable<string> folders, bool isLibraryScan,
-        IDictionary<string, IList<SeriesModified>> seriesPaths, Func<Tuple<bool, IList<ParserInfo>>, Task>? processSeriesInfos, bool forceCheck = false)
+        IDictionary<string, IList<SeriesModified>> seriesPaths, bool forceCheck = false)
     {
         await _eventHub.SendMessageAsync(MessageFactory.NotificationProgress, MessageFactory.FileScanProgressEvent("File Scan Starting", library.Name, ProgressEventType.Started));
 
@@ -347,13 +346,10 @@ public class ParseScannedFiles
 
                     foreach (var series in scannedSeries.Keys)
                     {
-                        if (scannedSeries[series].Count <= 0 || processSeriesInfos == null) continue;
+                        if (scannedSeries[series].Count <= 0) continue;
 
                         UpdateSortOrder(scannedSeries, series);
 
-                        // This should be a return statement I think and we should invoke the actual series work on a background thread
-                        // Refactor: Create a ParsedSeries with the ParserInfo (or just return scanResult with a bit more information)
-                        //await processSeriesInfos.Invoke(new Tuple<bool, IList<ParserInfo>>(!scanResult.HasChanged, scannedSeries[series]));
                         processedScannedSeries.Add(new ScannedSeriesResult()
                         {
                             HasChanged = scanResult.HasChanged,

--- a/API/Services/Tasks/Scanner/Parser/BasicParser.cs
+++ b/API/Services/Tasks/Scanner/Parser/BasicParser.cs
@@ -92,6 +92,9 @@ public class BasicParser(IDirectoryService directoryService, IDefaultParser imag
             ret.Series = ret.Series.Substring(0, ret.Series.Length - ".pdf".Length);
         }
 
+        // Patch in other information from ComicInfo
+        UpdateFromComicInfo(ret);
+
         // v0.8.x: Introducing a change where Specials will go in a separate Volume with a reserved number
         if (ret.IsSpecial)
         {

--- a/API/Services/Tasks/Scanner/Parser/ComicVineParser.cs
+++ b/API/Services/Tasks/Scanner/Parser/ComicVineParser.cs
@@ -98,33 +98,4 @@ public class ComicVineParser(IDirectoryService directoryService) : DefaultParser
     {
         return type == LibraryType.ComicVine;
     }
-
-    private void UpdateFromComicInfo(ParserInfo info)
-    {
-        if (info.ComicInfo == null) return;
-
-        if (!string.IsNullOrEmpty(info.ComicInfo.Volume))
-        {
-            info.Volumes = info.ComicInfo.Volume;
-        }
-        if (string.IsNullOrEmpty(info.Series) && !string.IsNullOrEmpty(info.ComicInfo.Series))
-        {
-            info.Series = info.ComicInfo.Series.Trim();
-        }
-        if (!string.IsNullOrEmpty(info.ComicInfo.Number))
-        {
-            info.Chapters = info.ComicInfo.Number;
-            if (info.IsSpecial && Parser.DefaultChapter != info.Chapters)
-            {
-                info.IsSpecial = false;
-                info.Volumes = $"{Parser.SpecialVolumeNumber}";
-            }
-        }
-
-        // Patch is SeriesSort from ComicInfo
-        if (!string.IsNullOrEmpty(info.ComicInfo.TitleSort))
-        {
-            info.SeriesSort = info.ComicInfo.TitleSort.Trim();
-        }
-    }
 }

--- a/API/Services/Tasks/Scanner/Parser/DefaultParser.cs
+++ b/API/Services/Tasks/Scanner/Parser/DefaultParser.cs
@@ -99,6 +99,39 @@ public abstract class DefaultParser(IDirectoryService directoryService) : IDefau
         }
     }
 
+    protected void UpdateFromComicInfo(ParserInfo info)
+    {
+        if (info.ComicInfo == null) return;
+
+        if (!string.IsNullOrEmpty(info.ComicInfo.Volume))
+        {
+            info.Volumes = info.ComicInfo.Volume;
+        }
+        if (string.IsNullOrEmpty(info.Series) && !string.IsNullOrEmpty(info.ComicInfo.Series))
+        {
+            info.Series = info.ComicInfo.Series.Trim();
+        }
+        if (string.IsNullOrEmpty(info.LocalizedSeries) && !string.IsNullOrEmpty(info.ComicInfo.LocalizedSeries))
+        {
+            info.LocalizedSeries = info.ComicInfo.LocalizedSeries.Trim();
+        }
+        if (!string.IsNullOrEmpty(info.ComicInfo.Number))
+        {
+            info.Chapters = info.ComicInfo.Number;
+            if (info.IsSpecial && Parser.DefaultChapter != info.Chapters)
+            {
+                info.IsSpecial = false;
+                info.Volumes = $"{Parser.SpecialVolumeNumber}";
+            }
+        }
+
+        // Patch is SeriesSort from ComicInfo
+        if (!string.IsNullOrEmpty(info.ComicInfo.TitleSort))
+        {
+            info.SeriesSort = info.ComicInfo.TitleSort.Trim();
+        }
+    }
+
     public abstract bool IsApplicable(string filePath, LibraryType type);
 
     protected static bool IsEmptyOrDefault(string volumes, string chapters)

--- a/API/Services/Tasks/Scanner/ProcessSeries.cs
+++ b/API/Services/Tasks/Scanner/ProcessSeries.cs
@@ -20,6 +20,7 @@ using API.Services.Tasks.Scanner.Parser;
 using API.SignalR;
 using Hangfire;
 using Kavita.Common;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
 namespace API.Services.Tasks.Scanner;
@@ -207,7 +208,6 @@ public class ProcessSeries : IProcessSeries
                     return;
                 }
 
-                // TODO: put this on the background thread
 
                 // Process reading list after commit as we need to commit per list
                 //await _readingListService.CreateReadingListsFromSeries(series, library);

--- a/API/Services/Tasks/Scanner/ProcessSeries.cs
+++ b/API/Services/Tasks/Scanner/ProcessSeries.cs
@@ -36,11 +36,11 @@ public interface IProcessSeries
     void EnqueuePostSeriesProcessTasks(int libraryId, int seriesId, bool forceUpdate = false);
 
     // These exists only for Unit testing
-    void UpdateSeriesMetadata(Series series, Library library);
-    void UpdateVolumes(Series series, IList<ParserInfo> parsedInfos, bool forceUpdate = false);
-    void UpdateChapters(Series series, Volume volume, IList<ParserInfo> parsedInfos, bool forceUpdate = false);
-    void AddOrUpdateFileForChapter(Chapter chapter, ParserInfo info, bool forceUpdate = false);
-    void UpdateChapterFromComicInfo(Chapter chapter, ComicInfo? comicInfo, bool forceUpdate = false);
+    //void UpdateSeriesMetadata(Series series, Library library);
+    //void UpdateVolumes(Series series, IList<ParserInfo> parsedInfos, bool forceUpdate = false);
+    //void UpdateChapters(Series series, Volume volume, IList<ParserInfo> parsedInfos, bool forceUpdate = false);
+    //void AddOrUpdateFileForChapter(Chapter chapter, ParserInfo info, bool forceUpdate = false);
+    //void UpdateChapterFromComicInfo(Chapter chapter, ComicInfo? comicInfo, bool forceUpdate = false);
 }
 
 /// <summary>
@@ -553,7 +553,7 @@ public class ProcessSeries : IProcessSeries
 
     }
 
-    public void UpdateVolumes(Series series, IList<ParserInfo> parsedInfos, bool forceUpdate = false)
+    private void UpdateVolumes(Series series, IList<ParserInfo> parsedInfos, bool forceUpdate = false)
     {
         // Add new volumes and update chapters per volume
         var distinctVolumes = parsedInfos.DistinctVolumes();
@@ -634,7 +634,7 @@ public class ProcessSeries : IProcessSeries
         }
     }
 
-    public void UpdateChapters(Series series, Volume volume, IList<ParserInfo> parsedInfos, bool forceUpdate = false)
+    private void UpdateChapters(Series series, Volume volume, IList<ParserInfo> parsedInfos, bool forceUpdate = false)
     {
         // Add new chapters
         foreach (var info in parsedInfos)
@@ -701,7 +701,7 @@ public class ProcessSeries : IProcessSeries
         }
     }
 
-    public void AddOrUpdateFileForChapter(Chapter chapter, ParserInfo info, bool forceUpdate = false)
+    private void AddOrUpdateFileForChapter(Chapter chapter, ParserInfo info, bool forceUpdate = false)
     {
         chapter.Files ??= new List<MangaFile>();
         var existingFile = chapter.Files.SingleOrDefault(f => f.FilePath == info.FullFilePath);
@@ -727,7 +727,7 @@ public class ProcessSeries : IProcessSeries
         }
     }
 
-    public void UpdateChapterFromComicInfo(Chapter chapter, ComicInfo? comicInfo, bool forceUpdate = false)
+    private void UpdateChapterFromComicInfo(Chapter chapter, ComicInfo? comicInfo, bool forceUpdate = false)
     {
         if (comicInfo == null) return;
         var firstFile = chapter.Files.MinBy(x => x.Chapter);
@@ -960,6 +960,7 @@ public class ProcessSeries : IProcessSeries
     /// <param name="action">Callback for every item. Will give said item back and a bool if item was added</param>
     private void UpdateTag(IEnumerable<string> names, Action<Tag, bool> action)
     {
+        // TODO: Use TagHelper.UpdateTag instead
         foreach (var name in names)
         {
             if (string.IsNullOrEmpty(name.Trim())) continue;

--- a/API/Services/Tasks/Scanner/TagManagerService.cs
+++ b/API/Services/Tasks/Scanner/TagManagerService.cs
@@ -4,10 +4,12 @@ using System.Threading;
 using System.Threading.Tasks;
 using API.Data;
 using API.Entities;
+using API.Entities.Enums;
 using API.Extensions;
 using API.Helpers.Builders;
 
 namespace API.Services.Tasks.Scanner;
+#nullable enable
 
 public interface ITagManagerService
 {
@@ -18,6 +20,8 @@ public interface ITagManagerService
     Task Prime();
 
     Task<Genre?> GetGenre(string genre);
+    Task<Tag?> GetTag(string tag);
+    Task<Person?> GetPerson(string name, PersonRole role);
 }
 
 /// <summary>
@@ -28,19 +32,27 @@ public class TagManagerService : ITagManagerService
 {
     private readonly IUnitOfWork _unitOfWork;
     private Dictionary<string, Genre> _genres;
+    private Dictionary<string, Tag> _tags;
+    private Dictionary<string, Person> _people;
 
     private readonly SemaphoreSlim _genreSemaphore = new SemaphoreSlim(1, 1);
+    private readonly SemaphoreSlim _tagSemaphore = new SemaphoreSlim(1, 1);
+    private readonly SemaphoreSlim _personSemaphore = new SemaphoreSlim(1, 1);
 
     public TagManagerService(IUnitOfWork unitOfWork)
     {
         _unitOfWork = unitOfWork;
 
         _genres = new Dictionary<string, Genre>();
+        _tags = new Dictionary<string, Tag>();
+        _people = new Dictionary<string, Person>();
     }
 
     public async Task Prime()
     {
         _genres = (await _unitOfWork.GenreRepository.GetAllGenresAsync()).ToDictionary(t => t.NormalizedTitle);
+        _tags = (await _unitOfWork.TagRepository.GetAllTagsAsync()).ToDictionary(t => t.NormalizedTitle);
+        _people = (await _unitOfWork.PersonRepository.GetAllPeople()).ToDictionary(GetPersonKey);
     }
 
     /// <summary>
@@ -64,11 +76,84 @@ public class TagManagerService : ITagManagerService
             result = new GenreBuilder(genre).Build();
             _unitOfWork.GenreRepository.Attach(result);
             await _unitOfWork.CommitAsync();
+            _genres.Add(result.NormalizedTitle, result);
             return result;
         }
         finally
         {
             _genreSemaphore.Release();
         }
+    }
+
+    /// <summary>
+    /// Gets the Tag entity for the given string. If one doesn't exist, one will be created and committed.
+    /// </summary>
+    /// <param name="tag"></param>
+    /// <returns></returns>
+    public async Task<Tag?> GetTag(string tag)
+    {
+        if (string.IsNullOrEmpty(tag)) return null;
+
+        await _tagSemaphore.WaitAsync();
+        try
+        {
+            if (_tags.TryGetValue(tag.ToNormalized(), out var result))
+            {
+                return result;
+            }
+
+            // We need to create a new Genre
+            result = new TagBuilder(tag).Build();
+            _unitOfWork.TagRepository.Attach(result);
+            await _unitOfWork.CommitAsync();
+            _tags.Add(result.NormalizedTitle, result);
+            return result;
+        }
+        finally
+        {
+            _tagSemaphore.Release();
+        }
+    }
+
+    /// <summary>
+    /// Gets the Person entity for the given string and role. If one doesn't exist, one will be created and committed.
+    /// </summary>
+    /// <param name="name">Person Name</param>
+    /// <param name="role"></param>
+    /// <returns></returns>
+    public async Task<Person?> GetPerson(string name, PersonRole role)
+    {
+        if (string.IsNullOrEmpty(name)) return null;
+
+        await _personSemaphore.WaitAsync();
+        try
+        {
+            var key = GetPersonKey(name.ToNormalized(), role);
+            if (_people.TryGetValue(key, out var result))
+            {
+                return result;
+            }
+
+            // We need to create a new Genre
+            result = new PersonBuilder(name, role).Build();
+            _unitOfWork.PersonRepository.Attach(result);
+            await _unitOfWork.CommitAsync();
+            _people.Add(key, result);
+            return result;
+        }
+        finally
+        {
+            _personSemaphore.Release();
+        }
+    }
+
+    private static string GetPersonKey(string normalizedName, PersonRole role)
+    {
+        return normalizedName + "_" + role;
+    }
+
+    private static string GetPersonKey(Person p)
+    {
+        return GetPersonKey(p.NormalizedName, p.Role);
     }
 }

--- a/API/Services/Tasks/Scanner/TagManagerService.cs
+++ b/API/Services/Tasks/Scanner/TagManagerService.cs
@@ -1,0 +1,74 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using API.Data;
+using API.Entities;
+using API.Extensions;
+using API.Helpers.Builders;
+
+namespace API.Services.Tasks.Scanner;
+
+public interface ITagManagerService
+{
+    /// <summary>
+    /// Should be called once before any usage
+    /// </summary>
+    /// <returns></returns>
+    Task Prime();
+
+    Task<Genre?> GetGenre(string genre);
+}
+
+/// <summary>
+/// This is responsible for handling existing and new tags during the scan. When a new tag doesn't exist, it will create it.
+/// This is Thread Safe.
+/// </summary>
+public class TagManagerService : ITagManagerService
+{
+    private readonly IUnitOfWork _unitOfWork;
+    private Dictionary<string, Genre> _genres;
+
+    private readonly SemaphoreSlim _genreSemaphore = new SemaphoreSlim(1, 1);
+
+    public TagManagerService(IUnitOfWork unitOfWork)
+    {
+        _unitOfWork = unitOfWork;
+
+        _genres = new Dictionary<string, Genre>();
+    }
+
+    public async Task Prime()
+    {
+        _genres = (await _unitOfWork.GenreRepository.GetAllGenresAsync()).ToDictionary(t => t.NormalizedTitle);
+    }
+
+    /// <summary>
+    /// Gets the Genre entity for the given string. If one doesn't exist, one will be created and committed.
+    /// </summary>
+    /// <param name="genre"></param>
+    /// <returns></returns>
+    public async Task<Genre?> GetGenre(string genre)
+    {
+        if (string.IsNullOrEmpty(genre)) return null;
+
+        await _genreSemaphore.WaitAsync();
+        try
+        {
+            if (_genres.TryGetValue(genre.ToNormalized(), out var result))
+            {
+                return result;
+            }
+
+            // We need to create a new Genre
+            result = new GenreBuilder(genre).Build();
+            _unitOfWork.GenreRepository.Attach(result);
+            await _unitOfWork.CommitAsync();
+            return result;
+        }
+        finally
+        {
+            _genreSemaphore.Release();
+        }
+    }
+}

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -462,7 +462,7 @@ public class ScannerService : IScannerService
     [AutomaticRetry(Attempts = 3, OnAttemptsExceeded = AttemptsExceededAction.Delete)]
     public async Task ScanLibraries(bool forceUpdate = false)
     {
-        _logger.LogInformation("Starting Scan of All Libraries");
+        _logger.LogInformation("Starting Scan of All Libraries, Forced: {Forced}", forceUpdate);
         foreach (var lib in await _unitOfWork.LibraryRepository.GetLibrariesAsync())
         {
             await ScanLibrary(lib.Id, forceUpdate);

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -512,8 +512,11 @@ public class ScannerService : IScannerService
 
         // This grabs all the shared entities, like tags, genre, people. To be solved later in this refactor on how to not have blocking access.
         await _processSeries.Prime();
+        // We need to remove any keys where there is no actual parser info
         foreach (var pSeries in parsedSeries.Keys)
         {
+            if (parsedSeries[pSeries].Count == 0 || string.IsNullOrEmpty(parsedSeries[pSeries][0].Filename)) continue;
+
             totalFiles += parsedSeries[pSeries].Count;
             await _seriesProcessingSemaphore.WaitAsync();
             try

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -1527,7 +1527,7 @@
         "general-tab": "General",
         "cover-image-tab": "Cover Image",
         "close": "{{common.close}}",
-        "save": "{common.save}}",
+        "save": "{{common.save}}",
         "year-validation": "Must be greater than 1000, 0 or blank",
         "month-validation": "Must be between 1 and 12 or blank",
         "name-unique-validation": "Name must be unique",

--- a/openapi.json
+++ b/openapi.json
@@ -7,7 +7,7 @@
       "name": "GPL-3.0",
       "url": "https://github.com/Kareadita/Kavita/blob/develop/LICENSE"
     },
-    "version": "0.7.14.7"
+    "version": "0.7.14.8"
   },
   "servers": [
     {


### PR DESCRIPTION
This is a fairly large amount of code changes to the scanner. Testers, please make sure things are operating as you expect. Please pay attention to if you see any Foreign Key Constraints or not. 

# Changed
- Changed: When a new series is added and Kavita+ data is prefetched, do that in a background job (develop)
- Changed: ComicVine library will no longer talk to Kavita+ as it's not applicable (until Hardcover integration) (develop)
- Changed: Brought back parallel processing of series in the scanner. 
- Changed: Trim strings from ComicInfo more aggressively to prevent weird parsing for things like Number.
- Changed: Optimized a lot of the scanner and cleaned up the code deeply. 

# Fixed
- Fixed: Fixed a bad localization on edit reading list modal.
- Fixed: Fixed another check around rescheduling Kavita+ tasks once a valid check came through. There was a lack of a checking mechanism and Kavita was doing more than needed.
- Fixed: I believe the Foreign Key constraint issue is solved once and for all (#2747)

# Removed
- Removed .kavitaignore file support as Library Exclude patterns are much easier to use and flexible enough. 

Closes #2776