### PR TITLE
Reading List Enhancement

### DIFF
--- a/API/DTOs/ReadingLists/ReadingListItemDto.cs
+++ b/API/DTOs/ReadingLists/ReadingListItemDto.cs
@@ -39,4 +39,8 @@ public class ReadingListItemDto
     /// </summary>
     /// <remarks>This is only used for CDisplayEx</remarks>
     public long FileSize { get; set; }
+    /// <summary>
+    /// The chapter summary
+    /// </summary>
+    public string? Summary { get; set; }
 }

--- a/API/Services/Tasks/Scanner/ProcessSeries.cs
+++ b/API/Services/Tasks/Scanner/ProcessSeries.cs
@@ -579,52 +579,61 @@ public class ProcessSeries : IProcessSeries
 
     }
 
-    private static void DeterminePublicationStatus(Series series, List<Chapter> chapters)
+    private void DeterminePublicationStatus(Series series, List<Chapter> chapters)
     {
-        // Count (aka expected total number of chapters or volumes from metadata) across all chapters
-        series.Metadata.TotalCount = chapters.Max(chapter => chapter.TotalCount);
-        // The actual number of count's defined across all chapter's metadata
-        series.Metadata.MaxCount = chapters.Max(chapter => chapter.Count);
+        try
+        {
+            // Count (aka expected total number of chapters or volumes from metadata) across all chapters
+            series.Metadata.TotalCount = chapters.Max(chapter => chapter.TotalCount);
+            // The actual number of count's defined across all chapter's metadata
+            series.Metadata.MaxCount = chapters.Max(chapter => chapter.Count);
 
-        var nonSpecialVolumes = series.Volumes.Where(v => v.MaxNumber.IsNot(Parser.Parser.SpecialVolumeNumber));
+            var nonSpecialVolumes = series.Volumes.Where(v => v.MaxNumber.IsNot(Parser.Parser.SpecialVolumeNumber));
 
-        var maxVolume = (int) (nonSpecialVolumes.Any() ? nonSpecialVolumes.Max(v => v.MaxNumber) : 0);
-        var maxChapter = (int) chapters.Max(c => c.MaxNumber);
+            var maxVolume = (int) (nonSpecialVolumes.Any() ? nonSpecialVolumes.Max(v => v.MaxNumber) : 0);
+            var maxChapter = (int) chapters.Max(c => c.MaxNumber);
 
-        // Single books usually don't have a number in their Range (filename)
-        if (series.Format == MangaFormat.Epub || series.Format == MangaFormat.Pdf && chapters.Count == 1)
-        {
-            series.Metadata.MaxCount = 1;
-        }
-        else if (series.Metadata.TotalCount <= 1 && chapters.Count == 1 && chapters[0].IsSpecial)
-        {
-            // If a series has a TotalCount of 1 (or no total count) and there is only a Special, mark it as Complete
-            series.Metadata.MaxCount = series.Metadata.TotalCount;
-        }
-        else if ((maxChapter == Parser.Parser.DefaultChapterNumber || maxChapter > series.Metadata.TotalCount) && maxVolume <= series.Metadata.TotalCount)
-        {
-            series.Metadata.MaxCount = maxVolume;
-        }
-        else if (maxVolume == series.Metadata.TotalCount)
-        {
-            series.Metadata.MaxCount = maxVolume;
-        }
-        else
-        {
-            series.Metadata.MaxCount = maxChapter;
-        }
+            // Single books usually don't have a number in their Range (filename)
+            if (series.Format == MangaFormat.Epub || series.Format == MangaFormat.Pdf && chapters.Count == 1)
+            {
+                series.Metadata.MaxCount = 1;
+            }
+            else if (series.Metadata.TotalCount <= 1 && chapters.Count == 1 && chapters[0].IsSpecial)
+            {
+                // If a series has a TotalCount of 1 (or no total count) and there is only a Special, mark it as Complete
+                series.Metadata.MaxCount = series.Metadata.TotalCount;
+            }
+            else if ((maxChapter == Parser.Parser.DefaultChapterNumber || maxChapter > series.Metadata.TotalCount) &&
+                     maxVolume <= series.Metadata.TotalCount)
+            {
+                series.Metadata.MaxCount = maxVolume;
+            }
+            else if (maxVolume == series.Metadata.TotalCount)
+            {
+                series.Metadata.MaxCount = maxVolume;
+            }
+            else
+            {
+                series.Metadata.MaxCount = maxChapter;
+            }
 
-        if (!series.Metadata.PublicationStatusLocked)
+            if (!series.Metadata.PublicationStatusLocked)
+            {
+                series.Metadata.PublicationStatus = PublicationStatus.OnGoing;
+                if (series.Metadata.MaxCount == series.Metadata.TotalCount && series.Metadata.TotalCount > 0)
+                {
+                    series.Metadata.PublicationStatus = PublicationStatus.Completed;
+                }
+                else if (series.Metadata.TotalCount > 0 && series.Metadata.MaxCount > 0)
+                {
+                    series.Metadata.PublicationStatus = PublicationStatus.Ended;
+                }
+            }
+        }
+        catch (Exception ex)
         {
+            _logger.LogCritical(ex, "There was an issue determining Publication Status");
             series.Metadata.PublicationStatus = PublicationStatus.OnGoing;
-            if (series.Metadata.MaxCount == series.Metadata.TotalCount && series.Metadata.TotalCount > 0)
-            {
-                series.Metadata.PublicationStatus = PublicationStatus.Completed;
-            }
-            else if (series.Metadata.TotalCount > 0 && series.Metadata.MaxCount > 0)
-            {
-                series.Metadata.PublicationStatus = PublicationStatus.Ended;
-            }
         }
     }
 

--- a/API/Services/Tasks/Scanner/ProcessSeries.cs
+++ b/API/Services/Tasks/Scanner/ProcessSeries.cs
@@ -586,24 +586,30 @@ public class ProcessSeries : IProcessSeries
         // The actual number of count's defined across all chapter's metadata
         series.Metadata.MaxCount = chapters.Max(chapter => chapter.Count);
 
-        var maxVolume = (int) series.Volumes.Where(v => v.MaxNumber.IsNot(Parser.Parser.SpecialVolumeNumber)).Max(v => v.MaxNumber);
+        var nonSpecialVolumes = series.Volumes.Where(v => v.MaxNumber.IsNot(Parser.Parser.SpecialVolumeNumber));
+
+        var maxVolume = (int) (nonSpecialVolumes.Any() ? nonSpecialVolumes.Max(v => v.MaxNumber) : 0);
         var maxChapter = (int) chapters.Max(c => c.MaxNumber);
 
         // Single books usually don't have a number in their Range (filename)
         if (series.Format == MangaFormat.Epub || series.Format == MangaFormat.Pdf && chapters.Count == 1)
         {
             series.Metadata.MaxCount = 1;
-        } else if (series.Metadata.TotalCount <= 1 && chapters.Count == 1 && chapters[0].IsSpecial)
+        }
+        else if (series.Metadata.TotalCount <= 1 && chapters.Count == 1 && chapters[0].IsSpecial)
         {
             // If a series has a TotalCount of 1 (or no total count) and there is only a Special, mark it as Complete
             series.Metadata.MaxCount = series.Metadata.TotalCount;
-        } else if ((maxChapter == Parser.Parser.DefaultChapterNumber || maxChapter > series.Metadata.TotalCount) && maxVolume <= series.Metadata.TotalCount)
+        }
+        else if ((maxChapter == Parser.Parser.DefaultChapterNumber || maxChapter > series.Metadata.TotalCount) && maxVolume <= series.Metadata.TotalCount)
         {
             series.Metadata.MaxCount = maxVolume;
-        } else if (maxVolume == series.Metadata.TotalCount)
+        }
+        else if (maxVolume == series.Metadata.TotalCount)
         {
             series.Metadata.MaxCount = maxVolume;
-        } else
+        }
+        else
         {
             series.Metadata.MaxCount = maxChapter;
         }
@@ -614,7 +620,8 @@ public class ProcessSeries : IProcessSeries
             if (series.Metadata.MaxCount == series.Metadata.TotalCount && series.Metadata.TotalCount > 0)
             {
                 series.Metadata.PublicationStatus = PublicationStatus.Completed;
-            } else if (series.Metadata.TotalCount > 0 && series.Metadata.MaxCount > 0)
+            }
+            else if (series.Metadata.TotalCount > 0 && series.Metadata.MaxCount > 0)
             {
                 series.Metadata.PublicationStatus = PublicationStatus.Ended;
             }

--- a/API/config/appsettings.Development.json
+++ b/API/config/appsettings.Development.json
@@ -2,7 +2,7 @@
   "TokenKey": "super secret unguessable key that is longer because we require it",
   "Port": 5000,
   "IpAddresses": "0.0.0.0,::",
-  "BaseUrl": "/",
+  "BaseUrl": "/tes/",
   "Cache": 75,
   "AllowIFraming": false
 }

--- a/UI/Web/src/app/_models/reading-list.ts
+++ b/UI/Web/src/app/_models/reading-list.ts
@@ -17,6 +17,7 @@ export interface ReadingListItem {
     title: string;
     libraryType: LibraryType;
     libraryName: string;
+    summary?: string;
 }
 
 export interface ReadingList {

--- a/UI/Web/src/app/reading-list/_components/reading-list-item/reading-list-item.component.html
+++ b/UI/Web/src/app/reading-list/_components/reading-list-item/reading-list-item.component.html
@@ -32,12 +32,13 @@
           </div>
 
         </h5>
-        <div class="ps-1 d-none d-md-inline-block">
+        <div class="ps-1 d-none d-md-inline-block mb-1">
           <app-series-format [format]="item.seriesFormat"></app-series-format>
           <a href="/library/{{item.libraryId}}/series/{{item.seriesId}}">{{item.seriesName}}</a>
         </div>
 
-        <!-- TODO: Let's add summary here-->
+        <app-read-more [text]="item.summary || ''"></app-read-more>
+
 
         @if (item.releaseDate !== '0001-01-01T00:00:00') {
           <div class="ps-1 mt-2">

--- a/UI/Web/src/app/reading-list/_components/reading-list-item/reading-list-item.component.ts
+++ b/UI/Web/src/app/reading-list/_components/reading-list-item/reading-list-item.component.ts
@@ -10,6 +10,7 @@ import { DatePipe } from '@angular/common';
 import { ImageComponent } from '../../../shared/image/image.component';
 import {TranslocoDirective} from "@ngneat/transloco";
 import {SeriesFormatComponent} from "../../../shared/series-format/series-format.component";
+import {ReadMoreComponent} from "../../../shared/read-more/read-more.component";
 
 @Component({
     selector: 'app-reading-list-item',
@@ -17,7 +18,7 @@ import {SeriesFormatComponent} from "../../../shared/series-format/series-format
     styleUrls: ['./reading-list-item.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush,
     standalone: true,
-  imports: [ImageComponent, NgbProgressbar, DatePipe, MangaFormatPipe, MangaFormatIconPipe, TranslocoDirective, SeriesFormatComponent]
+  imports: [ImageComponent, NgbProgressbar, DatePipe, MangaFormatPipe, MangaFormatIconPipe, TranslocoDirective, SeriesFormatComponent, ReadMoreComponent]
 })
 export class ReadingListItemComponent {
 


### PR DESCRIPTION
# Changed
- Changed: Reading Lists in both OPDS/UI now have the underlying issue's summary. (#3002)
- Changed: Smart Filter OPDS feeds are now smart-filters/{id} instead of smart-filter/{id}

# Fixed
- Fixed: Fixed a bug where OPDS urls could have api/opds//api/opds instead of just api/opds/
- Fixed: Fixed a case where publication status could fail to be determined when the whole series is just specials (develop)

