### PR TITLE
Clear font settings before rendering the page

### DIFF
--- a/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.ts
+++ b/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.ts
@@ -931,6 +931,8 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       this.updateSingleImagePageStyles()
       this.page = this.domSanitizer.bypassSecurityTrustHtml(content); // PERF: Potential optimization to prefetch next/prev page and store in localStorage
 
+        let cleanedContent = this.clearFontSettings(content); // Reset font settings to avoid conflicts with reader settings
+        this.page = this.domSanitizer.bypassSecurityTrustHtml(cleanedContent); // PERF: Potential optimization to prefetch next/prev page and store in localStorage
 
       this.cdRef.markForCheck();
 
@@ -1022,6 +1024,10 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
 
   }
 
+  clearFontSettings(content: string) {
+    const regCleaner = /font-(family|size):[^;]+;/g;
+    return content.replace(regCleaner, '');
+  }
 
   setupPage(part?: string | undefined, scrollTop?: number | undefined) {
     this.isLoading = false;

--- a/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.ts
+++ b/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.ts
@@ -78,11 +78,11 @@ const COLUMN_GAP = 20; // px
 /**
  * Styles that should be applied on the top level book-content tag
  */
-const pageLevelStyles = ['margin-left', 'margin-right', 'font-size'];
+const pageLevelStyles = ['margin-left', 'margin-right'];
 /**
  * Styles that should be applied on every element within book-content tag
  */
-const elementLevelStyles = ['line-height', 'font-family'];
+const elementLevelStyles = ['line-height', 'font-family', 'font-size'];
 
 @Component({
     selector: 'app-book-reader',

--- a/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.ts
+++ b/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.ts
@@ -931,8 +931,6 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       this.updateSingleImagePageStyles()
       this.page = this.domSanitizer.bypassSecurityTrustHtml(content); // PERF: Potential optimization to prefetch next/prev page and store in localStorage
 
-        let cleanedContent = this.clearFontSettings(content); // Reset font settings to avoid conflicts with reader settings
-        this.page = this.domSanitizer.bypassSecurityTrustHtml(cleanedContent); // PERF: Potential optimization to prefetch next/prev page and store in localStorage
 
       this.cdRef.markForCheck();
 
@@ -1024,10 +1022,6 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
 
   }
 
-  clearFontSettings(content: string) {
-    const regCleaner = /font-(family|size):[^;]+;/g;
-    return content.replace(regCleaner, '');
-  }
 
   setupPage(part?: string | undefined, scrollTop?: number | undefined) {
     this.isLoading = false;


### PR DESCRIPTION
# Behavior
- When the EPUB has the following CSS style, the reader cannot override the font-size while reading. (Font-size won't change when scrolling the bar)
```
.p_normal {
     font-size: 26px;
}
```

# Purpose solution
- Clean the font-size, family before rendering the page


