### PR TITLE
MAL Interest Stacks

### DIFF
--- a/UI/Web/angular.json
+++ b/UI/Web/angular.json
@@ -24,11 +24,11 @@
       "prefix": "app",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:browser-esbuild",
+          "builder": "@angular-devkit/build-angular:application",
           "options": {
             "outputPath": "dist",
             "index": "src/index.html",
-            "main": "src/main.ts",
+            "browser": "src/main.ts",
             "polyfills": [
               "zone.js"
             ],

--- a/UI/Web/package-lock.json
+++ b/UI/Web/package-lock.json
@@ -21,7 +21,7 @@
         "@fortawesome/fontawesome-free": "^6.5.2",
         "@iharbeck/ngx-virtual-scroller": "^17.0.2",
         "@iplab/ngx-file-upload": "^17.1.0",
-        "@microsoft/signalr": "^8.0.0",
+        "@microsoft/signalr": "^7.0.14",
         "@ng-bootstrap/ng-bootstrap": "^16.0.0",
         "@ngneat/transloco": "^6.0.4",
         "@ngneat/transloco-locale": "^5.1.2",
@@ -3277,9 +3277,9 @@
       }
     },
     "node_modules/@microsoft/signalr": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/signalr/-/signalr-8.0.0.tgz",
-      "integrity": "sha512-K/wS/VmzRWePCGqGh8MU8OWbS1Zvu7DG7LSJS62fBB8rJUXwwj4axQtqrAAwKGUZHQF6CuteuQR9xMsVpM2JNA==",
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/@microsoft/signalr/-/signalr-7.0.14.tgz",
+      "integrity": "sha512-dnS7gSJF5LxByZwJaj82+F1K755ya7ttPT+JnSeCBef3sL8p8FBkHePXphK8NSuOquIb7vsphXWa28A+L2SPpw==",
       "dependencies": {
         "abort-controller": "^3.0.0",
         "eventsource": "^2.0.2",

--- a/UI/Web/package.json
+++ b/UI/Web/package.json
@@ -28,7 +28,7 @@
     "@fortawesome/fontawesome-free": "^6.5.2",
     "@iharbeck/ngx-virtual-scroller": "^17.0.2",
     "@iplab/ngx-file-upload": "^17.1.0",
-    "@microsoft/signalr": "^8.0.0",
+    "@microsoft/signalr": "^7.0.14",
     "@ng-bootstrap/ng-bootstrap": "^16.0.0",
     "@ngneat/transloco": "^6.0.4",
     "@ngneat/transloco-locale": "^5.1.2",

--- a/UI/Web/src/app/_services/message-hub.service.ts
+++ b/UI/Web/src/app/_services/message-hub.service.ts
@@ -148,7 +148,7 @@ export class MessageHubService {
         accessTokenFactory: () => user.token
       })
       .withAutomaticReconnect()
-      .withStatefulReconnect()
+      //.withStatefulReconnect() // Requires signalr@8.0
       .build();
 
     this.hubConnection


### PR DESCRIPTION
![image](https://github.com/Kareadita/Kavita/assets/735851/af221ad8-3aa3-424d-be7e-d27c4e40492e)


# Added
- Added: Kavita+ users can now import their MAL interest stacks/restacks into Kavita as Smart Collections. These collections will synchronize back with MAL to update with new series and summary information every 2 days. Smart Collections work just as normal collections except are non-editable as the MAL stack controls the data. They can be promoted given the user has promotion role. They are not admin-specific. (Closes #2925)

# Changed
- Changed: On forgot password, even if email isn't setup or user doesn't have email setup, still allow the reset link to log. (Fixes #2831)
- Changed: Updated SignalR to v0.8 which should help with quicker reconnects (not user-facing)
- Changed: Reduced memory for adding a set of series to a collection.

