### PR TITLE
Migration to fix the People mess up I made

### DIFF
--- a/API/Data/ManualMigrations/ManualMigrateRemovePeople.cs
+++ b/API/Data/ManualMigrations/ManualMigrateRemovePeople.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using API.Entities;
+using Kavita.Common.EnvironmentInfo;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace API.Data.ManualMigrations;
+
+/// <summary>
+/// Due to a bug in the initial merge of People/Scanner rework, people got messed up bad. This migration will clear out the table only for nightly users: 0.8.3.15/0.8.3.16
+/// </summary>
+public static class ManualMigrateRemovePeople
+{
+    public static async Task Migrate(DataContext context, ILogger<Program> logger)
+    {
+        if (await context.ManualMigrationHistory.AnyAsync(m => m.Name == "ManualMigrateRemovePeople"))
+        {
+            return;
+        }
+
+        var version = BuildInfo.Version.ToString();
+        if (version != "0.8.3.15" && version != "0.8.3.16")
+        {
+            return;
+        }
+
+        logger.LogCritical("Running ManualMigrateRemovePeople migration - Please be patient, this may take some time. This is not an error");
+
+       context.Person.RemoveRange(context.Person);
+
+        if (context.ChangeTracker.HasChanges())
+        {
+            await context.SaveChangesAsync();
+        }
+
+        await context.ManualMigrationHistory.AddAsync(new ManualMigrationHistory()
+        {
+            Name = "ManualMigrateRemovePeople",
+            ProductVersion = BuildInfo.Version.ToString(),
+            RanAt = DateTime.UtcNow
+        });
+        await context.SaveChangesAsync();
+
+        logger.LogCritical("Running ManualMigrateRemovePeople migration - Completed. This is not an error");
+    }
+}

--- a/API/Startup.cs
+++ b/API/Startup.cs
@@ -273,6 +273,7 @@ public class Startup
 
                     // v0.8.4
                     await MigrateLowestSeriesFolderPath2.Migrate(dataContext, unitOfWork, logger);
+                    await ManualMigrateRemovePeople.Migrate(dataContext, logger);
 
                     //  Update the version in the DB after all migrations are run
                     var installVersion = await unitOfWork.SettingsRepository.GetSettingAsync(ServerSettingKey.InstallVersion);


### PR DESCRIPTION
Nightly users, this will wipe all the people. Unfortunately a bug slipped through which set all people to normalized strings with no way to fix it. This will only run for specific versions, so you'll need to upgrade to this version before the next nightly. 

# Changed
- Changed: Wipe the People table only for users on 0.8.3.15/0.8.3.16