### PR TITLE
More Bugfixes

### DIFF
--- a/API.Tests/API.Tests.csproj
+++ b/API.Tests/API.Tests.csproj
@@ -6,13 +6,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.5" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.6" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
         <PackageReference Include="NSubstitute" Version="5.1.0" />
         <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="21.0.2" />
         <PackageReference Include="TestableIO.System.IO.Abstractions.Wrappers" Version="21.0.2" />
-        <PackageReference Include="xunit" Version="2.8.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+        <PackageReference Include="xunit" Version="2.8.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/API.Tests/Parsing/MangaParsingTests.cs
+++ b/API.Tests/Parsing/MangaParsingTests.cs
@@ -210,6 +210,7 @@ public class MangaParsingTests
     [InlineData("เด็กคนนี้ขอลาออกจากการเป็นเจ้าของปราสาท เล่ม 1", "เด็กคนนี้ขอลาออกจากการเป็นเจ้าของปราสาท")]
     [InlineData("Max Level Returner เล่มที่ 5", "Max Level Returner")]
     [InlineData("หนึ่งความคิด นิจนิรันดร์ เล่ม 2", "หนึ่งความคิด นิจนิรันดร์")]
+    [InlineData("不安の種\uff0b - 01", "不安の種\uff0b")]
     public void ParseSeriesTest(string filename, string expected)
     {
         Assert.Equal(expected, API.Services.Tasks.Scanner.Parser.Parser.ParseSeries(filename, LibraryType.Manga));

--- a/API.Tests/Parsing/ParsingTests.cs
+++ b/API.Tests/Parsing/ParsingTests.cs
@@ -201,7 +201,6 @@ public class ParsingTests
     [InlineData("06", "06")]
     [InlineData("", "")]
     [InlineData("不安の種+", "不安の種+")]
-    [InlineData("不安の種*", "不安の種*")]
     public void NormalizeTest(string input, string expected)
     {
         Assert.Equal(expected, Normalize(input));

--- a/API.Tests/Services/ParseScannedFilesTests.cs
+++ b/API.Tests/Services/ParseScannedFilesTests.cs
@@ -244,7 +244,7 @@ public class ParseScannedFilesTests : AbstractDbTest
         var directoriesSeen = new HashSet<string>();
         var library = await _unitOfWork.LibraryRepository.GetLibraryForIdAsync(1,
                 LibraryIncludes.Folders | LibraryIncludes.FileTypes);
-        var scanResults = psf.ProcessFiles("C:/Data/", true, await _unitOfWork.SeriesRepository.GetFolderPathMap(1), library);
+        var scanResults = await psf.ProcessFiles("C:/Data/", true, await _unitOfWork.SeriesRepository.GetFolderPathMap(1), library);
         foreach (var scanResult in scanResults)
         {
             directoriesSeen.Add(scanResult.Folder);
@@ -266,7 +266,7 @@ public class ParseScannedFilesTests : AbstractDbTest
         Assert.NotNull(library);
 
         var directoriesSeen = new HashSet<string>();
-        var scanResults = psf.ProcessFiles("C:/Data/", false,
+        var scanResults = await psf.ProcessFiles("C:/Data/", false,
             await _unitOfWork.SeriesRepository.GetFolderPathMap(1), library);
 
         foreach (var scanResult in scanResults)
@@ -299,7 +299,7 @@ public class ParseScannedFilesTests : AbstractDbTest
         var library = await _unitOfWork.LibraryRepository.GetLibraryForIdAsync(1,
             LibraryIncludes.Folders | LibraryIncludes.FileTypes);
         Assert.NotNull(library);
-        var scanResults = psf.ProcessFiles("C:/Data", true, await _unitOfWork.SeriesRepository.GetFolderPathMap(1), library);
+        var scanResults = await psf.ProcessFiles("C:/Data", true, await _unitOfWork.SeriesRepository.GetFolderPathMap(1), library);
 
         Assert.Equal(2, scanResults.Count);
     }
@@ -328,7 +328,7 @@ public class ParseScannedFilesTests : AbstractDbTest
         var library = await _unitOfWork.LibraryRepository.GetLibraryForIdAsync(1,
             LibraryIncludes.Folders | LibraryIncludes.FileTypes);
         Assert.NotNull(library);
-        var scanResults = psf.ProcessFiles("C:/Data", false,
+        var scanResults = await psf.ProcessFiles("C:/Data", false,
             await _unitOfWork.SeriesRepository.GetFolderPathMap(1), library);
 
         Assert.Single(scanResults);

--- a/API/API.csproj
+++ b/API/API.csproj
@@ -53,9 +53,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-      <PackageReference Include="CsvHelper" Version="32.0.1" />
-      <PackageReference Include="MailKit" Version="4.5.0" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.4">
+      <PackageReference Include="CsvHelper" Version="32.0.3" />
+      <PackageReference Include="MailKit" Version="4.6.0" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.6">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
@@ -66,17 +66,17 @@
     <PackageReference Include="Flurl" Version="3.0.7" />
     <PackageReference Include="Flurl.Http" Version="3.2.4" />
     <PackageReference Include="Hangfire" Version="1.8.12" />
-    <PackageReference Include="Hangfire.InMemory" Version="0.9.0" />
+    <PackageReference Include="Hangfire.InMemory" Version="0.10.0" />
     <PackageReference Include="Hangfire.MaximumConcurrentExecutions" Version="1.1.0" />
     <PackageReference Include="Hangfire.Storage.SQLite" Version="0.4.2" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.61" />
     <PackageReference Include="MarkdownDeep.NET.Core" Version="1.5.0.4" />
     <PackageReference Include="Hangfire.AspNetCore" Version="1.8.12" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.6" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.0" />
     <PackageReference Include="MimeTypeMapOfficial" Version="1.0.17" />
@@ -84,7 +84,7 @@
     <PackageReference Include="NetVips" Version="2.4.1" />
     <PackageReference Include="NetVips.Native" Version="8.15.2" />
     <PackageReference Include="NReco.Logging.File" Version="1.2.0" />
-    <PackageReference Include="Serilog" Version="3.1.1" />
+    <PackageReference Include="Serilog" Version="4.0.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.2.0-dev-00752" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="8.0.0" />
@@ -95,16 +95,16 @@
     <PackageReference Include="Serilog.Sinks.SignalR.Core" Version="0.1.2" />
     <PackageReference Include="SharpCompress" Version="0.37.2" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.4" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="9.25.0.90414">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="9.26.0.92422">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
     <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="8.0.2" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.5.2" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.6.0" />
     <PackageReference Include="System.IO.Abstractions" Version="21.0.2" />
-    <PackageReference Include="System.Drawing.Common" Version="8.0.4" />
-    <PackageReference Include="VersOne.Epub" Version="3.3.1" />
+    <PackageReference Include="System.Drawing.Common" Version="8.0.6" />
+    <PackageReference Include="VersOne.Epub" Version="3.3.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/API/Controllers/OPDSController.cs
+++ b/API/Controllers/OPDSController.cs
@@ -853,7 +853,7 @@ public class OpdsController : BaseApiController
         var seriesDetail =  await _seriesService.GetSeriesDetail(seriesId, userId);
         foreach (var volume in seriesDetail.Volumes)
         {
-            var chaptersForVolume = await _unitOfWork.ChapterRepository.GetChaptersAsync(volume.Id, ChapterIncludes.Files);
+            var chaptersForVolume = await _unitOfWork.ChapterRepository.GetChaptersAsync(volume.Id, ChapterIncludes.Files | ChapterIncludes.People);
 
             foreach (var chapter in chaptersForVolume)
             {
@@ -861,7 +861,8 @@ public class OpdsController : BaseApiController
                 var chapterDto = _mapper.Map<ChapterDto>(chapter);
                 foreach (var mangaFile in chapter.Files)
                 {
-                    feed.Entries.Add(await CreateChapterWithFile(userId, seriesId, volume.Id, chapterId, mangaFile, series, chapterDto, apiKey, prefix, baseUrl));
+                    feed.Entries.Add(await CreateChapterWithFile(userId, seriesId, volume.Id, chapterId, _mapper.Map<MangaFileDto>(mangaFile), series,
+                        chapterDto, apiKey, prefix, baseUrl));
                 }
             }
 
@@ -879,7 +880,8 @@ public class OpdsController : BaseApiController
             var chapterDto = _mapper.Map<ChapterDto>(chapter);
             foreach (var mangaFile in files)
             {
-                feed.Entries.Add(await CreateChapterWithFile(userId, seriesId, chapter.VolumeId, chapter.Id, mangaFile, series, chapterDto, apiKey, prefix, baseUrl));
+                feed.Entries.Add(await CreateChapterWithFile(userId, seriesId, chapter.VolumeId, chapter.Id, _mapper.Map<MangaFileDto>(mangaFile), series,
+                    chapterDto, apiKey, prefix, baseUrl));
             }
         }
 
@@ -889,7 +891,8 @@ public class OpdsController : BaseApiController
             var chapterDto = _mapper.Map<ChapterDto>(special);
             foreach (var mangaFile in files)
             {
-                feed.Entries.Add(await CreateChapterWithFile(userId, seriesId, special.VolumeId, special.Id, mangaFile, series, chapterDto, apiKey, prefix, baseUrl));
+                feed.Entries.Add(await CreateChapterWithFile(userId, seriesId, special.VolumeId, special.Id, _mapper.Map<MangaFileDto>(mangaFile), series,
+                    chapterDto, apiKey, prefix, baseUrl));
             }
         }
 
@@ -915,9 +918,9 @@ public class OpdsController : BaseApiController
         SetFeedId(feed, $"series-{series.Id}-volume-{volume.Id}-{_seriesService.FormatChapterName(userId, libraryType)}s");
         foreach (var chapter in chapters)
         {
-            var files = await _unitOfWork.ChapterRepository.GetFilesForChapterAsync(chapter.Id);
-            var chapterDto = await _unitOfWork.ChapterRepository.GetChapterDtoAsync(chapter.Id);
-            foreach (var mangaFile in files)
+            //var files = await _unitOfWork.ChapterRepository.GetFilesForChapterAsync(chapter.Id);
+            var chapterDto = await _unitOfWork.ChapterRepository.GetChapterDtoAsync(chapter.Id, ChapterIncludes.Files | ChapterIncludes.People);
+            foreach (var mangaFile in chapterDto.Files)
             {
                 feed.Entries.Add(await CreateChapterWithFile(userId, seriesId, volumeId, chapter.Id, mangaFile, series, chapterDto!, apiKey, prefix, baseUrl));
             }
@@ -934,17 +937,20 @@ public class OpdsController : BaseApiController
         if (!(await _unitOfWork.SettingsRepository.GetSettingsDtoAsync()).EnableOpds)
             return BadRequest(await _localizationService.Translate(userId, "opds-disabled"));
         var (baseUrl, prefix) = await GetPrefix();
+
         var series = await _unitOfWork.SeriesRepository.GetSeriesDtoByIdAsync(seriesId, userId);
         var libraryType = await _unitOfWork.LibraryRepository.GetLibraryTypeAsync(series.LibraryId);
-        var chapter = await _unitOfWork.ChapterRepository.GetChapterDtoAsync(chapterId);
+        var chapter = await _unitOfWork.ChapterRepository.GetChapterDtoAsync(chapterId, ChapterIncludes.Files | ChapterIncludes.People);
+
         if (chapter == null) return BadRequest(await _localizationService.Translate(userId, "chapter-doesnt-exist"));
+
         var volume = await _unitOfWork.VolumeRepository.GetVolumeAsync(volumeId);
-        var files = await _unitOfWork.ChapterRepository.GetFilesForChapterAsync(chapterId);
 
         var feed = CreateFeed(series.Name + " - Volume " + volume!.Name + $" - {_seriesService.FormatChapterName(userId, libraryType)}s",
             $"{prefix}{apiKey}/series/{seriesId}/volume/{volumeId}/chapter/{chapterId}", apiKey, prefix);
         SetFeedId(feed, $"series-{series.Id}-volume-{volumeId}-{_seriesService.FormatChapterName(userId, libraryType)}-{chapterId}-files");
-        foreach (var mangaFile in files)
+
+        foreach (var mangaFile in chapter.Files)
         {
             feed.Entries.Add(await CreateChapterWithFile(userId, seriesId, volumeId, chapterId, mangaFile, series, chapter, apiKey, prefix, baseUrl));
         }
@@ -1034,22 +1040,30 @@ public class OpdsController : BaseApiController
             Summary = $"Format: {seriesDto.Format}" + (string.IsNullOrWhiteSpace(metadata.Summary)
                 ? string.Empty
                 : $"     Summary: {metadata.Summary}"),
-            Authors = metadata.Writers.Select(p => new FeedAuthor()
-            {
-                Name = p.Name,
-                Uri = "http://opds-spec.org/author/" + p.Id
-            }).ToList(),
+            Authors = metadata.Writers.Select(CreateAuthor).ToList(),
             Categories = metadata.Genres.Select(g => new FeedCategory()
             {
                 Label = g.Title,
                 Term = string.Empty
             }).ToList(),
-            Links = new List<FeedLink>()
-            {
-                CreateLink(FeedLinkRelation.SubSection, FeedLinkType.AtomNavigation,  $"{prefix}{apiKey}/series/{seriesDto.Id}"),
-                CreateLink(FeedLinkRelation.Image, FeedLinkType.Image, $"{baseUrl}api/image/series-cover?seriesId={seriesDto.Id}&apiKey={apiKey}"),
-                CreateLink(FeedLinkRelation.Thumbnail, FeedLinkType.Image, $"{baseUrl}api/image/series-cover?seriesId={seriesDto.Id}&apiKey={apiKey}")
-            }
+            Links =
+            [
+                CreateLink(FeedLinkRelation.SubSection, FeedLinkType.AtomNavigation,
+                    $"{prefix}{apiKey}/series/{seriesDto.Id}"),
+                CreateLink(FeedLinkRelation.Image, FeedLinkType.Image,
+                    $"{baseUrl}api/image/series-cover?seriesId={seriesDto.Id}&apiKey={apiKey}"),
+                CreateLink(FeedLinkRelation.Thumbnail, FeedLinkType.Image,
+                    $"{baseUrl}api/image/series-cover?seriesId={seriesDto.Id}&apiKey={apiKey}")
+            ]
+        };
+    }
+
+    private static FeedAuthor CreateAuthor(PersonDto person)
+    {
+        return new FeedAuthor()
+        {
+            Name = person.Name,
+            Uri = "http://opds-spec.org/author/" + person.Id
         };
     }
 
@@ -1076,6 +1090,7 @@ public class OpdsController : BaseApiController
             Id = chapterId.ToString(),
             Title = title,
             Summary = summary ?? string.Empty,
+
             Links = new List<FeedLink>()
             {
                 CreateLink(FeedLinkRelation.SubSection, FeedLinkType.AtomNavigation,
@@ -1088,7 +1103,7 @@ public class OpdsController : BaseApiController
         };
     }
 
-    private async Task<FeedEntry> CreateChapterWithFile(int userId, int seriesId, int volumeId, int chapterId, MangaFile mangaFile, SeriesDto series, ChapterDto chapter, string apiKey, string prefix, string baseUrl)
+    private async Task<FeedEntry> CreateChapterWithFile(int userId, int seriesId, int volumeId, int chapterId, MangaFileDto mangaFile, SeriesDto series, ChapterDto chapter, string apiKey, string prefix, string baseUrl)
     {
         var fileSize =
             mangaFile.Bytes > 0 ? DirectoryService.GetHumanReadableBytes(mangaFile.Bytes) :
@@ -1149,7 +1164,8 @@ public class OpdsController : BaseApiController
             {
                 Text = fileType,
                 Type = "text"
-            }
+            },
+            Authors = chapter.Writers.Select(CreateAuthor).ToList()
         };
 
         var canPageStream = mangaFile.Extension != ".epub";
@@ -1247,7 +1263,7 @@ public class OpdsController : BaseApiController
         throw new KavitaException(await _localizationService.Get("en", "user-doesnt-exist"));
     }
 
-    private async Task<FeedLink> CreatePageStreamLink(int libraryId, int seriesId, int volumeId, int chapterId, MangaFile mangaFile, string apiKey, string prefix)
+    private async Task<FeedLink> CreatePageStreamLink(int libraryId, int seriesId, int volumeId, int chapterId, MangaFileDto mangaFile, string apiKey, string prefix)
     {
         var userId = await GetUser(apiKey);
         var progress = await _unitOfWork.AppUserProgressRepository.GetUserProgressDtoAsync(chapterId, userId);

--- a/API/Controllers/ReaderController.cs
+++ b/API/Controllers/ReaderController.cs
@@ -263,9 +263,9 @@ public class ReaderController : BaseApiController
             info.Title += " - " + info.ChapterTitle;
         }
 
-        if (info.IsSpecial && dto.VolumeNumber.Equals(Services.Tasks.Scanner.Parser.Parser.LooseLeafVolume))
+        if (info.IsSpecial)
         {
-            info.Subtitle = info.FileName;
+            info.Subtitle = Path.GetFileNameWithoutExtension(info.FileName);
         } else if (!info.IsSpecial && info.VolumeNumber.Equals(Services.Tasks.Scanner.Parser.Parser.LooseLeafVolume))
         {
             info.Subtitle = ReaderService.FormatChapterName(info.LibraryType, true, true) + info.ChapterNumber;

--- a/API/DTOs/MangaFileDto.cs
+++ b/API/DTOs/MangaFileDto.cs
@@ -6,10 +6,23 @@ namespace API.DTOs;
 public class MangaFileDto
 {
     public int Id { get; init; }
+    /// <summary>
+    /// Absolute path to the archive file (normalized)
+    /// </summary>
     public string FilePath { get; init; } = default!;
+    /// <summary>
+    /// Number of pages for the given file
+    /// </summary>
     public int Pages { get; init; }
+    /// <summary>
+    /// How many bytes make up this file
+    /// </summary>
     public long Bytes { get; init; }
     public MangaFormat Format { get; init; }
     public DateTime Created { get; init; }
+    /// <summary>
+    /// File extension
+    /// </summary>
+    public string? Extension { get; set; }
 
 }

--- a/API/DTOs/Settings/ServerSettingDTO.cs
+++ b/API/DTOs/Settings/ServerSettingDTO.cs
@@ -1,4 +1,5 @@
-﻿using API.Entities.Enums;
+﻿using System;
+using API.Entities.Enums;
 using API.Services;
 
 namespace API.DTOs.Settings;
@@ -88,6 +89,14 @@ public class ServerSettingDto
     /// SMTP Configuration
     /// </summary>
     public SmtpConfigDto SmtpConfig { get; set; }
+    /// <summary>
+    /// The Date Kavita was first installed
+    /// </summary>
+    public DateTime? FirstInstallDate { get; set; }
+    /// <summary>
+    /// The Version of Kavita on the first run
+    /// </summary>
+    public string? FirstInstallVersion { get; set; }
 
     /// <summary>
     /// Are at least some basics filled in

--- a/API/DTOs/Stats/ServerInfoSlimDto.cs
+++ b/API/DTOs/Stats/ServerInfoSlimDto.cs
@@ -1,4 +1,6 @@
-﻿namespace API.DTOs.Stats;
+﻿using System;
+
+namespace API.DTOs.Stats;
 
 /// <summary>
 /// This is just for the Server tab on UI
@@ -17,5 +19,13 @@ public class ServerInfoSlimDto
     /// Version of Kavita
     /// </summary>
     public required string KavitaVersion { get; set; }
+    /// <summary>
+    /// The Date Kavita was first installed
+    /// </summary>
+    public DateTime? FirstInstallDate { get; set; }
+    /// <summary>
+    /// The Version of Kavita on the first run
+    /// </summary>
+    public string? FirstInstallVersion { get; set; }
 
 }

--- a/API/Data/ManualMigrations/MigrateInitialInstallData.cs
+++ b/API/Data/ManualMigrations/MigrateInitialInstallData.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using API.Entities;
+using API.Entities.Enums;
+using API.Services;
+using Kavita.Common.EnvironmentInfo;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace API.Data.ManualMigrations;
+
+/// <summary>
+/// v0.8.2 I started collecting information on when the user first installed Kavita as a nice to have info for the user
+/// </summary>
+public static class MigrateInitialInstallData
+{
+    public static async Task Migrate(DataContext dataContext, ILogger<Program> logger, IDirectoryService directoryService)
+    {
+        if (await dataContext.ManualMigrationHistory.AnyAsync(m => m.Name == "MigrateInitialInstallData"))
+        {
+            return;
+        }
+
+        logger.LogCritical(
+            "Running MigrateInitialInstallData migration - Please be patient, this may take some time. This is not an error");
+
+        var settings = await dataContext.ServerSetting.ToListAsync();
+
+        // Get the Install Date as Date the DB was written
+        var dbFile = Path.Join(directoryService.ConfigDirectory, "kavita.db");
+        if (!string.IsNullOrEmpty(dbFile) && directoryService.FileSystem.File.Exists(dbFile))
+        {
+            var fi = directoryService.FileSystem.FileInfo.New(dbFile);
+            var setting = settings.First(s => s.Key == ServerSettingKey.FirstInstallDate);
+            setting.Value = fi.CreationTimeUtc.ToString();
+            await dataContext.SaveChangesAsync();
+        }
+
+
+        dataContext.ManualMigrationHistory.Add(new ManualMigrationHistory()
+        {
+            Name = "MigrateInitialInstallData",
+            ProductVersion = BuildInfo.Version.ToString(),
+            RanAt = DateTime.UtcNow
+        });
+        await dataContext.SaveChangesAsync();
+
+        logger.LogCritical(
+            "Running MigrateInitialInstallData migration - Completed. This is not an error");
+    }
+}

--- a/API/Data/Repositories/ChapterRepository.cs
+++ b/API/Data/Repositories/ChapterRepository.cs
@@ -22,6 +22,7 @@ public enum ChapterIncludes
     None = 1,
     Volumes = 2,
     Files = 4,
+    People = 8
 }
 
 public interface IChapterRepository

--- a/API/Data/Seed.cs
+++ b/API/Data/Seed.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
@@ -251,6 +252,9 @@ public static class Seed
             new() {Key = ServerSettingKey.EmailEnableSsl, Value = "true"},
             new() {Key = ServerSettingKey.EmailSizeLimit, Value = 26_214_400 + string.Empty},
             new() {Key = ServerSettingKey.EmailCustomizedTemplates, Value = "false"},
+            new() {Key = ServerSettingKey.FirstInstallVersion, Value = BuildInfo.Version.ToString()},
+            new() {Key = ServerSettingKey.FirstInstallDate, Value = DateTime.UtcNow.ToString()},
+
         }.ToArray());
 
         foreach (var defaultSetting in DefaultSettings)

--- a/API/Entities/Enums/ServerSettingKey.cs
+++ b/API/Entities/Enums/ServerSettingKey.cs
@@ -186,5 +186,15 @@ public enum ServerSettingKey
     /// When the cleanup task should run - Critical to keeping Kavita working
     /// </summary>
     [Description("TaskCleanup")]
-    TaskCleanup = 37
+    TaskCleanup = 37,
+    /// <summary>
+    /// The Date Kavita was first installed
+    /// </summary>
+    [Description("FirstInstallDate")]
+    FirstInstallDate = 38,
+    /// <summary>
+    /// The Version of Kavita on the first run
+    /// </summary>
+    [Description("FirstInstallVersion")]
+    FirstInstallVersion = 39,
 }

--- a/API/Extensions/QueryExtensions/IncludesExtensions.cs
+++ b/API/Extensions/QueryExtensions/IncludesExtensions.cs
@@ -53,6 +53,12 @@ public static class IncludesExtensions
                 .Include(c => c.Files);
         }
 
+        if (includes.HasFlag(ChapterIncludes.People))
+        {
+            queryable = queryable
+                .Include(c => c.People);
+        }
+
         return queryable.AsSplitQuery();
     }
 

--- a/API/Helpers/Converters/ServerSettingConverter.cs
+++ b/API/Helpers/Converters/ServerSettingConverter.cs
@@ -122,6 +122,12 @@ public class ServerSettingConverter : ITypeConverter<IEnumerable<ServerSetting>,
                     destination.SmtpConfig ??= new SmtpConfigDto();
                     destination.SmtpConfig.CustomizedTemplates = bool.Parse(row.Value);
                     break;
+                case ServerSettingKey.FirstInstallDate:
+                    destination.FirstInstallDate = DateTime.Parse(row.Value);
+                    break;
+                case ServerSettingKey.FirstInstallVersion:
+                    destination.FirstInstallVersion = row.Value;
+                    break;
             }
         }
 

--- a/API/Services/DownloadService.cs
+++ b/API/Services/DownloadService.cs
@@ -35,6 +35,12 @@ public class DownloadService : IDownloadService
         // Figures out what the content type should be based on the file name.
         if (!_fileTypeProvider.TryGetContentType(filepath, out var contentType))
         {
+            if (contentType == null)
+            {
+                // Get extension
+                contentType = Path.GetExtension(filepath);
+            }
+
             contentType = Path.GetExtension(filepath).ToLowerInvariant() switch
             {
                 ".cbz" => "application/x-cbz",

--- a/API/Services/Plus/SmartCollectionSyncService.cs
+++ b/API/Services/Plus/SmartCollectionSyncService.cs
@@ -169,6 +169,9 @@ public class SmartCollectionSyncService : ISmartCollectionSyncService
                      s.NormalizedLocalizedName == normalizedSeriesName)
                     && formats.Contains(s.Format));
 
+                _logger.LogDebug("Trying to find {SeriesName} with formats ({Formats}) within Kavita for linking. Found: {ExistingSeriesName} ({ExistingSeriesId})",
+                    seriesInfo.SeriesName, formats, existingSeries?.Name, existingSeries?.Id);
+
                 if (existingSeries != null)
                 {
                     await _eventHub.SendMessageAsync(MessageFactory.NotificationProgress,

--- a/API/Services/StatisticService.cs
+++ b/API/Services/StatisticService.cs
@@ -57,7 +57,10 @@ public class StatisticService : IStatisticService
     public async Task<UserReadStatistics> GetUserReadStatistics(int userId, IList<int> libraryIds)
     {
         if (libraryIds.Count == 0)
+        {
             libraryIds = await _context.Library.GetUserLibraries(userId).ToListAsync();
+        }
+
 
         // Total Pages Read
         var totalPagesRead = await _context.AppUserProgresses

--- a/API/Services/Tasks/Scanner/LibraryWatcher.cs
+++ b/API/Services/Tasks/Scanner/LibraryWatcher.cs
@@ -56,9 +56,9 @@ public class LibraryWatcher : ILibraryWatcher
     /// <summary>
     /// Counts within a time frame how many times the buffer became full. Is used to reschedule LibraryWatcher to start monitoring much later rather than instantly
     /// </summary>
-    private int _bufferFullCounter;
-    private int _restartCounter;
-    private DateTime _lastErrorTime = DateTime.MinValue;
+    private static int _bufferFullCounter;
+    private static int _restartCounter;
+    private static DateTime _lastErrorTime = DateTime.MinValue;
     /// <summary>
     /// Used to lock buffer Full Counter
     /// </summary>

--- a/API/Services/Tasks/Scanner/LibraryWatcher.cs
+++ b/API/Services/Tasks/Scanner/LibraryWatcher.cs
@@ -273,6 +273,10 @@ public class LibraryWatcher : ILibraryWatcher
 
     private string GetFolder(string filePath, IEnumerable<string> libraryFolders)
     {
+        // TODO: I can optimize this to avoid a library scan and instead do a Series Scan by finding the series that has a lowestFolderPath higher or equal to the filePath
+
+
+
         var parentDirectory = _directoryService.GetParentDirectoryName(filePath);
         _logger.LogTrace("[LibraryWatcher] Parent Directory: {ParentDirectory}", parentDirectory);
         if (string.IsNullOrEmpty(parentDirectory)) return string.Empty;

--- a/API/Services/Tasks/Scanner/LibraryWatcher.cs
+++ b/API/Services/Tasks/Scanner/LibraryWatcher.cs
@@ -262,20 +262,18 @@ public class LibraryWatcher : ILibraryWatcher
                 return;
             }
 
-            _taskScheduler.ScanFolder(fullPath, _queueWaitTime);
+            _taskScheduler.ScanFolder(fullPath, filePath, _queueWaitTime);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "[LibraryWatcher] An error occured when processing a watch event");
         }
-        _logger.LogDebug("[LibraryWatcher] ProcessChange completed in {ElapsedMilliseconds}ms", sw.ElapsedMilliseconds);
+        _logger.LogTrace("[LibraryWatcher] ProcessChange completed in {ElapsedMilliseconds}ms", sw.ElapsedMilliseconds);
     }
 
     private string GetFolder(string filePath, IEnumerable<string> libraryFolders)
     {
         // TODO: I can optimize this to avoid a library scan and instead do a Series Scan by finding the series that has a lowestFolderPath higher or equal to the filePath
-
-
 
         var parentDirectory = _directoryService.GetParentDirectoryName(filePath);
         _logger.LogTrace("[LibraryWatcher] Parent Directory: {ParentDirectory}", parentDirectory);

--- a/API/Services/Tasks/Scanner/ParseScannedFiles.cs
+++ b/API/Services/Tasks/Scanner/ParseScannedFiles.cs
@@ -142,6 +142,7 @@ public class ParseScannedFiles
                 normalizedPath = Parser.Parser.NormalizePath(directory);
                 await _eventHub.SendMessageAsync(MessageFactory.NotificationProgress,
                     MessageFactory.FileScanProgressEvent(normalizedPath, library.Name, ProgressEventType.Updated));
+
                 if (HasSeriesFolderNotChangedSinceLastScan(seriesPaths, normalizedPath, forceCheck))
                 {
                     result.Add(CreateScanResult(directory, folderPath, false, ArraySegment<string>.Empty));
@@ -153,6 +154,7 @@ public class ParseScannedFiles
                     _logger.LogDebug("{Directory} is dirty and has multiple series folders, checking if we can avoid a full scan", normalizedPath);
                     foreach (var seriesModified in series)
                     {
+
                         if (HasSeriesFolderNotChangedSinceLastScan(seriesModified, seriesModified.LowestFolderPath!))
                         {
                             result.Add(CreateScanResult(directory, folderPath, false, ArraySegment<string>.Empty));

--- a/API/Services/Tasks/Scanner/Parser/BasicParser.cs
+++ b/API/Services/Tasks/Scanner/Parser/BasicParser.cs
@@ -26,7 +26,7 @@ public class BasicParser(IDirectoryService directoryService, IDefaultParser imag
         {
             Filename = Path.GetFileName(filePath),
             Format = Parser.ParseFormat(filePath),
-            Title = Parser.RemoveExtensionIfSupported(fileName),
+            Title = Parser.RemoveExtensionIfSupported(fileName)!,
             FullFilePath = Parser.NormalizePath(filePath),
             Series = string.Empty,
             ComicInfo = comicInfo

--- a/API/Services/Tasks/Scanner/Parser/BasicParser.cs
+++ b/API/Services/Tasks/Scanner/Parser/BasicParser.cs
@@ -76,6 +76,9 @@ public class BasicParser(IDirectoryService directoryService, IDefaultParser imag
             ret.Chapters = Parser.DefaultChapter;
             ret.Volumes = Parser.SpecialVolume;
 
+            // NOTE: This uses rootPath. LibraryRoot works better for manga, but it's not always that way.
+            // It might be worth writing some logic if the file is a special, to take the folder above the Specials/
+            // if present
             ParseFromFallbackFolders(filePath, rootPath, type, ref ret);
         }
 

--- a/API/Services/Tasks/Scanner/Parser/DefaultParser.cs
+++ b/API/Services/Tasks/Scanner/Parser/DefaultParser.cs
@@ -101,7 +101,7 @@ public abstract class DefaultParser(IDirectoryService directoryService) : IDefau
         }
     }
 
-    protected void UpdateFromComicInfo(ParserInfo info)
+    protected static void UpdateFromComicInfo(ParserInfo info)
     {
         if (info.ComicInfo == null) return;
 

--- a/API/Services/Tasks/Scanner/Parser/DefaultParser.cs
+++ b/API/Services/Tasks/Scanner/Parser/DefaultParser.cs
@@ -109,6 +109,10 @@ public abstract class DefaultParser(IDirectoryService directoryService) : IDefau
         {
             info.Volumes = info.ComicInfo.Volume;
         }
+        if (!string.IsNullOrEmpty(info.ComicInfo.Number))
+        {
+            info.Chapters = info.ComicInfo.Number;
+        }
         if (!string.IsNullOrEmpty(info.ComicInfo.Series))
         {
             info.Series = info.ComicInfo.Series.Trim();
@@ -123,16 +127,6 @@ public abstract class DefaultParser(IDirectoryService directoryService) : IDefau
             info.IsSpecial = true;
             info.Chapters = Parser.DefaultChapter;
             info.Volumes = Parser.SpecialVolume;
-        }
-
-        if (!string.IsNullOrEmpty(info.ComicInfo.Number))
-        {
-            info.Chapters = info.ComicInfo.Number;
-            if (info.IsSpecial && Parser.DefaultChapter != info.Chapters)
-            {
-                info.IsSpecial = false;
-                info.Volumes = Parser.SpecialVolume;
-            }
         }
 
         // Patch is SeriesSort from ComicInfo

--- a/API/Services/Tasks/Scanner/Parser/Parser.cs
+++ b/API/Services/Tasks/Scanner/Parser/Parser.cs
@@ -103,7 +103,11 @@ public static class Parser
     private static readonly Regex CoverImageRegex = new Regex(@"(?<![[a-z]\d])(?:!?)(?<!back)(?<!back_)(?<!back-)(cover|folder)(?![\w\d])",
         MatchOptions, RegexTimeout);
 
-    private static readonly Regex NormalizeRegex = new Regex(@"[^\p{L}0-9\+!\*]",
+    /// <summary>
+    /// Normalize everything within Kavita. Some characters don't fall under Unicode, like full-width characters and need to be
+    /// added on a case-by-case basis.
+    /// </summary>
+    private static readonly Regex NormalizeRegex = new Regex(@"[^\p{L}0-9\+!＊！＋]",
         MatchOptions, RegexTimeout);
 
     /// <summary>

--- a/API/Services/Tasks/StatsService.cs
+++ b/API/Services/Tasks/StatsService.cs
@@ -181,7 +181,9 @@ public class StatsService : IStatsService
         {
             InstallId = serverSettings.InstallId,
             KavitaVersion = serverSettings.InstallVersion,
-            IsDocker = OsInfo.IsDocker
+            IsDocker = OsInfo.IsDocker,
+            FirstInstallDate = serverSettings.FirstInstallDate,
+            FirstInstallVersion = serverSettings.FirstInstallVersion
         };
     }
 

--- a/API/Startup.cs
+++ b/API/Startup.cs
@@ -268,6 +268,7 @@ public class Startup
 
                     // v0.8.2
                     await ManualMigrateThemeDescription.Migrate(dataContext, logger);
+                    await MigrateInitialInstallData.Migrate(dataContext, logger, directoryService);
 
                     //  Update the version in the DB after all migrations are run
                     var installVersion = await unitOfWork.SettingsRepository.GetSettingAsync(ServerSettingKey.InstallVersion);

--- a/Kavita.Common/Kavita.Common.csproj
+++ b/Kavita.Common/Kavita.Common.csproj
@@ -14,10 +14,10 @@
       <PackageReference Include="Flurl.Http" Version="3.2.4" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
       <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-      <PackageReference Include="SonarAnalyzer.CSharp" Version="9.25.0.90414">
+      <PackageReference Include="SonarAnalyzer.CSharp" Version="9.26.0.92422">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="xunit.assert" Version="2.8.0" />
+      <PackageReference Include="xunit.assert" Version="2.8.1" />
     </ItemGroup>
 </Project>

--- a/UI/Web/src/app/_services/action-factory.service.ts
+++ b/UI/Web/src/app/_services/action-factory.service.ts
@@ -10,6 +10,7 @@ import { Volume } from '../_models/volume';
 import { AccountService } from './account.service';
 import { DeviceService } from './device.service';
 import {SideNavStream} from "../_models/sidenav/sidenav-stream";
+import {SmartFilter} from "../_models/metadata/v2/smart-filter";
 
 export enum Action {
   Submenu = -1,
@@ -150,6 +151,7 @@ export class ActionFactoryService {
   bookmarkActions: Array<ActionItem<Series>> = [];
 
   sideNavStreamActions: Array<ActionItem<SideNavStream>> = [];
+  smartFilterActions: Array<ActionItem<SmartFilter>> = [];
 
   isAdmin = false;
 
@@ -176,6 +178,10 @@ export class ActionFactoryService {
 
   getSideNavStreamActions(callback: ActionCallback<SideNavStream>) {
     return this.applyCallbackToList(this.sideNavStreamActions, callback);
+  }
+
+  getSmartFilterActions(callback: ActionCallback<SmartFilter>) {
+    return this.applyCallbackToList(this.smartFilterActions, callback);
   }
 
   getVolumeActions(callback: ActionCallback<Volume>) {
@@ -615,6 +621,16 @@ export class ActionFactoryService {
       {
         action: Action.MarkAsInvisible,
         title: 'mark-invisible',
+        callback: this.dummyCallback,
+        requiresAdmin: false,
+        children: [],
+      },
+    ];
+
+    this.smartFilterActions = [
+      {
+        action: Action.Delete,
+        title: 'delete',
         callback: this.dummyCallback,
         requiresAdmin: false,
         children: [],

--- a/UI/Web/src/app/admin/_models/server-info.ts
+++ b/UI/Web/src/app/admin/_models/server-info.ts
@@ -1,5 +1,7 @@
 export interface ServerInfoSlim {
-    kavitaVersion: string;
-    installId: string;
-    isDocker: boolean;
+  kavitaVersion: string;
+  installId: string;
+  isDocker: boolean;
+  firstInstallVersion?: string;
+  firstInstallDate?: string;
 }

--- a/UI/Web/src/app/admin/manage-system/manage-system.component.html
+++ b/UI/Web/src/app/admin/manage-system/manage-system.component.html
@@ -14,7 +14,7 @@
         <dd>{{serverInfo.firstInstallVersion | defaultValue}}</dd>
 
         <dt>{{t('first-install-date-title')}}</dt>
-        <dd>{{serverInfo.firstInstallDate | date:'short'}}</dd>
+        <dd>{{serverInfo.firstInstallDate | date:'shortDate'}}</dd>
       </dl>
     </div>
 

--- a/UI/Web/src/app/admin/manage-system/manage-system.component.html
+++ b/UI/Web/src/app/admin/manage-system/manage-system.component.html
@@ -9,6 +9,12 @@
 
         <dt>{{t('installId-title')}}</dt>
         <dd>{{serverInfo.installId}}</dd>
+
+        <dt>{{t('first-install-version-title')}}</dt>
+        <dd>{{serverInfo.firstInstallVersion | defaultValue}}</dd>
+
+        <dt>{{t('first-install-date-title')}}</dt>
+        <dd>{{serverInfo.firstInstallDate | date:'short'}}</dd>
       </dl>
     </div>
 

--- a/UI/Web/src/app/admin/manage-system/manage-system.component.ts
+++ b/UI/Web/src/app/admin/manage-system/manage-system.component.ts
@@ -1,9 +1,11 @@
 import {ChangeDetectionStrategy, ChangeDetectorRef, Component, inject, OnInit} from '@angular/core';
 import {ServerService} from 'src/app/_services/server.service';
 import {ServerInfoSlim} from '../_models/server-info';
-import {NgIf} from '@angular/common';
+import {DatePipe, NgIf} from '@angular/common';
 import {TranslocoDirective} from "@ngneat/transloco";
 import {ChangelogComponent} from "../../announcements/_components/changelog/changelog.component";
+import {DefaultDatePipe} from "../../_pipes/default-date.pipe";
+import {DefaultValuePipe} from "../../_pipes/default-value.pipe";
 
 @Component({
     selector: 'app-manage-system',
@@ -11,18 +13,16 @@ import {ChangelogComponent} from "../../announcements/_components/changelog/chan
     styleUrls: ['./manage-system.component.scss'],
     standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [NgIf, TranslocoDirective, ChangelogComponent]
+  imports: [NgIf, TranslocoDirective, ChangelogComponent, DefaultDatePipe, DefaultValuePipe, DatePipe]
 })
 export class ManageSystemComponent implements OnInit {
 
-  serverInfo!: ServerInfoSlim;
   private readonly cdRef = inject(ChangeDetectorRef);
+  private readonly serverService = inject(ServerService);
 
-
-  constructor(public serverService: ServerService) { }
+  serverInfo!: ServerInfoSlim;
 
   ngOnInit(): void {
-
     this.serverService.getServerInfo().subscribe(info => {
       this.serverInfo = info;
       this.cdRef.markForCheck();

--- a/UI/Web/src/app/all-filters/all-filters.component.html
+++ b/UI/Web/src/app/all-filters/all-filters.component.html
@@ -3,32 +3,18 @@
     <h2 title>
       {{t('title')}}
     </h2>
-    <h6 subtitle >{{t('count', {count: filters.length | number})}}</h6>
+    <div subtitle>
+      <h6>
+        <span>{{t('count', {count: filters.length | number})}}</span>
+        <a class="ms-2" href="/all-series?name=New%20Filter">{{t('create')}}</a>
+      </h6>
+
+    </div>
+
   </app-side-nav-companion-bar>
-  <app-card-detail-layout
-                          [isLoading]="isLoading"
-                          [items]="filters"
-                          [trackByIdentity]="trackByIdentity"
-                          [jumpBarKeys]="jumpbarKeys"
-  >
-    <ng-template #cardItem let-item let-position="idx">
-      <!-- TODO: figure a way to get a hover effect -->
-      <div class="card-item-container card clickable" (click)="loadSmartFilter(item)">
-        <div class="overlay filter">
-          <div class="card-overlay"></div>
-          <div class="overlay-information overlay-information--centered">
-            <div class="position-relative">
-            <span class="card-title library mx-auto" style="width: auto;">
-              <i class="fa-solid fa-filter" style="font-size: 26px;" [ngClass]="{'error': isErrored(item)}" aria-hidden="true"></i>
-            </span>
-            </div>
-          </div>
-        </div>
-        <div class="card-body">
-          <span class="card-title">{{item.name}}</span>
-        </div>
-      </div>
-    </ng-template>
-  </app-card-detail-layout>
+
+  <app-manage-smart-filters></app-manage-smart-filters>
+
+
 
 </ng-container>

--- a/UI/Web/src/app/all-filters/all-filters.component.scss
+++ b/UI/Web/src/app/all-filters/all-filters.component.scss
@@ -1,16 +1,2 @@
-.card-title  {
-  width: 146px;
-}
 
-.error {
-  color: var(--error-color);
-}
 
-.card, .overlay {
-  height: 160px;
-}
-
-.card-item-container .overlay-information.overlay-information--centered {
-  top: 54px;
-  left: 51px;
-}

--- a/UI/Web/src/app/all-filters/all-filters.component.ts
+++ b/UI/Web/src/app/all-filters/all-filters.component.ts
@@ -2,7 +2,7 @@ import {ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, injec
 import {CommonModule} from '@angular/common';
 import {JumpKey} from "../_models/jumpbar/jump-key";
 import {EVENTS, Message, MessageHubService} from "../_services/message-hub.service";
-import {TranslocoDirective} from "@ngneat/transloco";
+import {translate, TranslocoDirective} from "@ngneat/transloco";
 import {CardItemComponent} from "../cards/card-item/card-item.component";
 import {
   SideNavCompanionBarComponent
@@ -11,14 +11,20 @@ import {SmartFilter} from "../_models/metadata/v2/smart-filter";
 import {FilterService} from "../_services/filter.service";
 import {CardDetailLayoutComponent} from "../cards/card-detail-layout/card-detail-layout.component";
 import {SafeHtmlPipe} from "../_pipes/safe-html.pipe";
-import {Router} from "@angular/router";
+import {Router, RouterLink} from "@angular/router";
 import {Series} from "../_models/series";
 import {JumpbarService} from "../_services/jumpbar.service";
+import {Action, ActionFactoryService, ActionItem} from "../_services/action-factory.service";
+import {CardActionablesComponent} from "../_single-module/card-actionables/card-actionables.component";
+import {ActionService} from "../_services/action.service";
+import {FilterPipe} from "../_pipes/filter.pipe";
+import {filter} from "rxjs";
+import {ManageSmartFiltersComponent} from "../sidenav/_components/manage-smart-filters/manage-smart-filters.component";
 
 @Component({
   selector: 'app-all-filters',
   standalone: true,
-  imports: [CommonModule, TranslocoDirective, CardItemComponent, SideNavCompanionBarComponent, CardDetailLayoutComponent, SafeHtmlPipe],
+  imports: [CommonModule, TranslocoDirective, CardItemComponent, SideNavCompanionBarComponent, CardDetailLayoutComponent, SafeHtmlPipe, CardActionablesComponent, RouterLink, FilterPipe, ManageSmartFiltersComponent],
   templateUrl: './all-filters.component.html',
   styleUrl: './all-filters.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush
@@ -28,13 +34,20 @@ export class AllFiltersComponent implements OnInit {
   private readonly jumpbarService = inject(JumpbarService);
   private readonly router = inject(Router);
   private readonly filterService = inject(FilterService);
+  private readonly actionFactory = inject(ActionFactoryService);
+  private readonly actionService = inject(ActionService);
 
+  filterActions = this.actionFactory.getSmartFilterActions(this.handleAction.bind(this));
   jumpbarKeys: Array<JumpKey> = [];
   filters: SmartFilter[] = [];
   isLoading = true;
   trackByIdentity = (index: number, item: SmartFilter) => item.name;
 
   ngOnInit() {
+    this.loadData();
+  }
+
+  loadData() {
     this.filterService.getAllFilters().subscribe(filters => {
       this.filters = filters;
       this.jumpbarKeys = this.jumpbarService.getJumpKeys(this.filters, (s: Series) => s.name);
@@ -51,4 +64,23 @@ export class AllFiltersComponent implements OnInit {
     return !decodeURIComponent(filter.filter).includes('¦');
   }
 
+  async deleteFilter(filter: SmartFilter) {
+    await this.actionService.deleteFilter(filter.id, success => {
+      this.filters = this.filters.filter(f => f.id != filter.id);
+      this.jumpbarKeys = this.jumpbarService.getJumpKeys(this.filters, (s: Series) => s.name);
+      this.cdRef.markForCheck();
+    });
+  }
+
+  async handleAction(action: ActionItem<SmartFilter>, filter: SmartFilter) {
+    switch (action.action) {
+      case(Action.Delete):
+        await this.deleteFilter(filter);
+        break;
+      default:
+        break;
+    }
+  }
+
+  protected readonly filter = filter;
 }

--- a/UI/Web/src/app/cards/card-item/card-item.component.html
+++ b/UI/Web/src/app/cards/card-item/card-item.component.html
@@ -57,15 +57,18 @@
     @if (title.length > 0 || actions.length > 0) {
       <div class="card-body">
         <div>
-        <span class="card-title" placement="top" id="{{title}}_{{entity.id}}" [ngbTooltip]="tooltipTitle" (click)="handleClick($event)" tabindex="0">
-          <app-promoted-icon [promoted]="isPromoted()"></app-promoted-icon>
-          <app-series-format [format]="format"></app-series-format>
-          {{title}}
-        </span>
-          <span class="card-actions float-end" *ngIf="actions && actions.length > 0">
-          <app-card-actionables (actionHandler)="performAction($event)" [actions]="actions" [labelBy]="title"></app-card-actionables>
-        </span>
+          <span class="card-title" placement="top" id="{{title}}_{{entity.id}}" [ngbTooltip]="tooltipTitle" (click)="handleClick($event)" tabindex="0">
+            <app-promoted-icon [promoted]="isPromoted()"></app-promoted-icon>
+            <app-series-format [format]="format"></app-series-format>
+            {{title}}
+          </span>
+          @if (actions && actions.length > 0) {
+            <span class="card-actions float-end">
+              <app-card-actionables (actionHandler)="performAction($event)" [actions]="actions" [labelBy]="title"></app-card-actionables>
+            </span>
+          }
         </div>
+
         @if (subtitleTemplate) {
           <div style="text-align: center">
             <ng-container [ngTemplateOutlet]="subtitleTemplate" [ngTemplateOutletContext]="{ $implicit: entity }"></ng-container>

--- a/UI/Web/src/app/cards/card-item/card-item.component.ts
+++ b/UI/Web/src/app/cards/card-item/card-item.component.ts
@@ -37,7 +37,7 @@ import {FormsModule} from "@angular/forms";
 import {MangaFormatPipe} from "../../_pipes/manga-format.pipe";
 import {MangaFormatIconPipe} from "../../_pipes/manga-format-icon.pipe";
 import {SentenceCasePipe} from "../../_pipes/sentence-case.pipe";
-import {CommonModule} from "@angular/common";
+import {DecimalPipe, NgTemplateOutlet} from "@angular/common";
 import {RouterLink, RouterLinkActive} from "@angular/router";
 import {TranslocoModule} from "@ngneat/transloco";
 import {CardActionablesComponent} from "../../_single-module/card-actionables/card-actionables.component";
@@ -51,7 +51,6 @@ import {SeriesFormatComponent} from "../../shared/series-format/series-format.co
   selector: 'app-card-item',
   standalone: true,
   imports: [
-    CommonModule,
     ImageComponent,
     NgbProgressbar,
     DownloadIndicatorComponent,
@@ -66,7 +65,9 @@ import {SeriesFormatComponent} from "../../shared/series-format/series-format.co
     SafeHtmlPipe,
     RouterLinkActive,
     PromotedIconComponent,
-    SeriesFormatComponent
+    SeriesFormatComponent,
+    DecimalPipe,
+    NgTemplateOutlet
   ],
   templateUrl: './card-item.component.html',
   styleUrls: ['./card-item.component.scss'],

--- a/UI/Web/src/app/collections/_components/collection-detail/collection-detail.component.html
+++ b/UI/Web/src/app/collections/_components/collection-detail/collection-detail.component.html
@@ -22,7 +22,7 @@
                          width="16px" height="16px" [styles]="{'vertical-align': 'text-top'}"
                          [ngbTooltip]="collectionTag.source | providerName" tabindex="0"></app-image>
               <span class="ms-2 me-2">{{t('sync-progress', {title: series.length + ' / ' + collectionTag.totalSourceCount})}}</span>
-              <i class="fa-solid fa-question-circle" aria-hidden="true" [ngbTooltip]="t('last-sync', {date: collectionTag.lastSyncUtc | date: 'shortDate' | defaultDate })"></i>
+              <i class="fa-solid fa-question-circle" aria-hidden="true" [ngbTooltip]="t('last-sync', {date: collectionTag.lastSyncUtc | date: 'short' | defaultDate })"></i>
             </div>
           }
         </div>

--- a/UI/Web/src/app/nav/_components/grouped-typeahead/grouped-typeahead.component.html
+++ b/UI/Web/src/app/nav/_components/grouped-typeahead/grouped-typeahead.component.html
@@ -154,12 +154,17 @@
             </ul>
           }
 
-          @if (hasData && !includeChapterAndFiles) {
-            <li class="list-group-item" style="min-height: 34px">
+          @if (hasData && (isAdmin$ | async)) {
+            <li class="list-group-item" style="min-height: 34px" (click)="$event.stopPropagation()">
               <ng-container [ngTemplateOutlet]="extraTemplate"></ng-container>
-              <a href="javascript:void(0)" (click)="toggleIncludeFiles()" class="float-end">
-                {{t('include-extras')}}
-              </a>
+              <form [formGroup]="searchSettingsForm">
+                <div class="form-check form-switch">
+                  <input type="checkbox" id="search-include-extras" role="switch" formControlName="includeExtras" class="form-check-input"
+                         aria-labelledby="auto-close-label" aria-describedby="tag-promoted-help">
+                  <label class="form-check-label" for="search-include-extras">{{t('include-extras')}}</label>
+                </div>
+              </form>
+
             </li>
           }
         </ul>

--- a/UI/Web/src/app/shared/edit-list/edit-list.component.html
+++ b/UI/Web/src/app/shared/edit-list/edit-list.component.html
@@ -1,6 +1,6 @@
 <form [formGroup]="form" *transloco="let t">
 
-  @for(item of Items; let i = $index; track item) {
+  @for(item of Items; let i = $index; track item; let isFirst = $first) {
     <div class="row g-0 mb-3">
       <div class="col-lg-10 col-md-12 pe-2">
         <div class="mb-3">
@@ -13,7 +13,7 @@
           <i class="fa-solid fa-plus" aria-hidden="true"></i>
           <span class="visually-hidden">{{t('common.add')}}</span>
         </button>
-        <button class="btn btn-secondary" (click)="remove(i)">
+        <button class="btn btn-secondary" (click)="remove(i)" [disabled]="isFirst">
           <i class="fa-solid fa-xmark" aria-hidden="true"></i>
           <span class="visually-hidden">{{t('common.remove')}}</span>
         </button>

--- a/UI/Web/src/app/sidenav/_components/manage-smart-filters/manage-smart-filters.component.html
+++ b/UI/Web/src/app/sidenav/_components/manage-smart-filters/manage-smart-filters.component.html
@@ -1,25 +1,35 @@
 <ng-container *transloco="let t; read:'manage-smart-filters'">
   <form [formGroup]="listForm">
-    <div class="mb-3" *ngIf="filters.length >= 3">
-      <label for="filter" class="form-label">{{t('filter')}}</label>
-      <div class="input-group">
-        <input id="filter" autocomplete="off" class="form-control" formControlName="filterQuery" type="text" aria-describedby="reset-input">
-        <button class="btn btn-outline-secondary" type="button" id="reset-input" (click)="resetFilter()">{{t('clear')}}</button>
+    @if (filters.length >= 3) {
+      <div class="mb-3">
+        <label for="filter" class="form-label">{{t('filter')}}</label>
+        <div class="input-group">
+          <input id="filter" autocomplete="off" class="form-control" formControlName="filterQuery" type="text" aria-describedby="reset-input">
+          <button class="btn btn-outline-secondary" type="button" id="reset-input" (click)="resetFilter()">{{t('clear')}}</button>
+        </div>
       </div>
-    </div>
+    }
   </form>
 
   <ul>
-    <li class="list-group-item" *ngFor="let f of filters | filter: filterList">
-      <a [href]="'all-series?' + f.filter" target="_blank">{{f.name}}</a>
-      <button class="btn btn-danger float-end" (click)="deleteFilter(f)">
-        <i class="fa-solid fa-trash" aria-hidden="true"></i>
-        <span class="visually-hidden">{{t('delete')}}</span>
-      </button>
-    </li>
-
-    <li class="list-group-item" *ngIf="filters.length === 0">
-      {{t('no-data')}}
-    </li>
+    @for(f of filters | filter: filterList; track f.name) {
+      <li class="list-group-item">
+        <span>
+          @if (isErrored(f)) {
+            <i class="fa-solid fa-triangle-exclamation red me-2" [ngbTooltip]="t('errored')"></i>
+            <span class="visually-hidden">{{t('errored')}}</span>
+          }
+          <a [href]="'all-series?' + f.filter" target="_blank">{{f.name}}</a>
+        </span>
+        <button class="btn btn-danger float-end" (click)="deleteFilter(f)">
+          <i class="fa-solid fa-trash" aria-hidden="true"></i>
+          <span class="visually-hidden">{{t('delete')}}</span>
+        </button>
+      </li>
+    } @empty {
+      <li class="list-group-item">
+        {{t('no-data')}}
+      </li>
+    }
   </ul>
 </ng-container>

--- a/UI/Web/src/app/sidenav/_components/manage-smart-filters/manage-smart-filters.component.scss
+++ b/UI/Web/src/app/sidenav/_components/manage-smart-filters/manage-smart-filters.component.scss
@@ -19,3 +19,7 @@ ul {
         }
     }
 }
+
+.red {
+  color: var(--error-color);
+}

--- a/UI/Web/src/app/sidenav/_components/side-nav/side-nav.component.ts
+++ b/UI/Web/src/app/sidenav/_components/side-nav/side-nav.component.ts
@@ -147,8 +147,10 @@ export class SideNavComponent implements OnInit {
     this.accountService.hasValidLicense$.subscribe(res =>{
       if (!res) return;
 
-      this.homeActions.push({action: Action.Import, title: 'import-mal-stack', children: [], requiresAdmin: true, callback: this.importMalCollection.bind(this)});
-      this.cdRef.markForCheck();
+      if (this.homeActions.filter(f => f.title === 'import-mal-stack').length === 0) {
+        this.homeActions.push({action: Action.Import, title: 'import-mal-stack', children: [], requiresAdmin: true, callback: this.importMalCollection.bind(this)});
+        this.cdRef.markForCheck();
+      }
     })
   }
 

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -573,7 +573,8 @@
 
     "all-filters": {
         "title": "All Smart Filters",
-        "count": "{{count}} {{customize-dashboard-modal.title-smart-filters}}"
+        "count": "{{count}} {{customize-dashboard-modal.title-smart-filters}}",
+        "create": "{{common.create}}"
     },
 
     "announcements": {
@@ -2022,7 +2023,8 @@
         "delete": "{{common.delete}}",
         "no-data": "No Smart Filters created",
         "filter": "{{common.filter}}",
-        "clear": "{{common.clear}}"
+        "clear": "{{common.clear}}",
+        "errored": "There is an encoding error in the filter. You need to recreate it."
     },
 
     "edit-external-source-item": {

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -1274,6 +1274,8 @@
         "version-title": "Version",
         "installId-title": "Install ID",
         "more-info-title": "More Info",
+        "first-install-version-title": "First Install Version",
+        "first-install-date-title": "First Install Date",
         "home-page-title": "Home page:",
         "wiki-title": "Wiki:",
         "discord-title": "Discord:",


### PR DESCRIPTION
This PR (in addition to the last) has a lot of new optimizations in place in the scan loop to try and avoid extra work and make scanning for larger libraries or libraries that use a Publisher folder from root much faster. There are new debug loggers to help users understand what is happening. 

# Added
- Added: Added a create link to create a new smart filter in case it's not clear for first time users exploring the software.
- Added: Added first install version and date to the DB so admin's can look back at it. This data is available in System tab.

# Changed
- Changed: Updates dependencies which includes a fix for nav items in epub toc that are more loose. (Fixes #2341 )
- Changed: Removed * from normalization (develop) and added a few full-wdith characters instead: ＊！＋ (Fixes #2976 )
- Changed: All smart filters page now uses the same design as the flow from Customize modal. 
- Changed: Disable the first remove button for weblinks/exclude pattern component as it isn't removable
- Changed: Updated ScanFolder to be more aggressive in finding the underlying series by also checking against a partial match on lowest folder path to find a series. This should result in less work for well structured libraries.
- Changed: (Performance) Cleaned up some extra db calls that aren't needed in the OPDS apis.
- Changed: You can now toggle including chapters/files back off in Search now (develop)

# Fixed
- Fixed: Fixed an edge case bug when performing a series scan, it wouldn't respect the exclude patterns of the library.
- Fixed: Fixed a case where specials in the manga reader weren't giving the special name (Fixes #2981)
- Fixed: Fixed a case where there could be no storyline chapters but just normal chapters and OPDS feed wouldn't render correctly. (Fixes #2888)
- Fixed: Fixed a case where content type could fail, for example with avif. Now a failsafe is in place.
- Fixed: Fixed some OPDS feeds where author (writer) wasn't being sent. (Fixes #2984)
- Fixed: Fixed a parser case where a file was marked as special but also had an issue number, the issue number would un-specialize it. (Fixes #2986)
