### PR TITLE
Scanner Bugfixes

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,12 +10,12 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
             fetch-depth: 0
 
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
             dotnet-version: 8.0.x
 
@@ -26,7 +26,7 @@ jobs:
       - name: Install dependencies
         run: dotnet restore
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: csproj
           path: Kavita.Common/Kavita.Common.csproj

--- a/.github/workflows/canary-workflow.yml
+++ b/.github/workflows/canary-workflow.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
             fetch-depth: 0
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: csproj
           path: Kavita.Common/Kavita.Common.csproj
@@ -26,12 +26,12 @@ jobs:
     needs: [ build ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
             dotnet-version: 8.0.x
 
@@ -59,14 +59,14 @@ jobs:
                 github-token: ${{ secrets.GITHUB_TOKEN }}
 
           - name: Check Out Repo
-            uses: actions/checkout@v3
+            uses: actions/checkout@v4
             with:
                 ref: canary
 
           - name: NodeJS to Compile WebUI
-            uses: actions/setup-node@v3
+            uses: actions/setup-node@v4
             with:
-                node-version: '18.13.x'
+                node-version: 20
           - run: |
                 cd UI/Web || exit
                 echo 'Installing web dependencies'
@@ -96,7 +96,7 @@ jobs:
             run: echo "${{steps.get-version.outputs.assembly-version}}"
 
           - name: Compile dotnet app
-            uses: actions/setup-dotnet@v3
+            uses: actions/setup-dotnet@v4
             with:
                 dotnet-version: 8.0.x
 

--- a/.github/workflows/canary-workflow.yml
+++ b/.github/workflows/canary-workflow.yml
@@ -81,7 +81,7 @@ jobs:
                 cd ../ || exit
 
           - name: Get csproj Version
-            uses: kzrnm/get-net-sdk-project-versions-action@v1
+            uses: kzrnm/get-net-sdk-project-versions-action@v2
             id: get-version
             with:
                 proj-path: Kavita.Common/Kavita.Common.csproj
@@ -106,28 +106,28 @@ jobs:
           - run: ./monorepo-build.sh
 
           - name: Login to Docker Hub
-            uses: docker/login-action@v2
+            uses: docker/login-action@v3
             with:
                 username: ${{ secrets.DOCKER_HUB_USERNAME }}
                 password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
           - name: Login to GitHub Container Registry
-            uses: docker/login-action@v2
+            uses: docker/login-action@v3
             with:
                 registry: ghcr.io
                 username: ${{ github.actor }}
                 password: ${{ secrets.GITHUB_TOKEN }}
 
           - name: Set up QEMU
-            uses: docker/setup-qemu-action@v2
+            uses: docker/setup-qemu-action@v3
 
           - name: Set up Docker Buildx
             id: buildx
-            uses: docker/setup-buildx-action@v2
+            uses: docker/setup-buildx-action@v3
 
           - name: Build and push
             id: docker_build
-            uses: docker/build-push-action@v4
+            uses: docker/build-push-action@v5
             with:
                 context: .
                 platforms: linux/amd64,linux/arm/v7,linux/arm64

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Install Swashbuckle CLI
       shell: bash

--- a/.github/workflows/develop-workflow.yml
+++ b/.github/workflows/develop-workflow.yml
@@ -21,11 +21,11 @@ jobs:
     if: github.ref == 'refs/heads/develop'
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: csproj
           path: Kavita.Common/Kavita.Common.csproj
@@ -36,12 +36,12 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/develop'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
             dotnet-version: 8.0.x
 
@@ -89,14 +89,14 @@ jobs:
           echo "BODY=$body" >> $GITHUB_OUTPUT
 
       - name: Check Out Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: develop
 
       - name: NodeJS to Compile WebUI
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '18.13.x'
+          node-version: 20
       - run: |
           cd UI/Web || exit
           echo 'Installing web dependencies'
@@ -126,7 +126,7 @@ jobs:
         run: echo "${{steps.get-version.outputs.assembly-version}}"
 
       - name: Compile dotnet app
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
             dotnet-version: 8.0.x
 

--- a/.github/workflows/develop-workflow.yml
+++ b/.github/workflows/develop-workflow.yml
@@ -111,7 +111,7 @@ jobs:
           cd ../ || exit
 
       - name: Get csproj Version
-        uses: kzrnm/get-net-sdk-project-versions-action@v1
+        uses: kzrnm/get-net-sdk-project-versions-action@v2
         id: get-version
         with:
           proj-path: Kavita.Common/Kavita.Common.csproj
@@ -136,28 +136,28 @@ jobs:
       - run: ./monorepo-build.sh
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
           platforms: linux/amd64,linux/arm/v7,linux/arm64

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -30,11 +30,11 @@ jobs:
     if: github.event.pull_request.merged == true && contains(github.head_ref, 'release')
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: csproj
           path: Kavita.Common/Kavita.Common.csproj
@@ -77,14 +77,14 @@ jobs:
           echo "BODY=$body" >> $GITHUB_OUTPUT
 
       - name: Check Out Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: develop
 
       - name: NodeJS to Compile WebUI
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '18.13.x'
+          node-version: 20
       - run: |
 
           cd UI/Web || exit
@@ -117,7 +117,7 @@ jobs:
         id: parse-version
 
       - name: Compile dotnet app
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
             dotnet-version: 8.0.x
       - name: Install Swashbuckle CLI

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -100,7 +100,7 @@ jobs:
           cd ../ || exit
 
       - name: Get csproj Version
-        uses: kzrnm/get-net-sdk-project-versions-action@v1
+        uses: kzrnm/get-net-sdk-project-versions-action@v2
         id: get-version
         with:
           proj-path: Kavita.Common/Kavita.Common.csproj
@@ -126,28 +126,28 @@ jobs:
       - run: ./monorepo-build.sh
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Build and push stable
         id: docker_build_stable
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
           platforms: linux/amd64,linux/arm/v7,linux/arm64
@@ -156,7 +156,7 @@ jobs:
 
       - name: Build and push nightly
         id: docker_build_nightly
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
           platforms: linux/amd64,linux/arm/v7,linux/arm64

--- a/API.Tests/Parsing/MangaParsingTests.cs
+++ b/API.Tests/Parsing/MangaParsingTests.cs
@@ -206,6 +206,7 @@ public class MangaParsingTests
     [InlineData("test 2 years 1권", "test 2 years")]
     [InlineData("test 2 years 1화", "test 2 years")]
     [InlineData("Nagasarete Airantou - Vol. 30 Ch. 187.5 - Vol.30 Omake", "Nagasarete Airantou")]
+    [InlineData("Cynthia The Mission - c000 - c006 (v06)", "Cynthia The Mission")]
     public void ParseSeriesTest(string filename, string expected)
     {
         Assert.Equal(expected, API.Services.Tasks.Scanner.Parser.Parser.ParseSeries(filename));

--- a/API/API.csproj
+++ b/API/API.csproj
@@ -66,7 +66,7 @@
     <PackageReference Include="Flurl" Version="3.0.7" />
     <PackageReference Include="Flurl.Http" Version="3.2.4" />
     <PackageReference Include="Hangfire" Version="1.8.11" />
-    <PackageReference Include="Hangfire.InMemory" Version="0.8.0" />
+    <PackageReference Include="Hangfire.InMemory" Version="0.8.1" />
     <PackageReference Include="Hangfire.MaximumConcurrentExecutions" Version="1.1.0" />
     <PackageReference Include="Hangfire.Storage.SQLite" Version="0.4.1" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.59" />

--- a/API/Data/ManualMigrations/ManualMigrateLooseLeafChapters.cs
+++ b/API/Data/ManualMigrations/ManualMigrateLooseLeafChapters.cs
@@ -113,7 +113,35 @@ public static class MigrateLooseLeafChapters
                     //UpdateCoverImage(directoryService, logger, chapter, extension, newVolume);
                 }
 
-                // Update the progress table with the new VolumeId
+
+                var oldVolumeBookmarks = await dataContext.AppUserBookmark
+                    .Where(p => p.VolumeId == distinctVolume.Volume.Id).ToListAsync();
+                logger.LogInformation("Moving {Count} existing Bookmarks from Volume Id {OldVolumeId} to New Volume {NewVolumeId}",
+                    oldVolumeBookmarks.Count, distinctVolume.Volume.Id, newVolume.Id);
+                foreach (var bookmark in oldVolumeBookmarks)
+                {
+                    bookmark.VolumeId = newVolume.Id;
+                }
+
+
+                var oldVolumePersonalToC = await dataContext.AppUserTableOfContent
+                    .Where(p => p.VolumeId == distinctVolume.Volume.Id).ToListAsync();
+                logger.LogInformation("Moving {Count} existing Personal ToC from Volume Id {OldVolumeId} to New Volume {NewVolumeId}",
+                    oldVolumePersonalToC.Count, distinctVolume.Volume.Id, newVolume.Id);
+                foreach (var pToc in oldVolumePersonalToC)
+                {
+                    pToc.VolumeId = newVolume.Id;
+                }
+
+                var oldVolumeReadingListItems = await dataContext.ReadingListItem
+                    .Where(p => p.VolumeId == distinctVolume.Volume.Id).ToListAsync();
+                logger.LogInformation("Moving {Count} existing Personal ToC from Volume Id {OldVolumeId} to New Volume {NewVolumeId}",
+                    oldVolumeReadingListItems.Count, distinctVolume.Volume.Id, newVolume.Id);
+                foreach (var readingListItem in oldVolumeReadingListItems)
+                {
+                    readingListItem.VolumeId = newVolume.Id;
+                }
+
 
                 await dataContext.SaveChangesAsync();
             }

--- a/API/Data/ManualMigrations/ManualMigrateMixedSpecials.cs
+++ b/API/Data/ManualMigrations/ManualMigrateMixedSpecials.cs
@@ -129,6 +129,35 @@ public static class MigrateMixedSpecials
 
                     //UpdateCoverImage(directoryService, logger, specialChapter, extension, newVolume);
                 }
+
+                var oldVolumeBookmarks = await dataContext.AppUserBookmark
+                    .Where(p => p.VolumeId == distinctVolume.Volume.Id).ToListAsync();
+                logger.LogInformation("Moving {Count} existing Bookmarks from Volume Id {OldVolumeId} to New Volume {NewVolumeId}",
+                    oldVolumeBookmarks.Count, distinctVolume.Volume.Id, newVolume.Id);
+                foreach (var bookmark in oldVolumeBookmarks)
+                {
+                    bookmark.VolumeId = newVolume.Id;
+                }
+
+
+                var oldVolumePersonalToC = await dataContext.AppUserTableOfContent
+                    .Where(p => p.VolumeId == distinctVolume.Volume.Id).ToListAsync();
+                logger.LogInformation("Moving {Count} existing Personal ToC from Volume Id {OldVolumeId} to New Volume {NewVolumeId}",
+                    oldVolumePersonalToC.Count, distinctVolume.Volume.Id, newVolume.Id);
+                foreach (var pToc in oldVolumePersonalToC)
+                {
+                    pToc.VolumeId = newVolume.Id;
+                }
+
+                var oldVolumeReadingListItems = await dataContext.ReadingListItem
+                    .Where(p => p.VolumeId == distinctVolume.Volume.Id).ToListAsync();
+                logger.LogInformation("Moving {Count} existing Personal ToC from Volume Id {OldVolumeId} to New Volume {NewVolumeId}",
+                    oldVolumeReadingListItems.Count, distinctVolume.Volume.Id, newVolume.Id);
+                foreach (var readingListItem in oldVolumeReadingListItems)
+                {
+                    readingListItem.VolumeId = newVolume.Id;
+                }
+
                 await dataContext.SaveChangesAsync();
             }
 

--- a/API/Entities/AppUserProgress.cs
+++ b/API/Entities/AppUserProgress.cs
@@ -7,7 +7,7 @@ namespace API.Entities;
 /// <summary>
 /// Represents the progress a single user has on a given Chapter.
 /// </summary>
-public class AppUserProgress : IEntityDate
+public class AppUserProgress
 {
     /// <summary>
     /// Id of Entity
@@ -59,4 +59,10 @@ public class AppUserProgress : IEntityDate
     /// User this progress belongs to
     /// </summary>
     public int AppUserId { get; set; }
+
+    public void MarkModified()
+    {
+        LastModified = DateTime.Now;
+        LastModifiedUtc = DateTime.UtcNow;
+    }
 }

--- a/API/Extensions/ChapterListExtensions.cs
+++ b/API/Extensions/ChapterListExtensions.cs
@@ -31,7 +31,7 @@ public static class ChapterListExtensions
     {
         var normalizedPath = Parser.NormalizePath(info.FullFilePath);
         var specialTreatment = info.IsSpecialInfo();
-         return specialTreatment
+        return specialTreatment
              ? chapters.FirstOrDefault(c => c.Range == Parser.RemoveExtensionIfSupported(info.Filename) || c.Files.Select(f => Parser.NormalizePath(f.FilePath)).Contains(normalizedPath))
              : chapters.FirstOrDefault(c => c.Range == info.Chapters);
     }

--- a/API/Extensions/QueryExtensions/Filtering/SeriesSort.cs
+++ b/API/Extensions/QueryExtensions/Filtering/SeriesSort.cs
@@ -31,7 +31,7 @@ public static class SeriesSort
             SortField.TimeToRead => query.DoOrderBy(s => s.AvgHoursToRead, sortOptions),
             SortField.ReleaseYear => query.DoOrderBy(s => s.Metadata.ReleaseYear, sortOptions),
             SortField.ReadProgress => query.DoOrderBy(s => s.Progress.Where(p => p.SeriesId == s.Id && p.AppUserId == userId)
-                .Select(p => p.LastModified)
+                .Select(p => p.LastModified) // TODO: Migrate this to UTC
                 .Max(), sortOptions),
             SortField.AverageRating => query.DoOrderBy(s => s.ExternalSeriesMetadata.ExternalRatings
                 .Where(p => p.SeriesId == s.Id).Average(p => p.AverageScore), sortOptions),

--- a/API/Services/ReaderService.cs
+++ b/API/Services/ReaderService.cs
@@ -134,7 +134,11 @@ public class ReaderService : IReaderService
                     VolumeId = chapter.VolumeId,
                     SeriesId = seriesId,
                     ChapterId = chapter.Id,
-                    LibraryId = series.LibraryId
+                    LibraryId = series.LibraryId,
+                    Created = DateTime.Now,
+                    CreatedUtc = DateTime.UtcNow,
+                    LastModified = DateTime.Now,
+                    LastModifiedUtc = DateTime.UtcNow
                 });
             }
             else
@@ -143,6 +147,8 @@ public class ReaderService : IReaderService
                 userProgress.SeriesId = seriesId;
                 userProgress.VolumeId = chapter.VolumeId;
             }
+
+            userProgress?.MarkModified();
 
             await _eventHub.SendMessageAsync(MessageFactory.UserProgressUpdate,
                 MessageFactory.UserProgressUpdateEvent(user.Id, user.UserName!, seriesId, chapter.VolumeId, chapter.Id, chapter.Pages));
@@ -177,6 +183,7 @@ public class ReaderService : IReaderService
             userProgress.PagesRead = 0;
             userProgress.SeriesId = seriesId;
             userProgress.VolumeId = chapter.VolumeId;
+            userProgress.MarkModified();
 
             await _eventHub.SendMessageAsync(MessageFactory.UserProgressUpdate,
                 MessageFactory.UserProgressUpdateEvent(user.Id, user.UserName!, userProgress.SeriesId, userProgress.VolumeId, userProgress.ChapterId, 0));
@@ -266,7 +273,11 @@ public class ReaderService : IReaderService
                     SeriesId = progressDto.SeriesId,
                     ChapterId = progressDto.ChapterId,
                     LibraryId = progressDto.LibraryId,
-                    BookScrollId = progressDto.BookScrollId
+                    BookScrollId = progressDto.BookScrollId,
+                    Created = DateTime.Now,
+                    CreatedUtc = DateTime.UtcNow,
+                    LastModified = DateTime.Now,
+                    LastModifiedUtc = DateTime.UtcNow
                 });
                 _unitOfWork.UserRepository.Update(userWithProgress);
             }
@@ -279,6 +290,8 @@ public class ReaderService : IReaderService
                 userProgress.BookScrollId = progressDto.BookScrollId;
                 _unitOfWork.AppUserProgressRepository.Update(userProgress);
             }
+
+            userProgress?.MarkModified();
 
             if (!_unitOfWork.HasChanges() || await _unitOfWork.CommitAsync())
             {

--- a/API/Services/Tasks/Scanner/Parser/BookParser.cs
+++ b/API/Services/Tasks/Scanner/Parser/BookParser.cs
@@ -31,7 +31,7 @@ public class BookParser(IDirectoryService directoryService, IBookService bookSer
             {
                 var info2 = basicParser.Parse(filePath, rootPath, libraryRoot, LibraryType.Book, comicInfo);
                 info.Merge(info2);
-                if (type == LibraryType.LightNovel && hasVolumeInSeries && info2 != null && Parser.ParseVolume(info2.Series)
+                if (hasVolumeInSeries && info2 != null && Parser.ParseVolume(info2.Series)
                         .Equals(Parser.LooseLeafVolume))
                 {
                     // Override the Series name so it groups appropriately

--- a/API/Services/Tasks/Scanner/Parser/DefaultParser.cs
+++ b/API/Services/Tasks/Scanner/Parser/DefaultParser.cs
@@ -107,11 +107,11 @@ public abstract class DefaultParser(IDirectoryService directoryService) : IDefau
         {
             info.Volumes = info.ComicInfo.Volume;
         }
-        if (string.IsNullOrEmpty(info.Series) && !string.IsNullOrEmpty(info.ComicInfo.Series))
+        if (!string.IsNullOrEmpty(info.ComicInfo.Series))
         {
             info.Series = info.ComicInfo.Series.Trim();
         }
-        if (string.IsNullOrEmpty(info.LocalizedSeries) && !string.IsNullOrEmpty(info.ComicInfo.LocalizedSeries))
+        if (!string.IsNullOrEmpty(info.ComicInfo.LocalizedSeries))
         {
             info.LocalizedSeries = info.ComicInfo.LocalizedSeries.Trim();
         }

--- a/API/Services/Tasks/Scanner/Parser/Parser.cs
+++ b/API/Services/Tasks/Scanner/Parser/Parser.cs
@@ -232,7 +232,7 @@ public static class Parser
             RegexTimeout),
         // Gokukoku no Brynhildr - c001-008 (v01) [TrinityBAKumA], Black Bullet - v4 c17 [batoto]
         new Regex(
-            @"(?<Series>.*)( - )(?:v|vo|c|chapters)\d",
+            @"(?<Series>.+?)( - )(?:v|vo|c|chapters)\d",
             MatchOptions, RegexTimeout),
         // Kedouin Makoto - Corpse Party Musume, Chapter 19 [Dametrans].zip
         new Regex(

--- a/API/Services/Tasks/Scanner/Parser/PdfParser.cs
+++ b/API/Services/Tasks/Scanner/Parser/PdfParser.cs
@@ -22,6 +22,11 @@ public class PdfParser(IDirectoryService directoryService) : DefaultParser(direc
                 : Parser.ParseChapter(fileName)
         };
 
+        if (type == LibraryType.Book)
+        {
+            ret.Chapters = Parser.DefaultChapter;
+        }
+
         ret.Series = type == LibraryType.Comic ? Parser.ParseComicSeries(fileName) : Parser.ParseSeries(fileName);
         ret.Volumes = type == LibraryType.Comic ? Parser.ParseComicVolume(fileName) : Parser.ParseVolume(fileName);
 

--- a/UI/Web/package-lock.json
+++ b/UI/Web/package-lock.json
@@ -688,6 +688,7 @@
       "version": "17.3.0",
       "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-17.3.0.tgz",
       "integrity": "sha512-ewo+pb0QUC69Ey15z4vPteoBeO81HitqplysOoeXbyVBjMnKmZl3343wx7ukgcI97lmj4d38d1r4AnIoO5n/Vw==",
+      "dev": true,
       "dependencies": {
         "@babel/core": "7.23.9",
         "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -5752,6 +5753,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -6013,6 +6015,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -6323,6 +6326,7 @@
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
       "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -6571,7 +6575,8 @@
     "node_modules/convert-source-map": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "dev": true
     },
     "node_modules/cookie": {
       "version": "0.5.0",
@@ -7473,6 +7478,7 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
@@ -7482,6 +7488,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -8558,6 +8565,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -9332,6 +9340,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -11115,6 +11124,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12527,6 +12537,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -12537,7 +12548,8 @@
     "node_modules/reflect-metadata": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.1.tgz",
-      "integrity": "sha512-i5lLI6iw9AU3Uu4szRNPPEkomnkjRTaVt9hy/bn5g/oSzekBSMeLZblcjP74AW0vBabqERLLIrz+gR8QYR54Tw=="
+      "integrity": "sha512-i5lLI6iw9AU3Uu4szRNPPEkomnkjRTaVt9hy/bn5g/oSzekBSMeLZblcjP74AW0vBabqERLLIrz+gR8QYR54Tw==",
+      "dev": true
     },
     "node_modules/regenerate": {
       "version": "1.4.2",
@@ -12989,7 +13001,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/sass": {
       "version": "1.71.1",
@@ -13108,6 +13120,7 @@
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
       "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -13122,6 +13135,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -13132,7 +13146,8 @@
     "node_modules/semver/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/send": {
       "version": "0.18.0",
@@ -14244,6 +14259,7 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
       "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/UI/Web/package-lock.json
+++ b/UI/Web/package-lock.json
@@ -688,7 +688,6 @@
       "version": "17.3.0",
       "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-17.3.0.tgz",
       "integrity": "sha512-ewo+pb0QUC69Ey15z4vPteoBeO81HitqplysOoeXbyVBjMnKmZl3343wx7ukgcI97lmj4d38d1r4AnIoO5n/Vw==",
-      "dev": true,
       "dependencies": {
         "@babel/core": "7.23.9",
         "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -5753,7 +5752,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dev": true,
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -6015,7 +6013,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -6326,7 +6323,6 @@
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
       "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -6575,8 +6571,7 @@
     "node_modules/convert-source-map": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
-      "dev": true
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
     },
     "node_modules/cookie": {
       "version": "0.5.0",
@@ -7478,7 +7473,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
@@ -7488,7 +7482,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -8565,7 +8558,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -9340,7 +9332,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -11124,7 +11115,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12537,7 +12527,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -12548,8 +12537,7 @@
     "node_modules/reflect-metadata": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.1.tgz",
-      "integrity": "sha512-i5lLI6iw9AU3Uu4szRNPPEkomnkjRTaVt9hy/bn5g/oSzekBSMeLZblcjP74AW0vBabqERLLIrz+gR8QYR54Tw==",
-      "dev": true
+      "integrity": "sha512-i5lLI6iw9AU3Uu4szRNPPEkomnkjRTaVt9hy/bn5g/oSzekBSMeLZblcjP74AW0vBabqERLLIrz+gR8QYR54Tw=="
     },
     "node_modules/regenerate": {
       "version": "1.4.2",
@@ -13001,7 +12989,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/sass": {
       "version": "1.71.1",
@@ -13120,7 +13108,6 @@
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
       "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -13135,7 +13122,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -13146,8 +13132,7 @@
     "node_modules/semver/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/send": {
       "version": "0.18.0",
@@ -14259,7 +14244,6 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
       "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
-      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/UI/Web/src/app/_pipes/filter.pipe.ts
+++ b/UI/Web/src/app/_pipes/filter.pipe.ts
@@ -14,6 +14,6 @@ export class FilterPipe implements PipeTransform {
     const ret = items.filter(item => callback(item));
     if (ret.length === items.length) return items; // This will prevent a re-render
     return ret;
-}
+  }
 
 }

--- a/UI/Web/src/app/series-detail/_components/series-detail/series-detail.component.ts
+++ b/UI/Web/src/app/series-detail/_components/series-detail/series-detail.component.ts
@@ -339,6 +339,9 @@ export class SeriesDetailComponent implements OnInit, AfterContentChecked {
 
   get ShowStorylineTab() {
     if (this.libraryType === LibraryType.ComicVine) return false;
+    // Edge case for bad pdf parse
+    if (this.libraryType === LibraryType.Book && (this.volumes.length === 0 && this.chapters.length === 0 && this.storyChapters.length > 0)) return true;
+
     return (this.libraryType !== LibraryType.Book && this.libraryType !== LibraryType.LightNovel && this.libraryType !== LibraryType.Comic)
       && (this.volumes.length > 0 || this.chapters.length > 0);
   }
@@ -727,7 +730,12 @@ export class SeriesDetailComponent implements OnInit, AfterContentChecked {
     // Book libraries only have Volumes or Specials enabled
     if (this.libraryType === LibraryType.Book || this.libraryType === LibraryType.LightNovel) {
       if (this.volumes.length === 0) {
-        this.activeTabId = TabID.Specials;
+        if (this.specials.length === 0 && this.storyChapters.length > 0) {
+          // NOTE: This is an edge case caused by bad parsing of pdf files. Once the new pdf parser is in place, this should be removed
+          this.activeTabId = TabID.Storyline;
+        } else {
+          this.activeTabId = TabID.Specials;
+        }
       } else {
         this.activeTabId = TabID.Volumes;
       }

--- a/UI/Web/src/app/sidenav/_modals/library-settings-modal/library-settings-modal.component.ts
+++ b/UI/Web/src/app/sidenav/_modals/library-settings-modal/library-settings-modal.component.ts
@@ -258,7 +258,10 @@ export class LibrarySettingsModalComponent implements OnInit {
 
   forceScan() {
     this.libraryService.scan(this.library!.id, true)
-      .subscribe(() => this.toastr.info(translate('toasts.forced-scan-queued', {name: this.library!.name})));
+      .subscribe(() => {
+        this.toastr.info(translate('toasts.forced-scan-queued', {name: this.library!.name}));
+        this.close();
+      });
   }
 
   async save() {

--- a/UI/Web/src/app/statistics/_components/kavitaplus-metadata-breakdown-stats/kavitaplus-metadata-breakdown-stats.component.html
+++ b/UI/Web/src/app/statistics/_components/kavitaplus-metadata-breakdown-stats/kavitaplus-metadata-breakdown-stats.component.html
@@ -1,37 +1,23 @@
 <ng-container *transloco="let t; read: 'kavitaplus-metadata-breakdown-stats'">
   <div class="dashboard-card-content">
     <h4>{{t('title')}}</h4>
+    <p>{{t('description')}}</p>
 
     @if(breakdown) {
       @if(breakdown.totalSeries === 0 || breakdown.seriesCompleted === 0) {
         <div>{{t('no-data')}}</div>
-      }
-      @if (percentDone >= 1) {
-        <p>{{t('complete') }}</p>
       } @else {
-        <p>{{t('total-series-progress-label', {percent: percentDone * 100 | percent}) }}</p>
-
-        <div class="day-breakdown-chart">
-          <table class="charts-css pie show-labels">
-            <tbody>
-
-            <tr>
-              <th scope="row">{{t('completed-series-label')}}</th>
-              <td class="completed" style="--start: 0; --end: ' + {{ completedEnd }}">
-                <span class="data">{{ breakdown.seriesCompleted }}</span>
-              </td>
-            </tr>
-
-            <tr>
-              <th scope="row">{{t('errored-series-label')}}</th>
-              <td class="error" style="--start: ' + {{ errorStart }}; --end: {{ errorEnd }}'">
-                <span class="data">{{ breakdown.erroredSeries }}</span>
-              </td>
-            </tr>
-
-            </tbody>
-          </table>
-        </div>
+        <ngb-progressbar-stacked>
+          <ngb-progressbar type="danger" [value]="errorPercent" [ngbTooltip]="t('errored-series-label') + ' ' + breakdown.erroredSeries"></ngb-progressbar>
+          <ngb-progressbar type="success" [value]="completedPercent" [ngbTooltip]="t('completed-series-label') + ' ' + breakdown.seriesCompleted"></ngb-progressbar>
+        </ngb-progressbar-stacked>
+        @if (breakdown.seriesCompleted >= breakdown.totalSeries) {
+          <p>{{t('complete') }}
+            @if (breakdown.erroredSeries > 0) {
+              {{t('errored-series-label') }} {{breakdown.erroredSeries}}
+            }
+          </p>
+        }
       }
     }
   </div>

--- a/UI/Web/src/app/statistics/_components/kavitaplus-metadata-breakdown-stats/kavitaplus-metadata-breakdown-stats.component.ts
+++ b/UI/Web/src/app/statistics/_components/kavitaplus-metadata-breakdown-stats/kavitaplus-metadata-breakdown-stats.component.ts
@@ -3,13 +3,17 @@ import {StatisticsService} from "../../../_services/statistics.service";
 import {KavitaPlusMetadataBreakdown} from "../../_models/kavitaplus-metadata-breakdown";
 import {TranslocoDirective} from "@ngneat/transloco";
 import {PercentPipe} from "@angular/common";
+import {NgbProgressbar, NgbProgressbarStacked, NgbTooltip} from "@ng-bootstrap/ng-bootstrap";
 
 @Component({
   selector: 'app-kavitaplus-metadata-breakdown-stats',
   standalone: true,
   imports: [
     TranslocoDirective,
-    PercentPipe
+    PercentPipe,
+    NgbProgressbarStacked,
+    NgbProgressbar,
+    NgbTooltip
   ],
   templateUrl: './kavitaplus-metadata-breakdown-stats.component.html',
   styleUrl: './kavitaplus-metadata-breakdown-stats.component.scss',
@@ -20,20 +24,18 @@ export class KavitaplusMetadataBreakdownStatsComponent {
   private readonly statsService = inject(StatisticsService);
 
   breakdown: KavitaPlusMetadataBreakdown | undefined;
-  completedStart!: number;
-  completedEnd!: number;
-  errorStart!: number;
-  errorEnd!: number;
-  percentDone!: number;
+
+  errorPercent!: number;
+  completedPercent!: number;
+
 
   constructor() {
     this.statsService.getKavitaPlusMetadataBreakdown().subscribe(res => {
       this.breakdown = res;
-      this.completedStart = 0;
-      this.completedEnd = ((res.seriesCompleted - res.erroredSeries) / res.totalSeries);
-      this.errorStart = this.completedEnd;
-      this.errorEnd = Math.max(1, ((res.seriesCompleted) / res.totalSeries));
-      this.percentDone = res.seriesCompleted / res.totalSeries;
+
+      this.errorPercent = (res.erroredSeries / res.totalSeries) * 100;
+      this.completedPercent = ((res.seriesCompleted - res.erroredSeries) / res.totalSeries) * 100;
+
       this.cdRef.markForCheck();
     });
   }

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -1786,10 +1786,10 @@
 
     "kavitaplus-metadata-breakdown-stats": {
         "title": "Kavita+ Metadata Breakdown",
+        "description": "Kavita fetches metadata (ratings, reviews, recommendations, etc) slowly over time for eligible series.",
         "no-data": "No data",
         "errored-series-label": "Errored Series",
         "completed-series-label": "Completed Series",
-        "total-series-progress-label": "Series Processed: {{percent}}",
         "complete": "All Series have metadata"
     },
 

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -579,7 +579,7 @@
         "published-label": "Published: ",
         "available": "Available",
         "description": "If you do not see an {{installed}}",
-        "description-continued": "tag, you are on a nightly release. Only major versions will show as available."
+        "description-continued": "tag, you are on a nightly release. Only major versions will show as available. A nightly tag will show when on a nightly from that stable."
     },
 
     "invite-user": {

--- a/openapi.json
+++ b/openapi.json
@@ -7,7 +7,7 @@
       "name": "GPL-3.0",
       "url": "https://github.com/Kareadita/Kavita/blob/develop/LICENSE"
     },
-    "version": "0.7.14.8"
+    "version": "0.7.14.9"
   },
   "servers": [
     {


### PR DESCRIPTION
Nightly Testers, this contains modifications to existing manual migrations. This fixes missing migrations for select volume re-creation updating Foreign Keys on Reading Lists, Bookmarks (not used), and Personal Table of Contents (not used). Rolling back to v0.7.14.3 then updating to the latest will result in the most stable build, but is not needed unless you are heavily into reading lists. 

As of this PR, I am confident that there will be minimal data loss (none for me on my prod instance).

# Changed
- Changed: Updated almost all GA to use Node 20
- Changed: Removed the pie chart and use stack progress bar for Kavita+ graphic on stats (develop)
- Changed: Tweaked some wording about the changelog component to better indicate to nightly users that are not on the latest stable-based nightlies. 
- Changed: Migrated personal toc, bookmarks, and reading list items when we have to construct new volumes on the manual migrations. 
- Changed: When using Force Scan on library settings, automatically close the modal.
- Changed: (Scanner) Change pdf parser so if it's a library type book, we override chapters as chapter number is RARELY used and mainly results in false positives.
- Changed: (Scanner) Fixed up the parsing so that book parser will coerced when the series in the metadata is wrong but there is a volume tag in said series, it will override.
- Changed: Added a fallback to the series detail page to handle bad pdf parses (until the upcoming pdf parser rewrite comes) to avoid no cards showing.

# Fixed
- Fixed: (Scanner) Fixed an issue where basic parser wasn't overriding the series/localized series during parsing when coming from comicinfo. (develop)
- Fixed: Fixed an issue where the manual migrations, when updating progress table, would change the last modified and break some smart lists/expected ordering. 
- Fixed: Fixed a parsing case for 'Cynthia The Mission - c000 - c006 (v06)'

