### PR TITLE
Lots of Bugfixes

### DIFF
--- a/API.Tests/Parsing/ParsingTests.cs
+++ b/API.Tests/Parsing/ParsingTests.cs
@@ -200,6 +200,8 @@ public class ParsingTests
     [InlineData("카비타", "카비타")]
     [InlineData("06", "06")]
     [InlineData("", "")]
+    [InlineData("不安の種+", "不安の種+")]
+    [InlineData("不安の種*", "不安の種*")]
     public void NormalizeTest(string input, string expected)
     {
         Assert.Equal(expected, Normalize(input));

--- a/API/Controllers/OPDSController.cs
+++ b/API/Controllers/OPDSController.cs
@@ -1137,8 +1137,7 @@ public class OpdsController : BaseApiController
                 CreateLink(FeedLinkRelation.Thumbnail, FeedLinkType.Image,
                     $"{baseUrl}api/image/chapter-cover?chapterId={chapterId}&apiKey={apiKey}"),
                 // We MUST include acc link in the feed, panels doesn't work with just page streaming option. We have to block download directly
-                accLink,
-                await CreatePageStreamLink(series.LibraryId, seriesId, volumeId, chapterId, mangaFile, apiKey, prefix)
+                accLink
             ],
             Content = new FeedEntryContent()
             {
@@ -1146,6 +1145,12 @@ public class OpdsController : BaseApiController
                 Type = "text"
             }
         };
+
+        var canPageStream = mangaFile.Extension != ".epub";
+        if (canPageStream)
+        {
+            entry.Links.Add(await CreatePageStreamLink(series.LibraryId, seriesId, volumeId, chapterId, mangaFile, apiKey, prefix));
+        }
 
         return entry;
     }

--- a/API/Controllers/OPDSController.cs
+++ b/API/Controllers/OPDSController.cs
@@ -22,6 +22,7 @@ using API.Extensions;
 using API.Helpers;
 using API.Services;
 using API.Services.Tasks.Scanner.Parser;
+using AutoMapper;
 using Kavita.Common;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -42,6 +43,7 @@ public class OpdsController : BaseApiController
     private readonly ISeriesService _seriesService;
     private readonly IAccountService _accountService;
     private readonly ILocalizationService _localizationService;
+    private readonly IMapper _mapper;
 
 
     private readonly XmlSerializer _xmlSerializer;
@@ -78,7 +80,8 @@ public class OpdsController : BaseApiController
     public OpdsController(IUnitOfWork unitOfWork, IDownloadService downloadService,
         IDirectoryService directoryService, ICacheService cacheService,
         IReaderService readerService, ISeriesService seriesService,
-        IAccountService accountService, ILocalizationService localizationService)
+        IAccountService accountService, ILocalizationService localizationService,
+        IMapper mapper)
     {
         _unitOfWork = unitOfWork;
         _downloadService = downloadService;
@@ -88,6 +91,7 @@ public class OpdsController : BaseApiController
         _seriesService = seriesService;
         _accountService = accountService;
         _localizationService = localizationService;
+        _mapper = mapper;
 
         _xmlSerializer = new XmlSerializer(typeof(Feed));
         _xmlOpenSearchSerializer = new XmlSerializer(typeof(OpenSearchDescription));
@@ -289,7 +293,7 @@ public class OpdsController : BaseApiController
     {
         var baseUrl = (await _unitOfWork.SettingsRepository.GetSettingAsync(ServerSettingKey.BaseUrl)).Value;
         var prefix = "/api/opds/";
-        if (!Configuration.DefaultBaseUrl.Equals(baseUrl))
+        if (!Configuration.DefaultBaseUrl.Equals(baseUrl, StringComparison.InvariantCultureIgnoreCase))
         {
             // We need to update the Prefix to account for baseUrl
             prefix = baseUrl + "api/opds/";
@@ -849,16 +853,15 @@ public class OpdsController : BaseApiController
         var seriesDetail =  await _seriesService.GetSeriesDetail(seriesId, userId);
         foreach (var volume in seriesDetail.Volumes)
         {
-            var chapters = (await _unitOfWork.ChapterRepository.GetChaptersAsync(volume.Id))
-                .OrderBy(x => x.MinNumber, _chapterSortComparerDefaultLast);
+            var chapters = await _unitOfWork.ChapterRepository.GetChaptersAsync(volume.Id, ChapterIncludes.Files);
 
-            foreach (var chapterId in chapters.Select(c => c.Id))
+            foreach (var chapter in chapters)
             {
-                var files = await _unitOfWork.ChapterRepository.GetFilesForChapterAsync(chapterId);
-                var chapterTest = await _unitOfWork.ChapterRepository.GetChapterDtoAsync(chapterId);
-                foreach (var mangaFile in files)
+                var chapterId = chapter.Id;
+                var chapterDto = _mapper.Map<ChapterDto>(chapter);
+                foreach (var mangaFile in chapter.Files)
                 {
-                    feed.Entries.Add(await CreateChapterWithFile(userId, seriesId, volume.Id, chapterId, mangaFile, series, chapterTest, apiKey, prefix, baseUrl));
+                    feed.Entries.Add(await CreateChapterWithFile(userId, seriesId, volume.Id, chapterId, mangaFile, series, chapterDto, apiKey, prefix, baseUrl));
                 }
             }
 
@@ -867,20 +870,20 @@ public class OpdsController : BaseApiController
         foreach (var storylineChapter in seriesDetail.StorylineChapters.Where(c => !c.IsSpecial))
         {
             var files = await _unitOfWork.ChapterRepository.GetFilesForChapterAsync(storylineChapter.Id);
-            var chapterTest = await _unitOfWork.ChapterRepository.GetChapterDtoAsync(storylineChapter.Id);
+            var chapterDto = _mapper.Map<ChapterDto>(storylineChapter);
             foreach (var mangaFile in files)
             {
-                feed.Entries.Add(await CreateChapterWithFile(userId, seriesId, storylineChapter.VolumeId, storylineChapter.Id, mangaFile, series, chapterTest, apiKey, prefix, baseUrl));
+                feed.Entries.Add(await CreateChapterWithFile(userId, seriesId, storylineChapter.VolumeId, storylineChapter.Id, mangaFile, series, chapterDto, apiKey, prefix, baseUrl));
             }
         }
 
         foreach (var special in seriesDetail.Specials)
         {
             var files = await _unitOfWork.ChapterRepository.GetFilesForChapterAsync(special.Id);
-            var chapterTest = await _unitOfWork.ChapterRepository.GetChapterDtoAsync(special.Id);
+            var chapterDto = _mapper.Map<ChapterDto>(special);
             foreach (var mangaFile in files)
             {
-                feed.Entries.Add(await CreateChapterWithFile(userId, seriesId, special.VolumeId, special.Id, mangaFile, series, chapterTest, apiKey, prefix, baseUrl));
+                feed.Entries.Add(await CreateChapterWithFile(userId, seriesId, special.VolumeId, special.Id, mangaFile, series, chapterDto, apiKey, prefix, baseUrl));
             }
         }
 
@@ -1127,14 +1130,16 @@ public class OpdsController : BaseApiController
                 ? string.Empty
                 : $"     Summary: {chapter.Summary}"),
             Format = mangaFile.Format.ToString(),
-            Links = new List<FeedLink>()
-            {
-                CreateLink(FeedLinkRelation.Image, FeedLinkType.Image, $"{baseUrl}api/image/chapter-cover?chapterId={chapterId}&apiKey={apiKey}"),
-                CreateLink(FeedLinkRelation.Thumbnail, FeedLinkType.Image, $"{baseUrl}api/image/chapter-cover?chapterId={chapterId}&apiKey={apiKey}"),
+            Links =
+            [
+                CreateLink(FeedLinkRelation.Image, FeedLinkType.Image,
+                    $"{baseUrl}api/image/chapter-cover?chapterId={chapterId}&apiKey={apiKey}"),
+                CreateLink(FeedLinkRelation.Thumbnail, FeedLinkType.Image,
+                    $"{baseUrl}api/image/chapter-cover?chapterId={chapterId}&apiKey={apiKey}"),
                 // We can't not include acc link in the feed, panels doesn't work with just page streaming option. We have to block download directly
                 accLink,
                 await CreatePageStreamLink(series.LibraryId, seriesId, volumeId, chapterId, mangaFile, apiKey, prefix)
-            },
+            ],
             Content = new FeedEntryContent()
             {
                 Text = fileType,
@@ -1162,7 +1167,7 @@ public class OpdsController : BaseApiController
     {
         var userId = await GetUser(apiKey);
         if (pageNumber < 0) return BadRequest(await _localizationService.Translate(userId, "greater-0", "Page"));
-        var chapter = await _cacheService.Ensure(chapterId);
+        var chapter = await _cacheService.Ensure(chapterId, true);
         if (chapter == null) return BadRequest(await _localizationService.Translate(userId, "cache-file-find"));
 
         try
@@ -1188,7 +1193,7 @@ public class OpdsController : BaseApiController
                     SeriesId = seriesId,
                     VolumeId = volumeId,
                     LibraryId =libraryId
-                }, await GetUser(apiKey));
+                }, userId);
             }
 
 

--- a/API/Controllers/SearchController.cs
+++ b/API/Controllers/SearchController.cs
@@ -50,8 +50,14 @@ public class SearchController : BaseApiController
         return Ok(await _unitOfWork.SeriesRepository.GetSeriesForChapter(chapterId, User.GetUserId()));
     }
 
+    /// <summary>
+    /// Searches against different entities in the system against a query string
+    /// </summary>
+    /// <param name="queryString"></param>
+    /// <param name="includeChapterAndFiles">Include Chapter and Filenames in the entities. This can slow down the search on larger systems</param>
+    /// <returns></returns>
     [HttpGet("search")]
-    public async Task<ActionResult<SearchResultGroupDto>> Search(string queryString)
+    public async Task<ActionResult<SearchResultGroupDto>> Search(string queryString, [FromQuery] bool includeChapterAndFiles = true)
     {
         queryString = Services.Tasks.Scanner.Parser.Parser.CleanQuery(queryString);
 
@@ -63,7 +69,7 @@ public class SearchController : BaseApiController
         var isAdmin = await _unitOfWork.UserRepository.IsUserAdminAsync(user);
 
         var series = await _unitOfWork.SeriesRepository.SearchSeries(user.Id, isAdmin,
-            libraries, queryString);
+            libraries, queryString, includeChapterAndFiles);
 
         return Ok(series);
     }

--- a/API/Data/Repositories/ChapterRepository.cs
+++ b/API/Data/Repositories/ChapterRepository.cs
@@ -34,7 +34,7 @@ public interface IChapterRepository
     Task<ChapterDto?> GetChapterDtoAsync(int chapterId, ChapterIncludes includes = ChapterIncludes.Files);
     Task<ChapterMetadataDto?> GetChapterMetadataDtoAsync(int chapterId, ChapterIncludes includes = ChapterIncludes.Files);
     Task<IList<MangaFile>> GetFilesForChapterAsync(int chapterId);
-    Task<IList<Chapter>> GetChaptersAsync(int volumeId);
+    Task<IList<Chapter>> GetChaptersAsync(int volumeId, ChapterIncludes includes = ChapterIncludes.None);
     Task<IList<MangaFile>> GetFilesForChaptersAsync(IReadOnlyList<int> chapterIds);
     Task<string?> GetChapterCoverImageAsync(int chapterId);
     Task<IList<string>> GetAllCoverImagesAsync();
@@ -184,10 +184,11 @@ public class ChapterRepository : IChapterRepository
     /// </summary>
     /// <param name="volumeId"></param>
     /// <returns></returns>
-    public async Task<IList<Chapter>> GetChaptersAsync(int volumeId)
+    public async Task<IList<Chapter>> GetChaptersAsync(int volumeId, ChapterIncludes includes = ChapterIncludes.None)
     {
         return await _context.Chapter
             .Where(c => c.VolumeId == volumeId)
+            .Includes(includes)
             .OrderBy(c => c.SortOrder)
             .ToListAsync();
     }

--- a/API/Data/Repositories/SeriesRepository.cs
+++ b/API/Data/Repositories/SeriesRepository.cs
@@ -2094,6 +2094,7 @@ public class SeriesRepository : ISeriesRepository
                 LastScanned = s.LastFolderScanned,
                 SeriesName = s.Name,
                 FolderPath = s.FolderPath,
+                LowestFolderPath = s.LowestFolderPath,
                 Format = s.Format,
                 LibraryRoots = s.Library.Folders.Select(f => f.Path)
             }).ToListAsync();
@@ -2101,7 +2102,7 @@ public class SeriesRepository : ISeriesRepository
         var map = new Dictionary<string, IList<SeriesModified>>();
         foreach (var series in info)
         {
-            if (series.FolderPath == null) continue;
+            if (string.IsNullOrEmpty(series.FolderPath)) continue;
             if (!map.TryGetValue(series.FolderPath, out var value))
             {
                 map.Add(series.FolderPath, new List<SeriesModified>()
@@ -2112,6 +2113,20 @@ public class SeriesRepository : ISeriesRepository
             else
             {
                 value.Add(series);
+            }
+
+
+            if (string.IsNullOrEmpty(series.LowestFolderPath)) continue;
+            if (!map.TryGetValue(series.LowestFolderPath, out var value2))
+            {
+                map.Add(series.LowestFolderPath, new List<SeriesModified>()
+                {
+                    series
+                });
+            }
+            else
+            {
+                value2.Add(series);
             }
         }
 

--- a/API/Data/Repositories/SeriesRepository.cs
+++ b/API/Data/Repositories/SeriesRepository.cs
@@ -91,8 +91,9 @@ public interface ISeriesRepository
     /// <param name="isAdmin"></param>
     /// <param name="libraryIds"></param>
     /// <param name="searchQuery"></param>
+    /// <param name="includeChapterAndFiles">Includes Files in the Search</param>
     /// <returns></returns>
-    Task<SearchResultGroupDto> SearchSeries(int userId, bool isAdmin, IList<int> libraryIds, string searchQuery);
+    Task<SearchResultGroupDto> SearchSeries(int userId, bool isAdmin, IList<int> libraryIds, string searchQuery, bool includeChapterAndFiles = true);
     Task<IEnumerable<Series>> GetSeriesForLibraryIdAsync(int libraryId, SeriesIncludes includes = SeriesIncludes.None);
     Task<SeriesDto?> GetSeriesDtoByIdAsync(int seriesId, int userId);
     Task<Series?> GetSeriesByIdAsync(int seriesId, SeriesIncludes includes = SeriesIncludes.Volumes | SeriesIncludes.Metadata);
@@ -353,7 +354,7 @@ public class SeriesRepository : ISeriesRepository
         return [libraryId];
     }
 
-    public async Task<SearchResultGroupDto> SearchSeries(int userId, bool isAdmin, IList<int> libraryIds, string searchQuery)
+    public async Task<SearchResultGroupDto> SearchSeries(int userId, bool isAdmin, IList<int> libraryIds, string searchQuery, bool includeChapterAndFiles = true)
     {
         const int maxRecords = 15;
         var result = new SearchResultGroupDto();
@@ -452,42 +453,45 @@ public class SeriesRepository : ISeriesRepository
             .ProjectTo<TagDto>(_mapper.ConfigurationProvider)
             .ToListAsync();
 
-        var fileIds = _context.Series
-            .Where(s => seriesIds.Contains(s.Id))
-            .AsSplitQuery()
-            .SelectMany(s => s.Volumes)
-            .SelectMany(v => v.Chapters)
-            .SelectMany(c => c.Files.Select(f => f.Id));
+        result.Files = new List<MangaFileDto>();
+        result.Chapters = new List<ChapterDto>();
 
-        // Need to check if an admin
-        var user = await _context.AppUser.FirstAsync(u => u.Id == userId);
-        if (await _userManager.IsInRoleAsync(user, PolicyConstants.AdminRole))
+
+        if (includeChapterAndFiles)
         {
-            result.Files = await _context.MangaFile
-                .Where(m => EF.Functions.Like(m.FilePath, $"%{searchQuery}%") && fileIds.Contains(m.Id))
+            var fileIds = _context.Series
+                .Where(s => seriesIds.Contains(s.Id))
                 .AsSplitQuery()
-                .OrderBy(f => f.FilePath)
+                .SelectMany(s => s.Volumes)
+                .SelectMany(v => v.Chapters)
+                .SelectMany(c => c.Files.Select(f => f.Id));
+
+            // Need to check if an admin
+            var user = await _context.AppUser.FirstAsync(u => u.Id == userId);
+            if (await _userManager.IsInRoleAsync(user, PolicyConstants.AdminRole))
+            {
+                result.Files = await _context.MangaFile
+                    .Where(m => EF.Functions.Like(m.FilePath, $"%{searchQuery}%") && fileIds.Contains(m.Id))
+                    .AsSplitQuery()
+                    .OrderBy(f => f.FilePath)
+                    .Take(maxRecords)
+                    .ProjectTo<MangaFileDto>(_mapper.ConfigurationProvider)
+                    .ToListAsync();
+            }
+
+            result.Chapters = await _context.Chapter
+                .Include(c => c.Files)
+                .Where(c => EF.Functions.Like(c.TitleName, $"%{searchQuery}%")
+                            || EF.Functions.Like(c.ISBN, $"%{searchQuery}%")
+                            || EF.Functions.Like(c.Range, $"%{searchQuery}%")
+                )
+                .Where(c => c.Files.All(f => fileIds.Contains(f.Id)))
+                .AsSplitQuery()
+                .OrderBy(c => c.TitleName)
                 .Take(maxRecords)
-                .ProjectTo<MangaFileDto>(_mapper.ConfigurationProvider)
+                .ProjectTo<ChapterDto>(_mapper.ConfigurationProvider)
                 .ToListAsync();
         }
-        else
-        {
-            result.Files = new List<MangaFileDto>();
-        }
-
-        result.Chapters = await _context.Chapter
-            .Include(c => c.Files)
-            .Where(c => EF.Functions.Like(c.TitleName, $"%{searchQuery}%")
-                        || EF.Functions.Like(c.ISBN, $"%{searchQuery}%")
-                        || EF.Functions.Like(c.Range, $"%{searchQuery}%")
-                )
-            .Where(c => c.Files.All(f => fileIds.Contains(f.Id)))
-            .AsSplitQuery()
-            .OrderBy(c => c.TitleName)
-            .Take(maxRecords)
-            .ProjectTo<ChapterDto>(_mapper.ConfigurationProvider)
-            .ToListAsync();
 
         return result;
     }

--- a/API/Extensions/ClaimsPrincipalExtensions.cs
+++ b/API/Extensions/ClaimsPrincipalExtensions.cs
@@ -7,17 +7,23 @@ namespace API.Extensions;
 
 public static class ClaimsPrincipalExtensions
 {
+    private const string NotAuthenticatedMessage = "User is not authenticated";
+    /// <summary>
+    /// Get's the authenticated user's username
+    /// </summary>
+    /// <remarks>Warning! Username's can contain .. and /, do not use folders or filenames explicitly with the Username</remarks>
+    /// <param name="user"></param>
+    /// <returns></returns>
+    /// <exception cref="KavitaException"></exception>
     public static string GetUsername(this ClaimsPrincipal user)
     {
-        var userClaim = user.FindFirst(JwtRegisteredClaimNames.Name);
-        if (userClaim == null) throw new KavitaException("User is not authenticated");
+        var userClaim = user.FindFirst(JwtRegisteredClaimNames.Name) ?? throw new KavitaException(NotAuthenticatedMessage);
         return userClaim.Value;
     }
 
     public static int GetUserId(this ClaimsPrincipal user)
     {
-        var userClaim = user.FindFirst(ClaimTypes.NameIdentifier);
-        if (userClaim == null) throw new KavitaException("User is not authenticated");
+        var userClaim = user.FindFirst(ClaimTypes.NameIdentifier) ?? throw new KavitaException(NotAuthenticatedMessage);
         return int.Parse(userClaim.Value);
     }
 }

--- a/API/Services/BookService.cs
+++ b/API/Services/BookService.cs
@@ -847,7 +847,7 @@ public class BookService : IBookService
                         Filename = Path.GetFileName(filePath),
                         Title = specialName?.Trim() ?? string.Empty,
                         FullFilePath = Parser.NormalizePath(filePath),
-                        IsSpecial = false,
+                        IsSpecial = Parser.HasSpecialMarker(filePath),
                         Series = series.Trim(),
                         SeriesSort = series.Trim(),
                         Volumes = seriesIndex
@@ -869,7 +869,7 @@ public class BookService : IBookService
                 Filename = Path.GetFileName(filePath),
                 Title = epubBook.Title.Trim(),
                 FullFilePath = Parser.NormalizePath(filePath),
-                IsSpecial = false,
+                IsSpecial = Parser.HasSpecialMarker(filePath),
                 Series = epubBook.Title.Trim(),
                 Volumes = Parser.LooseLeafVolume,
             };

--- a/API/Services/CacheService.cs
+++ b/API/Services/CacheService.cs
@@ -322,7 +322,7 @@ public class CacheService : ICacheService
         var path = GetCachePath(chapterId);
         // NOTE: We can optimize this by extracting and renaming, so we don't need to scan for the files and can do a direct access
         var files = _directoryService.GetFilesWithExtension(path, Tasks.Scanner.Parser.Parser.ImageFileExtensions)
-            .OrderByNatural(Path.GetFileNameWithoutExtension)
+            //.OrderByNatural(Path.GetFileNameWithoutExtension) // This is already done in GetPageFromFiles
             .ToArray();
 
         return GetPageFromFiles(files, page);

--- a/API/Services/ReadingListService.cs
+++ b/API/Services/ReadingListService.cs
@@ -394,7 +394,7 @@ public class ReadingListService : IReadingListService
         var existingChapterExists = readingList.Items.Select(rli => rli.ChapterId).ToHashSet();
         var chaptersForSeries = (await _unitOfWork.ChapterRepository.GetChaptersByIdsAsync(chapterIds, ChapterIncludes.Volumes))
             .OrderBy(c => c.Volume.MinNumber)
-            .ThenBy(x => x.MinNumber, _chapterSortComparerForInChapterSorting)
+            .ThenBy(x => x.SortOrder)
             .ToList();
 
         var index = readingList.Items.Count == 0 ? 0 : lastOrder + 1;

--- a/API/Services/Tasks/Scanner/ParseScannedFiles.cs
+++ b/API/Services/Tasks/Scanner/ParseScannedFiles.cs
@@ -79,6 +79,7 @@ public class ScannedSeriesResult
 public class SeriesModified
 {
     public required string? FolderPath { get; set; }
+    public required string? LowestFolderPath { get; set; }
     public required string SeriesName { get; set; }
     public DateTime LastScanned { get; set; }
     public MangaFormat Format { get; set; }
@@ -151,6 +152,34 @@ public class ParseScannedFiles
                         HasChanged = false
                     });
                 }
+                else if (seriesPaths.TryGetValue(normalizedPath, out var series) && series.All(s => !string.IsNullOrEmpty(s.LowestFolderPath)))
+                {
+                    // If there are multiple series inside this path, let's check each of them to see which was modified and only scan those
+                    // This is very helpful for ComicVine libraries by Publisher
+                    foreach (var seriesModified in series)
+                    {
+                        if (HasSeriesFolderNotChangedSinceLastScan(seriesModified, seriesModified.LowestFolderPath!))
+                        {
+                            result.Add(new ScanResult()
+                            {
+                                Files = ArraySegment<string>.Empty,
+                                Folder = directory,
+                                LibraryRoot = folderPath,
+                                HasChanged = false
+                            });
+                        }
+                        else
+                        {
+                            result.Add(new ScanResult()
+                            {
+                                Files = _directoryService.ScanFiles(seriesModified.LowestFolderPath!, fileExtensions, matcher),
+                                Folder = directory,
+                                LibraryRoot = folderPath,
+                                HasChanged = true
+                            });
+                        }
+                    }
+                }
                 else
                 {
                     // For a scan, this is doing everything in the directory loop before the folder Action is called...which leads to no progress indication
@@ -183,14 +212,18 @@ public class ParseScannedFiles
                 HasChanged = false
             });
         }
-
-        result.Add(new ScanResult()
+        else
         {
-            Files = _directoryService.ScanFiles(folderPath, fileExtensions),
-            Folder = folderPath,
-            LibraryRoot = libraryRoot,
-            HasChanged = true
-        });
+            result.Add(new ScanResult()
+            {
+                Files = _directoryService.ScanFiles(folderPath, fileExtensions),
+                Folder = folderPath,
+                LibraryRoot = libraryRoot,
+                HasChanged = true
+            });
+        }
+
+
 
         return result;
     }
@@ -535,9 +568,28 @@ public class ParseScannedFiles
     {
         if (forceCheck) return false;
 
-        return seriesPaths.ContainsKey(normalizedFolder) && seriesPaths[normalizedFolder].All(f => f.LastScanned.Truncate(TimeSpan.TicksPerSecond) >=
-            _directoryService.GetLastWriteTime(normalizedFolder).Truncate(TimeSpan.TicksPerSecond));
+        if (seriesPaths.TryGetValue(normalizedFolder, out var v))
+        {
+            return HasAllSeriesFolderNotChangedSinceLastScan(v, normalizedFolder);
+        }
+
+        return false;
     }
+
+    private bool HasAllSeriesFolderNotChangedSinceLastScan(IList<SeriesModified> seriesFolders,
+        string normalizedFolder)
+    {
+        return seriesFolders.All(f => HasSeriesFolderNotChangedSinceLastScan(f, normalizedFolder));
+    }
+
+    private bool HasSeriesFolderNotChangedSinceLastScan(SeriesModified seriesModified, string normalizedFolder)
+    {
+        return seriesModified.LastScanned.Truncate(TimeSpan.TicksPerSecond) >=
+               _directoryService.GetLastWriteTime(normalizedFolder)
+                   .Truncate(TimeSpan.TicksPerSecond);
+    }
+
+
 
     /// <summary>
     /// Checks if there are any ParserInfos that have a Series that matches the LocalizedSeries field in any other info. If so,

--- a/API/Services/Tasks/Scanner/ParseScannedFiles.cs
+++ b/API/Services/Tasks/Scanner/ParseScannedFiles.cs
@@ -160,36 +160,20 @@ public class ParseScannedFiles
                     {
                         if (HasSeriesFolderNotChangedSinceLastScan(seriesModified, seriesModified.LowestFolderPath!))
                         {
-                            result.Add(new ScanResult()
-                            {
-                                Files = ArraySegment<string>.Empty,
-                                Folder = directory,
-                                LibraryRoot = folderPath,
-                                HasChanged = false
-                            });
+                            result.Add(CreateScanResult(directory, folderPath, false, ArraySegment<string>.Empty));
                         }
                         else
                         {
-                            result.Add(new ScanResult()
-                            {
-                                Files = _directoryService.ScanFiles(seriesModified.LowestFolderPath!, fileExtensions, matcher),
-                                Folder = directory,
-                                LibraryRoot = folderPath,
-                                HasChanged = true
-                            });
+                            result.Add(CreateScanResult(directory, folderPath, true,
+                                _directoryService.ScanFiles(seriesModified.LowestFolderPath!, fileExtensions, matcher)));
                         }
                     }
                 }
                 else
                 {
                     // For a scan, this is doing everything in the directory loop before the folder Action is called...which leads to no progress indication
-                    result.Add(new ScanResult()
-                    {
-                        Files = _directoryService.ScanFiles(directory, fileExtensions, matcher),
-                        Folder = directory,
-                        LibraryRoot = folderPath,
-                        HasChanged = true
-                    });
+                    result.Add(CreateScanResult(directory, folderPath, true,
+                        _directoryService.ScanFiles(directory, fileExtensions)));
                 }
             }
 
@@ -204,28 +188,28 @@ public class ParseScannedFiles
 
         if (HasSeriesFolderNotChangedSinceLastScan(seriesPaths, normalizedPath, forceCheck))
         {
-            result.Add(new ScanResult()
-            {
-                Files = ArraySegment<string>.Empty,
-                Folder = folderPath,
-                LibraryRoot = libraryRoot,
-                HasChanged = false
-            });
+            result.Add(CreateScanResult(folderPath, libraryRoot, false, ArraySegment<string>.Empty));
         }
         else
         {
-            result.Add(new ScanResult()
-            {
-                Files = _directoryService.ScanFiles(folderPath, fileExtensions),
-                Folder = folderPath,
-                LibraryRoot = libraryRoot,
-                HasChanged = true
-            });
+            result.Add(CreateScanResult(folderPath, libraryRoot, true,
+                _directoryService.ScanFiles(folderPath, fileExtensions)));
         }
 
 
-
         return result;
+    }
+
+    private static ScanResult CreateScanResult(string folderPath, string libraryRoot, bool hasChanged,
+        IList<string> files)
+    {
+        return new ScanResult()
+        {
+            Files = files,
+            Folder = folderPath,
+            LibraryRoot = libraryRoot,
+            HasChanged = hasChanged
+        };
     }
 
 

--- a/API/Services/Tasks/Scanner/Parser/BookParser.cs
+++ b/API/Services/Tasks/Scanner/Parser/BookParser.cs
@@ -13,7 +13,7 @@ public class BookParser(IDirectoryService directoryService, IBookService bookSer
         info.ComicInfo = comicInfo;
 
         // We need a special piece of code to override the Series IF there is a special marker in the filename for epub files
-        if (info.IsSpecial && info.ComicInfo.Series != info.Series)
+        if (info.IsSpecial && info.Volumes == "0" && info.ComicInfo.Series != info.Series)
         {
             info.Series = info.ComicInfo.Series;
         }

--- a/API/Services/Tasks/Scanner/Parser/BookParser.cs
+++ b/API/Services/Tasks/Scanner/Parser/BookParser.cs
@@ -12,8 +12,14 @@ public class BookParser(IDirectoryService directoryService, IBookService bookSer
 
         info.ComicInfo = comicInfo;
 
+        // We need a special piece of code to override the Series IF there is a special marker in the filename for epub files
+        if (info.IsSpecial && info.ComicInfo.Series != info.Series)
+        {
+            info.Series = info.ComicInfo.Series;
+        }
+
         // This catches when original library type is Manga/Comic and when parsing with non
-        if (Parser.ParseVolume(info.Series, type) != Parser.LooseLeafVolume) // Shouldn't this be info.Volume != DefaultVolume?
+        if (Parser.ParseVolume(info.Series, type) != Parser.LooseLeafVolume)
         {
             var hasVolumeInTitle = !Parser.ParseVolume(info.Title, type)
                 .Equals(Parser.LooseLeafVolume);

--- a/API/Services/Tasks/Scanner/Parser/Parser.cs
+++ b/API/Services/Tasks/Scanner/Parser/Parser.cs
@@ -103,7 +103,7 @@ public static class Parser
     private static readonly Regex CoverImageRegex = new Regex(@"(?<![[a-z]\d])(?:!?)(?<!back)(?<!back_)(?<!back-)(cover|folder)(?![\w\d])",
         MatchOptions, RegexTimeout);
 
-    private static readonly Regex NormalizeRegex = new Regex(@"[^\p{L}0-9\+!]",
+    private static readonly Regex NormalizeRegex = new Regex(@"[^\p{L}0-9\+!\*]",
         MatchOptions, RegexTimeout);
 
     /// <summary>

--- a/API/Services/Tasks/Scanner/ProcessSeries.cs
+++ b/API/Services/Tasks/Scanner/ProcessSeries.cs
@@ -710,6 +710,12 @@ public class ProcessSeries : IProcessSeries
                 chapter.SortOrder = info.IssueOrder;
             }
             chapter.Range = chapter.GetNumberTitle();
+            if (float.TryParse(chapter.Title, out var _))
+            {
+                // If we have float based chapters, first scan can have the chapter formatted as Chapter 0.2 - .2 as the title is wrong.
+                chapter.Title = chapter.GetNumberTitle();
+            }
+
         }
 
 

--- a/API/Startup.cs
+++ b/API/Startup.cs
@@ -358,7 +358,14 @@ public class Startup
 
         app.UseStaticFiles(new StaticFileOptions
         {
-            ContentTypeProvider = new FileExtensionContentTypeProvider(),
+            // bcmap files needed for PDF reader localizations (https://github.com/Kareadita/Kavita/issues/2970)
+            ContentTypeProvider = new FileExtensionContentTypeProvider
+            {
+                Mappings =
+                {
+                    [".bcmap"] = "application/octet-stream"
+                }
+            },
             HttpsCompression = HttpsCompressionMode.Compress,
             OnPrepareResponse = ctx =>
             {

--- a/UI/Web/src/app/_services/search.service.ts
+++ b/UI/Web/src/app/_services/search.service.ts
@@ -14,11 +14,11 @@ export class SearchService {
 
   constructor(private httpClient: HttpClient) { }
 
-  search(term: string) {
+  search(term: string, includeChapterAndFiles: boolean = false) {
     if (term === '') {
       return of(new SearchResultGroup());
     }
-    return this.httpClient.get<SearchResultGroup>(this.baseUrl + 'search/search?queryString=' + encodeURIComponent(term));
+    return this.httpClient.get<SearchResultGroup>(this.baseUrl + `search/search?includeChapterAndFiles=${includeChapterAndFiles}&queryString=${encodeURIComponent(term)}`);
   }
 
   getSeriesForMangaFile(mangaFileId: number) {

--- a/UI/Web/src/app/collections/_components/import-mal-collection-modal/import-mal-collection-modal.component.ts
+++ b/UI/Web/src/app/collections/_components/import-mal-collection-modal/import-mal-collection-modal.component.ts
@@ -11,7 +11,6 @@ import {forkJoin} from "rxjs";
 import {ToastrService} from "ngx-toastr";
 import {DecimalPipe} from "@angular/common";
 import {LoadingComponent} from "../../../shared/loading/loading.component";
-import {AccountService} from "../../../_services/account.service";
 import {ConfirmService} from "../../../shared/confirm.service";
 
 @Component({

--- a/UI/Web/src/app/nav/_components/grouped-typeahead/grouped-typeahead.component.html
+++ b/UI/Web/src/app/nav/_components/grouped-typeahead/grouped-typeahead.component.html
@@ -5,126 +5,165 @@
         <input #input [id]="id" type="text" inputmode="search" autocomplete="off" formControlName="typeahead" [placeholder]="placeholder"
                aria-haspopup="listbox" aria-owns="dropdown"
                [attr.aria-expanded]="hasFocus && hasData"
-               aria-autocomplete="list" (focusout)="close($event)" (focus)="open($event)" role="search"
+               aria-autocomplete="list" (focusout)="close($event)" (focus)="open($event)" role="searchbox"
         >
-        <div class="spinner-border spinner-border-sm" role="status" *ngIf="isLoading">
-          <span class="visually-hidden">{{t('loading')}}</span>
-        </div>
-        <button type="button" class="btn-close" [attr.aria-label]="t('close')" (click)="resetField()" *ngIf="typeaheadForm.get('typeahead')?.value.length > 0"></button>
+        @if (isLoading) {
+          <div class="spinner-border spinner-border-sm" role="status">
+            <span class="visually-hidden">{{t('loading')}}</span>
+          </div>
+        }
+
+
+        @if (typeaheadForm.get('typeahead')?.value && typeaheadForm.get('typeahead')!.value.length > 0) {
+          <button type="button" class="btn-close" [attr.aria-label]="t('close')" (click)="resetField()"></button>
+        }
       </div>
     </div>
-    <div class="dropdown" *ngIf="hasFocus">
-      <ul class="list-group" role="listbox" id="dropdown">
-        <ng-container *ngIf="seriesTemplate !== undefined && groupedData.series.length > 0">
-          <li class="list-group-item section-header"><h5 id="series-group">Series</h5></li>
-          <ul class="list-group results" role="group" aria-describedby="series-group">
-            <li *ngFor="let option of groupedData.series; let index = index;" (click)="handleResultlick(option)" tabindex="0"
-                class="list-group-item" aria-labelledby="series-group" role="option">
-              <ng-container [ngTemplateOutlet]="seriesTemplate" [ngTemplateOutletContext]="{ $implicit: option, idx: index }"></ng-container>
-            </li>
-          </ul>
-        </ng-container>
+    @if (hasFocus) {
+      <div class="dropdown">
+        <ul class="list-group" role="listbox" id="dropdown">
+          @if (seriesTemplate !== undefined && groupedData.series.length > 0) {
+            <li class="list-group-item section-header"><h5 id="series-group">Series</h5></li>
+            <ul class="list-group results" role="group" aria-describedby="series-group">
+              @for(option of groupedData.series; track option; let index = $index) {
+                <li (click)="handleResultClick(option)" tabindex="0"
+                    class="list-group-item" aria-labelledby="series-group" role="option">
+                  <ng-container [ngTemplateOutlet]="seriesTemplate" [ngTemplateOutletContext]="{ $implicit: option, idx: index }"></ng-container>
+                </li>
+              }
+            </ul>
+          }
 
-        <ng-container *ngIf="collectionTemplate !== undefined && groupedData.collections.length > 0">
-          <li class="list-group-item section-header"><h5>{{t('collections')}}</h5></li>
-          <ul class="list-group results">
-            <li *ngFor="let option of groupedData.collections; let index = index;" (click)="handleResultlick(option)" tabindex="0"
-                class="list-group-item" role="option">
-              <ng-container [ngTemplateOutlet]="collectionTemplate" [ngTemplateOutletContext]="{ $implicit: option, idx: index }"></ng-container>
-            </li>
-          </ul>
-        </ng-container>
 
-        <ng-container *ngIf="readingListTemplate !== undefined && groupedData.readingLists.length > 0">
-          <li class="list-group-item section-header"><h5>{{t('reading-lists')}}</h5></li>
-          <ul class="list-group results">
-            <li *ngFor="let option of groupedData.readingLists; let index = index;" (click)="handleResultlick(option)" tabindex="0"
-                class="list-group-item" role="option">
-              <ng-container [ngTemplateOutlet]="readingListTemplate" [ngTemplateOutletContext]="{ $implicit: option, idx: index }"></ng-container>
-            </li>
-          </ul>
-        </ng-container>
+          @if (collectionTemplate !== undefined && groupedData.collections.length > 0) {
+            <li class="list-group-item section-header"><h5>{{t('collections')}}</h5></li>
+            <ul class="list-group results">
+              @for(option of groupedData.collections; track option; let index = $index) {
+                <li (click)="handleResultClick(option)" tabindex="0"
+                    class="list-group-item" role="option">
+                  <ng-container [ngTemplateOutlet]="collectionTemplate" [ngTemplateOutletContext]="{ $implicit: option, idx: index }"></ng-container>
+                </li>
+              }
+            </ul>
+          }
 
-        <ng-container *ngIf="bookmarkTemplate !== undefined && groupedData.bookmarks.length > 0">
-          <li class="list-group-item section-header"><h5>{{t('bookmarks')}}</h5></li>
-          <ul class="list-group results">
-            <li *ngFor="let option of groupedData.bookmarks; let index = index;" (click)="handleResultlick(option)" tabindex="0"
-                class="list-group-item" role="option">
-              <ng-container [ngTemplateOutlet]="bookmarkTemplate" [ngTemplateOutletContext]="{ $implicit: option, idx: index }"></ng-container>
-            </li>
-          </ul>
-        </ng-container>
 
-        <ng-container *ngIf="libraryTemplate !== undefined && groupedData.libraries.length > 0">
-          <li class="list-group-item section-header"><h5 id="libraries-group">{{t('libraries')}}</h5></li>
-          <ul class="list-group results" role="group" aria-describedby="libraries-group">
-            <li *ngFor="let option of groupedData.libraries; let index = index;" (click)="handleResultlick(option)" tabindex="0"
-                class="list-group-item" aria-labelledby="libraries-group" role="option">
-              <ng-container [ngTemplateOutlet]="libraryTemplate" [ngTemplateOutletContext]="{ $implicit: option, idx: index }"></ng-container>
-            </li>
-          </ul>
-        </ng-container>
+          @if (readingListTemplate !== undefined && groupedData.readingLists.length > 0) {
+            <li class="list-group-item section-header"><h5>{{t('reading-lists')}}</h5></li>
+            <ul class="list-group results">
+              @for(option of groupedData.readingLists; track option; let index = $index) {
+                <li (click)="handleResultClick(option)" tabindex="0"
+                    class="list-group-item" role="option">
+                  <ng-container [ngTemplateOutlet]="readingListTemplate" [ngTemplateOutletContext]="{ $implicit: option, idx: index }"></ng-container>
+                </li>
+              }
+            </ul>
+          }
 
-        <ng-container *ngIf="genreTemplate !== undefined && groupedData.genres.length > 0">
-          <li class="list-group-item section-header"><h5>{{t('genres')}}</h5></li>
-          <ul class="list-group results">
-            <li *ngFor="let option of groupedData.genres; let index = index;" (click)="handleResultlick(option)" tabindex="0"
-                class="list-group-item" role="option">
-              <ng-container [ngTemplateOutlet]="genreTemplate" [ngTemplateOutletContext]="{ $implicit: option, idx: index }"></ng-container>
-            </li>
-          </ul>
-        </ng-container>
+          @if (bookmarkTemplate !== undefined && groupedData.bookmarks.length > 0) {
+            <li class="list-group-item section-header"><h5>{{t('bookmarks')}}</h5></li>
+            <ul class="list-group results">
+              @for(option of groupedData.bookmarks; track option; let index = $index) {
+                <li (click)="handleResultClick(option)" tabindex="0"
+                    class="list-group-item" role="option">
+                  <ng-container [ngTemplateOutlet]="bookmarkTemplate" [ngTemplateOutletContext]="{ $implicit: option, idx: index }"></ng-container>
+                </li>
+              }
+            </ul>
+          }
 
-        <ng-container *ngIf="tagTemplate !== undefined && groupedData.tags.length > 0">
-          <li class="list-group-item section-header"><h5>{{t('tags')}}</h5></li>
-          <ul class="list-group results">
-            <li *ngFor="let option of groupedData.tags; let index = index;" (click)="handleResultlick(option)" tabindex="0"
-                class="list-group-item" role="option">
-              <ng-container [ngTemplateOutlet]="tagTemplate" [ngTemplateOutletContext]="{ $implicit: option, idx: index }"></ng-container>
-            </li>
-          </ul>
-        </ng-container>
 
-        <ng-container *ngIf="personTemplate !== undefined && groupedData.persons.length > 0">
-          <li class="list-group-item section-header"><h5>{{t('people')}}</h5></li>
-          <ul class="list-group results">
-            <li *ngFor="let option of groupedData.persons; let index = index;" (click)="handleResultlick(option)" tabindex="0"
-                class="list-group-item" role="option">
-              <ng-container [ngTemplateOutlet]="personTemplate" [ngTemplateOutletContext]="{ $implicit: option, idx: index }"></ng-container>
-            </li>
-          </ul>
-        </ng-container>
+          @if (libraryTemplate !== undefined && groupedData.libraries.length > 0) {
+            <li class="list-group-item section-header"><h5 id="libraries-group">{{t('libraries')}}</h5></li>
+            <ul class="list-group results" role="group" aria-describedby="libraries-group">
+              @for(option of groupedData.libraries; track option; let index = $index) {
+                <li (click)="handleResultClick(option)" tabindex="0"
+                    class="list-group-item" aria-labelledby="libraries-group" role="option">
+                  <ng-container [ngTemplateOutlet]="libraryTemplate" [ngTemplateOutletContext]="{ $implicit: option, idx: index }"></ng-container>
+                </li>
+              }
+            </ul>
+          }
 
-        <ng-container *ngIf="chapterTemplate !== undefined && groupedData.chapters.length > 0">
-          <li class="list-group-item section-header"><h5>{{t('chapters')}}</h5></li>
-          <ul class="list-group results">
-            <li *ngFor="let option of groupedData.chapters; let index = index;" (click)="handleResultlick(option)" tabindex="0"
-                class="list-group-item" role="option">
-              <ng-container [ngTemplateOutlet]="chapterTemplate" [ngTemplateOutletContext]="{ $implicit: option, idx: index }"></ng-container>
-            </li>
-          </ul>
-        </ng-container>
+          @if (genreTemplate !== undefined && groupedData.genres.length > 0) {
+            <li class="list-group-item section-header"><h5>{{t('genres')}}</h5></li>
+            <ul class="list-group results">
+              @for(option of groupedData.genres; track option; let index = $index) {
+                <li (click)="handleResultClick(option)" tabindex="0"
+                    class="list-group-item" role="option">
+                  <ng-container [ngTemplateOutlet]="genreTemplate" [ngTemplateOutletContext]="{ $implicit: option, idx: index }"></ng-container>
+                </li>
+              }
+            </ul>
+          }
 
-        <ng-container *ngIf="fileTemplate !== undefined && groupedData.files.length > 0">
-          <li class="list-group-item section-header"><h5>{{t('files')}}</h5></li>
-          <ul class="list-group results">
-            <li *ngFor="let option of groupedData.files; let index = index;" (click)="handleResultlick(option)" tabindex="0"
-                class="list-group-item" role="option">
-              <ng-container [ngTemplateOutlet]="fileTemplate" [ngTemplateOutletContext]="{ $implicit: option, idx: index }"></ng-container>
-            </li>
-          </ul>
-        </ng-container>
+          @if (tagTemplate !== undefined && groupedData.tags.length > 0) {
+            <li class="list-group-item section-header"><h5>{{t('tags')}}</h5></li>
+            <ul class="list-group results">
+              @for(option of groupedData.tags; track option; let index = $index) {
+                <li (click)="handleResultClick(option)" tabindex="0"
+                    class="list-group-item" role="option">
+                  <ng-container [ngTemplateOutlet]="tagTemplate" [ngTemplateOutletContext]="{ $implicit: option, idx: index }"></ng-container>
+                </li>
+              }
+            </ul>
+          }
 
-        <ng-container *ngIf="!hasData && searchTerm.length > 0">
-          <ul class="list-group results">
-            <li class="list-group-item">
-              <ng-container [ngTemplateOutlet]="noResultsTemplate"></ng-container>
-            </li>
-          </ul>
+          @if (personTemplate !== undefined && groupedData.persons.length > 0) {
+            <li class="list-group-item section-header"><h5>{{t('people')}}</h5></li>
+            <ul class="list-group results">
+              @for(option of groupedData.persons; track option; let index = $index) {
+                <li (click)="handleResultClick(option)" tabindex="0"
+                    class="list-group-item" role="option">
+                  <ng-container [ngTemplateOutlet]="personTemplate" [ngTemplateOutletContext]="{ $implicit: option, idx: index }"></ng-container>
+                </li>
+              }
+            </ul>
+          }
 
-        </ng-container>
-      </ul>
-    </div>
+          @if (chapterTemplate !== undefined && groupedData.chapters.length > 0) {
+            <li class="list-group-item section-header"><h5>{{t('chapters')}}</h5></li>
+            <ul class="list-group results">
+              @for(option of groupedData.chapters; track option; let index = $index) {
+                <li (click)="handleResultClick(option)" tabindex="0"
+                    class="list-group-item" role="option">
+                  <ng-container [ngTemplateOutlet]="chapterTemplate" [ngTemplateOutletContext]="{ $implicit: option, idx: index }"></ng-container>
+                </li>
+              }
+            </ul>
+          }
+
+          @if (fileTemplate !== undefined && groupedData.files.length > 0) {
+            <li class="list-group-item section-header"><h5>{{t('files')}}</h5></li>
+            <ul class="list-group results">
+              @for(option of groupedData.files; track option; let index = $index) {
+                <li (click)="handleResultClick(option)" tabindex="0"
+                    class="list-group-item" role="option">
+                  <ng-container [ngTemplateOutlet]="fileTemplate" [ngTemplateOutletContext]="{ $implicit: option, idx: index }"></ng-container>
+                </li>
+              }
+            </ul>
+          }
+
+          @if (!hasData && searchTerm.length > 0) {
+            <ul class="list-group results">
+              <li class="list-group-item">
+                <ng-container [ngTemplateOutlet]="noResultsTemplate"></ng-container>
+              </li>
+            </ul>
+          }
+
+          @if (hasData && !includeChapterAndFiles) {
+            <li class="list-group-item" style="min-height: 34px">
+              <ng-container [ngTemplateOutlet]="extraTemplate"></ng-container>
+              <a href="javascript:void(0)" (click)="toggleIncludeFiles()" class="float-end">
+                {{t('include-extras')}}
+              </a>
+            </li>
+          }
+        </ul>
+      </div>
+    }
 
   </form>
 

--- a/UI/Web/src/app/nav/_components/grouped-typeahead/grouped-typeahead.component.html
+++ b/UI/Web/src/app/nav/_components/grouped-typeahead/grouped-typeahead.component.html
@@ -7,21 +7,21 @@
                [attr.aria-expanded]="hasFocus && hasData"
                aria-autocomplete="list" (focusout)="close($event)" (focus)="open($event)" role="searchbox"
         >
-        @if (isLoading) {
-          <div class="spinner-border spinner-border-sm" role="status">
-            <span class="visually-hidden">{{t('loading')}}</span>
-          </div>
-        }
-
-
-        @if (typeaheadForm.get('typeahead')?.value && typeaheadForm.get('typeahead')!.value.length > 0) {
-          <button type="button" class="btn-close" [attr.aria-label]="t('close')" (click)="resetField()"></button>
+        @if (searchTerm.length > 0) {
+          @if (isLoading) {
+            <div class="spinner-border spinner-border-sm" role="status">
+              <span class="visually-hidden">{{t('loading')}}</span>
+            </div>
+          } @else {
+            <button type="button" class="btn-close" [attr.aria-label]="t('close')" (click)="resetField()"></button>
+          }
         }
       </div>
     </div>
     @if (hasFocus) {
       <div class="dropdown">
         <ul class="list-group" role="listbox" id="dropdown">
+
           @if (seriesTemplate !== undefined && groupedData.series.length > 0) {
             <li class="list-group-item section-header"><h5 id="series-group">Series</h5></li>
             <ul class="list-group results" role="group" aria-describedby="series-group">
@@ -145,7 +145,8 @@
             </ul>
           }
 
-          @if (!hasData && searchTerm.length > 0) {
+          @if (!hasData && searchTerm.length > 0 && !isLoading) {
+
             <ul class="list-group results">
               <li class="list-group-item">
                 <ng-container [ngTemplateOutlet]="noResultsTemplate"></ng-container>

--- a/UI/Web/src/app/nav/_components/grouped-typeahead/grouped-typeahead.component.ts
+++ b/UI/Web/src/app/nav/_components/grouped-typeahead/grouped-typeahead.component.ts
@@ -18,8 +18,9 @@ import { debounceTime } from 'rxjs/operators';
 import { KEY_CODES } from 'src/app/shared/_services/utility.service';
 import { SearchResultGroup } from 'src/app/_models/search/search-result-group';
 import {takeUntilDestroyed} from "@angular/core/rxjs-interop";
-import { NgClass, NgIf, NgFor, NgTemplateOutlet } from '@angular/common';
+import { NgClass, NgTemplateOutlet } from '@angular/common';
 import {TranslocoDirective} from "@ngneat/transloco";
+import {LoadingComponent} from "../../../shared/loading/loading.component";
 
 export interface SearchEvent {
   value: string;
@@ -32,7 +33,7 @@ export interface SearchEvent {
     styleUrls: ['./grouped-typeahead.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush,
     standalone: true,
-  imports: [ReactiveFormsModule, NgClass, NgIf, NgFor, NgTemplateOutlet, TranslocoDirective]
+  imports: [ReactiveFormsModule, NgClass, NgTemplateOutlet, TranslocoDirective, LoadingComponent]
 })
 export class GroupedTypeaheadComponent implements OnInit {
   private readonly destroyRef = inject(DestroyRef);
@@ -55,6 +56,10 @@ export class GroupedTypeaheadComponent implements OnInit {
    * Placeholder for the input
    */
   @Input() placeholder: string = '';
+  /**
+   * When the search is active
+   */
+  @Input() isLoading: boolean = false;
   /**
    * Number of milliseconds after typing before triggering inputChanged for data fetching
    */
@@ -94,7 +99,6 @@ export class GroupedTypeaheadComponent implements OnInit {
 
 
   hasFocus: boolean = false;
-  isLoading: boolean = false;
   typeaheadForm: FormGroup = new FormGroup({});
   includeChapterAndFiles: boolean = false;
 
@@ -135,7 +139,10 @@ export class GroupedTypeaheadComponent implements OnInit {
     this.typeaheadForm.addControl('typeahead', new FormControl(this.initialValue, []));
     this.cdRef.markForCheck();
 
-    this.typeaheadForm.valueChanges.pipe(debounceTime(this.debounceTime), takeUntilDestroyed(this.destroyRef)).subscribe(change => {
+    this.typeaheadForm.valueChanges.pipe(
+      debounceTime(this.debounceTime),
+      takeUntilDestroyed(this.destroyRef)
+    ).subscribe(change => {
       const value = this.typeaheadForm.get('typeahead')?.value;
 
       if (value != undefined && value != '' && !this.hasFocus) {

--- a/UI/Web/src/app/nav/_components/nav-header/nav-header.component.html
+++ b/UI/Web/src/app/nav/_components/nav-header/nav-header.component.html
@@ -16,6 +16,7 @@
               #search
               id="nav-search"
               [minQueryLength]="2"
+              [isLoading]="isLoading"
               initialValue=""
               [placeholder]="t('search-alt')"
               [groupedData]="searchResults"

--- a/UI/Web/src/app/nav/_components/nav-header/nav-header.component.html
+++ b/UI/Web/src/app/nav/_components/nav-header/nav-header.component.html
@@ -147,7 +147,6 @@
               <ng-template #noResultsTemplate let-notFound>
                 {{t('no-data')}}
               </ng-template>
-
             </app-grouped-typeahead>
           </div>
         </div>

--- a/UI/Web/src/app/nav/_components/nav-header/nav-header.component.ts
+++ b/UI/Web/src/app/nav/_components/nav-header/nav-header.component.ts
@@ -33,7 +33,7 @@ import {NgbDropdown, NgbDropdownItem, NgbDropdownMenu, NgbDropdownToggle} from '
 import {EventsWidgetComponent} from '../events-widget/events-widget.component';
 import {SeriesFormatComponent} from '../../../shared/series-format/series-format.component';
 import {ImageComponent} from '../../../shared/image/image.component';
-import {GroupedTypeaheadComponent} from '../grouped-typeahead/grouped-typeahead.component';
+import {GroupedTypeaheadComponent, SearchEvent} from '../grouped-typeahead/grouped-typeahead.component';
 import {TranslocoDirective} from "@ngneat/transloco";
 import {FilterUtilitiesService} from "../../../shared/_services/filter-utilities.service";
 import {FilterStatement} from "../../../_models/metadata/v2/filter-statement";
@@ -65,7 +65,6 @@ export class NavHeaderComponent implements OnInit {
   debounceTime = 300;
   searchResults: SearchResultGroup = new SearchResultGroup();
   searchTerm = '';
-
 
   backToTopNeeded = false;
   searchFocused: boolean = false;
@@ -121,12 +120,14 @@ export class NavHeaderComponent implements OnInit {
 
 
 
-  onChangeSearch(val: string) {
+
+
+  onChangeSearch(evt: SearchEvent) {
       this.isLoading = true;
-      this.searchTerm = val.trim();
+      this.searchTerm = evt.value.trim();
       this.cdRef.markForCheck();
 
-      this.searchService.search(val.trim()).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(results => {
+      this.searchService.search(this.searchTerm, evt.includeFiles).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(results => {
         this.searchResults = results;
         this.isLoading = false;
         this.cdRef.markForCheck();

--- a/UI/Web/src/app/pdf-reader/_components/pdf-reader/pdf-reader.component.ts
+++ b/UI/Web/src/app/pdf-reader/_components/pdf-reader/pdf-reader.component.ts
@@ -34,7 +34,6 @@ import {SpreadType} from "ngx-extended-pdf-viewer/lib/options/spread-type";
 import {PdfLayoutModePipe} from "../../_pipe/pdf-layout-mode.pipe";
 import {PdfScrollModePipe} from "../../_pipe/pdf-scroll-mode.pipe";
 import {PdfSpreadModePipe} from "../../_pipe/pdf-spread-mode.pipe";
-import {HandtoolChanged} from "ngx-extended-pdf-viewer/lib/events/handtool-changed";
 
 @Component({
     selector: 'app-pdf-reader',

--- a/UI/Web/src/app/series-detail/_components/series-metadata-detail/series-metadata-detail.component.ts
+++ b/UI/Web/src/app/series-detail/_components/series-metadata-detail/series-metadata-detail.component.ts
@@ -94,7 +94,7 @@ export class SeriesMetadataDetailComponent implements OnChanges, OnInit {
 
   ngOnInit() {
     // If on desktop, we can just have all the data expanded by default:
-    this.isCollapsed = this.utilityService.getActiveBreakpoint() < Breakpoint.Desktop;
+    this.isCollapsed = true; // this.utilityService.getActiveBreakpoint() < Breakpoint.Desktop;
     // Check if there is a lot of extended data, if so, re-collapse
     const sum = (this.seriesMetadata.colorists.length + this.seriesMetadata.editors.length
       + this.seriesMetadata.coverArtists.length + this.seriesMetadata.inkers.length

--- a/UI/Web/src/app/shared/_services/utility.service.ts
+++ b/UI/Web/src/app/shared/_services/utility.service.ts
@@ -133,7 +133,7 @@ export class UtilityService {
     );
   }
 
-  deepEqual(object1: any, object2: any) {
+  deepEqual(object1: any | undefined | null, object2: any | undefined | null) {
     if ((object1 === null || object1 === undefined) && (object2 !== null || object2 !== undefined)) return false;
     if ((object2 === null || object2 === undefined) && (object1 !== null || object1 !== undefined)) return false;
     if (object1 === null && object2 === null) return true;

--- a/UI/Web/src/app/sidenav/_components/side-nav/side-nav.component.ts
+++ b/UI/Web/src/app/sidenav/_components/side-nav/side-nav.component.ts
@@ -65,7 +65,6 @@ export class SideNavComponent implements OnInit {
   homeActions = [
     {action: Action.Edit, title: 'customize', children: [], requiresAdmin: false, callback: this.openCustomize.bind(this)},
     {action: Action.Import, title: 'import-cbl', children: [], requiresAdmin: true, callback: this.importCbl.bind(this)},
-    {action: Action.Import, title: 'import-mal-stack', children: [], requiresAdmin: true, callback: this.importMalCollection.bind(this)}, // This requires the Collection Rework (https://github.com/Kareadita/Kavita/issues/2810)
   ];
 
   filterQuery: string = '';
@@ -144,6 +143,13 @@ export class SideNavComponent implements OnInit {
         this.navService.toggleSideNav();
         this.cdRef.markForCheck();
     });
+
+    this.accountService.hasValidLicense$.subscribe(res =>{
+      if (!res) return;
+
+      this.homeActions.push({action: Action.Import, title: 'import-mal-stack', children: [], requiresAdmin: true, callback: this.importMalCollection.bind(this)});
+      this.cdRef.markForCheck();
+    })
   }
 
   ngOnInit(): void {

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -1605,7 +1605,7 @@
         "description": "Import your MAL Interest Stacks and create Collections within Kavita",
         "series-count": "{{common.series-count}}",
         "restack-count": "{{num}} Restacks",
-        "nothing-found": ""
+        "nothing-found": "Nothing found"
     },
 
     "edit-chapter-progress": {

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -1537,8 +1537,8 @@
         "reading-lists": "Reading Lists",
         "collections": "Collections",
         "close": "{{common.close}}",
-        "loading": "{{common.loading}}"
-
+        "loading": "{{common.loading}}",
+        "include-extras": "Include Chapters & Files"
     },
 
     "nav-header": {


### PR DESCRIPTION
Holiday is coming up, need to flush out the work for a Stable. This contains a ton of bug fixes and performance improvements, especially around the Scanner. Nightly testers, please observe and let me know if the scanner is acting differently. It should work much better for those that use Comic Vine library type. 

# Added
- Added: Book series can now have specials. In order to be classified as a Special, the SP marker must be in the filename, the calibre:series must be set to the Series name and calibre:series_index must be 0. (Closes #2943 )
- Added: OPDS-PS on PDF files is now possible. Kavita will convert to images. 

# Changed
- Changed: Added * as an exception for Normalization (Fixes #2976)
- Changed: Series Detail page will now show people/genre/tags  as collapsed even on desktop, but summary will have same code to be expanded up to 1000 characters on desktop. 
- Changed: (Scanner) Refactored Scan Loop to avoid doing extra work on lower folders in a folder map path, so that users that group by publisher or another arbitrary folder, can avoid a lot of scanning on lower level folders just because the highest level changed. (Fixes #2912 )
- Changed: (Performance) Applied some performance optimizations on Series ODPS route which should help speed up heavier Series. 
- Changed: (Performance) Small optimization to image reader to make finding the next/prev page faster. 
- Changed: Search will no longer search against Chapter titles and Files by default. Instead, there is a new link in the search window to perform with those included. This should help users with larger libraries find their files faster. 
- Changed: (Kavita+) Kavita+ scrobbling will now take AniList/Mal ids from External metadata (which is prefetched from Kavita+ for the external metadata) whenever possible. This can help with matching when there are no weblinks.

# Fixed
- Fixed: Fixed a bug where Import MAL Stack was available to non Kavita+ users. (develop)
- Fixed: Fixed bcmap files not loading in the pdf reader (Fixes #2970 )
- Fixed: Fixed a bug when adding items to a reading list in bulk, sorting order of those chapters was not being respected.
- Fixed: Fixed a bug when a file of Chapter 0.2 first scanned in, Kavita would render the card as 'Chapter 0.2 - .2' then on another scan, Kavita would correctly render out 'Chapter 0.2'.
- Fixed: Loading indicator wasn't properly wired up in the search component (Fixes #2953)
