### PR TITLE
Scanner Refactor

### DIFF
--- a/API.Tests/Extensions/SeriesExtensionsTests.cs
+++ b/API.Tests/Extensions/SeriesExtensionsTests.cs
@@ -186,6 +186,35 @@ public class SeriesExtensionsTests
     }
 
     [Fact]
+    public void GetCoverImage_JustVolumes_ButVolume0()
+    {
+        var series = new SeriesBuilder("Test 1")
+            .WithFormat(MangaFormat.Archive)
+
+            .WithVolume(new VolumeBuilder("0")
+                .WithName("Volume 0")
+                .WithChapter(new ChapterBuilder(Parser.DefaultChapter)
+                    .WithCoverImage("Volume 0")
+                    .Build())
+                .Build())
+
+            .WithVolume(new VolumeBuilder("1")
+                .WithName("Volume 1")
+                .WithChapter(new ChapterBuilder(Parser.DefaultChapter)
+                    .WithCoverImage("Volume 1")
+                    .Build())
+                .Build())
+            .Build();
+
+        foreach (var vol in series.Volumes)
+        {
+            vol.CoverImage = vol.Chapters.MinBy(x => x.SortOrder, ChapterSortComparerDefaultFirst.Default)?.CoverImage;
+        }
+
+        Assert.Equal("Volume 1", series.GetCoverImage());
+    }
+
+    [Fact]
     public void GetCoverImage_JustSpecials_WithDecimal()
     {
         var series = new SeriesBuilder("Test 1")

--- a/API.Tests/Services/DirectoryServiceTests.cs
+++ b/API.Tests/Services/DirectoryServiceTests.cs
@@ -749,6 +749,9 @@ public class DirectoryServiceTests
     [InlineData(new [] {"/manga"},
         new [] {"/manga/Love Hina/Hina/Vol. 01.cbz", "/manga/Love Hina/Specials/Sp01.cbz"},
         "/manga/Love Hina")]
+    [InlineData(new [] {"/manga"},
+        new [] {"/manga/Dress Up Darling/Dress Up Darling Ch 01.cbz", "/manga/Dress Up Darling/Dress Up Darling/Dress Up Darling Vol 01.cbz"},
+        "/manga/Dress Up Darling")]
     public void FindLowestDirectoriesFromFilesTest(string[] rootDirectories, string[] files, string expectedDirectory)
     {
         var fileSystem = new MockFileSystem();

--- a/API.Tests/Services/DirectoryServiceTests.cs
+++ b/API.Tests/Services/DirectoryServiceTests.cs
@@ -746,6 +746,9 @@ public class DirectoryServiceTests
     [InlineData(new [] {"/manga"},
         new [] {"/manga/Love Hina/Vol. 01.cbz", "/manga/Love Hina/Specials/Sp01.cbz"},
         "/manga/Love Hina")]
+    [InlineData(new [] {"/manga"},
+        new [] {"/manga/Love Hina/Hina/Vol. 01.cbz", "/manga/Love Hina/Specials/Sp01.cbz"},
+        "/manga/Love Hina")]
     public void FindLowestDirectoriesFromFilesTest(string[] rootDirectories, string[] files, string expectedDirectory)
     {
         var fileSystem = new MockFileSystem();

--- a/API.Tests/Services/DirectoryServiceTests.cs
+++ b/API.Tests/Services/DirectoryServiceTests.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using API.Services;
+using Kavita.Common.Helpers;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using Xunit;
@@ -920,8 +921,9 @@ public class DirectoryServiceTests
 
         var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), fileSystem);
 
-
-        var allFiles = ds.ScanFiles("C:/Data/", API.Services.Tasks.Scanner.Parser.Parser.SupportedExtensions);
+        var globMatcher = new GlobMatcher();
+        globMatcher.AddExclude("*.*");
+        var allFiles = ds.ScanFiles("C:/Data/", API.Services.Tasks.Scanner.Parser.Parser.SupportedExtensions, globMatcher);
 
         Assert.Empty(allFiles);
 
@@ -945,7 +947,9 @@ public class DirectoryServiceTests
 
         var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), fileSystem);
 
-        var allFiles = ds.ScanFiles("C:/Data/", API.Services.Tasks.Scanner.Parser.Parser.SupportedExtensions);
+        var globMatcher = new GlobMatcher();
+        globMatcher.AddExclude("**/Accel World/*");
+        var allFiles = ds.ScanFiles("C:/Data/", API.Services.Tasks.Scanner.Parser.Parser.SupportedExtensions, globMatcher);
 
         Assert.Single(allFiles); // Ignore files are not counted in files, only valid extensions
 
@@ -974,7 +978,10 @@ public class DirectoryServiceTests
 
         var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), fileSystem);
 
-        var allFiles = ds.ScanFiles("C:/Data/", API.Services.Tasks.Scanner.Parser.Parser.SupportedExtensions);
+        var globMatcher = new GlobMatcher();
+        globMatcher.AddExclude("**/Accel World/*");
+        globMatcher.AddExclude("**/ArtBooks/*");
+        var allFiles = ds.ScanFiles("C:/Data/", API.Services.Tasks.Scanner.Parser.Parser.SupportedExtensions, globMatcher);
 
         Assert.Equal(2, allFiles.Count); // Ignore files are not counted in files, only valid extensions
 

--- a/API.Tests/Services/ParseScannedFilesTests.cs
+++ b/API.Tests/Services/ParseScannedFilesTests.cs
@@ -273,7 +273,7 @@ public class ParseScannedFilesTests : AbstractDbTest
         var directoriesSeen = new HashSet<string>();
         var library = await _unitOfWork.LibraryRepository.GetLibraryForIdAsync(1,
                 LibraryIncludes.Folders | LibraryIncludes.FileTypes);
-        var scanResults = await psf.ProcessFiles("C:/Data/", true, await _unitOfWork.SeriesRepository.GetFolderPathMap(1), library);
+        var scanResults = await psf.ScanFiles("C:/Data/", true, await _unitOfWork.SeriesRepository.GetFolderPathMap(1), library);
         foreach (var scanResult in scanResults)
         {
             directoriesSeen.Add(scanResult.Folder);
@@ -295,7 +295,7 @@ public class ParseScannedFilesTests : AbstractDbTest
         Assert.NotNull(library);
 
         var directoriesSeen = new HashSet<string>();
-        var scanResults = await psf.ProcessFiles("C:/Data/", false,
+        var scanResults = await psf.ScanFiles("C:/Data/", false,
             await _unitOfWork.SeriesRepository.GetFolderPathMap(1), library);
 
         foreach (var scanResult in scanResults)
@@ -328,7 +328,7 @@ public class ParseScannedFilesTests : AbstractDbTest
         var library = await _unitOfWork.LibraryRepository.GetLibraryForIdAsync(1,
             LibraryIncludes.Folders | LibraryIncludes.FileTypes);
         Assert.NotNull(library);
-        var scanResults = await psf.ProcessFiles("C:/Data", true, await _unitOfWork.SeriesRepository.GetFolderPathMap(1), library);
+        var scanResults = await psf.ScanFiles("C:/Data", true, await _unitOfWork.SeriesRepository.GetFolderPathMap(1), library);
 
         Assert.Equal(2, scanResults.Count);
     }
@@ -357,7 +357,7 @@ public class ParseScannedFilesTests : AbstractDbTest
         var library = await _unitOfWork.LibraryRepository.GetLibraryForIdAsync(1,
             LibraryIncludes.Folders | LibraryIncludes.FileTypes);
         Assert.NotNull(library);
-        var scanResults = await psf.ProcessFiles("C:/Data", false,
+        var scanResults = await psf.ScanFiles("C:/Data", false,
             await _unitOfWork.SeriesRepository.GetFolderPathMap(1), library);
 
         Assert.Single(scanResults);

--- a/API.Tests/Services/ParseScannedFilesTests.cs
+++ b/API.Tests/Services/ParseScannedFilesTests.cs
@@ -206,24 +206,6 @@ public class ParseScannedFilesTests : AbstractDbTest
         var psf = new ParseScannedFiles(Substitute.For<ILogger<ParseScannedFiles>>(), ds,
             new MockReadingItemService(ds, Substitute.For<IBookService>()), Substitute.For<IEventHub>());
 
-        // var parsedSeries = new Dictionary<ParsedSeries, IList<ParserInfo>>();
-        //
-        // Task TrackFiles(Tuple<bool, IList<ParserInfo>> parsedInfo)
-        // {
-        //     var skippedScan = parsedInfo.Item1;
-        //     var parsedFiles = parsedInfo.Item2;
-        //     if (parsedFiles.Count == 0) return Task.CompletedTask;
-        //
-        //     var foundParsedSeries = new ParsedSeries()
-        //     {
-        //         Name = parsedFiles.First().Series,
-        //         NormalizedName = parsedFiles.First().Series.ToNormalized(),
-        //         Format = parsedFiles.First().Format
-        //     };
-        //
-        //     parsedSeries.Add(foundParsedSeries, parsedFiles);
-        //     return Task.CompletedTask;
-        // }
 
         var library =
             await _unitOfWork.LibraryRepository.GetLibraryForIdAsync(1,

--- a/API.Tests/Services/ScannerServiceTests.cs
+++ b/API.Tests/Services/ScannerServiceTests.cs
@@ -51,60 +51,6 @@ public class ScannerServiceTests : AbstractDbTest
     }
 
     [Fact]
-    public void FindSeriesNotOnDisk_Should_Remove1()
-    {
-        var infos = new Dictionary<ParsedSeries, IList<ParserInfo>>();
-
-        ParserInfoFactory.AddToParsedInfo(infos, new ParserInfo() {Series = "Darker than Black", Volumes = "1", Format = MangaFormat.Archive});
-        //AddToParsedInfo(infos, new ParserInfo() {Series = "Darker than Black", Volumes = "1", Format = MangaFormat.Epub});
-
-        var existingSeries = new List<Series>
-        {
-            new SeriesBuilder("Darker Than Black")
-                .WithFormat(MangaFormat.Epub)
-
-                .WithVolume(new VolumeBuilder("1")
-                .WithName("1")
-                .Build())
-                .WithLocalizedName("Darker Than Black")
-                .Build()
-        };
-
-        Assert.Single(ScannerService.FindSeriesNotOnDisk(existingSeries, infos));
-    }
-
-    [Fact]
-    public void FindSeriesNotOnDisk_Should_RemoveNothing_Test()
-    {
-        var infos = new Dictionary<ParsedSeries, IList<ParserInfo>>();
-
-        ParserInfoFactory.AddToParsedInfo(infos, new ParserInfo() {Series = "Darker than Black", Format = MangaFormat.Archive});
-        ParserInfoFactory.AddToParsedInfo(infos, new ParserInfo() {Series = "Cage of Eden", Volumes = "1", Format = MangaFormat.Archive});
-        ParserInfoFactory.AddToParsedInfo(infos, new ParserInfo() {Series = "Cage of Eden", Volumes = "10", Format = MangaFormat.Archive});
-
-        var existingSeries = new List<Series>
-        {
-            new SeriesBuilder("Cage of Eden")
-                .WithFormat(MangaFormat.Archive)
-
-                .WithVolume(new VolumeBuilder("1")
-                    .WithName("1")
-                    .Build())
-                .WithLocalizedName("Darker Than Black")
-                .Build(),
-            new SeriesBuilder("Darker Than Black")
-                .WithFormat(MangaFormat.Archive)
-                .WithVolume(new VolumeBuilder("1")
-                    .WithName("1")
-                    .Build())
-                .WithLocalizedName("Darker Than Black")
-                .Build(),
-        };
-
-        Assert.Empty(ScannerService.FindSeriesNotOnDisk(existingSeries, infos));
-    }
-
-    [Fact]
     public async Task ScanLibrary_ComicVine_PublisherFolder()
     {
         var testcase = "Publisher - ComicVine.json";

--- a/API.Tests/Services/ScannerServiceTests.cs
+++ b/API.Tests/Services/ScannerServiceTests.cs
@@ -116,6 +116,16 @@ public class ScannerServiceTests : AbstractDbTest
         _unitOfWork.LibraryRepository.Add(library);
         await _unitOfWork.CommitAsync();
 
+        var scanner = CreateServices();
+
+        await scanner.ScanLibrary(library.Id);
+
+        var postLib = await _unitOfWork.LibraryRepository.GetLibraryForIdAsync(library.Id, LibraryIncludes.Series);
+        return postLib;
+    }
+
+    private ScannerService CreateServices()
+    {
         var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), new FileSystem());
         var mockReadingService = new MockReadingItemService(ds, Substitute.For<IBookService>());
         var processSeries = new ProcessSeries(_unitOfWork, Substitute.For<ILogger<ProcessSeries>>(),
@@ -130,11 +140,7 @@ public class ScannerServiceTests : AbstractDbTest
             Substitute.For<IMetadataService>(),
             Substitute.For<ICacheService>(), Substitute.For<IEventHub>(), ds,
             mockReadingService, processSeries, Substitute.For<IWordCountAnalyzerService>());
-
-        await scanner.ScanLibrary(library.Id);
-
-        var postLib = await _unitOfWork.LibraryRepository.GetLibraryForIdAsync(library.Id, LibraryIncludes.Series);
-        return postLib;
+        return scanner;
     }
 
     private static (string Publisher, LibraryType Type) SplitPublisherAndLibraryType(string input)

--- a/API.Tests/Services/ScannerServiceTests.cs
+++ b/API.Tests/Services/ScannerServiceTests.cs
@@ -132,7 +132,7 @@ public class ScannerServiceTests : AbstractDbTest
             Substitute.For<IEventHub>(),
             ds, Substitute.For<ICacheHelper>(), mockReadingService, Substitute.For<IFileService>(),
             Substitute.For<IMetadataService>(),
-            Substitute.For<IWordCountAnalyzerService>(), Substitute.For<ICollectionTagService>(),
+            Substitute.For<IWordCountAnalyzerService>(),
             Substitute.For<IReadingListService>(),
             Substitute.For<IExternalMetadataService>(), new TagManagerService(_unitOfWork, Substitute.For<ILogger<TagManagerService>>()));
 

--- a/API.Tests/Services/ScannerServiceTests.cs
+++ b/API.Tests/Services/ScannerServiceTests.cs
@@ -68,8 +68,33 @@ public class ScannerServiceTests : AbstractDbTest
 
         Assert.NotNull(postLib);
         Assert.Single(postLib.Series);
-        Assert.Single(postLib.Series);
         Assert.Equal(2, postLib.Series.First().Volumes.Count);
+    }
+
+
+    [Fact]
+    public async Task ScanLibrary_FlatSeries()
+    {
+        var testcase = "Flat Series - Manga.json";
+        var postLib = await GenerateScannerData(testcase);
+
+        Assert.NotNull(postLib);
+        Assert.Single(postLib.Series);
+        Assert.Equal(3, postLib.Series.First().Volumes.Count);
+
+        // TODO: Trigger a deletion of ch 10
+    }
+
+    [Fact]
+    public async Task ScanLibrary_FlatSeriesWithSpecial()
+    {
+        var testcase = "Flat Series with Specials - Manga.json";
+        var postLib = await GenerateScannerData(testcase);
+
+        Assert.NotNull(postLib);
+        Assert.Single(postLib.Series);
+        Assert.Equal(4, postLib.Series.First().Volumes.Count);
+        Assert.NotNull(postLib.Series.First().Volumes.FirstOrDefault(v => v.Chapters.FirstOrDefault(c => c.IsSpecial) != null));
     }
 
     private async Task<Library> GenerateScannerData(string testcase)

--- a/API.Tests/Services/Test Data/ScannerService/TestCases/Flat Series - Manga.json
+++ b/API.Tests/Services/Test Data/ScannerService/TestCases/Flat Series - Manga.json
@@ -1,0 +1,5 @@
+[
+    "My Dress-Up Darling/My Dress-Up Darling v01.cbz",
+    "My Dress-Up Darling/My Dress-Up Darling v02.cbz",
+    "My Dress-Up Darling/My Dress-Up Darling ch 10.cbz"
+]

--- a/API.Tests/Services/Test Data/ScannerService/TestCases/Flat Series with Specials - Manga.json
+++ b/API.Tests/Services/Test Data/ScannerService/TestCases/Flat Series with Specials - Manga.json
@@ -1,0 +1,6 @@
+[
+    "My Dress-Up Darling/My Dress-Up Darling v01.cbz",
+    "My Dress-Up Darling/My Dress-Up Darling v02.cbz",
+    "My Dress-Up Darling/My Dress-Up Darling ch 10.cbz",
+    "My Dress-Up Darling/Specials/Official Anime Fanbook SP05 (2024) (Digital).cbz"
+]

--- a/API.Tests/Services/Test Data/ScannerService/TestCases/Nested Chapters - Manga.json
+++ b/API.Tests/Services/Test Data/ScannerService/TestCases/Nested Chapters - Manga.json
@@ -1,0 +1,4 @@
+[
+    "My Dress-Up Darling/Chapter 1/01.cbz",
+    "My Dress-Up Darling/Chapter 2/02.cbz"
+]

--- a/API/Data/ManualMigrations/MigrateLowestSeriesFolderPath2.cs
+++ b/API/Data/ManualMigrations/MigrateLowestSeriesFolderPath2.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using API.Entities;
+using API.Services.Tasks.Scanner.Parser;
+using Kavita.Common.EnvironmentInfo;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace API.Data.ManualMigrations;
+
+/// <summary>
+/// v0.8.3 still had a bug around LowestSeriesPath. This resets it for all users.
+/// </summary>
+public static class MigrateLowestSeriesFolderPath2
+{
+    public static async Task Migrate(DataContext dataContext, IUnitOfWork unitOfWork, ILogger<Program> logger)
+    {
+        if (await dataContext.ManualMigrationHistory.AnyAsync(m => m.Name == "MigrateLowestSeriesFolderPath2"))
+        {
+            return;
+        }
+
+        logger.LogCritical(
+            "Running MigrateLowestSeriesFolderPath2 migration - Please be patient, this may take some time. This is not an error");
+
+        var series = await dataContext.Series.Where(s => !string.IsNullOrEmpty(s.LowestFolderPath)).ToListAsync();
+        foreach (var s in series)
+        {
+            s.LowestFolderPath = string.Empty;
+            unitOfWork.SeriesRepository.Update(s);
+        }
+
+        // Save changes after processing all series
+        if (dataContext.ChangeTracker.HasChanges())
+        {
+            await dataContext.SaveChangesAsync();
+        }
+
+        dataContext.ManualMigrationHistory.Add(new ManualMigrationHistory()
+        {
+            Name = "MigrateLowestSeriesFolderPath2",
+            ProductVersion = BuildInfo.Version.ToString(),
+            RanAt = DateTime.UtcNow
+        });
+
+        await dataContext.SaveChangesAsync();
+        logger.LogCritical(
+            "Running MigrateLowestSeriesFolderPath2 migration - Completed. This is not an error");
+    }
+}

--- a/API/Data/Repositories/PersonRepository.cs
+++ b/API/Data/Repositories/PersonRepository.cs
@@ -106,7 +106,8 @@ public class PersonRepository : IPersonRepository
     public async Task<IList<PersonDto>> GetAllPersonDtosAsync(int userId)
     {
         var ageRating = await _context.AppUser.GetUserAgeRestriction(userId);
-        var libraryIds = await _context.Library.GetUserLibraries(userId).ToListAsync();
+        // TODO: Figure out how to fix this lack of RBS
+        //var libraryIds = await _context.Library.GetUserLibraries(userId).ToListAsync();
         return await _context.Person
             .OrderBy(p => p.Name)
             .RestrictAgainstAgeRestriction(ageRating)

--- a/API/Data/Repositories/TagRepository.cs
+++ b/API/Data/Repositories/TagRepository.cs
@@ -5,6 +5,7 @@ using API.DTOs.Metadata;
 using API.Entities;
 using API.Extensions;
 using API.Extensions.QueryExtensions;
+using API.Services.Tasks.Scanner.Parser;
 using AutoMapper;
 using AutoMapper.QueryableExtensions;
 using Microsoft.EntityFrameworkCore;
@@ -20,6 +21,7 @@ public interface ITagRepository
     Task<IList<TagDto>> GetAllTagDtosAsync(int userId);
     Task RemoveAllTagNoLongerAssociated();
     Task<IList<TagDto>> GetAllTagDtosForLibrariesAsync(int userId, IList<int>? libraryIds = null);
+    Task<List<string>> GetAllTagsNotInListAsync(ICollection<string> tags);
 }
 
 public class TagRepository : ITagRepository
@@ -77,6 +79,27 @@ public class TagRepository : ITagRepository
             .AsNoTracking()
             .ProjectTo<TagDto>(_mapper.ConfigurationProvider)
             .ToListAsync();
+    }
+
+    public async Task<List<string>> GetAllTagsNotInListAsync(ICollection<string> tags)
+    {
+        // Create a dictionary mapping normalized names to non-normalized names
+        var normalizedToOriginalMap = tags.Distinct()
+            .ToDictionary(Parser.Normalize, tag => tag);
+
+        var normalizedTagNames = normalizedToOriginalMap.Keys.ToList();
+
+        // Query the database for existing genres using the normalized names
+        var existingTags = await _context.Tag
+            .Where(g => normalizedTagNames.Contains(g.NormalizedTitle)) // Assuming you have a normalized field
+            .Select(g => g.NormalizedTitle)
+            .ToListAsync();
+
+        // Find the normalized genres that do not exist in the database
+        var missingTags = normalizedTagNames.Except(existingTags).ToList();
+
+        // Return the original non-normalized genres for the missing ones
+        return missingTags.Select(normalizedName => normalizedToOriginalMap[normalizedName]).ToList();
     }
 
     public async Task<IList<Tag>> GetAllTagsAsync()

--- a/API/Extensions/SeriesExtensions.cs
+++ b/API/Extensions/SeriesExtensions.cs
@@ -28,6 +28,12 @@ public static class SeriesExtensions
             firstVolume = volumes[1];
         }
 
+        // If the first volume is 0, then use Volume 1
+        if (firstVolume.MinNumber.Is(0f) && volumes.Count > 1)
+        {
+            firstVolume = volumes[1];
+        }
+
         var chapters = firstVolume.Chapters
             .OrderBy(c => c.SortOrder)
             .ToList();

--- a/API/Services/DirectoryService.cs
+++ b/API/Services/DirectoryService.cs
@@ -769,16 +769,26 @@ public class DirectoryService : IDirectoryService
     /// <summary>
     /// Recursively scans a folder and returns the max last write time on any folders and files
     /// </summary>
-    /// <remarks>If the folder is empty or non-existant, this will return MaxValue for a DateTime</remarks>
+    /// <remarks>If the folder is empty or non-existent, this will return MaxValue for a DateTime</remarks>
     /// <param name="folderPath"></param>
     /// <returns>Max Last Write Time</returns>
     public DateTime GetLastWriteTime(string folderPath)
     {
         if (!FileSystem.Directory.Exists(folderPath)) return DateTime.MaxValue;
+
         var fileEntries = FileSystem.Directory.GetFileSystemEntries(folderPath, "*.*", SearchOption.AllDirectories);
         if (fileEntries.Length == 0) return DateTime.MaxValue;
-        return fileEntries.Max(path => FileSystem.File.GetLastWriteTime(path));
+
+        // Find the max last write time of the files
+        var maxFiles = fileEntries.Max(path => FileSystem.File.GetLastWriteTime(path));
+
+        // Get the last write time of the directory itself
+        var directoryLastWriteTime = FileSystem.Directory.GetLastWriteTime(folderPath);
+
+        // Use comparison to get the max DateTime value
+        return directoryLastWriteTime > maxFiles ? directoryLastWriteTime : maxFiles;
     }
+
 
     /// <summary>
     /// Recursively scans files and applies an action on them. This uses as many cores the underlying PC has to speed

--- a/API/Services/DirectoryService.cs
+++ b/API/Services/DirectoryService.cs
@@ -650,17 +650,18 @@ public class DirectoryService : IDirectoryService
         }
 
         // Now find the deepest common directory among all paths
-        var commonPath = dirs.Aggregate(GetCommonPath);
+        var commonPath = dirs.Aggregate(GetDeepestCommonPath); // Use new method to get deepest path
 
         // Return the common path if it exists and is not one of the root directories
         return libraryFolders.Any(folder => commonPath == Parser.NormalizePath(folder)) ? null : commonPath;
     }
 
-    private static string GetCommonPath(string path1, string path2)
+    private static string GetDeepestCommonPath(string path1, string path2)
     {
         var parts1 = path1.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
         var parts2 = path2.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
 
+        // Get the longest matching parts, ensuring that deeper parts in hierarchy are considered
         var commonParts = parts1.Zip(parts2, (p1, p2) => p1 == p2 ? p1 : null)
             .TakeWhile(part => part != null)
             .ToArray();

--- a/API/Services/DirectoryService.cs
+++ b/API/Services/DirectoryService.cs
@@ -69,14 +69,13 @@ public interface IDirectoryService
         SearchOption searchOption = SearchOption.TopDirectoryOnly);
     IEnumerable<string> GetDirectories(string folderPath);
     IEnumerable<string> GetDirectories(string folderPath, GlobMatcher? matcher);
-    IEnumerable<string> GetAllDirectories(string folderPath, GlobMatcher? matcher);
+    IEnumerable<string> GetAllDirectories(string folderPath, GlobMatcher? matcher = null);
     string GetParentDirectoryName(string fileOrFolder);
     IList<string> ScanFiles(string folderPath, string fileTypes, GlobMatcher? matcher = null);
     DateTime GetLastWriteTime(string folderPath);
 }
 public class DirectoryService : IDirectoryService
 {
-    public const string KavitaIgnoreFile = ".kavitaignore";
     public IFileSystem FileSystem { get; }
     public string CacheDirectory { get; }
     public string CoverImageDirectory { get; }
@@ -690,7 +689,7 @@ public class DirectoryService : IDirectoryService
     /// <param name="folderPath"></param>
     /// <param name="matcher"></param>
     /// <returns></returns>
-    public IEnumerable<string> GetAllDirectories(string folderPath, GlobMatcher? matcher)
+    public IEnumerable<string> GetAllDirectories(string folderPath, GlobMatcher? matcher = null)
     {
         if (!FileSystem.Directory.Exists(folderPath)) return ImmutableArray<string>.Empty;
         var directories = new List<string>();

--- a/API/Services/DirectoryService.cs
+++ b/API/Services/DirectoryService.cs
@@ -656,7 +656,7 @@ public class DirectoryService : IDirectoryService
         return libraryFolders.Any(folder => commonPath == Parser.NormalizePath(folder)) ? null : commonPath;
     }
 
-    private static string GetDeepestCommonPath(string path1, string path2)
+    public static string GetDeepestCommonPath(string path1, string path2)
     {
         var parts1 = path1.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
         var parts2 = path2.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
@@ -668,7 +668,6 @@ public class DirectoryService : IDirectoryService
 
         return Parser.NormalizePath(string.Join(Path.DirectorySeparatorChar.ToString(), commonParts));
     }
-
 
 
     /// <summary>

--- a/API/Services/DirectoryService.cs
+++ b/API/Services/DirectoryService.cs
@@ -69,6 +69,7 @@ public interface IDirectoryService
         SearchOption searchOption = SearchOption.TopDirectoryOnly);
     IEnumerable<string> GetDirectories(string folderPath);
     IEnumerable<string> GetDirectories(string folderPath, GlobMatcher? matcher);
+    IEnumerable<string> GetAllDirectories(string folderPath, GlobMatcher? matcher);
     string GetParentDirectoryName(string fileOrFolder);
     IList<string> ScanFiles(string folderPath, string fileTypes, GlobMatcher? matcher = null);
     DateTime GetLastWriteTime(string folderPath);
@@ -687,8 +688,9 @@ public class DirectoryService : IDirectoryService
     /// Returns all directories, including subdirectories. Automatically excludes directories that shouldn't be in scope.
     /// </summary>
     /// <param name="folderPath"></param>
+    /// <param name="matcher"></param>
     /// <returns></returns>
-    public IEnumerable<string> GetAllDirectories(string folderPath)
+    public IEnumerable<string> GetAllDirectories(string folderPath, GlobMatcher? matcher)
     {
         if (!FileSystem.Directory.Exists(folderPath)) return ImmutableArray<string>.Empty;
         var directories = new List<string>();
@@ -697,7 +699,7 @@ public class DirectoryService : IDirectoryService
         foreach (var foundDir in foundDirs)
         {
             directories.Add(foundDir);
-            directories.AddRange(GetAllDirectories(foundDir));
+            directories.AddRange(GetAllDirectories(foundDir, matcher));
         }
 
         return directories;

--- a/API/Services/Tasks/Scanner/ParseScannedFiles.cs
+++ b/API/Services/Tasks/Scanner/ParseScannedFiles.cs
@@ -122,7 +122,7 @@ public class ParseScannedFiles
     /// <param name="seriesPaths">A dictionary mapping a normalized path to a list of <see cref="SeriesModified"/> to help scanner skip I/O</param>
     /// <param name="folderPath">A library folder or series folder</param>
     /// <param name="forceCheck">If we should bypass any folder last write time checks on the scan and force I/O</param>
-    public async Task<IList<ScanResult>> ProcessFiles(string folderPath, bool scanDirectoryByDirectory,
+    public async Task<IList<ScanResult>> ScanFiles(string folderPath, bool scanDirectoryByDirectory,
         IDictionary<string, IList<SeriesModified>> seriesPaths, Library library, bool forceCheck = false)
     {
         var fileExtensions = string.Join("|", library.LibraryFileTypes.Select(l => l.FileTypeGroup.GetRegex()));
@@ -595,7 +595,7 @@ private bool HasSeriesFolderNotChangedSinceLastScan(IDictionary<string, IList<Se
         ConcurrentBag<ScannedSeriesResult> processedScannedSeries, bool forceCheck)
     {
         _logger.LogDebug("\t[ScannerService] Library {LibraryName} Step 1.B: Scan files in {Folder}", library.Name, folderPath);
-        var scanResults = await ProcessFiles(folderPath, isLibraryScan, seriesPaths, library, forceCheck);
+        var scanResults = await ScanFiles(folderPath, isLibraryScan, seriesPaths, library, forceCheck);
 
         _logger.LogDebug("\t[ScannerService] Library {LibraryName} Step 1.C: Process files in {Folder}", library.Name, folderPath);
         foreach (var scanResult in scanResults)

--- a/API/Services/Tasks/Scanner/ParseScannedFiles.cs
+++ b/API/Services/Tasks/Scanner/ParseScannedFiles.cs
@@ -597,7 +597,7 @@ public class ParseScannedFiles
 
         if (distinctSeries.Count == 0) return scanResults;
 
-        string? nonLocalizedSeries = null;
+        string? nonLocalizedSeries;
 
         switch (distinctSeries.Count)
         {

--- a/API/Services/Tasks/Scanner/ParseScannedFiles.cs
+++ b/API/Services/Tasks/Scanner/ParseScannedFiles.cs
@@ -152,7 +152,7 @@ public class ParseScannedFiles
         foreach (var directory in allDirectories)
         {
             // Don't process any folders where we've already scanned everything below
-            if (processedDirs.Any(d => d.StartsWith(directory)))
+            if (processedDirs.Any(d => d.StartsWith(directory + Path.DirectorySeparatorChar) || d.Equals(directory)))
             {
                 // Skip this directory as we've already processed a parent
                 continue;

--- a/API/Services/Tasks/Scanner/ParseScannedFiles.cs
+++ b/API/Services/Tasks/Scanner/ParseScannedFiles.cs
@@ -152,7 +152,7 @@ public class ParseScannedFiles
         foreach (var directory in allDirectories)
         {
             // Don't process any folders where we've already scanned everything below
-            if (processedDirs.Any(d => d.StartsWith(directory + Path.DirectorySeparatorChar) || d.Equals(directory)))
+            if (processedDirs.Any(d => d.StartsWith(directory + Path.AltDirectorySeparatorChar) || d.Equals(directory)))
             {
                 // Skip this directory as we've already processed a parent
                 continue;
@@ -166,7 +166,7 @@ public class ParseScannedFiles
                 continue;
             }
 
-            var sw = Stopwatch.StartNew();
+            //var sw = Stopwatch.StartNew();
             await _eventHub.SendMessageAsync(MessageFactory.NotificationProgress,
                 MessageFactory.FileScanProgressEvent(directory, library.Name, ProgressEventType.Updated));
 
@@ -180,7 +180,7 @@ public class ParseScannedFiles
             }
 
             processedDirs.Add(directory);
-            _logger.LogDebug("Processing {Directory} took {TimeMs}ms to check", directory, sw.ElapsedMilliseconds);
+            //_logger.LogDebug("Processing {Directory} took {TimeMs}ms to check", directory, sw.ElapsedMilliseconds);
         }
 
         return result;

--- a/API/Services/Tasks/Scanner/Parser/BasicParser.cs
+++ b/API/Services/Tasks/Scanner/Parser/BasicParser.cs
@@ -79,7 +79,13 @@ public class BasicParser(IDirectoryService directoryService, IDefaultParser imag
             // NOTE: This uses rootPath. LibraryRoot works better for manga, but it's not always that way.
             // It might be worth writing some logic if the file is a special, to take the folder above the Specials/
             // if present
-            ParseFromFallbackFolders(filePath, rootPath, type, ref ret);
+            var tempRootPath = rootPath;
+            if (rootPath.EndsWith("Specials") || rootPath.EndsWith("Specials/"))
+            {
+                tempRootPath = rootPath.Replace("Specials", string.Empty).TrimEnd('/');
+            }
+
+            ParseFromFallbackFolders(filePath, tempRootPath, type, ref ret);
         }
 
         if (string.IsNullOrEmpty(ret.Series))

--- a/API/Services/Tasks/Scanner/Parser/PdfParser.cs
+++ b/API/Services/Tasks/Scanner/Parser/PdfParser.cs
@@ -59,7 +59,13 @@ public class PdfParser(IDirectoryService directoryService) : DefaultParser(direc
             ret.Chapters = Parser.DefaultChapter;
             ret.Volumes = Parser.SpecialVolume;
 
-            ParseFromFallbackFolders(filePath, rootPath, type, ref ret);
+            var tempRootPath = rootPath;
+            if (rootPath.EndsWith("Specials") || rootPath.EndsWith("Specials/"))
+            {
+                tempRootPath = rootPath.Replace("Specials", string.Empty).TrimEnd('/');
+            }
+
+            ParseFromFallbackFolders(filePath, tempRootPath, type, ref ret);
         }
 
         if (ret.Chapters == Parser.DefaultChapter && ret.Volumes == Parser.LooseLeafVolume && type == LibraryType.Book)

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -264,7 +264,7 @@ public class ScannerService : IScannerService
             MessageFactory.LibraryScanProgressEvent(library.Name, ProgressEventType.Started, series.Name, 1));
 
         _logger.LogInformation("Beginning file scan on {SeriesName}", series.Name);
-        var (scanElapsedTime, parsedSeries) = await ScanFiles(library, new []{ folderPath },
+        var (scanElapsedTime, parsedSeries) = await ScanFiles(library, [folderPath],
             false, true);
 
         // // Transform seen series into the parsedSeries (I think we can actually just have processedSeries be used instead
@@ -537,20 +537,14 @@ public class ScannerService : IScannerService
         var (scanElapsedTime, parsedSeries) = await ScanFiles(library, libraryFolderPaths,
             shouldUseLibraryScan, forceUpdate);
 
-        // _logger.LogDebug("[ScannerService] Library {LibraryName} Step 2: Track Found Series", library.Name);
-
-        // We need to collect SeenSeries and filter out anything that hasn't changed
-
-
         // We need to remove any keys where there is no actual parser info
-        _logger.LogDebug("[ScannerService] Library {LibraryName} Step 3: Process Parsed Series", library.Name);
+        _logger.LogDebug("[ScannerService] Library {LibraryName} Step 2: Process and Update Database", library.Name);
         var totalFiles = await ProcessParsedSeries(forceUpdate, parsedSeries, library, scanElapsedTime);
 
         UpdateLastScanned(library);
         _unitOfWork.LibraryRepository.Update(library);
 
-
-        _logger.LogDebug("[ScannerService] Library {LibraryName} Step 4: Save Library", library.Name);
+        _logger.LogDebug("[ScannerService] Library {LibraryName} Step 3: Save Library", library.Name);
         if (await _unitOfWork.CommitAsync())
         {
             if (isSingleScan)
@@ -678,7 +672,7 @@ public class ScannerService : IScannerService
         library.UpdateLastScanned(time);
     }
 
-    private async Task<Tuple<long, Dictionary<ParsedSeries, IList<ParserInfo>>>> ScanFiles(Library library, IEnumerable<string> dirs,
+    private async Task<Tuple<long, Dictionary<ParsedSeries, IList<ParserInfo>>>> ScanFiles(Library library, IList<string> dirs,
         bool isLibraryScan, bool forceChecks = false)
     {
         var scanner = new ParseScannedFiles(_logger, _directoryService, _readingItemService, _eventHub);

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -630,7 +630,6 @@ public class ScannerService : IScannerService
 
         if (toProcess.Count > 0)
         {
-
             // For all Genres in the ParserInfos, do a bulk check against the DB on what is not in the DB and create them
             // This will ensure all Genres are pre-created and allow our Genre lookup (and Priming) to be much simpler. It will be slower, but more consistent.
             var allGenres = toProcess
@@ -643,7 +642,15 @@ public class ScannerService : IScannerService
 
             await _processSeries.CreateAllGenresAsync(allGenres.ToList());
 
-            // TODO: Do the above for Tags as well
+            var allTags = toProcess
+                .SelectMany(s => s.Value
+                    .SelectMany(p => p.ComicInfo?.Tags?
+                                         .Split(",", StringSplitOptions.RemoveEmptyEntries) // Split on comma and remove empty entries
+                                         .Select(g => g.Trim()) // Trim each genre
+                                         .Where(g => !string.IsNullOrWhiteSpace(g)) // Ensure no null/empty genres
+                                     ?? [])); // Handle null Tag or ComicInfo safely
+
+            await _processSeries.CreateAllTagsAsync(allTags.ToList());
 
             // TODO: Do the above for People as well (until we overhaul the People code)
 

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -634,7 +634,7 @@ public class ScannerService : IScannerService
             await _processSeries.Prime();
 
             // TODO: For all Genres in the ParserInfos, do a bulk check against the DB on what is not in the DB and create them
-            // This will ensure all Genres are pre-created and allow our Genre lookup (and Priming) to be much simplier. It will be slower, but more consistent.
+            // This will ensure all Genres are pre-created and allow our Genre lookup (and Priming) to be much simpler. It will be slower, but more consistent.
 
             // TODO: Do the above for Tags as well
 

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -638,6 +638,14 @@ public class ScannerService : IScannerService
         {
             // Prime shared entities if there are any series to process
             await _processSeries.Prime();
+
+            // TODO: For all Genres in the ParserInfos, do a bulk check against the DB on what is not in the DB and create them
+            // This will ensure all Genres are pre-created and allow our Genre lookup (and Priming) to be much simplier. It will be slower, but more consistent.
+
+            // TODO: Do the above for Tags as well
+
+            // TODO: Do the above for People as well (until we overhaul the People code)
+
         }
 
         var totalFiles = 0;

--- a/API/Startup.cs
+++ b/API/Startup.cs
@@ -271,6 +271,9 @@ public class Startup
                     await MigrateInitialInstallData.Migrate(dataContext, logger, directoryService);
                     await MigrateSeriesLowestFolderPath.Migrate(dataContext, logger, directoryService);
 
+                    // v0.8.4
+                    await MigrateLowestSeriesFolderPath2.Migrate(dataContext, unitOfWork, logger);
+
                     //  Update the version in the DB after all migrations are run
                     var installVersion = await unitOfWork.SettingsRepository.GetSettingAsync(ServerSettingKey.InstallVersion);
                     installVersion.Value = BuildInfo.Version.ToString();

--- a/UI/Web/src/app/nav/_components/grouped-typeahead/grouped-typeahead.component.ts
+++ b/UI/Web/src/app/nav/_components/grouped-typeahead/grouped-typeahead.component.ts
@@ -119,9 +119,7 @@ export class GroupedTypeaheadComponent implements OnInit {
 
   @HostListener('window:click', ['$event'])
   handleDocumentClick(event: MouseEvent) {
-    console.log('click: ', event)
     this.close();
-
   }
 
   @HostListener('window:keydown', ['$event'])

--- a/UI/Web/src/app/sidenav/_components/sidenav-stream-list-item/sidenav-stream-list-item.component.ts
+++ b/UI/Web/src/app/sidenav/_components/sidenav-stream-list-item/sidenav-stream-list-item.component.ts
@@ -20,9 +20,4 @@ export class SidenavStreamListItemComponent {
   @Output() hide: EventEmitter<SideNavStream> = new EventEmitter<SideNavStream>();
   protected readonly SideNavStreamType = SideNavStreamType;
   protected readonly baseUrl = inject(APP_BASE_HREF);
-
-  constructor() {
-    console.log('baseUrl', this.baseUrl);
-  }
-
 }


### PR DESCRIPTION
This is a canary release to test out the new scanner. These scanner enhancements are part of an effort to bring more reliability into the scanner and have ingestion of changes after the first scan to be faster. This new code is likely to make the first scan take longer, but with the scope of what Kavita does, it's acceptable for a first scan to take some time. 

For those that are testing this, please report back to me on scan time for first scan (vs size of library), if ingestion is fast after the fact and if files are being picked up and scanned correctly (ie, updated a nested directory, you should only see that directory scanned). 

Do not try to use this for your main server. I make no guarantees that it will work exactly (although from spot checking against my prod library, it's looking pretty good)

# Changed
- Changed: Optimized a number of methods within the Scanner to reduce memory and CPU time
- Changed: Scanner can now choose to parallel parse files when there are over 100 in a directory
- Changed: Changed how detection and scanning of dirty directories works. The scanner will now parse bottom-up to reduce any potential misses and avoid different layouts working differently. This has extra I/O checks but much greater reliability and should reduce the amount of work needed to ingest changes after the first scan.
- Changed: LocalizedSeries merging with Series is now done at a higher level and performs much better (in terms of reliability)
- Changed: The scanner will now pre-save all new Genres/Tags before processing Series to avoid any FK issues. 

# Fixed
- Fixed: Fixed a bug where Series Cover image could choose a Volume 0 instead of Volume 1
- Fixed: Fixed a bug where calculating the Lowest Folder for a Series could be incorrect when there are nested folders. This includes a migration to clear out existing entries to avoid scan series not seeing files.
Example:
/ <- Lib root assume
/love hina/love hina/v01.cbz
/love hina/specials/sp01.cbz

The lowest series folder was /love hina/love hina/ for some reason, meaning series scan wasn't getting the full series (all folders) scanned in. 
