### PR TITLE
v0.8.2 - Theme Overhaul, Smart Collections, & a lot of Scanner work

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -1,0 +1,175 @@
+name: Stable Workflow
+
+on:
+  push:
+    branches: ['release/**']
+  pull_request:
+    branches: [ 'develop' ]
+    types: [ closed ]
+  workflow_dispatch:
+
+jobs:
+  debug:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Debug Info
+        run: |
+          echo "Event Name: ${{ github.event_name }}"
+          echo "Ref: ${{ github.ref }}"
+          echo "Not Contains Release: ${{ !contains(github.head_ref, 'release') }}"
+          echo "Matches Develop: ${{ github.ref == 'refs/heads/develop' }}"
+  if_merged:
+    if: github.event.pull_request.merged == true && contains(github.head_ref, 'release')
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo The PR was merged
+  build:
+    name: Upload Kavita.Common for Version Bump
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true && contains(github.head_ref, 'release')
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: csproj
+          path: Kavita.Common/Kavita.Common.csproj
+
+  stable:
+    name: Build Stable and Nightly Docker if Release
+    needs: [ build ]
+    if: github.event.pull_request.merged == true && contains(github.head_ref, 'release')
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: Find Current Pull Request
+        uses: jwalton/gh-find-current-pr@v1
+        id: findPr
+        with:
+          state: all
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Parse PR body
+        id: parse-body
+        run: |
+          body="Read full changelog: https://github.com/Kareadita/Kavita/releases/latest"
+
+          echo $body
+          echo "BODY=$body" >> $GITHUB_OUTPUT
+
+      - name: Check Out Repo
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+
+      - name: NodeJS to Compile WebUI
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: |
+
+          cd UI/Web || exit
+          echo 'Installing web dependencies'
+          npm ci
+
+          echo 'Building UI'
+          npm run prod
+
+          echo 'Copying back to Kavita wwwroot'
+          rsync -a dist/ ../../API/wwwroot/
+
+          cd ../ || exit
+
+      - name: Get csproj Version
+        uses: kzrnm/get-net-sdk-project-versions-action@v2
+        id: get-version
+        with:
+          proj-path: Kavita.Common/Kavita.Common.csproj
+
+      - name: Echo csproj version
+        run: echo "${{steps.get-version.outputs.assembly-version}}"
+
+      - name: Parse Version
+        run: |
+          version='${{steps.get-version.outputs.assembly-version}}'
+          newVersion=${version%.*}
+          echo $newVersion
+          echo "VERSION=$newVersion" >> $GITHUB_OUTPUT
+        id: parse-version
+
+      - name: Compile dotnet app
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+      - name: Install Swashbuckle CLI
+        run: dotnet tool install -g --version 6.5.0 Swashbuckle.AspNetCore.Cli
+
+      - run: ./monorepo-build.sh
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push stable
+        id: docker_build_stable
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm/v7,linux/arm64
+          push: true
+          tags: jvmilazz0/kavita:latest, jvmilazz0/kavita:${{ steps.parse-version.outputs.VERSION }}, ghcr.io/kareadita/kavita:latest, ghcr.io/kareadita/kavita:${{ steps.parse-version.outputs.VERSION }}
+
+      - name: Build and push nightly
+        id: docker_build_nightly
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm/v7,linux/arm64
+          push: true
+          tags: jvmilazz0/kavita:nightly, jvmilazz0/kavita:nightly-${{ steps.parse-version.outputs.VERSION }}, ghcr.io/kareadita/kavita:nightly, ghcr.io/kareadita/kavita:nightly-${{ steps.parse-version.outputs.VERSION }}
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build_stable.outputs.digest }}
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build_nightly.outputs.digest }}
+
+      - name: Notify Discord
+        uses: rjstone/discord-webhook-notify@v1
+        with:
+          severity: info
+          description: v${{steps.get-version.outputs.assembly-version}} - ${{ steps.findPr.outputs.title }}
+          details: '${{ steps.findPr.outputs.body }}'
+          text: <@&939225192553644133> A new stable build has been released.
+          webhookUrl: ${{ secrets.DISCORD_DOCKER_UPDATE_URL }}
+
+      - name: Notify Discord
+        uses: rjstone/discord-webhook-notify@v1
+        with:
+          severity: info
+          description: v${{steps.get-version.outputs.assembly-version}} - ${{ steps.findPr.outputs.title }}
+          details: '${{ steps.findPr.outputs.body }}'
+          text: <@&939225459156217917> <@&939225350775406643>  A new nightly build has been released for docker.
+          webhookUrl: ${{ secrets.DISCORD_DOCKER_UPDATE_URL }}

--- a/Kavita.Common/Kavita.Common.csproj
+++ b/Kavita.Common/Kavita.Common.csproj
@@ -3,7 +3,7 @@
         <TargetFramework>net8.0</TargetFramework>
         <Company>kavitareader.com</Company>
         <Product>Kavita</Product>
-        <AssemblyVersion>0.8.1.20</AssemblyVersion>
+        <AssemblyVersion>0.8.2.0</AssemblyVersion>
         <NeutralLanguage>en</NeutralLanguage>
         <TieredPGO>true</TieredPGO>
     </PropertyGroup>


### PR DESCRIPTION
A new stable release is here and it is yet again another big one. Initially I set out to focus on 3 items: Scanner, Smart Collections, and CBL v2 (new schema), but here I am delivering 3 massive improvements and a ton of smaller changes. This release includes a bit of everything spread about. Let's get into it.

### Built-in Theme Explorer
One thing I wanted since day one of adding theme support into Kavita was the ability for users you just browse a list of themes and download what they want to use. It's not easy when the admin has to add the theme for you and hit scan, dealing with the underlying filesystem. I finally got around to setting up the initial version of this (open to feedback to expand on this system) with v0.8.2. All users will have the ability to browse themes uploaded to the theme repo, preview the images and description, and download and apply theme. This currently does not have any role permission and I didn't hear much from nightly users thinking it's needed. If you feel otherwise, raise a discussion. If you don't want to use a theme on the repo, you can upload your own file via the interface. Existing theme users should delete their themes and re-acquire them. This will allow them to be updated for you automatically (assuming the supported version matches yours). 

### Smart Collections for Kavita+
This is another one I've wanted for a while and is part of the theme of introducing more synchronization systems into Kavita. Smart Collections allow for you to import any Interest Stacks/Restacks from your MAL account into Kavita. Every 2 days, Kavita will resync with upstream and add any Series that you own to the collection. The collection is otherwise read-only and promotable, so if you want to setup a few best of X and promote them for your server, you can. These features are also not admin-specific. Any user can import their interest stacks into the server (and if they have the promotion role, can promote them). I hope you all enjoy this feature as much as I am. Another level of bringing a top notch experience for my users. 

### Scanner Changes
I've been working a lot with our users that have larger libraries, ranging from 100k files to 10k series. One of the major problems is that when you have a library of 10k, it's going to take a long time as expected. These users are mainly new users coming from the comic rework and have folder structures Kavita wasn't originally built around. I spent a good chunk of time building optimizations to reduce the amount of processing work Kavita does for these folder layouts (not restrictive to comic libraries) and fixing some bugs around parsing and whatnot that surfaced thanks to the numerous bug reports. If you aren't finding good results after this update, please do reach out.

### Misc Changes
A few other big changes come with this release. The first is WAL is now on by default. You can always turn this off manually in the DB, but fresh installs (and existing) will turn WAL on. WAL fixes the common 'database is locked' issue due to Kavita writing too much data too fast. Another big one is double scrollbar on mobile. This was an annoying bug on some mobile browsers on some pages. Robbie took this up and fixed it everywhere to my knowledge. A great QoL enhancement. OPDS has gotten a lot of love in this release thanks to some great reports by @MnsieurJF around reading lists and missing metadata in the feeds. Lastly, the Manga Reader has had some tweaking to how fit to height/width works. It's not easy to put into words, but I find the fitting to be MUCH better. 

I have loose plans for what the next release is going to be. The PDF rework will need to come after v0.8.3 to allow people who upgrade into the v0.8.x series not to loose data from the massive changes. I have a lot of holiday coming up as well, so the release may be longer or shorter depending. 

Lastly, I want to mention (as I keep forgetting) that @DieselTech has joined the Kavita team a few months ago. His name should be well known as he's very active in most of the reading and comic discords as well as being a core member in the CBL Reading Order group. He's already driven a lot of great changes in Kavita for hardcore comic users and I have no doubt he will continue to be a great resource for me to rely on in the future. 

# Added
- Added: Kavita+ users can now import their MAL interest stacks/restacks into Kavita as Smart Collections. These collections will synchronize back with MAL to update with new series and summary information every 2 days. Smart Collections work just as normal collections except are non-editable as the MAL stack controls the data. They can be promoted given the user has promotion role. They are not admin-specific. 
- Added: Added the ability for any user to download themes from the Theme Repo directly via Kavita. Kavita will keep these themes up to data automatically (unless the reported version from the Repo is greater than the server version).
- Added: Book series can now have specials. In order to be classified as a Special, the SP marker must be in the filename, the calibre:series must be set to the Series name and `calibre:series_index` must be 0. (Feature Request: 3 upvotes)
- Added: OPDS-PS on PDF files is now possible. Kavita will convert to images.
- Added: Added a create link to create a new smart filter in case it's not clear for first time users exploring the software.
- Added: Added first install version and date to the DB so admin's can look back at it. This data is available in System tab.
- Added: Added new Random sort option to allow a stream like 'Top Unread in X' (Thanks @Fesaa)
- Added: Added the following css variables --event-widget-activity-bg-color, --event-widget-update-bg-color, --event-widget-error-bg-color
- Added: Implemented the ability to click download on any file extension from stats page (formats table) and download a report of all files that are of that extension.
- Added: Added the ability to manually override the width in the manga/webtoon reader when using Width scaling (Thanks @Marsimplodation) (Feature Request: 19 upvotes)
- Added: Added bulk promote/demote/delete for reading lists to align with collections.

# Changed
- Changed: On forgot password, even if email isn't setup or user doesn't have email setup, still allow the reset link to log. 
- Changed: Reduced memory for adding a set of series to a collection.
- Changed: Scan button no longer exists on themes tab. Now, admin's can upload their custom css files via the UI.
- Changed: Admin's can no longer delete themes and force users with that theme active off.
- Changed: Changed how scaling works in the manga reader to be more inline with the expected behavior. Height will scale to viewport height even if it is beyond the image's original dimensions. Width will scale to viewport width even if it is beyond the image's original dimensions. Original will show the image at its intrinsic dimensions, no scaling is applied (Thanks @therobbiedavis)
- Changed: Enable WAL journal mode by default in all Kavita installs. Users can turn it off after the first run if needed.
- Changed: Show a warning on dirty email setting form to inform the user they need to save before testing settings.
- Changed: Ensure users know that Scrobbling providers will always keep the highest number from kavita.
- Changed: On < tablet viewports, reading list page should use order numbers rather than drag and drop, as there isn't enough real estate.
- Changed: Series Detail page will now show people/genre/tags as collapsed even on desktop, but summary will have same code to be expanded up to 1000 characters on desktop.
- Changed: (Scanner) Refactored Scan Loop to avoid doing extra work on lower folders in a folder map path, so that users that group by publisher or another arbitrary folder, can avoid a lot of scanning on lower level folders just because the highest level changed.
- Changed: (Performance) Applied some performance optimizations on Series OPDS route which should help speed up heavier Series.
- Changed: (Performance) Small optimization to image reader to make finding the next/prev page faster.
- Changed: Search will no longer search against Chapter titles and Files by default. Instead, there is a new link in the search window to perform with those included. This should help users with larger libraries find their files faster.
- Changed: (Kavita+) Kavita+ scrobbling will now take AniList/Mal ids from External metadata (which is prefetched from Kavita+ for the external metadata) whenever possible. This can help with matching when there are no weblinks.
- Changed: Updates dependencies which includes a fix for nav items in epub toc that are more loose. 
- Changed: Added a few full-wdith characters for normalization: ＊！＋
- Changed: All smart filters page now uses the same design as the flow from Customize modal.
- Changed: Disable the first remove button for weblinks/exclude pattern component as it isn't removable
- Changed: Updated ScanFolder to be more aggressive in finding the underlying series by also checking against a partial match on lowest folder path to find a series. This should result in less work for well structured libraries.
- Changed: (Performance) Cleaned up some extra db calls that aren't needed in the OPDS apis.
- Changed: Reading Lists in both OPDS/UI now have the underlying issue's summary.
- Changed: Smart Filter OPDS feeds are now smart-filters/{id} instead of smart-filter/{id}
- Changed: Updated the cover generation logic to handle webtoons better. The new code will now check if the image scales well or not and if not, use a more attention focused scaling/cropping method. (Thanks @arition for the [initial PR](https://github.com/Kareadita/Kavita/pull/2612))
- Changed: For OPDS Reading Lists, when there is only one underlying file (common), send an acquisition link rather than a subsection. This allows the removal of one of the clicks for nearly all users. 
- Changed: When a scan is enqueued or in progress, have the scanner aware and reschedule tasks mins into the future (except scan series which is 1 min)
- Changed: Added more logging into scanner service and ensure folder watching isn't over triggering the scan loop.
- Changed: Redesigned the loading indicators on the events widget to be cleaner and more expressive. Added the online user count to the nav bar like Plex has. Added an update icon like error/info to help users know when there are updates.
- Changed: (Performance) Converted series detail to control flow syntax to hopefully speed up change detection when there is a large amount of chapters.
- Changed: (Performance) Don't render all tabs by default on series detail. When switching tabs, it will destroy the DOM. This helps a lot with change detection on first load and later changes. First load on big series can take over 30 seconds to process. This means you will incur the long load when activating the tab with a lot of cards.
- Changed: Tweaked how jobs are queued and what messages we send to the UI. First, Scan tasks invoked via the UI will now send reschedule alerts when a scan is in progress and another is about to be kicked off. Scan Series now will retry 200 times instead of 3 given new rescheduling code.

# Fixed
- Fixed: Fixed a bug where Hangfire could be accessible when it wasn't supposed to. (Thanks @theGEBIRGE)
- Fixed: Fixed a bug where Update Preferences API was taking SiteTheme instead of SiteThemeDto
- Fixed: Fixed a bug where multiple extractions of the same archive would start concurrently and create file system problems. This caused out of order reading in Mihon (Thanks @SamuelBMartins)
- Fixed: Fixed an issue where one some screens images would stack instead of being side by side while using the double setting in the manga reader. (Thanks @therobbiedavis)
- Fixed: Fixed an issue where the cover and last page would not be positioned correctly when using the double (Manga) setting in the manga reader. (Thanks @therobbiedavis)
- Fixed: Fixed the issue with review cards provider and score extending outside it's card boundary. (Thanks @therobbiedavis)
- Fixed: Fixed an issue with double scrollbar when viewing saved smart filters (Thanks @therobbiedavis)
- Fixed: Fixed up the info icon cards on series detail to be better with responsiveness on some breakpoints.
- Fixed: Fixed an issue where one-shot/specials in Scrobble History would show internal encoding
- Fixed: Fixed a bug with Image series where caching the images for reading could create a ton of folders with the same files inside. 
- Fixed: Word count analysis will now handle missing manifest items gracefully and report media errors around said file.
- Fixed: Fixed bcmap files not loading in the pdf reader 
- Fixed: Fixed a bug when adding items to a reading list in bulk, sorting order of those chapters was not being respected.
- Fixed: Fixed a bug when a file of Chapter 0.2 first scanned in, Kavita would render the card as 'Chapter 0.2 - .2' then on another scan, Kavita would correctly render out 'Chapter 0.2'.
- Fixed: Loading indicator wasn't properly wired up in the search component 
- Fixed: Fixed an edge case bug when performing a series scan, it wouldn't respect the exclude patterns of the library.
- Fixed: Fixed a case where specials in the manga reader weren't giving the special name 
- Fixed: Fixed a case where there could be no storyline chapters but just normal chapters and OPDS feed wouldn't render correctly. 
- Fixed: Fixed a case where content type could fail, for example with avif. Now a failsafe is in place.
- Fixed: Fixed some OPDS feeds where author (writer) wasn't being sent. 
- Fixed: Fixed a parser case where a file was marked as special but also had an issue number, the issue number would un-specialize it. 
- Fixed: Added a migration to nullify LowestFolderPaths that did not start with a library root. This was caused by an old bug likely that has hence been fixed, yet old records break the new scan loop.
- Fixed: Fixed a bug where LowestSeriesFolder was not a full rooted path on linux
- Fixed: Fixed an issue where metadata apis could return genres/tags/people coming from libraries a user doesn't have access to.
- Fixed: Fixed a bug with publication status when there is a set number of volumes but that series also has a special in it.
- Fixed: Fixed a bug where OPDS urls could have api/opds//api/opds instead of just api/opds/
- Fixed: Fixed up the code in the system tab where users may be on a revision of 0 but the Github release doesn't have a revision, causing the page to always show as nightly, even though it's a stable. 
- Fixed: Fixes the pdf search button not displaying (Thanks @Zackaree)
- Fixed: Fixed double scrollbar 
- Fixed: Fixed a bug where continue from title was not taking library type into consideration nor was localized
- Fixed: Cleaned up the event widget showing nothing going on here when it shouldn't. Fixed a missing localization.
- Fixed: Fixed a bug where some events weren't sending their name and event widget wasn't clearing them after opening their detail modal.
- Fixed: Fixed a case where when mass deleting series from library detail page, the page could refresh a lot more than needed. Now, each call is debounced by 100ms.
- Fixed: Fixed a bug where on mobile devices the continuous scroller wouldn't trigger when scrolling on webtoon mode (Thanks @Zackareee)
- Fixed: Fixed an annoying parse case for 'Giant Ojou-sama - Ch. 33.5 - Volume 04 Bonus Chapter' parsing as 'Giant Ojou-sama - Ch. 33.5' instead of 'Giant Ojou-sama'
- Fixed: Updated some rendering of tags to not be people tags, like teams
- Fixed: Fixed a bug where series-level imprint tags weren't showing