### PR TITLE
Bugfix: Chapter changing when scrolling on webtoons

### DIFF
--- a/UI/Web/src/app/manga-reader/_components/infinite-scroller/infinite-scroller.component.ts
+++ b/UI/Web/src/app/manga-reader/_components/infinite-scroller/infinite-scroller.component.ts
@@ -369,9 +369,13 @@ export class InfiniteScrollerComponent implements OnInit, OnChanges, OnDestroy, 
   }
 
   checkIfShouldTriggerContinuousReader() {
-    if (this.isScrolling) return;
+    console.log("checking trigger")
 
+    if (this.isScrolling) return;
+    console.log(this.scrollingDirection)
     if (this.scrollingDirection === PAGING_DIRECTION.FORWARD) {
+      console.log(this.getTotalScroll(), this.getTotalHeight(), SPACER_SCROLL_INTO_PX, this.atBottom)
+
       const totalHeight = this.getTotalHeight();
       const totalScroll = this.getTotalScroll();
 
@@ -380,8 +384,8 @@ export class InfiniteScrollerComponent implements OnInit, OnChanges, OnDestroy, 
         this.atTop = false;
         this.cdRef.markForCheck();
       }
-
-      if (totalScroll === totalHeight && !this.atBottom) {
+      if (totalHeight != 0 && totalScroll >= totalHeight && !this.atBottom) {
+        console.log("triggering the change")
         this.atBottom = true;
         this.cdRef.markForCheck();
         this.setPageNum(this.totalPages);
@@ -392,6 +396,7 @@ export class InfiniteScrollerComponent implements OnInit, OnChanges, OnDestroy, 
           document.body.scrollTop = this.previousScrollHeightMinusTop + (SPACER_SCROLL_INTO_PX / 2);
           this.cdRef.markForCheck();
         });
+        this.checkIfShouldTriggerContinuousReader()
       } else if (totalScroll >= totalHeight + SPACER_SCROLL_INTO_PX && this.atBottom) {
         // This if statement will fire once we scroll into the spacer at all
         this.loadNextChapter.emit();

--- a/UI/Web/src/app/manga-reader/_components/infinite-scroller/infinite-scroller.component.ts
+++ b/UI/Web/src/app/manga-reader/_components/infinite-scroller/infinite-scroller.component.ts
@@ -369,13 +369,9 @@ export class InfiniteScrollerComponent implements OnInit, OnChanges, OnDestroy, 
   }
 
   checkIfShouldTriggerContinuousReader() {
-    console.log("checking trigger")
-
     if (this.isScrolling) return;
-    console.log(this.scrollingDirection)
-    if (this.scrollingDirection === PAGING_DIRECTION.FORWARD) {
-      console.log(this.getTotalScroll(), this.getTotalHeight(), SPACER_SCROLL_INTO_PX, this.atBottom)
 
+    if (this.scrollingDirection === PAGING_DIRECTION.FORWARD) {
       const totalHeight = this.getTotalHeight();
       const totalScroll = this.getTotalScroll();
 
@@ -384,8 +380,8 @@ export class InfiniteScrollerComponent implements OnInit, OnChanges, OnDestroy, 
         this.atTop = false;
         this.cdRef.markForCheck();
       }
+
       if (totalHeight != 0 && totalScroll >= totalHeight && !this.atBottom) {
-        console.log("triggering the change")
         this.atBottom = true;
         this.cdRef.markForCheck();
         this.setPageNum(this.totalPages);


### PR DESCRIPTION
# Fixed
- Fixed: Fixes the continuous reader logic (Fixes #2352 )

When scrolling quickly, `this.atBottom` isn't always being set to True.

Fix by setting `this.atBottom` when `totalScroll` is greater than `totalHeight`. 
Then, `this.checkIfShouldTriggerContinuousReader()` will load the next chapter. 