### PR TITLE
Last Batch before Release 

### DIFF
--- a/API.Tests/Parsing/BookParsingTests.cs
+++ b/API.Tests/Parsing/BookParsingTests.cs
@@ -1,4 +1,5 @@
-﻿using Xunit;
+﻿using API.Entities.Enums;
+using Xunit;
 
 namespace API.Tests.Parsing;
 
@@ -10,7 +11,7 @@ public class BookParsingTests
     [InlineData("Faust - Volume 01 [Del Rey][Scans_Compressed]", "Faust")]
     public void ParseSeriesTest(string filename, string expected)
     {
-        Assert.Equal(expected, API.Services.Tasks.Scanner.Parser.Parser.ParseSeries(filename));
+        Assert.Equal(expected, API.Services.Tasks.Scanner.Parser.Parser.ParseSeries(filename, LibraryType.Book));
     }
 
     [Theory]
@@ -18,7 +19,7 @@ public class BookParsingTests
     [InlineData("Faust - Volume 01 [Del Rey][Scans_Compressed]", "1")]
     public void ParseVolumeTest(string filename, string expected)
     {
-        Assert.Equal(expected, API.Services.Tasks.Scanner.Parser.Parser.ParseVolume(filename));
+        Assert.Equal(expected, API.Services.Tasks.Scanner.Parser.Parser.ParseVolume(filename, LibraryType.Book));
     }
 
     // [Theory]

--- a/API.Tests/Parsing/ComicParsingTests.cs
+++ b/API.Tests/Parsing/ComicParsingTests.cs
@@ -1,4 +1,5 @@
 using System.IO.Abstractions.TestingHelpers;
+using API.Entities.Enums;
 using API.Services;
 using API.Services.Tasks.Scanner.Parser;
 using Microsoft.Extensions.Logging;
@@ -10,16 +11,6 @@ namespace API.Tests.Parsing;
 
 public class ComicParsingTests
 {
-    private readonly ITestOutputHelper _testOutputHelper;
-    private readonly IDefaultParser _basicParser;
-
-    public ComicParsingTests(ITestOutputHelper testOutputHelper)
-    {
-        _testOutputHelper = testOutputHelper;
-        var directoryService = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), new MockFileSystem());
-        _basicParser = new BasicParser(directoryService, new ImageParser(directoryService));
-    }
-
     [Theory]
     [InlineData("04 - Asterix the Gladiator (1964) (Digital-Empire) (WebP by Doc MaKS)", "Asterix the Gladiator")]
     [InlineData("The First Asterix Frieze (WebP by Doc MaKS)", "The First Asterix Frieze")]
@@ -188,7 +179,7 @@ public class ComicParsingTests
     [InlineData("หนึ่งความคิด นิจนิรันดร์ บทที่ 112", "112")]
     public void ParseComicChapterTest(string filename, string expected)
     {
-        Assert.Equal(expected, API.Services.Tasks.Scanner.Parser.Parser.ParseComicChapter(filename));
+        Assert.Equal(expected, API.Services.Tasks.Scanner.Parser.Parser.ParseChapter(filename, LibraryType.Comic));
     }
 
 
@@ -219,6 +210,6 @@ public class ComicParsingTests
     [InlineData("Blood Syndicate Annual #001", true)]
     public void IsComicSpecialTest(string input, bool expected)
     {
-        Assert.Equal(expected, Parser.IsComicSpecial(input));
+        Assert.Equal(expected, Parser.IsSpecial(input, LibraryType.Comic));
     }
 }

--- a/API.Tests/Parsing/MangaParsingTests.cs
+++ b/API.Tests/Parsing/MangaParsingTests.cs
@@ -86,7 +86,7 @@ public class MangaParsingTests
     [InlineData("Nagasarete Airantou - Vol. 30 Ch. 187.5 - Vol.31 Omake", "30")]
     public void ParseVolumeTest(string filename, string expected)
     {
-        Assert.Equal(expected, API.Services.Tasks.Scanner.Parser.Parser.ParseVolume(filename));
+        Assert.Equal(expected, API.Services.Tasks.Scanner.Parser.Parser.ParseVolume(filename, LibraryType.Manga));
     }
 
     [Theory]
@@ -212,7 +212,7 @@ public class MangaParsingTests
     [InlineData("หนึ่งความคิด นิจนิรันดร์ เล่ม 2", "หนึ่งความคิด นิจนิรันดร์")]
     public void ParseSeriesTest(string filename, string expected)
     {
-        Assert.Equal(expected, API.Services.Tasks.Scanner.Parser.Parser.ParseSeries(filename));
+        Assert.Equal(expected, API.Services.Tasks.Scanner.Parser.Parser.ParseSeries(filename, LibraryType.Manga));
     }
 
     [Theory]
@@ -304,7 +304,7 @@ public class MangaParsingTests
     [InlineData("หนึ่งความคิด นิจนิรันดร์ บทที่ 112", "112")]
     public void ParseChaptersTest(string filename, string expected)
     {
-        Assert.Equal(expected, API.Services.Tasks.Scanner.Parser.Parser.ParseChapter(filename));
+        Assert.Equal(expected, API.Services.Tasks.Scanner.Parser.Parser.ParseChapter(filename, LibraryType.Manga));
     }
 
 
@@ -342,7 +342,7 @@ public class MangaParsingTests
     [InlineData("Hajime no Ippo - Artbook", false)]
     public void IsMangaSpecialTest(string input, bool expected)
     {
-        Assert.Equal(expected, API.Services.Tasks.Scanner.Parser.Parser.IsMangaSpecial(input));
+        Assert.Equal(expected, API.Services.Tasks.Scanner.Parser.Parser.IsSpecial(input, LibraryType.Manga));
     }
 
     [Theory]

--- a/API/Controllers/OPDSController.cs
+++ b/API/Controllers/OPDSController.cs
@@ -961,7 +961,7 @@ public class OpdsController : BaseApiController
         var user = await _unitOfWork.UserRepository.GetUserByIdAsync(await GetUser(apiKey));
         if (!await _accountService.HasDownloadPermission(user))
         {
-            return BadRequest("User does not have download permissions");
+            return Forbid("User does not have download permissions");
         }
 
         var files = await _unitOfWork.ChapterRepository.GetFilesForChapterAsync(chapterId);

--- a/API/Data/Migrations/20240418163829_ChapterSortOrderLock.Designer.cs
+++ b/API/Data/Migrations/20240418163829_ChapterSortOrderLock.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using API.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace API.Data.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20240418163829_ChapterSortOrderLock")]
+    partial class ChapterSortOrderLock
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "8.0.4");

--- a/API/Data/Migrations/20240418163829_ChapterSortOrderLock.cs
+++ b/API/Data/Migrations/20240418163829_ChapterSortOrderLock.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace API.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class ChapterSortOrderLock : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PdfLayoutMode",
+                table: "AppUserPreferences");
+
+            migrationBuilder.AddColumn<bool>(
+                name: "SortOrderLocked",
+                table: "Chapter",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "SortOrderLocked",
+                table: "Chapter");
+
+            migrationBuilder.AddColumn<int>(
+                name: "PdfLayoutMode",
+                table: "AppUserPreferences",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0);
+        }
+    }
+}

--- a/API/Entities/AppUserPreferences.cs
+++ b/API/Entities/AppUserPreferences.cs
@@ -116,11 +116,6 @@ public class AppUserPreferences
     /// </summary>
     public PdfScrollMode PdfScrollMode { get; set; } = PdfScrollMode.Vertical;
     /// <summary>
-    /// PDF Reader: Layout Mode of the reader
-    /// </summary>
-    /// Book mode is too buggy to include
-    //public PdfLayoutMode PdfLayoutMode { get; set; } = PdfLayoutMode.Multiple;
-    /// <summary>
     /// PDF Reader: Spread Mode of the reader
     /// </summary>
     public PdfSpreadMode PdfSpreadMode { get; set; } = PdfSpreadMode.None;

--- a/API/Entities/Chapter.cs
+++ b/API/Entities/Chapter.cs
@@ -33,6 +33,10 @@ public class Chapter : IEntityDate, IHasReadTimeEstimate
     /// </summary>
     public float SortOrder { get; set; }
     /// <summary>
+    /// Can the sort order be updated on scan or is it locked from UI
+    /// </summary>
+    public bool SortOrderLocked { get; set; }
+    /// <summary>
     /// The files that represent this Chapter
     /// </summary>
     public ICollection<MangaFile> Files { get; set; } = null!;

--- a/API/Entities/Chapter.cs
+++ b/API/Entities/Chapter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using API.Entities.Enums;
 using API.Entities.Interfaces;
@@ -175,7 +176,7 @@ public class Chapter : IEntityDate, IHasReadTimeEstimate
                 return Parser.RemoveExtensionIfSupported(Title);
             }
 
-            if (MinNumber.Is(0) && !float.TryParse(Range, out _))
+            if (MinNumber.Is(0) && !float.TryParse(Range, CultureInfo.InvariantCulture, out _))
             {
                 return $"{Range}";
             }

--- a/API/Extensions/ChapterListExtensions.cs
+++ b/API/Extensions/ChapterListExtensions.cs
@@ -38,7 +38,7 @@ public static class ChapterListExtensions
         fakeChapter.UpdateFrom(info);
         return specialTreatment
              ? chapters.FirstOrDefault(c => c.Range == Parser.RemoveExtensionIfSupported(info.Filename) || c.Files.Select(f => Parser.NormalizePath(f.FilePath)).Contains(normalizedPath))
-             : chapters.FirstOrDefault(c => c.Range == fakeChapter.GetNumberTitle());
+             : chapters.FirstOrDefault(c => c.Range == fakeChapter.GetNumberTitle()); // BUG: TODO: On non-english locales, for floats, the range will be 20,5 but the NumberTitle will return 20.5
     }
 
     /// <summary>

--- a/API/Helpers/Converters/FilterFieldValueConverter.cs
+++ b/API/Helpers/Converters/FilterFieldValueConverter.cs
@@ -86,7 +86,7 @@ public static class FilterFieldValueConverter
                 .Select(x => (MangaFormat) Enum.Parse(typeof(MangaFormat), x))
                 .ToList(),
             FilterField.ReadTime => int.Parse(value),
-            FilterField.AverageRating => float.Parse(value),
+            FilterField.AverageRating => value.AsFloat(),
             _ => throw new ArgumentException("Invalid field type")
         };
     }

--- a/API/Program.cs
+++ b/API/Program.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.IO.Abstractions;
 using System.Linq;
 using System.Security.Cryptography;
@@ -37,6 +38,9 @@ public class Program
 
     public static async Task Main(string[] args)
     {
+        CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture;
+        CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.InvariantCulture;
+
         Console.OutputEncoding = System.Text.Encoding.UTF8;
         Log.Logger = new LoggerConfiguration()
             .WriteTo.Console()

--- a/API/Services/ReaderService.cs
+++ b/API/Services/ReaderService.cs
@@ -489,7 +489,7 @@ public class ReaderService : IReaderService
                 currentChapter.SortOrder,
                 dto => dto.SortOrder);
             if (chapterId > 0) return chapterId;
-            currentVolume = volumes.FirstOrDefault(v => v.IsLooseLeaf());
+            currentVolume = volumes.Find(v => v.IsLooseLeaf());
         }
 
         if (currentVolume != null && currentVolume.IsLooseLeaf())
@@ -506,7 +506,7 @@ public class ReaderService : IReaderService
         // When we started as a special and there was no loose leafs, reset the currentVolume
         if (currentVolume == null)
         {
-            currentVolume = volumes.FirstOrDefault(v => !v.IsLooseLeaf() && !v.IsSpecial());
+            currentVolume = volumes.Find(v => !v.IsLooseLeaf() && !v.IsSpecial());
             if (currentVolume == null) return -1;
             return currentVolume.Chapters.OrderBy(x => x.SortOrder).Last()?.Id ?? -1;
         }
@@ -786,7 +786,7 @@ public class ReaderService : IReaderService
             }
 
             var files = _directoryService.GetFilesWithExtension(outputDirectory,
-                Tasks.Scanner.Parser.Parser.ImageFileExtensions);
+                Parser.ImageFileExtensions);
             return CacheService.GetPageFromFiles(files, pageNum);
         }
         catch (Exception ex)

--- a/API/Services/Tasks/Scanner/ParseScannedFiles.cs
+++ b/API/Services/Tasks/Scanner/ParseScannedFiles.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -484,17 +485,17 @@ public class ParseScannedFiles
                 }
 
                 chapters = infos
-                    .OrderByNatural(info => info.Chapters)
+                    .OrderByNatural(info => info.Chapters, StringComparer.InvariantCulture)
                     .ToList();
 
                 counter = 0f;
                 var prevIssue = string.Empty;
                 foreach (var chapter in chapters)
                 {
-                    if (float.TryParse(chapter.Chapters, out var parsedChapter))
+                    if (float.TryParse(chapter.Chapters, CultureInfo.InvariantCulture, out var parsedChapter))
                     {
                         counter = parsedChapter;
-                        if (!string.IsNullOrEmpty(prevIssue) && float.TryParse(prevIssue, out var prevIssueFloat) && parsedChapter.Is(prevIssueFloat))
+                        if (!string.IsNullOrEmpty(prevIssue) && float.TryParse(prevIssue, CultureInfo.InvariantCulture, out var prevIssueFloat) && parsedChapter.Is(prevIssueFloat))
                         {
                             // Bump by 0.1
                             counter += 0.1f;
@@ -566,7 +567,10 @@ public class ParseScannedFiles
         // Normalize this as many of the cases is a capitalization difference
         var nonLocalizedSeriesFound = infos
             .Where(i => !i.IsSpecial)
-            .Select(i => i.Series).DistinctBy(Parser.Parser.Normalize).ToList();
+            .Select(i => i.Series)
+            .DistinctBy(Parser.Parser.Normalize)
+            .ToList();
+
         if (nonLocalizedSeriesFound.Count == 1)
         {
             nonLocalizedSeries = nonLocalizedSeriesFound[0];

--- a/API/Services/Tasks/Scanner/ParseScannedFiles.cs
+++ b/API/Services/Tasks/Scanner/ParseScannedFiles.cs
@@ -421,6 +421,7 @@ public class ParseScannedFiles
         _logger.LogDebug("[ScannerService] Found {Count} files for {Folder}", files.Count, folder);
         await _eventHub.SendMessageAsync(MessageFactory.NotificationProgress,
             MessageFactory.FileScanProgressEvent($"{files.Count} files in {folder}", library.Name, ProgressEventType.Updated));
+
         if (files.Count == 0)
         {
             _logger.LogInformation("[ScannerService] {Folder} is empty, no longer in this location, or has no file types that match Library File Types", folder);

--- a/API/Services/Tasks/Scanner/Parser/BasicParser.cs
+++ b/API/Services/Tasks/Scanner/Parser/BasicParser.cs
@@ -35,17 +35,15 @@ public class BasicParser(IDirectoryService directoryService, IDefaultParser imag
         // This will be called if the epub is already parsed once then we call and merge the information, if the
         if (Parser.IsEpub(filePath))
         {
-            ret.Chapters = Parser.ParseChapter(fileName);
-            ret.Series = Parser.ParseSeries(fileName);
-            ret.Volumes = Parser.ParseVolume(fileName);
+            ret.Chapters = Parser.ParseChapter(fileName, type);
+            ret.Series = Parser.ParseSeries(fileName, type);
+            ret.Volumes = Parser.ParseVolume(fileName, type);
         }
         else
         {
-            ret.Chapters = type == LibraryType.Comic
-                ? Parser.ParseComicChapter(fileName)
-                : Parser.ParseChapter(fileName);
-            ret.Series = type == LibraryType.Comic ? Parser.ParseComicSeries(fileName) : Parser.ParseSeries(fileName);
-            ret.Volumes = type == LibraryType.Comic ? Parser.ParseComicVolume(fileName) : Parser.ParseVolume(fileName);
+            ret.Chapters = Parser.ParseChapter(fileName, type);
+            ret.Series = type == LibraryType.Comic ? Parser.ParseComicSeries(fileName) : Parser.ParseSeries(fileName, type);
+            ret.Volumes = type == LibraryType.Comic ? Parser.ParseComicVolume(fileName) : Parser.ParseVolume(fileName, type);
         }
 
         if (ret.Series == string.Empty || Parser.IsImage(filePath))
@@ -61,7 +59,7 @@ public class BasicParser(IDirectoryService directoryService, IDefaultParser imag
             ret.Edition = edition;
         }
 
-        var isSpecial = type == LibraryType.Comic ? Parser.IsComicSpecial(fileName) : Parser.IsMangaSpecial(fileName);
+        var isSpecial = Parser.IsSpecial(fileName, type);
         // We must ensure that we can only parse a special out. As some files will have v20 c171-180+Omake and that
         // could cause a problem as Omake is a special term, but there is valid volume/chapter information.
         if (ret.Chapters == Parser.DefaultChapter && ret.Volumes == Parser.LooseLeafVolume && isSpecial)

--- a/API/Services/Tasks/Scanner/Parser/BookParser.cs
+++ b/API/Services/Tasks/Scanner/Parser/BookParser.cs
@@ -13,25 +13,25 @@ public class BookParser(IDirectoryService directoryService, IBookService bookSer
         info.ComicInfo = comicInfo;
 
         // This catches when original library type is Manga/Comic and when parsing with non
-        if (Parser.ParseVolume(info.Series) != Parser.LooseLeafVolume) // Shouldn't this be info.Volume != DefaultVolume?
+        if (Parser.ParseVolume(info.Series, type) != Parser.LooseLeafVolume) // Shouldn't this be info.Volume != DefaultVolume?
         {
-            var hasVolumeInTitle = !Parser.ParseVolume(info.Title)
+            var hasVolumeInTitle = !Parser.ParseVolume(info.Title, type)
                 .Equals(Parser.LooseLeafVolume);
-            var hasVolumeInSeries = !Parser.ParseVolume(info.Series)
+            var hasVolumeInSeries = !Parser.ParseVolume(info.Series, type)
                 .Equals(Parser.LooseLeafVolume);
 
             if (string.IsNullOrEmpty(info.ComicInfo?.Volume) && hasVolumeInTitle && (hasVolumeInSeries || string.IsNullOrEmpty(info.Series)))
             {
                 // NOTE: I'm not sure the comment is true. I've never seen this triggered
                 // This is likely a light novel for which we can set series from parsed title
-                info.Series = Parser.ParseSeries(info.Title);
-                info.Volumes = Parser.ParseVolume(info.Title);
+                info.Series = Parser.ParseSeries(info.Title, type);
+                info.Volumes = Parser.ParseVolume(info.Title, type);
             }
             else
             {
                 var info2 = basicParser.Parse(filePath, rootPath, libraryRoot, LibraryType.Book, comicInfo);
                 info.Merge(info2);
-                if (hasVolumeInSeries && info2 != null && Parser.ParseVolume(info2.Series)
+                if (hasVolumeInSeries && info2 != null && Parser.ParseVolume(info2.Series, type)
                         .Equals(Parser.LooseLeafVolume))
                 {
                     // Override the Series name so it groups appropriately

--- a/API/Services/Tasks/Scanner/Parser/ComicVineParser.cs
+++ b/API/Services/Tasks/Scanner/Parser/ComicVineParser.cs
@@ -37,8 +37,8 @@ public class ComicVineParser(IDirectoryService directoryService) : DefaultParser
             FullFilePath = Parser.NormalizePath(filePath),
             Series = string.Empty,
             ComicInfo = comicInfo,
-            Chapters = Parser.ParseComicChapter(fileName),
-            Volumes = Parser.ParseComicVolume(fileName)
+            Chapters = Parser.ParseChapter(fileName, type),
+            Volumes = Parser.ParseVolume(fileName, type)
         };
 
         // See if we can formulate the name from the ComicInfo
@@ -78,7 +78,7 @@ public class ComicVineParser(IDirectoryService directoryService) : DefaultParser
         }
 
         // Check if this is a Special/Annual
-        info.IsSpecial = Parser.IsComicSpecial(info.Filename) || Parser.IsComicSpecial(info.ComicInfo?.Format);
+        info.IsSpecial = Parser.IsSpecial(info.Filename, type) || Parser.IsSpecial(info.ComicInfo?.Format, type);
 
         // Patch in other information from ComicInfo
         UpdateFromComicInfo(info);

--- a/API/Services/Tasks/Scanner/Parser/DefaultParser.cs
+++ b/API/Services/Tasks/Scanner/Parser/DefaultParser.cs
@@ -64,16 +64,18 @@ public abstract class DefaultParser(IDirectoryService directoryService) : IDefau
         {
             var folder = fallbackFolders[i];
 
-            var parsedVolume = type is LibraryType.Manga ? Parser.ParseVolume(folder) : Parser.ParseComicVolume(folder);
-            var parsedChapter = type is LibraryType.Manga ? Parser.ParseChapter(folder) : Parser.ParseComicChapter(folder);
+            var parsedVolume = type is LibraryType.Comic or LibraryType.ComicVine ? Parser.ParseComicVolume(folder) : Parser.ParseVolume(folder);
+            var parsedChapter = type is LibraryType.Comic or LibraryType.ComicVine ? Parser.ParseComicChapter(folder) : Parser.ParseChapter(folder);
 
             if (!parsedVolume.Equals(Parser.LooseLeafVolume) || !parsedChapter.Equals(Parser.DefaultChapter))
             {
-                if ((string.IsNullOrEmpty(ret.Volumes) || ret.Volumes.Equals(Parser.LooseLeafVolume)) && !string.IsNullOrEmpty(parsedVolume) && !parsedVolume.Equals(Parser.LooseLeafVolume))
+                if ((string.IsNullOrEmpty(ret.Volumes) || ret.Volumes.Equals(Parser.LooseLeafVolume))
+                    && !string.IsNullOrEmpty(parsedVolume) && !parsedVolume.Equals(Parser.LooseLeafVolume))
                 {
                     ret.Volumes = parsedVolume;
                 }
-                if ((string.IsNullOrEmpty(ret.Chapters) || ret.Chapters.Equals(Parser.DefaultChapter)) && !string.IsNullOrEmpty(parsedChapter) && !parsedChapter.Equals(Parser.DefaultChapter))
+                if ((string.IsNullOrEmpty(ret.Chapters) || ret.Chapters.Equals(Parser.DefaultChapter))
+                    && !string.IsNullOrEmpty(parsedChapter) && !parsedChapter.Equals(Parser.DefaultChapter))
                 {
                     ret.Chapters = parsedChapter;
                 }

--- a/API/Services/Tasks/Scanner/Parser/DefaultParser.cs
+++ b/API/Services/Tasks/Scanner/Parser/DefaultParser.cs
@@ -39,13 +39,13 @@ public abstract class DefaultParser(IDirectoryService directoryService) : IDefau
     public void ParseFromFallbackFolders(string filePath, string rootPath, LibraryType type, ref ParserInfo ret)
     {
         var fallbackFolders = directoryService.GetFoldersTillRoot(rootPath, filePath)
-            .Where(f => !Parser.IsMangaSpecial(f))
+            .Where(f => !Parser.IsSpecial(f, type))
             .ToList();
 
         if (fallbackFolders.Count == 0)
         {
             var rootFolderName = directoryService.FileSystem.DirectoryInfo.New(rootPath).Name;
-            var series = Parser.ParseSeries(rootFolderName);
+            var series = Parser.ParseSeries(rootFolderName, type);
 
             if (string.IsNullOrEmpty(series))
             {
@@ -64,8 +64,8 @@ public abstract class DefaultParser(IDirectoryService directoryService) : IDefau
         {
             var folder = fallbackFolders[i];
 
-            var parsedVolume = type is LibraryType.Comic or LibraryType.ComicVine ? Parser.ParseComicVolume(folder) : Parser.ParseVolume(folder);
-            var parsedChapter = type is LibraryType.Comic or LibraryType.ComicVine ? Parser.ParseComicChapter(folder) : Parser.ParseChapter(folder);
+            var parsedVolume = Parser.ParseVolume(folder, type);
+            var parsedChapter = Parser.ParseChapter(folder, type);
 
             if (!parsedVolume.Equals(Parser.LooseLeafVolume) || !parsedChapter.Equals(Parser.DefaultChapter))
             {
@@ -84,7 +84,7 @@ public abstract class DefaultParser(IDirectoryService directoryService) : IDefau
             // Generally users group in series folders. Let's try to parse series from the top folder
             if (!folder.Equals(ret.Series) && i == fallbackFolders.Count - 1)
             {
-                var series = Parser.ParseSeries(folder);
+                var series = Parser.ParseSeries(folder, type);
 
                 if (string.IsNullOrEmpty(series))
                 {

--- a/API/Services/Tasks/Scanner/Parser/Parser.cs
+++ b/API/Services/Tasks/Scanner/Parser/Parser.cs
@@ -722,20 +722,37 @@ public static class Parser
         return int.Parse(match);
     }
 
-    public static bool IsMangaSpecial(string filePath)
+    public static bool IsSpecial(string? filePath, LibraryType type)
     {
-        filePath = ReplaceUnderscores(filePath);
-        return  MangaSpecialRegex.IsMatch(filePath);
+        return type switch
+        {
+            LibraryType.Manga => IsMangaSpecial(filePath),
+            LibraryType.Comic => IsComicSpecial(filePath),
+            LibraryType.Book => IsMangaSpecial(filePath),
+            LibraryType.Image => IsMangaSpecial(filePath),
+            LibraryType.LightNovel => IsMangaSpecial(filePath),
+            LibraryType.ComicVine => IsComicSpecial(filePath),
+            _ => false
+        };
     }
 
-    public static bool IsComicSpecial(string? filePath)
+    private static bool IsMangaSpecial(string? filePath)
+    {
+        if (string.IsNullOrEmpty(filePath)) return false;
+        filePath = ReplaceUnderscores(filePath);
+        return MangaSpecialRegex.IsMatch(filePath);
+    }
+
+    private static bool IsComicSpecial(string? filePath)
     {
         if (string.IsNullOrEmpty(filePath)) return false;
         filePath = ReplaceUnderscores(filePath);
         return ComicSpecialRegex.IsMatch(filePath);
     }
 
-    public static string ParseSeries(string filename)
+
+
+    public static string ParseMangaSeries(string filename)
     {
         foreach (var regex in MangaSeriesRegex)
         {
@@ -762,7 +779,7 @@ public static class Parser
         return string.Empty;
     }
 
-    public static string ParseVolume(string filename)
+    public static string ParseMangaVolume(string filename)
     {
         foreach (var regex in MangaVolumeRegex)
         {
@@ -818,7 +835,49 @@ public static class Parser
         return $"{from}-{to}";
     }
 
-    public static string ParseChapter(string filename)
+    public static string ParseSeries(string filename, LibraryType type)
+    {
+        return type switch
+        {
+            LibraryType.Manga => ParseMangaSeries(filename),
+            LibraryType.Comic => ParseComicSeries(filename),
+            LibraryType.Book => ParseMangaSeries(filename),
+            LibraryType.Image => ParseMangaSeries(filename),
+            LibraryType.LightNovel => ParseMangaSeries(filename),
+            LibraryType.ComicVine => ParseComicSeries(filename),
+            _ => string.Empty
+        };
+    }
+
+    public static string ParseVolume(string filename, LibraryType type)
+    {
+        return type switch
+        {
+            LibraryType.Manga => ParseMangaVolume(filename),
+            LibraryType.Comic => ParseComicVolume(filename),
+            LibraryType.Book => ParseMangaVolume(filename),
+            LibraryType.Image => ParseMangaVolume(filename),
+            LibraryType.LightNovel => ParseMangaVolume(filename),
+            LibraryType.ComicVine => ParseComicVolume(filename),
+            _ => LooseLeafVolume
+        };
+    }
+
+    public static string ParseChapter(string filename, LibraryType type)
+    {
+        return type switch
+        {
+            LibraryType.Manga => ParseMangaChapter(filename),
+            LibraryType.Comic => ParseComicChapter(filename),
+            LibraryType.Book => ParseMangaChapter(filename),
+            LibraryType.Image => ParseMangaChapter(filename),
+            LibraryType.LightNovel => ParseMangaChapter(filename),
+            LibraryType.ComicVine => ParseComicChapter(filename),
+            _ => DefaultChapter
+        };
+    }
+
+    private static string ParseMangaChapter(string filename)
     {
         foreach (var regex in MangaChapterRegex)
         {
@@ -847,7 +906,7 @@ public static class Parser
         return $"{value}.5";
     }
 
-    public static string ParseComicChapter(string filename)
+    private static string ParseComicChapter(string filename)
     {
         foreach (var regex in ComicChapterRegex)
         {

--- a/API/Services/Tasks/Scanner/Parser/Parser.cs
+++ b/API/Services/Tasks/Scanner/Parser/Parser.cs
@@ -1062,7 +1062,7 @@ public static class Parser
                 return tokens.Min(t => t.AsFloat());
             }
 
-            return float.Parse(range);
+            return range.AsFloat();
         }
         catch (Exception)
         {
@@ -1089,7 +1089,7 @@ public static class Parser
                 return tokens.Max(t => t.AsFloat());
             }
 
-            return float.Parse(range);
+            return range.AsFloat();
         }
         catch (Exception)
         {

--- a/API/Services/Tasks/Scanner/Parser/Parser.cs
+++ b/API/Services/Tasks/Scanner/Parser/Parser.cs
@@ -1,6 +1,6 @@
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -815,6 +815,7 @@ public static class Parser
         return LooseLeafVolume;
     }
 
+
     private static string FormatValue(string value, bool hasPart)
     {
         if (!value.Contains('-'))
@@ -824,6 +825,7 @@ public static class Parser
 
         var tokens = value.Split("-");
         var from = RemoveLeadingZeroes(tokens[0]);
+
         if (tokens.Length != 2) return from;
 
         // Occasionally users will use c01-c02 instead of c01-02, clean any leftover c

--- a/API/Services/Tasks/Scanner/Parser/PdfParser.cs
+++ b/API/Services/Tasks/Scanner/Parser/PdfParser.cs
@@ -17,9 +17,7 @@ public class PdfParser(IDirectoryService directoryService) : DefaultParser(direc
             FullFilePath = Parser.NormalizePath(filePath),
             Series = string.Empty,
             ComicInfo = comicInfo,
-            Chapters = type == LibraryType.Comic
-                ? Parser.ParseComicChapter(fileName)
-                : Parser.ParseChapter(fileName)
+            Chapters = Parser.ParseChapter(fileName, type)
         };
 
         if (type == LibraryType.Book)
@@ -27,8 +25,8 @@ public class PdfParser(IDirectoryService directoryService) : DefaultParser(direc
             ret.Chapters = Parser.DefaultChapter;
         }
 
-        ret.Series = type == LibraryType.Comic ? Parser.ParseComicSeries(fileName) : Parser.ParseSeries(fileName);
-        ret.Volumes = type == LibraryType.Comic ? Parser.ParseComicVolume(fileName) : Parser.ParseVolume(fileName);
+        ret.Series = Parser.ParseSeries(fileName, type);
+        ret.Volumes = Parser.ParseVolume(fileName, type);
 
         if (ret.Series == string.Empty)
         {
@@ -43,7 +41,7 @@ public class PdfParser(IDirectoryService directoryService) : DefaultParser(direc
             ret.Edition = edition;
         }
 
-        var isSpecial = type == LibraryType.Comic ? Parser.IsComicSpecial(fileName) : Parser.IsMangaSpecial(fileName);
+        var isSpecial = Parser.IsSpecial(fileName, type);
         // We must ensure that we can only parse a special out. As some files will have v20 c171-180+Omake and that
         // could cause a problem as Omake is a special term, but there is valid volume/chapter information.
         if (ret.Chapters == Parser.DefaultChapter && ret.Volumes == Parser.LooseLeafVolume && isSpecial)

--- a/API/Services/Tasks/Scanner/ProcessSeries.cs
+++ b/API/Services/Tasks/Scanner/ProcessSeries.cs
@@ -728,7 +728,8 @@ public class ProcessSeries : IProcessSeries
                 // Ensure we remove any files that no longer exist AND order
                 existingChapter.Files = existingChapter.Files
                     .Where(f => parsedInfos.Any(p => Parser.Parser.NormalizePath(p.FullFilePath) == Parser.Parser.NormalizePath(f.FilePath)))
-                    .OrderByNatural(f => f.FilePath).ToList();
+                    .OrderByNatural(f => f.FilePath)
+                    .ToList();
                 existingChapter.Pages = existingChapter.Files.Sum(f => f.Pages);
             }
         }

--- a/API/Services/Tasks/Scanner/ProcessSeries.cs
+++ b/API/Services/Tasks/Scanner/ProcessSeries.cs
@@ -705,7 +705,10 @@ public class ProcessSeries : IProcessSeries
             chapter.Number = Parser.Parser.MinNumberFromRange(info.Chapters).ToString(CultureInfo.InvariantCulture);
             chapter.MinNumber = Parser.Parser.MinNumberFromRange(info.Chapters);
             chapter.MaxNumber = Parser.Parser.MaxNumberFromRange(info.Chapters);
-            chapter.SortOrder = info.IssueOrder;
+            if (!chapter.SortOrderLocked)
+            {
+                chapter.SortOrder = info.IssueOrder;
+            }
             chapter.Range = chapter.GetNumberTitle();
         }
 

--- a/UI/Web/package-lock.json
+++ b/UI/Web/package-lock.json
@@ -504,6 +504,7 @@
       "version": "17.3.4",
       "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-17.3.4.tgz",
       "integrity": "sha512-TVWjpZSI/GIXTYsmVgEKYjBckcW8Aj62DcxLNehRFR+c7UB95OY3ZFjU8U4jL0XvWPgTkkVWQVq+P6N4KCBsyw==",
+      "dev": true,
       "dependencies": {
         "@babel/core": "7.23.9",
         "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -531,6 +532,7 @@
       "version": "7.23.9",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.9.tgz",
       "integrity": "sha512-5q0175NOjddqpvvzU+kDiSOAk4PfdO6FvwCWoQ6RO7rTzEe8vlo+4HVfcnAREhD4npMs0e9uZypjTwzZPCf/cw==",
+      "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.23.5",
@@ -559,12 +561,14 @@
     "node_modules/@angular/compiler-cli/node_modules/@babel/core/node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true
     },
     "node_modules/@angular/compiler-cli/node_modules/@babel/core/node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -745,6 +749,7 @@
       "version": "7.24.0",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.0.tgz",
       "integrity": "sha512-fQfkg0Gjkza3nf0c7/w6Xf34BW4YvzNfACRLmmb7XRLa6XHdR+K9AlJlxneFfWYf6uhOzuzZVTjF/8KfndZANw==",
+      "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.23.5",
@@ -773,12 +778,14 @@
     "node_modules/@babel/core/node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true
     },
     "node_modules/@babel/core/node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -5622,6 +5629,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -5634,6 +5642,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -5905,6 +5914,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       },
@@ -6216,6 +6226,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -6507,7 +6518,8 @@
     "node_modules/convert-source-map": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "dev": true
     },
     "node_modules/cookie": {
       "version": "0.6.0",
@@ -7409,6 +7421,7 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
@@ -7418,6 +7431,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -8526,6 +8540,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -9207,6 +9222,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -11047,6 +11063,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12436,6 +12453,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -12447,6 +12465,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -12457,7 +12476,8 @@
     "node_modules/reflect-metadata": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
-      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "dev": true
     },
     "node_modules/regenerate": {
       "version": "1.4.2",
@@ -12925,7 +12945,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/sass": {
       "version": "1.71.1",
@@ -13044,6 +13064,7 @@
       "version": "7.6.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
       "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -13058,6 +13079,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -13068,7 +13090,8 @@
     "node_modules/semver/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/send": {
       "version": "0.18.0",
@@ -14199,6 +14222,7 @@
       "version": "5.4.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
       "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/UI/Web/src/app/cards/series-info-cards/series-info-cards.component.html
+++ b/UI/Web/src/app/cards/series-info-cards/series-info-cards.component.html
@@ -34,7 +34,7 @@
         <ng-container *ngIf="seriesMetadata.publicationStatus | publicationStatus as pubStatus">
           <app-icon-and-title [label]="t('publication-status-title')" [clickable]="true" fontClasses="fa-solid fa-hourglass-{{pubStatus === t('ongoing') ? 'empty' : 'end'}}"
                               (click)="handleGoTo(FilterField.PublicationStatus, seriesMetadata.publicationStatus)"
-                              [ngbTooltip]="t('publication-status-tooltip') + ' (' + seriesMetadata.maxCount + ' / ' + seriesMetadata.totalCount + ')'">
+                              [ngbTooltip]="t('publication-status-tooltip') + (seriesMetadata.totalCount === 0 ? '' : ' (' + seriesMetadata.maxCount + ' / ' + seriesMetadata.totalCount + ')')">
             {{pubStatus}}
           </app-icon-and-title>
         </ng-container>

--- a/UI/Web/src/app/registration/_components/register/register.component.html
+++ b/UI/Web/src/app/registration/_components/register/register.component.html
@@ -16,7 +16,8 @@
         </div>
 
         <div class="mb-3" style="width:100%">
-          <label for="email" class="form-label">{{t('email-label')}}</label>&nbsp;<i class="fa fa-info-circle" placement="right" [ngbTooltip]="emailTooltip" role="button" tabindex="0"></i>
+          <label for="email" class="form-label">{{t('email-label')}}</label>
+          <i class="fa fa-info-circle ms-1" placement="right" [ngbTooltip]="emailTooltip" role="button" tabindex="0"></i>
           <ng-template #emailTooltip>{{t('email-tooltip')}}</ng-template>
           <span class="visually-hidden" id="email-help">
             <ng-container [ngTemplateOutlet]="emailTooltip"></ng-container>
@@ -34,21 +35,24 @@
         </div>
 
         <div class="mb-3">
-          <label for="password" class="form-label">Password</label>&nbsp;<i class="fa fa-info-circle" placement="right" [ngbTooltip]="passwordTooltip" role="button" tabindex="0"></i>
+          <label for="password" class="form-label">Password</label>
+          <i class="fa fa-info-circle ms-1" placement="right" [ngbTooltip]="passwordTooltip" role="button" tabindex="0"></i>
           <ng-template #passwordTooltip>
             {{t('password-validation')}}
           </ng-template>
           <span class="visually-hidden" id="password-help"><ng-container [ngTemplateOutlet]="passwordTooltip"></ng-container></span>
           <input id="password" class="form-control" maxlength="32" minlength="6" pattern="^.{6,32}$" formControlName="password" autocomplete="new-password"
                  type="password" aria-describedby="password-help" [class.is-invalid]="registerForm.get('password')?.invalid && registerForm.get('password')?.touched">
-          <div id="password-validations" class="invalid-feedback" *ngIf="registerForm.dirty || registerForm.touched">
-            <div *ngIf="registerForm.get('password')?.errors?.required">
-              {{t('required-field')}}
+          @if (registerForm.dirty || registerForm.touched) {
+            <div id="password-validations" class="invalid-feedback">
+              @if (registerForm.get('password')?.errors?.required) {
+                <div>{{t('required-field')}}</div>
+              }
+              @if (registerForm.get('password')?.errors?.minlength || registerForm.get('password')?.errors?.maxLength || registerForm.get('password')?.errors?.pattern) {
+                <div>{{t('password-validation')}}</div>
+              }
             </div>
-            <div *ngIf="registerForm.get('password')?.errors?.minlength || registerForm.get('password')?.errors?.maxLength || registerForm.get('password')?.errors?.pattern">
-              {{t('password-validation')}}
-            </div>
-          </div>
+          }
         </div>
 
         <div class="float-end">

--- a/UI/Web/src/app/registration/_components/register/register.component.ts
+++ b/UI/Web/src/app/registration/_components/register/register.component.ts
@@ -27,7 +27,8 @@ export class RegisterComponent {
   registerForm: FormGroup = new FormGroup({
     email: new FormControl('', [Validators.required]),
     username: new FormControl('', [Validators.required]),
-    password: new FormControl('', [Validators.required, Validators.maxLength(32), Validators.minLength(6), Validators.pattern("^.{6,32}$")]),
+    password: new FormControl('', [Validators.required, Validators.maxLength(32),
+      Validators.minLength(6), Validators.pattern("^.{6,32}$")]),
   });
 
   private readonly navService = inject(NavService);

--- a/UI/Web/src/app/series-detail/_components/series-detail/series-detail.component.ts
+++ b/UI/Web/src/app/series-detail/_components/series-detail/series-detail.component.ts
@@ -751,7 +751,11 @@ export class SeriesDetailComponent implements OnInit, AfterContentChecked {
     } else {
       if (this.libraryType == LibraryType.Comic || this.libraryType == LibraryType.ComicVine) {
         if (this.chapters.length === 0) {
-          this.activeTabId = TabID.Specials;
+          if (this.specials.length > 0) {
+            this.activeTabId = TabID.Specials;
+          } else {
+            this.activeTabId = TabID.Volumes;
+          }
         } else {
           this.activeTabId = TabID.Chapters;
         }

--- a/UI/Web/src/app/series-detail/_components/series-detail/series-detail.component.ts
+++ b/UI/Web/src/app/series-detail/_components/series-detail/series-detail.component.ts
@@ -382,6 +382,9 @@ export class SeriesDetailComponent implements OnInit, AfterContentChecked {
 
       // This is a lone chapter
       if (vol.length === 0) {
+        if (this.currentlyReadingChapter.minNumber === LooseLeafOrDefaultNumber) {
+          return this.currentlyReadingChapter.titleName;
+        }
         return 'Ch ' + this.currentlyReadingChapter.minNumber; // TODO: Refactor this to use DisplayTitle (or Range) and Localize it
       }
 

--- a/UI/Web/src/app/shared/edit-list/edit-list.component.ts
+++ b/UI/Web/src/app/shared/edit-list/edit-list.component.ts
@@ -64,15 +64,25 @@ export class EditListComponent implements OnInit {
   }
 
   remove(index: number) {
-    const tokens = this.combinedItems.split(',');
-    const tokenToRemove = tokens[index];
 
-    this.combinedItems = tokens.filter(t => t != tokenToRemove).join(',');
-    for (const [index, [key, value]] of Object.entries(Object.entries(this.form.controls))) {
-      if (key.startsWith('link') && this.form.get(key)?.value === tokenToRemove) {
-        this.form.removeControl('link' + index, {emitEvent: true});
-      }
+    const initialControls = Object.keys(this.form.controls)
+      .filter(key => key.startsWith('link'));
+
+    if (index == 0 && initialControls.length === 1) {
+      this.form.get(initialControls[0])?.setValue('', {emitEvent: true});
+      this.emit();
+      this.cdRef.markForCheck();
+      return;
     }
+
+    // Remove the form control explicitly then rebuild the combinedItems
+    this.form.removeControl('link' + index, {emitEvent: true});
+
+    this.combinedItems = Object.keys(this.form.controls)
+      .filter(key => key.startsWith('link'))
+      .map(key => this.form.get(key)?.value)
+      .join(',');
+
 
     this.emit();
     this.cdRef.markForCheck();

--- a/UI/Web/src/app/statistics/_components/kavitaplus-metadata-breakdown-stats/kavitaplus-metadata-breakdown-stats.component.html
+++ b/UI/Web/src/app/statistics/_components/kavitaplus-metadata-breakdown-stats/kavitaplus-metadata-breakdown-stats.component.html
@@ -8,8 +8,8 @@
         <div>{{t('no-data')}}</div>
       } @else {
         <ngb-progressbar-stacked>
-          <ngb-progressbar type="danger" [showValue]="true" [value]="errorPercent" [ngbTooltip]="t('errored-series-label') + ' ' + breakdown.erroredSeries"></ngb-progressbar>
-          <ngb-progressbar type="success" [showValue]="true" [value]="completedPercent" [ngbTooltip]="t('completed-series-label') + ' ' + breakdown.seriesCompleted"></ngb-progressbar>
+          <ngb-progressbar class="progress-bar-danger" type="danger" [showValue]="true" [value]="20" [ngbTooltip]="t('errored-series-label') + ' ' + breakdown.erroredSeries"></ngb-progressbar>
+          <ngb-progressbar type="success" [showValue]="true" [value]="80" [ngbTooltip]="t('completed-series-label') + ' ' + breakdown.seriesCompleted"></ngb-progressbar>
         </ngb-progressbar-stacked>
         @if (breakdown.seriesCompleted >= breakdown.totalSeries) {
           <p>{{t('complete') }}

--- a/UI/Web/src/app/statistics/_components/kavitaplus-metadata-breakdown-stats/kavitaplus-metadata-breakdown-stats.component.scss
+++ b/UI/Web/src/app/statistics/_components/kavitaplus-metadata-breakdown-stats/kavitaplus-metadata-breakdown-stats.component.scss
@@ -11,8 +11,12 @@
 }
 
 .error {
-  color: red;
+  color: var(--error-color);
 }
 .completed {
   color: var(--color-5);
+}
+
+.progress-bar-danger.progress-bar {
+  background-color: var(--error-color);
 }

--- a/UI/Web/src/theme/components/_progress.scss
+++ b/UI/Web/src/theme/components/_progress.scss
@@ -2,11 +2,16 @@
     background-color: var(--progress-bg-color);
 }
 
-.progress-bar {
+.progress-bar.text-bg-success {
     background-color: var(--progress-bar-color) !important;
 }
 
 .progress-bar-striped {
     background-image: var(--progress-striped-animated-color);
     background-color: unset;
+}
+
+// Bootstrap sliders:
+.form-range::-webkit-slider-thumb {
+  background-color: var(--primary-color);
 }

--- a/openapi.json
+++ b/openapi.json
@@ -14365,6 +14365,10 @@
             "description": "The sorting order of the Chapter. Inherits from MinNumber, but can be overridden.",
             "format": "float"
           },
+          "sortOrderLocked": {
+            "type": "boolean",
+            "description": "Can the sort order be updated on scan or is it locked from UI"
+          },
           "files": {
             "type": "array",
             "items": {

--- a/openapi.json
+++ b/openapi.json
@@ -7,7 +7,7 @@
       "name": "GPL-3.0",
       "url": "https://github.com/Kareadita/Kavita/blob/develop/LICENSE"
     },
-    "version": "0.8.0.4"
+    "version": "0.8.0.7"
   },
   "servers": [
     {
@@ -8580,7 +8580,8 @@
               }
             }
           }
-        }
+        },
+        "deprecated": true
       }
     },
     "/api/Series/update-rating": {


### PR DESCRIPTION
# Added
- Added: Added SortOrderLocked field for upcoming ability to set it in the UI, allowing customization of sort order on Series Detail page. (This is not yet in the UI, just in the DB and code)

# Changed
- Changed: When refusing OPDS download due to lack of role, use 403 Forbid.
- Changed: Don't show any of the internal information on publication status tooltip when the total items is set to 0 (or unset)

# Fixed
- Fixed: Fixed Continue -100000 when a series is read on series detail page
- Fixed: When parsing from fallback libraries, use comic parsing only for Comic/Comic Vine library types. (Fixes #2879 )
- Fixed: Fixed a bug where weblinks remove would not work well. Now it works more like you would assume.
- Fixed: Fixed a bug where active tab wouldn't default to volumes on comic libraries when there were no issues or specials.
- Fixed: Fixed a bug where progress bar on kavita+ metadata progress wasn't showing red.
- Fixed: Fixed a bug where on Chrome bootstrap sliders were blue and not the primary color.
- Fixed: Fixed a bug where chapters could duplicate due to some regions using ',' as a decimal separator. Now in Kavita, whenever we stringify any numbers, it will always choose English's way as that is how it was designed. (Fixes #2887)
- Fixed: Fixed a case where non-English locales wouldn't parse floats correctly for x.x chapters.