### PR TITLE
Fix #3116: UnauthorizedAccessException not surpressed

### DIFF
--- a/API/Startup.cs
+++ b/API/Startup.cs
@@ -448,9 +448,7 @@ public class Startup
         }
         catch (Exception ex)
         {
-            if ((ex.Message.Contains("Permission denied")
-                 || ex.Message.Contains("UnauthorizedAccessException"))
-                && baseUrl.Equals(Configuration.DefaultBaseUrl) && OsInfo.IsDocker)
+            if (ex is UnauthorizedAccessException && baseUrl.Equals(Configuration.DefaultBaseUrl) && OsInfo.IsDocker)
             {
                 // Swallow the exception as the install is non-root and Docker
                 return;


### PR DESCRIPTION
# Fixed
- Fixed: Fixed a bug where the UnauthorizedAccessException is not correctly ignored when using the docker container as non-root. (Fixes #3116)


I've recently switched to not starting as non-root, as the exception popped up, which annoyed me. Had a quick look, and from logging some stuff. ex.Message is equal to `Access to the path '/kavita/wwwroot/index.html' is denied.`; hence why it failed the if statement. The throw exception was `System.UnauthorizedAccessException` so just checking against that seems safer/better.
