### PR TITLE
bugfix: widthoverride label being none%

### DIFF
--- a/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.ts
+++ b/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.ts
@@ -594,6 +594,9 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
         takeUntilDestroyed(this.destroyRef)
       ).subscribe(() => {});
 
+      //sets the default override to 0, fixing the none% bug
+      this.generalSettingsForm.get('widthSlider')!.setValue(0);
+
       //send the current width override value to the label
       this.widthOverrideLabel$ = this.readerSettings$?.pipe(
         map(values => (parseInt(values.widthSlider) <= 0) ? '' : values.widthSlider + '%'),


### PR DESCRIPTION
# Fixed
When the user profile defaults to width, the width override label value would not have been set correctly, due to it being none, fixed by setting the default value for the slider, to 0, so off

before:
![image](https://github.com/Kareadita/Kavita/assets/46057569/2625ab4b-ea5f-40e5-a248-a73722bf22f9)

after:
![image](https://github.com/Kareadita/Kavita/assets/46057569/149f39ed-3380-4465-990d-7c829037c937)



