### PR TITLE
Small bugfixes 

### DIFF
--- a/API/Extensions/ChapterListExtensions.cs
+++ b/API/Extensions/ChapterListExtensions.cs
@@ -43,6 +43,6 @@ public static class ChapterListExtensions
     /// <returns></returns>
     public static int MinimumReleaseYear(this IList<Chapter> chapters)
     {
-        return chapters.Select(v => v.ReleaseDate.Year).Where(y => NumberHelper.IsValidYear(y)).DefaultIfEmpty().Min();
+        return chapters.Select(v => v.ReleaseDate.Year).Where(NumberHelper.IsValidYear).DefaultIfEmpty().Min();
     }
 }

--- a/API/Services/MetadataService.cs
+++ b/API/Services/MetadataService.cs
@@ -108,9 +108,15 @@ public class MetadataService : IMetadataService
                 null, volume.Created, forceUpdate)) return Task.FromResult(false);
 
 
+        // For cover selection, chapters need to try for issue 1 first, then fallback to first sort order
         volume.Chapters ??= new List<Chapter>();
-        var firstChapter = volume.Chapters.MinBy(x => x.MinNumber, ChapterSortComparerDefaultFirst.Default);
-        if (firstChapter == null) return Task.FromResult(false);
+
+        var firstChapter = volume.Chapters.FirstOrDefault(x => x.MinNumber.Is(1f));
+        if (firstChapter == null)
+        {
+            firstChapter = volume.Chapters.MinBy(x => x.SortOrder, ChapterSortComparerDefaultFirst.Default);
+            if (firstChapter == null) return Task.FromResult(false);
+        }
 
         volume.CoverImage = firstChapter.CoverImage;
         _updateEvents.Add(MessageFactory.CoverUpdateEvent(volume.Id, MessageFactoryEntityTypes.Volume));

--- a/API/Services/Tasks/Scanner/ProcessSeries.cs
+++ b/API/Services/Tasks/Scanner/ProcessSeries.cs
@@ -80,7 +80,14 @@ public class ProcessSeries : IProcessSeries
     /// </summary>
     public async Task Prime()
     {
-        await _tagManagerService.Prime();
+        try
+        {
+            await _tagManagerService.Prime();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogCritical(ex, "Unable to prime tag manager. Scan cannot proceed. Report to Kavita dev");
+        }
     }
 
     /// <summary>

--- a/API/Services/Tasks/Scanner/TagManagerService.cs
+++ b/API/Services/Tasks/Scanner/TagManagerService.cs
@@ -67,7 +67,10 @@ public class TagManagerService : ITagManagerService
     {
         _genres = (await _unitOfWork.GenreRepository.GetAllGenresAsync()).ToDictionary(t => t.NormalizedTitle);
         _tags = (await _unitOfWork.TagRepository.GetAllTagsAsync()).ToDictionary(t => t.NormalizedTitle);
-        _people = (await _unitOfWork.PersonRepository.GetAllPeople()).ToDictionary(GetPersonKey);
+        _people = (await _unitOfWork.PersonRepository.GetAllPeople())
+            .GroupBy(GetPersonKey)
+            .Select(g => g.First())
+            .ToDictionary(GetPersonKey);
         _collectionTags = (await _unitOfWork.CollectionTagRepository.GetAllTagsAsync(CollectionTagIncludes.SeriesMetadata))
             .ToDictionary(t => t.NormalizedTitle);
 

--- a/UI/Web/src/app/_pipes/library-type.pipe.ts
+++ b/UI/Web/src/app/_pipes/library-type.pipe.ts
@@ -24,6 +24,8 @@ export class LibraryTypePipe implements PipeTransform {
         return this.translocoService.translate('library-type-pipe.image');
       case LibraryType.Manga:
         return this.translocoService.translate('library-type-pipe.manga');
+      case LibraryType.LightNovel:
+        return this.translocoService.translate('library-type-pipe.lightNovel');
       default:
         return '';
     }

--- a/UI/Web/src/app/sidenav/_modals/library-settings-modal/library-settings-modal.component.ts
+++ b/UI/Web/src/app/sidenav/_modals/library-settings-modal/library-settings-modal.component.ts
@@ -197,6 +197,9 @@ export class LibrarySettingsModalComponent implements OnInit {
             this.libraryForm.get(FileTypeGroup.Epub + '')?.setValue(false);
             break;
         }
+
+        this.libraryForm.get('allowScrobbling')?.setValue(this.IsKavitaPlusEligible);
+        this.cdRef.markForCheck();
       }),
       takeUntilDestroyed(this.destroyRef)
     ).subscribe();

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -502,7 +502,8 @@
         "comic": "Comic",
         "manga": "Manga",
         "comicVine": "ComicVine",
-        "image": "Image"
+        "image": "Image",
+        "lightNovel": "Light Novel"
     },
 
     "age-rating-pipe": {

--- a/openapi.json
+++ b/openapi.json
@@ -7,7 +7,7 @@
       "name": "GPL-3.0",
       "url": "https://github.com/Kareadita/Kavita/blob/develop/LICENSE"
     },
-    "version": "0.7.14.9"
+    "version": "0.7.14.10"
   },
   "servers": [
     {


### PR DESCRIPTION
# Changed
- Changed: (Kavita+) During library setting modal, changing type will now automatically change the Allow Scrobbling control, if the underlying library type is not Kavita+ applicable.

# Fixed
- Fixed: Fixed a bug around cover image generation around volumes (develop)
- Fixed: Fixed a missing string for Light Novel library type (develop)
- Fixed: Fixed an edge case where some bad data can exist in Kavita and the priming of the tag service could fail.
