### PR TITLE
Change URL to skip redirect step for 3rd party favicons

### DIFF
--- a/API/Services/ImageService.cs
+++ b/API/Services/ImageService.cs
@@ -440,7 +440,7 @@ public class ImageService : IImageService
                 throw new KavitaException($"Could not grab favicon from {baseUrl}");
             }
 
-            correctSizeLink = "https://kavitareader.com/assets/favicons/" + externalFile;
+            correctSizeLink = "https://www.kavitareader.com/assets/favicons/" + externalFile;
         }
 
         return correctSizeLink;

--- a/API/Services/ImageService.cs
+++ b/API/Services/ImageService.cs
@@ -425,7 +425,7 @@ public class ImageService : IImageService
     private static string FallbackToKavitaReaderFavicon(string baseUrl)
     {
         var correctSizeLink = string.Empty;
-        var allOverrides = "https://kavitareader.com/assets/favicons/urls.txt".GetStringAsync().Result;
+        var allOverrides = "https://www.kavitareader.com/assets/favicons/urls.txt".GetStringAsync().Result;
         if (!string.IsNullOrEmpty(allOverrides))
         {
             var cleanedBaseUrl = baseUrl.Replace("https://", string.Empty);


### PR DESCRIPTION
# Fixed
- Fixed: Fixes 522 errors in some specific situations, causing external favicon icons to not show up 
