### PR TITLE
Last Canary Scanner Changes

### DIFF
--- a/API/Services/TaskScheduler.cs
+++ b/API/Services/TaskScheduler.cs
@@ -282,19 +282,16 @@ public class TaskScheduler : ITaskScheduler
     {
         var normalizedFolder = Tasks.Scanner.Parser.Parser.NormalizePath(folderPath);
         var normalizedOriginal = Tasks.Scanner.Parser.Parser.NormalizePath(originalPath);
+
         if (HasAlreadyEnqueuedTask(ScannerService.Name, "ScanFolder", [normalizedFolder, normalizedOriginal]) ||
             HasAlreadyEnqueuedTask(ScannerService.Name, "ScanFolder", [normalizedFolder, string.Empty]))
         {
-            _logger.LogInformation("Skipped scheduling ScanFolder for {Folder} as a job already queued",
-                normalizedFolder);
+            _logger.LogTrace("Skipped scheduling ScanFolder for {Folder} as a job already queued", normalizedFolder);
             return;
         }
 
         // Not sure where we should put this code, but we can get a bunch of ScanFolders when original has slight variations, like
         // create a folder, add a new file, etc. All of these can be merged into just 1 request.
-
-
-
 
         _logger.LogInformation("Scheduling ScanFolder for {Folder}", normalizedFolder);
         BackgroundJob.Schedule(() => _scannerService.ScanFolder(normalizedFolder, normalizedOriginal), delay);

--- a/API/Services/Tasks/Scanner/LibraryWatcher.cs
+++ b/API/Services/Tasks/Scanner/LibraryWatcher.cs
@@ -278,7 +278,7 @@ public class LibraryWatcher : ILibraryWatcher
             _logger.LogTrace("Folder path: {FolderPath}", fullPath);
             if (string.IsNullOrEmpty(fullPath))
             {
-                _logger.LogTrace("[LibraryWatcher] Change from {FilePath} could not find root level folder, ignoring change", filePath);
+                _logger.LogInformation("[LibraryWatcher] Change from {FilePath} could not find root level folder, ignoring change", filePath);
                 return;
             }
 


### PR DESCRIPTION
This should be the last canary to make sure folder watching is working well with Publisher type layouts. I had missed some logic for finding the series to perform the scan on when reacting to events in folder leaf nodes. 

Please note this also includes People support, you can read about it here: https://github.com/Kareadita/Kavita/pull/3279


# Changed
- Changed: Changed logging level on some of the loggers that could become noisy

# Fixed
- Fixed: Fixed up a check for using lowest folder path to lookup from a Folder Watcher task. This should find series much better from a lower file path. (develop)
