### PR TITLE
Fix images not loading in books when using a base url

### DIFF
--- a/API/Controllers/BookController.cs
+++ b/API/Controllers/BookController.cs
@@ -153,7 +153,7 @@ public class BookController : BaseApiController
         if (chapter == null) return BadRequest(await _localizationService.Translate(User.GetUserId(), "chapter-doesnt-exist"));
         var path = _cacheService.GetCachedFile(chapter);
 
-        var baseUrl = "//" + Request.Host + Request.PathBase + "/api/";
+        var baseUrl = "//" + Request.Host + Request.PathBase + Configuration.BaseUrl + "/api/";
 
         try
         {

--- a/API/Controllers/BookController.cs
+++ b/API/Controllers/BookController.cs
@@ -153,7 +153,9 @@ public class BookController : BaseApiController
         if (chapter == null) return BadRequest(await _localizationService.Translate(User.GetUserId(), "chapter-doesnt-exist"));
         var path = _cacheService.GetCachedFile(chapter);
 
-        var baseUrl = "//" + Request.Host + Request.PathBase + Configuration.BaseUrl + "/api/";
+        string basePath = Configuration.BaseUrl;
+        basePath = basePath == Configuration.DefaultBaseUrl ? "" : basePath;
+        var baseUrl = "//" + Request.Host + Request.PathBase + basePath + "/api/";
 
         try
         {

--- a/API/Controllers/BookController.cs
+++ b/API/Controllers/BookController.cs
@@ -153,8 +153,7 @@ public class BookController : BaseApiController
         if (chapter == null) return BadRequest(await _localizationService.Translate(User.GetUserId(), "chapter-doesnt-exist"));
         var path = _cacheService.GetCachedFile(chapter);
 
-        string basePath = Configuration.BaseUrl;
-        basePath = basePath == Configuration.DefaultBaseUrl ? "" : basePath;
+        var basePath = Configuration.BaseUrl == Configuration.DefaultBaseUrl ? string.Empty : Configuration.BaseUrl;
         var baseUrl = "//" + Request.Host + Request.PathBase + basePath + "/api/";
 
         try


### PR DESCRIPTION
# Fixed
- Fixed: Fixes images not loading in books when using a custom base url

The way baseUrl was constructed did not take the configuration option into account, this caused all requests to fail. I didn't notice any style missing, but looking at the code; this would also fix that.

<details>
<summary> Before</summary>
<img width="1680" alt="image" src="https://github.com/Kareadita/Kavita/assets/77553571/56f48e82-b178-4f7e-9d64-145916a11991">
</details>
<details>
<summary> After</summary>
<img width="1680" alt="image" src="https://github.com/Kareadita/Kavita/assets/77553571/39a80c28-1efc-4f28-aac4-680e0b5aadb3">
</details>