### PR TITLE
Sort Order Fix on Volume Detail Page

### DIFF
--- a/API.Tests/Services/ScannerServiceTests.cs
+++ b/API.Tests/Services/ScannerServiceTests.cs
@@ -112,8 +112,18 @@ public class ScannerServiceTests : AbstractDbTest
 
         Assert.NotNull(postLib);
         Assert.Equal(4, postLib.Series.Count);
+    }
 
-        Assert.True(true);
+    [Fact]
+    public async Task ScanLibrary_ShouldCombineNestedFolder()
+    {
+        var testcase = "Series and Series-Series Combined - Manga.json";
+        var postLib = await GenerateScannerData(testcase);
+
+        Assert.NotNull(postLib);
+        Assert.Single(postLib.Series);
+        Assert.Single(postLib.Series);
+        Assert.Equal(2, postLib.Series.First().Volumes.Count);
     }
 
     private async Task<Library> GenerateScannerData(string testcase)

--- a/API.Tests/Services/Test Data/ScannerService/TestCases/Series and Series-Series Combined - Manga.json
+++ b/API.Tests/Services/Test Data/ScannerService/TestCases/Series and Series-Series Combined - Manga.json
@@ -1,0 +1,4 @@
+﻿[
+    "Dress Up Darling/Dress Up Darling Ch 01.cbz",
+    "Dress Up Darling/Dress Up Darling/Dress Up Darling Vol 01.cbz"
+]

--- a/API/Data/Repositories/VolumeRepository.cs
+++ b/API/Data/Repositories/VolumeRepository.cs
@@ -127,9 +127,18 @@ public class VolumeRepository : IVolumeRepository
 
         if (includeChapters)
         {
-            query = query.Include(v => v.Chapters).AsSplitQuery();
+            query = query
+                .Includes(VolumeIncludes.Chapters)
+                .AsSplitQuery();
         }
-        return await query.ToListAsync();
+        var volumes =  await query.ToListAsync();
+
+        foreach (var volume in volumes)
+        {
+            volume.Chapters = volume.Chapters.OrderBy(c => c.SortOrder).ToList();
+        }
+
+        return volumes;
     }
 
     /// <summary>
@@ -142,12 +151,11 @@ public class VolumeRepository : IVolumeRepository
     {
         var volume = await _context.Volume
             .Where(vol => vol.Id == volumeId)
-            .Include(vol => vol.Chapters)
-            .ThenInclude(c => c.Files)
+            .Includes(VolumeIncludes.Chapters | VolumeIncludes.Files)
             .AsSplitQuery()
             .OrderBy(v => v.MinNumber)
             .ProjectTo<VolumeDto>(_mapper.ConfigurationProvider)
-            .SingleOrDefaultAsync(vol => vol.Id == volumeId);
+            .FirstOrDefaultAsync(vol => vol.Id == volumeId);
 
         if (volume == null) return null;
 
@@ -166,8 +174,7 @@ public class VolumeRepository : IVolumeRepository
     {
         return await _context.Volume
             .Where(vol => vol.SeriesId == seriesId)
-            .Include(vol => vol.Chapters)
-            .ThenInclude(c => c.Files)
+            .Includes(VolumeIncludes.Chapters | VolumeIncludes.Files)
             .AsSplitQuery()
             .OrderBy(vol => vol.MinNumber)
             .ToListAsync();
@@ -205,24 +212,19 @@ public class VolumeRepository : IVolumeRepository
 
         await AddVolumeModifiers(userId, volumes);
 
-        foreach (var volume in volumes)
-        {
-            volume.Chapters = volume.Chapters.OrderBy(c => c.SortOrder).ToList();
-        }
-
         return volumes;
     }
 
     public async Task<Volume?> GetVolumeByIdAsync(int volumeId)
     {
-        return await _context.Volume.SingleOrDefaultAsync(x => x.Id == volumeId);
+        return await _context.Volume.FirstOrDefaultAsync(x => x.Id == volumeId);
     }
 
     public async Task<IList<Volume>> GetAllWithCoversInDifferentEncoding(EncodeFormat encodeFormat)
     {
         var extension = encodeFormat.GetExtension();
         return await _context.Volume
-            .Include(v => v.Chapters)
+            .Includes(VolumeIncludes.Chapters)
             .Where(c => !string.IsNullOrEmpty(c.CoverImage) && !c.CoverImage.EndsWith(extension))
             .AsSplitQuery()
             .ToListAsync();

--- a/API/Extensions/QueryExtensions/IncludesExtensions.cs
+++ b/API/Extensions/QueryExtensions/IncludesExtensions.cs
@@ -80,25 +80,25 @@ public static class IncludesExtensions
         if (includes.HasFlag(VolumeIncludes.Files))
         {
             queryable = queryable
-                .Include(vol => vol.Chapters.OrderBy(c => c.SortOrder))
+                .Include(vol => vol.Chapters)
                 .ThenInclude(c => c.Files);
         } else if (includes.HasFlag(VolumeIncludes.Chapters))
         {
             queryable = queryable
-                .Include(vol => vol.Chapters.OrderBy(c => c.SortOrder));
+                .Include(vol => vol.Chapters);
         }
 
         if (includes.HasFlag(VolumeIncludes.People))
         {
             queryable = queryable
-                .Include(vol => vol.Chapters.OrderBy(c => c.SortOrder))
+                .Include(vol => vol.Chapters)
                 .ThenInclude(c => c.People);
         }
 
         if (includes.HasFlag(VolumeIncludes.Tags))
         {
             queryable = queryable
-                .Include(vol => vol.Chapters.OrderBy(c => c.SortOrder))
+                .Include(vol => vol.Chapters)
                 .ThenInclude(c => c.Tags);
         }
 

--- a/API/Helpers/AutoMapperProfiles.cs
+++ b/API/Helpers/AutoMapperProfiles.cs
@@ -51,7 +51,10 @@ public class AutoMapperProfiles : Profile
             .ForMember(dest => dest.Series, opt => opt.MapFrom(src => src.Series));
         CreateMap<LibraryDto, Library>();
         CreateMap<Volume, VolumeDto>()
-            .ForMember(dest => dest.Number, opt => opt.MapFrom(src => (int) src.MinNumber));
+            .ForMember(dest => dest.Number,
+                opt => opt.MapFrom(src => (int) src.MinNumber))
+            .ForMember(dest => dest.Chapters,
+                opt => opt.MapFrom(src => src.Chapters.OrderBy(c => c.SortOrder)));
         CreateMap<MangaFile, MangaFileDto>();
         CreateMap<Series, SeriesDto>();
         CreateMap<CollectionTag, CollectionTagDto>();

--- a/API/Services/SeriesService.cs
+++ b/API/Services/SeriesService.cs
@@ -453,10 +453,6 @@ public class SeriesService : ISeriesService
                 continue;
             }
 
-            volume.Chapters = volume.Chapters
-                .OrderBy(d => d.MinNumber, ChapterSortComparerDefaultLast.Default)
-                .ToList();
-
             if (RenameVolumeName(volume, libraryType, volumeLabel) || (bookTreatment && !volume.IsSpecial()))
             {
                 processedVolumes.Add(volume);

--- a/API/Services/TaskScheduler.cs
+++ b/API/Services/TaskScheduler.cs
@@ -220,6 +220,7 @@ public class TaskScheduler : ITaskScheduler
 
     public void AnalyzeFilesForLibrary(int libraryId, bool forceUpdate = false)
     {
+        _logger.LogInformation("Enqueuing library file analysis for: {LibraryId}", libraryId);
         BackgroundJob.Enqueue(() => _wordCountAnalyzerService.ScanLibrary(libraryId, forceUpdate));
     }
 

--- a/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.ts
+++ b/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.ts
@@ -812,7 +812,7 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       && (this.readerService.imageUrlToChapterId(img.src) == chapterId || this.readerService.imageUrlToChapterId(img.src) === -1)
     );
 
-    console.log('Requesting page ', pageNum, ' found page: ', img, ' and app is requesting new image? ', forceNew);
+    //console.log('Requesting page ', pageNum, ' found page: ', img, ' and app is requesting new image? ', forceNew);
     if (!img || forceNew) {
       img = new Image();
       img.src = this.getPageUrl(pageNum, chapterId);

--- a/UI/Web/src/app/nav/_components/grouped-typeahead/grouped-typeahead.component.ts
+++ b/UI/Web/src/app/nav/_components/grouped-typeahead/grouped-typeahead.component.ts
@@ -118,7 +118,8 @@ export class GroupedTypeaheadComponent implements OnInit {
 
 
   @HostListener('window:click', ['$event'])
-  handleDocumentClick(event: any) {
+  handleDocumentClick(event: MouseEvent) {
+    console.log('click: ', event)
     this.close();
 
   }
@@ -197,7 +198,7 @@ export class GroupedTypeaheadComponent implements OnInit {
   }
 
   toggleIncludeFiles(val: boolean) {
-    const firstRun = val === false && val === this.includeChapterAndFiles;
+    const firstRun = !val && val === this.includeChapterAndFiles;
 
     this.includeChapterAndFiles = val;
     this.inputChanged.emit({value: this.searchTerm, includeFiles: this.includeChapterAndFiles});

--- a/UI/Web/src/app/volume-detail/volume-detail.component.ts
+++ b/UI/Web/src/app/volume-detail/volume-detail.component.ts
@@ -666,7 +666,6 @@ export class VolumeDetailComponent implements OnInit {
     const chaptersWithProgress = this.volume.chapters.filter(c => c.pagesRead < c.pages);
     if (chaptersWithProgress.length > 0 && this.volume.chapters.length > 1) {
       this.currentlyReadingChapter =  chaptersWithProgress[0];
-      console.log('Updating currentlyReading chapter', this.currentlyReadingChapter)
       this.cdRef.markForCheck();
     } else {
       this.currentlyReadingChapter = undefined;


### PR DESCRIPTION
# Fixed
- Fixed: Fixed a bug where chapter order wasn't properly sorting on Volume Detail page (Fixes #3214)
- Fixed: Fixed an issue where bookmarking wouldn't check if the source file was already in the target encoding and thus had issue when trying to convert. Also added another check to not do anything if target encoding is PNG (aka Kavita doesn't convert webp -> png). (Fixes #3204 )
