### PR TITLE
Smart Collection UI Changes

### DIFF
--- a/API/Controllers/MetadataController.cs
+++ b/API/Controllers/MetadataController.cs
@@ -39,12 +39,6 @@ public class MetadataController(IUnitOfWork unitOfWork, ILocalizationService loc
     {
         var ids = libraryIds?.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries).Select(int.Parse).ToList();
 
-        // NOTE: libraryIds isn't hooked up in the frontend
-        // if (ids is {Count: > 0})
-        // {
-        //     return Ok(await unitOfWork.GenreRepository.GetAllGenreDtosForLibrariesAsync(User.GetUserId(), ids));
-        // }
-
         return Ok(await unitOfWork.GenreRepository.GetAllGenreDtosForLibrariesAsync(User.GetUserId(), ids, context));
     }
 

--- a/API/Controllers/MetadataController.cs
+++ b/API/Controllers/MetadataController.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using API.Constants;
 using API.Data;
+using API.Data.Repositories;
 using API.DTOs;
 using API.DTOs.Filtering;
 using API.DTOs.Metadata;
@@ -33,18 +34,18 @@ public class MetadataController(IUnitOfWork unitOfWork, ILocalizationService loc
     /// <param name="libraryIds">String separated libraryIds or null for all genres</param>
     /// <returns></returns>
     [HttpGet("genres")]
-    [ResponseCache(CacheProfileName = ResponseCacheProfiles.Instant, VaryByQueryKeys = new []{"libraryIds"})]
-    public async Task<ActionResult<IList<GenreTagDto>>> GetAllGenres(string? libraryIds)
+    [ResponseCache(CacheProfileName = ResponseCacheProfiles.Instant, VaryByQueryKeys = ["libraryIds", "context"])]
+    public async Task<ActionResult<IList<GenreTagDto>>> GetAllGenres(string? libraryIds, QueryContext context = QueryContext.None)
     {
         var ids = libraryIds?.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries).Select(int.Parse).ToList();
 
         // NOTE: libraryIds isn't hooked up in the frontend
-        if (ids is {Count: > 0})
-        {
-            return Ok(await unitOfWork.GenreRepository.GetAllGenreDtosForLibrariesAsync(User.GetUserId(), ids));
-        }
+        // if (ids is {Count: > 0})
+        // {
+        //     return Ok(await unitOfWork.GenreRepository.GetAllGenreDtosForLibrariesAsync(User.GetUserId(), ids));
+        // }
 
-        return Ok(await unitOfWork.GenreRepository.GetAllGenreDtosForLibrariesAsync(User.GetUserId()));
+        return Ok(await unitOfWork.GenreRepository.GetAllGenreDtosForLibrariesAsync(User.GetUserId(), ids, context));
     }
 
     /// <summary>

--- a/API/Data/Repositories/GenreRepository.cs
+++ b/API/Data/Repositories/GenreRepository.cs
@@ -21,7 +21,7 @@ public interface IGenreRepository
     Task<IList<Genre>> GetAllGenresAsync();
     Task<IList<Genre>> GetAllGenresByNamesAsync(IEnumerable<string> normalizedNames);
     Task RemoveAllGenreNoLongerAssociated(bool removeExternal = false);
-    Task<IList<GenreTagDto>> GetAllGenreDtosForLibrariesAsync(int userId, IList<int>? libraryIds = null);
+    Task<IList<GenreTagDto>> GetAllGenreDtosForLibrariesAsync(int userId, IList<int>? libraryIds = null, QueryContext context = QueryContext.None);
     Task<int> GetCountAsync();
     Task<GenreTagDto> GetRandomGenre();
     Task<GenreTagDto> GetGenreById(int id);
@@ -115,10 +115,10 @@ public class GenreRepository : IGenreRepository
     /// <param name="userId"></param>
     /// <param name="libraryIds"></param>
     /// <returns></returns>
-    public async Task<IList<GenreTagDto>> GetAllGenreDtosForLibrariesAsync(int userId, IList<int>? libraryIds = null)
+    public async Task<IList<GenreTagDto>> GetAllGenreDtosForLibrariesAsync(int userId, IList<int>? libraryIds = null, QueryContext context = QueryContext.None)
     {
         var userRating = await _context.AppUser.GetUserAgeRestriction(userId);
-        var userLibs = await _context.Library.GetUserLibraries(userId).ToListAsync();
+        var userLibs = await _context.Library.GetUserLibraries(userId, context).ToListAsync();
 
         if (libraryIds is {Count: > 0})
         {

--- a/API/Data/Repositories/SeriesRepository.cs
+++ b/API/Data/Repositories/SeriesRepository.cs
@@ -65,6 +65,7 @@ public enum QueryContext
 {
     None = 1,
     Search = 2,
+    [Obsolete("Use Dashboard")]
     Recommended = 3,
     Dashboard = 4,
 }
@@ -1509,7 +1510,7 @@ public class SeriesRepository : ISeriesRepository
 
     public async Task<PagedList<SeriesDto>> GetMoreIn(int userId, int libraryId, int genreId, UserParams userParams)
     {
-        var libraryIds = GetLibraryIdsForUser(userId, libraryId, QueryContext.Recommended)
+        var libraryIds = GetLibraryIdsForUser(userId, libraryId, QueryContext.Dashboard)
             .Where(id => libraryId == 0 || id == libraryId);
         var usersSeriesIds = GetSeriesIdsForLibraryIds(libraryIds);
 

--- a/API/Services/TaskScheduler.cs
+++ b/API/Services/TaskScheduler.cs
@@ -161,7 +161,6 @@ public class TaskScheduler : ITaskScheduler
         }
 
         setting = (await _unitOfWork.SettingsRepository.GetSettingAsync(ServerSettingKey.TaskCleanup)).Value;
-        _logger.LogDebug("Scheduling Cleanup Task for {Setting}", setting);
         if (setting == null || (!nonCronOptions.Contains(setting) && !CronHelper.IsValidCron(setting)))
         {
             _logger.LogDebug("Scheduling Cleanup Task for {Setting}", setting);

--- a/API/Services/TaskScheduler.cs
+++ b/API/Services/TaskScheduler.cs
@@ -12,6 +12,7 @@ using API.Services.Tasks;
 using API.Services.Tasks.Metadata;
 using API.SignalR;
 using Hangfire;
+using Kavita.Common.Helpers;
 using Microsoft.Extensions.Logging;
 
 namespace API.Services;
@@ -121,23 +122,32 @@ public class TaskScheduler : ITaskScheduler
     public async Task ScheduleTasks()
     {
         _logger.LogInformation("Scheduling reoccurring tasks");
+        var nonCronOptions = new List<string>(["disabled", "daily", "weekly"]);
 
         var setting = (await _unitOfWork.SettingsRepository.GetSettingAsync(ServerSettingKey.TaskScan)).Value;
-        if (setting != null)
+        if (setting == null || (!nonCronOptions.Contains(setting) && !CronHelper.IsValidCron(setting)))
+        {
+            _logger.LogError("Scan Task has invalid cron, defaulting to Daily");
+            RecurringJob.AddOrUpdate(ScanLibrariesTaskId, () => ScanLibraries(false),
+                Cron.Daily, RecurringJobOptions);
+        }
+        else
         {
             var scanLibrarySetting = setting;
             _logger.LogDebug("Scheduling Scan Library Task for {Setting}", scanLibrarySetting);
             RecurringJob.AddOrUpdate(ScanLibrariesTaskId, () => ScanLibraries(false),
                 () => CronConverter.ConvertToCronNotation(scanLibrarySetting), RecurringJobOptions);
         }
-        else
-        {
-            RecurringJob.AddOrUpdate(ScanLibrariesTaskId, () => ScanLibraries(false),
-                Cron.Daily, RecurringJobOptions);
-        }
+
 
         setting = (await _unitOfWork.SettingsRepository.GetSettingAsync(ServerSettingKey.TaskBackup)).Value;
-        if (setting != null)
+        if (setting == null || (!nonCronOptions.Contains(setting) && !CronHelper.IsValidCron(setting)))
+        {
+            _logger.LogError("Backup Task has invalid cron, defaulting to Daily");
+            RecurringJob.AddOrUpdate(BackupTaskId, () => _backupService.BackupDatabase(),
+                Cron.Weekly, RecurringJobOptions);
+        }
+        else
         {
             _logger.LogDebug("Scheduling Backup Task for {Setting}", setting);
             var schedule = CronConverter.ConvertToCronNotation(setting);
@@ -149,16 +159,22 @@ public class TaskScheduler : ITaskScheduler
             RecurringJob.AddOrUpdate(BackupTaskId, () => _backupService.BackupDatabase(),
                 () => schedule, RecurringJobOptions);
         }
-        else
-        {
-            RecurringJob.AddOrUpdate(BackupTaskId, () => _backupService.BackupDatabase(),
-                Cron.Weekly, RecurringJobOptions);
-        }
 
         setting = (await _unitOfWork.SettingsRepository.GetSettingAsync(ServerSettingKey.TaskCleanup)).Value;
         _logger.LogDebug("Scheduling Cleanup Task for {Setting}", setting);
-        RecurringJob.AddOrUpdate(CleanupTaskId, () => _cleanupService.Cleanup(),
-            CronConverter.ConvertToCronNotation(setting), RecurringJobOptions);
+        if (setting == null || (!nonCronOptions.Contains(setting) && !CronHelper.IsValidCron(setting)))
+        {
+            _logger.LogDebug("Scheduling Cleanup Task for {Setting}", setting);
+            RecurringJob.AddOrUpdate(CleanupTaskId, () => _cleanupService.Cleanup(),
+                CronConverter.ConvertToCronNotation(setting), RecurringJobOptions);
+        }
+        else
+        {
+            _logger.LogError("Cleanup Task has invalid cron, defaulting to Daily");
+            RecurringJob.AddOrUpdate(CleanupTaskId, () => _cleanupService.Cleanup(),
+                Cron.Daily, RecurringJobOptions);
+        }
+
 
         RecurringJob.AddOrUpdate(RemoveFromWantToReadTaskId, () => _cleanupService.CleanupWantToRead(),
             Cron.Daily, RecurringJobOptions);

--- a/UI/Web/package-lock.json
+++ b/UI/Web/package-lock.json
@@ -464,7 +464,6 @@
       "version": "18.2.9",
       "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-18.2.9.tgz",
       "integrity": "sha512-4iMoRvyMmq/fdI/4Gob9HKjL/jvTlCjbS4kouAYHuGO9w9dmUhi1pY1z+mALtCEl9/Q8CzU2W8e5cU2xtV4nVg==",
-      "dev": true,
       "dependencies": {
         "@babel/core": "7.25.2",
         "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -492,7 +491,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.1.tgz",
       "integrity": "sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==",
-      "dev": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -507,7 +505,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.2.tgz",
       "integrity": "sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA==",
-      "dev": true,
       "engines": {
         "node": ">= 14.16.0"
       },
@@ -4010,8 +4007,7 @@
     "node_modules/convert-source-map": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
-      "dev": true
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
     },
     "node_modules/cosmiconfig": {
       "version": "8.3.6",
@@ -4518,7 +4514,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
@@ -4528,7 +4523,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -7470,8 +7464,7 @@
     "node_modules/reflect-metadata": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
-      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "dev": true
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="
     },
     "node_modules/replace-in-file": {
       "version": "7.1.0",
@@ -7742,7 +7735,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/sass": {
       "version": "1.77.6",
@@ -7776,7 +7769,6 @@
       "version": "7.6.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
       "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -8331,7 +8323,6 @@
       "version": "5.5.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
       "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
-      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/UI/Web/src/app/_models/collection-tag.ts
+++ b/UI/Web/src/app/_models/collection-tag.ts
@@ -16,6 +16,9 @@ export interface UserCollection {
   source: ScrobbleProvider;
   sourceUrl: string | null;
   totalSourceCount: number;
+  /**
+   * HTML anchors separated by <br/>
+   */
   missingSeriesFromSource: string | null;
   ageRating: AgeRating;
   itemCount: number;

--- a/UI/Web/src/app/_services/colorscape.service.ts
+++ b/UI/Web/src/app/_services/colorscape.service.ts
@@ -2,7 +2,6 @@ import { Injectable, Inject } from '@angular/core';
 import { DOCUMENT } from '@angular/common';
 import {BehaviorSubject, filter, take, tap, timer} from 'rxjs';
 import {NavigationEnd, Router} from "@angular/router";
-import {debounceTime} from "rxjs/operators";
 
 interface ColorSpace {
   primary: string;
@@ -18,19 +17,8 @@ interface ColorSpaceRGBA {
   complementary: RGBAColor;
 }
 
-interface RGBAColor {
-  r: number;
-  g: number;
-  b: number;
-  a: number;
-}
-
-interface RGB {
-  r: number;
-  g: number;
-  b: number;
-}
-
+interface RGBAColor {r: number;g: number;b: number;a: number;}
+interface RGB { r: number;g: number; b: number; }
 interface HSL { h: number; s: number; l: number; }
 
 const colorScapeSelector = 'colorscape';
@@ -51,7 +39,6 @@ export class ColorscapeService {
   private defaultColorspaceDuration = 300; // duration to wait before defaulting back to default colorspace
 
   constructor(@Inject(DOCUMENT) private document: Document, private readonly router: Router) {
-
     this.router.events.pipe(
       filter(event => event instanceof NavigationEnd),
       tap(() => this.checkAndResetColorscapeAfterDelay())
@@ -102,8 +89,16 @@ export class ColorscapeService {
       this.colorSeedSubject.next({primary: primaryColor, complementary: complementaryColor});
       return;
     }
-
     this.colorSeedSubject.next({primary: primaryColor, complementary: complementaryColor});
+
+    // TODO: Check if there is a secondary color and if the color is a strong contrast (opposite on color wheel) to primary
+
+    // If we have a STRONG primary and secondary, generate LEFT/RIGHT orientation
+    // If we have only one color, randomize the position of the primary
+    // If we have 2 colors, but their contrast isn't STRONG, then use diagonal for Primary and Secondary
+
+
+
 
     const newColors: ColorSpace = primaryColor ?
       this.generateBackgroundColors(primaryColor, complementaryColor, this.isDarkTheme()) :
@@ -146,7 +141,8 @@ export class ColorscapeService {
     };
   }
 
-  private parseColorToRGBA(color: string): RGBAColor {
+  private parseColorToRGBA(color: string) {
+
     if (color.startsWith('#')) {
       return this.hexToRGBA(color);
     } else if (color.startsWith('rgb')) {
@@ -248,12 +244,19 @@ export class ColorscapeService {
     requestAnimationFrame(animate);
   }
 
+  private easeInOutCubic(t: number): number {
+    return t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
+  }
+
   private interpolateRGBAColor(color1: RGBAColor, color2: RGBAColor, progress: number): RGBAColor {
+
+    const easedProgress = this.easeInOutCubic(progress);
+
     return {
-      r: Math.round(color1.r + (color2.r - color1.r) * progress),
-      g: Math.round(color1.g + (color2.g - color1.g) * progress),
-      b: Math.round(color1.b + (color2.b - color1.b) * progress),
-      a: color1.a + (color2.a - color1.a) * progress
+      r: Math.round(color1.r + (color2.r - color1.r) * easedProgress),
+      g: Math.round(color1.g + (color2.g - color1.g) * easedProgress),
+      b: Math.round(color1.b + (color2.b - color1.b) * easedProgress),
+      a: color1.a + (color2.a - color1.a) * easedProgress
     };
   }
 

--- a/UI/Web/src/app/_services/colorscape.service.ts
+++ b/UI/Web/src/app/_services/colorscape.service.ts
@@ -31,6 +31,8 @@ interface RGB {
   b: number;
 }
 
+interface HSL { h: number; s: number; l: number; }
+
 const colorScapeSelector = 'colorscape';
 
 /**
@@ -300,7 +302,7 @@ export class ColorscapeService {
     });
   }
 
-  private calculateLightThemeDarkColors(primaryHSL: { h: number; s: number; l: number }, primary: RGB) {
+  private calculateLightThemeDarkColors(primaryHSL: HSL, primary: RGB) {
     const lighterHSL = {...primaryHSL};
     lighterHSL.s = Math.max(lighterHSL.s - 0.3, 0);
     lighterHSL.l = Math.min(lighterHSL.l + 0.5, 0.95);
@@ -321,7 +323,7 @@ export class ColorscapeService {
     };
   }
 
-  private calculateDarkThemeColors(secondaryHSL: { h: number; s: number; l: number }, primaryHSL: {
+  private calculateDarkThemeColors(secondaryHSL: HSL, primaryHSL: {
     h: number;
     s: number;
     l: number
@@ -406,7 +408,7 @@ export class ColorscapeService {
     return `#${((1 << 24) + (rgb.r << 16) + (rgb.g << 8) + rgb.b).toString(16).slice(1)}`;
   }
 
-  private rgbToHsl(rgb: RGB): { h: number; s: number; l: number } {
+  private rgbToHsl(rgb: RGB): HSL {
     const r = rgb.r / 255;
     const g = rgb.g / 255;
     const b = rgb.b / 255;
@@ -430,7 +432,7 @@ export class ColorscapeService {
     return { h, s, l };
   }
 
-  private hslToRgb(hsl: { h: number; s: number; l: number }): RGB {
+  private hslToRgb(hsl: HSL): RGB {
     const { h, s, l } = hsl;
     let r, g, b;
 
@@ -460,7 +462,7 @@ export class ColorscapeService {
     };
   }
 
-  private adjustHue(hsl: { h: number; s: number; l: number }, amount: number): { h: number; s: number; l: number } {
+  private adjustHue(hsl: HSL, amount: number): HSL {
     return {
       h: (hsl.h + amount / 360) % 1,
       s: hsl.s,

--- a/UI/Web/src/app/_services/metadata.service.ts
+++ b/UI/Web/src/app/_services/metadata.service.ts
@@ -1,4 +1,4 @@
-import { HttpClient } from '@angular/common/http';
+import {HttpClient} from '@angular/common/http';
 import {Injectable} from '@angular/core';
 import {tap} from 'rxjs/operators';
 import {of} from 'rxjs';
@@ -19,6 +19,7 @@ import {SeriesDetailPlus} from "../_models/series-detail/series-detail-plus";
 import {LibraryType} from "../_models/library/library";
 import {IHasCast} from "../_models/common/i-has-cast";
 import {TextResonse} from "../_types/text-response";
+import {QueryContext} from "../_models/metadata/v2/query-context";
 
 @Injectable({
   providedIn: 'root'
@@ -62,12 +63,12 @@ export class MetadataService {
     return this.httpClient.get<Array<Tag>>(this.baseUrl + method);
   }
 
-  getAllGenres(libraries?: Array<number>) {
+  getAllGenres(libraries?: Array<number>, context: QueryContext = QueryContext.None) {
     let method = 'metadata/genres'
     if (libraries != undefined && libraries.length > 0) {
       method += '?libraryIds=' + libraries.join(',');
     }
-    return this.httpClient.get<Array<Genre>>(this.baseUrl + method);
+    return this.httpClient.get<Array<Genre>>(this.baseUrl + method + '&context=' + context);
   }
 
   getAllLanguages(libraries?: Array<number>) {

--- a/UI/Web/src/app/_services/metadata.service.ts
+++ b/UI/Web/src/app/_services/metadata.service.ts
@@ -66,9 +66,12 @@ export class MetadataService {
   getAllGenres(libraries?: Array<number>, context: QueryContext = QueryContext.None) {
     let method = 'metadata/genres'
     if (libraries != undefined && libraries.length > 0) {
-      method += '?libraryIds=' + libraries.join(',');
+      method += '?libraryIds=' + libraries.join(',') + '&context=' + context;
+    } else {
+      method += '?context=' + context;
     }
-    return this.httpClient.get<Array<Genre>>(this.baseUrl + method + '&context=' + context);
+
+    return this.httpClient.get<Array<Genre>>(this.baseUrl + method);
   }
 
   getAllLanguages(libraries?: Array<number>) {

--- a/UI/Web/src/app/_single-module/edit-chapter-modal/edit-chapter-modal.component.html
+++ b/UI/Web/src/app/_single-module/edit-chapter-modal/edit-chapter-modal.component.html
@@ -123,7 +123,7 @@
                     <div class="mb-3">
                       <app-setting-item [title]="t('release-date-label')" [toggleOnViewClick]="false" [showEdit]="false">
                         <ng-template #view>
-                          <div class="input-group"  [ngClass]="{'lock-active': chapter.releaseDateLocked}">
+                          <div class="input-group" [ngClass]="{'lock-active': chapter.releaseDateLocked}">
                             <ng-container [ngTemplateOutlet]="lock" [ngTemplateOutletContext]="{ item: chapter, field: 'releaseDateLocked' }"></ng-container>
                             <input
                               class="form-control"

--- a/UI/Web/src/app/_single-module/smart-collection-drawer/smart-collection-drawer.component.html
+++ b/UI/Web/src/app/_single-module/smart-collection-drawer/smart-collection-drawer.component.html
@@ -36,8 +36,5 @@
         </ng-template>
       </app-setting-item>
     </div>
-
-
-
   </div>
 </ng-container>

--- a/UI/Web/src/app/_single-module/smart-collection-drawer/smart-collection-drawer.component.html
+++ b/UI/Web/src/app/_single-module/smart-collection-drawer/smart-collection-drawer.component.html
@@ -1,0 +1,43 @@
+<ng-container *transloco="let t">
+  <div class="offcanvas-header">
+    <h5 class="offcanvas-title">
+      {{collection.title}}
+    </h5>
+    <button type="button" class="btn-close text-reset" [attr.aria-label]="t('common.close')" (click)="close()"></button>
+  </div>
+
+  <div class="offcanvas-body">
+
+    <div class="mb-3">
+      <app-setting-item [title]="t('edit-collection-tags.last-sync-title')" [showEdit]="false" [canEdit]="false"
+                        [subtitle]="t('edit-collection-tags.last-sync-tooltip')">
+        <ng-template #view>
+          {{collection.lastSyncUtc | utcToLocalTime | date:'shortDate' | defaultDate}}
+        </ng-template>
+      </app-setting-item>
+    </div>
+
+
+    <div class="mb-3">
+      <app-setting-item [title]="t('edit-collection-tags.series-tab')" [showEdit]="false" [canEdit]="false">
+        <ng-template #titleExtra>
+          <span class="badge rounded-pill text-bg-primary ms-1" style="font-size: 11px">{{collection.totalSourceCount - series.length}} / {{collection.totalSourceCount | number}}</span>
+        </ng-template>
+
+        <ng-template #view>
+          @if(collection.missingSeriesFromSource) {
+            <p [innerHTML]="collection.missingSeriesFromSource | safeHtml"></p>
+          }
+          @for(s of series; track s.name) {
+            <div class="row g-0">
+              <del><a [routerLink]="['library', s.libraryId, 'series', s.id]" target="_blank" class="strike">{{s.name}}</a></del>
+            </div>
+          }
+        </ng-template>
+      </app-setting-item>
+    </div>
+
+
+
+  </div>
+</ng-container>

--- a/UI/Web/src/app/_single-module/smart-collection-drawer/smart-collection-drawer.component.scss
+++ b/UI/Web/src/app/_single-module/smart-collection-drawer/smart-collection-drawer.component.scss
@@ -1,0 +1,5 @@
+:host {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}

--- a/UI/Web/src/app/_single-module/smart-collection-drawer/smart-collection-drawer.component.ts
+++ b/UI/Web/src/app/_single-module/smart-collection-drawer/smart-collection-drawer.component.ts
@@ -1,0 +1,58 @@
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, inject, Input, OnInit} from '@angular/core';
+import {NgbActiveOffcanvas, NgbTooltip} from "@ng-bootstrap/ng-bootstrap";
+import {UserCollection} from "../../_models/collection-tag";
+import {ImageComponent} from "../../shared/image/image.component";
+import {LoadingComponent} from "../../shared/loading/loading.component";
+import {MetadataDetailComponent} from "../../series-detail/_components/metadata-detail/metadata-detail.component";
+import {DatePipe, DecimalPipe, NgOptimizedImage} from "@angular/common";
+import {ProviderImagePipe} from "../../_pipes/provider-image.pipe";
+import {PublicationStatusPipe} from "../../_pipes/publication-status.pipe";
+import {ReadMoreComponent} from "../../shared/read-more/read-more.component";
+import {TranslocoDirective} from "@jsverse/transloco";
+import {Series} from "../../_models/series";
+import {SafeHtmlPipe} from "../../_pipes/safe-html.pipe";
+import {RouterLink} from "@angular/router";
+import {DefaultDatePipe} from "../../_pipes/default-date.pipe";
+import {UtcToLocalTimePipe} from "../../_pipes/utc-to-local-time.pipe";
+import {SettingItemComponent} from "../../settings/_components/setting-item/setting-item.component";
+
+@Component({
+  selector: 'app-smart-collection-drawer',
+  standalone: true,
+  imports: [
+    ImageComponent,
+    LoadingComponent,
+    MetadataDetailComponent,
+    NgOptimizedImage,
+    NgbTooltip,
+    ProviderImagePipe,
+    PublicationStatusPipe,
+    ReadMoreComponent,
+    TranslocoDirective,
+    SafeHtmlPipe,
+    RouterLink,
+    DatePipe,
+    DefaultDatePipe,
+    UtcToLocalTimePipe,
+    SettingItemComponent,
+    DecimalPipe
+  ],
+  templateUrl: './smart-collection-drawer.component.html',
+  styleUrl: './smart-collection-drawer.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class SmartCollectionDrawerComponent implements OnInit {
+  private readonly activeOffcanvas = inject(NgbActiveOffcanvas);
+  private readonly cdRef = inject(ChangeDetectorRef);
+
+  @Input({required: true}) collection!: UserCollection;
+  @Input({required: true}) series: Series[] = [];
+
+  ngOnInit() {
+
+  }
+
+  close() {
+    this.activeOffcanvas.close();
+  }
+}

--- a/UI/Web/src/app/admin/manage-tasks-settings/manage-tasks-settings.component.html
+++ b/UI/Web/src/app/admin/manage-tasks-settings/manage-tasks-settings.component.html
@@ -8,7 +8,11 @@
           @if (settingsForm.get('taskScan'); as formControl) {
             <app-setting-item [title]="t('library-scan-label')" [subtitle]="t('library-scan-tooltip')">
               <ng-template #view>
-                {{t(formControl.value)}}
+                @if (formControl.value === customOption) {
+                  {{t(formControl.value)}} ({{settingsForm.get('taskScanCustom')?.value}})
+                } @else {
+                  {{t(formControl.value)}}
+                }
               </ng-template>
               <ng-template #edit>
 
@@ -27,7 +31,7 @@
                            aria-describedby="task-scan-validations">
 
                     @if (settingsForm.dirty || !settingsForm.untouched) {
-                      <div id="task-scan-validations" class="invalid-feedback">
+                      <div id="task-scan-validations" class="invalid-feedback" style="display: inline-block">
                         @if(settingsForm.get('taskScanCustom')?.errors?.required) {
                           <div>{{t('required')}}</div>
                         }
@@ -47,7 +51,11 @@
           @if (settingsForm.get('taskBackup'); as formControl) {
             <app-setting-item [title]="t('library-database-backup-label')" [subtitle]="t('library-database-backup-tooltip')">
               <ng-template #view>
-                {{t(formControl.value)}}
+                @if (formControl.value === customOption) {
+                  {{t(formControl.value)}} ({{settingsForm.get('taskBackupCustom')?.value}})
+                } @else {
+                  {{t(formControl.value)}}
+                }
               </ng-template>
               <ng-template #edit>
 
@@ -66,7 +74,7 @@
                            aria-describedby="task-scan-validations">
 
                     @if (settingsForm.dirty || !settingsForm.untouched) {
-                      <div id="task-backup-validations" class="invalid-feedback">
+                      <div id="task-backup-validations" class="invalid-feedback" style="display: inline-block">
                         @if(settingsForm.get('taskBackupCustom')?.errors?.required) {
                           <div>{{t('required')}}</div>
                         }
@@ -87,7 +95,11 @@
           @if (settingsForm.get('taskCleanup'); as formControl) {
             <app-setting-item [title]="t('cleanup-label')" [subtitle]="t('cleanup-tooltip')">
               <ng-template #view>
-                {{t(formControl.value)}}
+                @if (formControl.value === customOption) {
+                  {{t(formControl.value)}} ({{settingsForm.get('taskCleanupCustom')?.value}})
+                } @else {
+                  {{t(formControl.value)}}
+                }
               </ng-template>
               <ng-template #edit>
 
@@ -105,8 +117,8 @@
                            [class.is-invalid]="settingsForm.get('taskCleanupCustom')?.invalid && settingsForm.get('taskCleanupCustom')?.touched"
                            aria-describedby="task-scan-validations">
 
-                    @if (settingsForm.dirty || !settingsForm.untouched) {
-                      <div id="task-cleanup-validations" class="invalid-feedback">
+                    @if (settingsForm.get('taskCleanupCustom')?.invalid) {
+                      <div id="task-cleanup-validations" class="invalid-feedback" style="display: inline-block">
                         @if(settingsForm.get('taskCleanupCustom')?.errors?.required) {
                           <div>{{t('required')}}</div>
                         }
@@ -122,10 +134,6 @@
           }
         </div>
       </ng-container>
-
-      <div class="col-auto d-flex d-md-block justify-content-sm-center text-md-end">
-        <button type="button" class="flex-fill btn btn-secondary me-2" (click)="resetToDefaults()">{{t('reset-to-default')}}</button>
-      </div>
 
       <div class="setting-section-break"></div>
 

--- a/UI/Web/src/app/cards/_modals/edit-collection-tags/edit-collection-tags.component.html
+++ b/UI/Web/src/app/cards/_modals/edit-collection-tags/edit-collection-tags.component.html
@@ -16,7 +16,7 @@
                 <label for="library-name" class="form-label">{{t('name-label')}}</label>
                 <input id="library-name" class="form-control" formControlName="title" type="text"
                        [class.is-invalid]="collectionTagForm.get('title')?.invalid && collectionTagForm.get('title')?.touched">
-                @if (collectionTagForm.dirty || collectionTagForm.touched) {
+                @if (collectionTagForm.dirty || !collectionTagForm.untouched) {
                   <div id="inviteForm-validations" class="invalid-feedback">
                     @if (collectionTagForm.get('title')?.errors?.required) {
                       <div>{{t('required-field')}}</div>

--- a/UI/Web/src/app/cards/bulk-operations/bulk-operations.component.scss
+++ b/UI/Web/src/app/cards/bulk-operations/bulk-operations.component.scss
@@ -1,5 +1,6 @@
 .bulk-select-container {
     position: absolute;
+    width: 100%;
 
     .bulk-select {
         background-color: var(--bulk-selection-bg-color);

--- a/UI/Web/src/app/cards/card-item/card-item.component.html
+++ b/UI/Web/src/app/cards/card-item/card-item.component.html
@@ -73,9 +73,11 @@
     </div>
     @if (title.length > 0 || actions.length > 0) {
       <div class="card-title-container">
-        <span class="card-format">
+        <span>
           @if (showFormat) {
-            <app-series-format [format]="format"></app-series-format>
+            <span class="card-format">
+                <app-series-format [format]="format"></app-series-format>
+            </span>
           }
         </span>
 

--- a/UI/Web/src/app/cards/entity-title/entity-title.component.ts
+++ b/UI/Web/src/app/cards/entity-title/entity-title.component.ts
@@ -108,6 +108,8 @@ export class EntityTitleComponent implements OnInit {
     let renderText = '';
     if (this.titleName !== '' && this.prioritizeTitleName) {
       renderText = this.titleName;
+    } else if (this.fallbackToVolume && this.isChapter) { // (his is a single volume on volume detail page
+      renderText = translate('entity-title.single-volume');
     } else if (this.number === this.LooseLeafOrSpecial) {
       renderText = '';
     } else {
@@ -120,6 +122,8 @@ export class EntityTitleComponent implements OnInit {
     let renderText = '';
     if (this.titleName !== '' && this.prioritizeTitleName) {
       renderText = this.titleName;
+    } else if (this.fallbackToVolume && this.isChapter) { // (his is a single volume on volume detail page
+      renderText = translate('entity-title.single-volume');
     } else if (this.number === this.LooseLeafOrSpecial) {
       renderText = '';
     } else {

--- a/UI/Web/src/app/cards/external-series-card/external-series-card.component.ts
+++ b/UI/Web/src/app/cards/external-series-card/external-series-card.component.ts
@@ -25,6 +25,8 @@ import {SafeHtmlPipe} from "../../_pipes/safe-html.pipe";
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ExternalSeriesCardComponent {
+  private readonly offcanvasService = inject(NgbOffcanvas);
+
   @Input({required: true}) data!: ExternalSeries;
   /**
    * When clicking on the series, instead of opening, opens a preview drawer
@@ -32,8 +34,6 @@ export class ExternalSeriesCardComponent {
   @Input() previewOnClick: boolean = false;
   @ViewChild('link', {static: false}) link!: ElementRef<HTMLAnchorElement>;
 
-
-  private readonly offcanvasService = inject(NgbOffcanvas);
 
   handleClick() {
     if (this.previewOnClick) {

--- a/UI/Web/src/app/collections/_components/collection-detail/collection-detail.component.html
+++ b/UI/Web/src/app/collections/_components/collection-detail/collection-detail.component.html
@@ -26,6 +26,7 @@
           <div class="row mb-3">
             <div class="col-md-2 col-xs-4 col-sm-6 d-none d-sm-block">
               <app-image [styles]="{'max-width': '481px'}" [imageUrl]="imageService.getCollectionCoverImage(collectionTag.id)"></app-image>
+
               @if (collectionTag.source !== ScrobbleProvider.Kavita && collectionTag.missingSeriesFromSource !== null
               && series.length !== collectionTag.totalSourceCount && collectionTag.totalSourceCount > 0) {
                 <div class="under-image">
@@ -43,9 +44,11 @@
                   <app-read-more [text]="summary" [maxLength]="(utilityService.activeBreakpoint$ | async)! >= Breakpoint.Desktop ? 585 : 200"></app-read-more>
                 </div>
 
-                <div class="mt-2 mb-2">
-                  <button class="btn btn-primary-outline">Compare</button>
-                </div>
+                @if (collectionTag.source !== ScrobbleProvider.Kavita) {
+                  <div class="mt-2 mb-2">
+                    <button class="btn btn-primary-outline" (click)="openSyncDetailDrawer()">Sync Details</button>
+                  </div>
+                }
               }
             </div>
             <hr>

--- a/UI/Web/src/app/collections/_components/collection-detail/collection-detail.component.html
+++ b/UI/Web/src/app/collections/_components/collection-detail/collection-detail.component.html
@@ -42,6 +42,10 @@
                 <div class="mb-2">
                   <app-read-more [text]="summary" [maxLength]="(utilityService.activeBreakpoint$ | async)! >= Breakpoint.Desktop ? 585 : 200"></app-read-more>
                 </div>
+
+                <div class="mt-2 mb-2">
+                  <button class="btn btn-primary-outline">Compare</button>
+                </div>
               }
             </div>
             <hr>

--- a/UI/Web/src/app/collections/_components/collection-detail/collection-detail.component.html
+++ b/UI/Web/src/app/collections/_components/collection-detail/collection-detail.component.html
@@ -1,75 +1,95 @@
 <div class="main-container container-fluid">
   <ng-container *transloco="let t; read: 'collection-detail'">
     <div #companionBar>
-      <app-side-nav-companion-bar *ngIf="series !== undefined" [hasFilter]="true" (filterOpen)="filterOpen.emit($event)" [filterActive]="filterActive">
-        <ng-container title>
-          <h4 *ngIf="collectionTag !== undefined">
-            {{collectionTag.title}}<span class="ms-1" *ngIf="collectionTag.promoted">(<i aria-hidden="true" class="fa fa-angle-double-up"></i>)</span>
-            <app-card-actionables [disabled]="actionInProgress" (actionHandler)="performAction($event)" [actions]="collectionTagActions" [labelBy]="collectionTag.title" iconClass="fa-ellipsis-v"></app-card-actionables>
-          </h4>
-          <h5 subtitle class="subtitle-with-actionables">{{t('item-count', {num: series.length})}}</h5>
-        </ng-container>
-      </app-side-nav-companion-bar>
-    </div>
-
-    <div class="container-fluid" *ngIf="collectionTag !== undefined">
-      @if (summary.length > 0 || collectionTag.source !== ScrobbleProvider.Kavita) {
-        <div class="row mb-3">
-          <div class="col-md-2 col-xs-4 col-sm-6 d-none d-sm-block">
-            <app-image [styles]="{'max-width': '481px'}" [imageUrl]="imageService.getCollectionCoverImage(collectionTag.id)"></app-image>
-            @if (collectionTag.source !== ScrobbleProvider.Kavita && collectionTag.missingSeriesFromSource !== null
-            && series.length !== collectionTag.totalSourceCount && collectionTag.totalSourceCount > 0) {
-              <div class="under-image">
-                <app-image [imageUrl]="collectionTag.source | providerImage"
-                          width="16px" height="16px"
-                          [ngbTooltip]="collectionTag.source | providerName" tabindex="0"></app-image>
-                <span class="ms-2 me-2">{{t('sync-progress', {title: series.length + ' / ' + collectionTag.totalSourceCount})}}</span>
-                <i class="fa-solid fa-question-circle" aria-hidden="true" [ngbTooltip]="t('last-sync', {date: collectionTag.lastSyncUtc | date: 'short' | defaultDate })"></i>
-              </div>
+      @if (series) {
+        <app-side-nav-companion-bar [hasFilter]="true" (filterOpen)="filterOpen.emit($event)" [filterActive]="filterActive">
+          <ng-container title>
+            @if (collectionTag) {
+              <h4>
+                {{collectionTag.title}}
+                @if(collectionTag.promoted) {
+                  <span class="ms-1">(<i aria-hidden="true" class="fa fa-angle-double-up"></i>)</span>
+                }
+                <app-card-actionables [disabled]="actionInProgress" (actionHandler)="performAction($event)" [actions]="collectionTagActions" [labelBy]="collectionTag.title" iconClass="fa-ellipsis-v"></app-card-actionables>
+              </h4>
             }
-          </div>
-          <div class="col-md-10 col-xs-8 col-sm-6 mt-2">
-            @if (summary.length > 0) {
-              <div class="mb-2">
-                <app-read-more [text]="summary" [maxLength]="(utilityService.activeBreakpoint$ | async)! >= Breakpoint.Desktop ? 585 : 200"></app-read-more>
-              </div>
-            }
-          </div>
-          <hr>
-        </div>
+            <h5 subtitle class="subtitle-with-actionables">{{t('item-count', {num: series.length})}}</h5>
+          </ng-container>
+        </app-side-nav-companion-bar>
       }
 
-
-
-      <app-bulk-operations [actionCallback]="bulkActionCallback"></app-bulk-operations>
-
-      <app-card-detail-layout *ngIf="filter"
-        [isLoading]="isLoading"
-        [items]="series"
-        [pagination]="pagination"
-        [filterSettings]="filterSettings"
-        [filterOpen]="filterOpen"
-        [trackByIdentity]="trackByIdentity"
-        [jumpBarKeys]="jumpbarKeys"
-        (applyFilter)="updateFilter($event)">
-        <ng-template #cardItem let-item let-position="idx">
-          <app-series-card [series]="item" [libraryId]="item.libraryId" (reload)="loadPage()"
-                          (selection)="bulkSelectionService.handleCardSelection('series', position, series.length, $event)" [selected]="bulkSelectionService.isCardSelected('series', position)" [allowSelection]="true"
-          ></app-series-card>
-        </ng-template>
-
-        <div *ngIf="!filterActive && series.length === 0">
-          <ng-template #noData>
-            {{t('no-data')}}
-          </ng-template>
-        </div>
-
-        <div *ngIf="filterActive && series.length === 0">
-          <ng-template #noData>
-            {{t('no-data-filtered')}}
-          </ng-template>
-        </div>
-      </app-card-detail-layout>
     </div>
+
+    @if (collectionTag) {
+      <div class="container-fluid">
+        @if (summary.length > 0 || collectionTag.source !== ScrobbleProvider.Kavita) {
+          <div class="row mb-3">
+            <div class="col-md-2 col-xs-4 col-sm-6 d-none d-sm-block">
+              <app-image [styles]="{'max-width': '481px'}" [imageUrl]="imageService.getCollectionCoverImage(collectionTag.id)"></app-image>
+              @if (collectionTag.source !== ScrobbleProvider.Kavita && collectionTag.missingSeriesFromSource !== null
+              && series.length !== collectionTag.totalSourceCount && collectionTag.totalSourceCount > 0) {
+                <div class="under-image">
+                  <app-image [imageUrl]="collectionTag.source | providerImage"
+                             width="16px" height="16px"
+                             [ngbTooltip]="collectionTag.source | providerName" tabindex="0"></app-image>
+                  <span class="ms-2 me-2">{{t('sync-progress', {title: series.length + ' / ' + collectionTag.totalSourceCount})}}</span>
+                  <i class="fa-solid fa-question-circle" aria-hidden="true" [ngbTooltip]="t('last-sync', {date: collectionTag.lastSyncUtc | date: 'short' | defaultDate })"></i>
+                </div>
+              }
+            </div>
+            <div class="col-md-10 col-xs-8 col-sm-6 mt-2">
+              @if (summary.length > 0) {
+                <div class="mb-2">
+                  <app-read-more [text]="summary" [maxLength]="(utilityService.activeBreakpoint$ | async)! >= Breakpoint.Desktop ? 585 : 200"></app-read-more>
+                </div>
+              }
+            </div>
+            <hr>
+          </div>
+        }
+
+
+
+        <app-bulk-operations [actionCallback]="bulkActionCallback"></app-bulk-operations>
+
+        @if (filter) {
+          <app-card-detail-layout
+                                  [isLoading]="isLoading"
+                                  [items]="series"
+                                  [pagination]="pagination"
+                                  [filterSettings]="filterSettings"
+                                  [filterOpen]="filterOpen"
+                                  [trackByIdentity]="trackByIdentity"
+                                  [jumpBarKeys]="jumpbarKeys"
+                                  (applyFilter)="updateFilter($event)">
+            <ng-template #cardItem let-item let-position="idx">
+              <app-series-card [series]="item" [libraryId]="item.libraryId" (reload)="loadPage()"
+                               (selection)="bulkSelectionService.handleCardSelection('series', position, series.length, $event)"
+                               [selected]="bulkSelectionService.isCardSelected('series', position)" [allowSelection]="true"
+              ></app-series-card>
+            </ng-template>
+
+            @if(!filterActive && series.length === 0) {
+              <div>
+                <ng-template #noData>
+                  {{t('no-data')}}
+                </ng-template>
+              </div>
+            }
+
+            @if(filterActive && series.length === 0) {
+              <div>
+                <ng-template #noData>
+                  {{t('no-data-filtered')}}
+                </ng-template>
+              </div>
+            }
+
+          </app-card-detail-layout>
+        }
+
+      </div>
+    }
+
   </ng-container>
 </div>

--- a/UI/Web/src/app/collections/_components/collection-detail/collection-detail.component.ts
+++ b/UI/Web/src/app/collections/_components/collection-detail/collection-detail.component.ts
@@ -60,6 +60,7 @@ import {TranslocoDatePipe} from "@jsverse/transloco-locale";
 import {DefaultDatePipe} from "../../../_pipes/default-date.pipe";
 import {ProviderImagePipe} from "../../../_pipes/provider-image.pipe";
 import {ProviderNamePipe} from "../../../_pipes/provider-name.pipe";
+import {PromotedIconComponent} from "../../../shared/_components/promoted-icon/promoted-icon.component";
 
 @Component({
   selector: 'app-collection-detail',
@@ -67,7 +68,7 @@ import {ProviderNamePipe} from "../../../_pipes/provider-name.pipe";
   styleUrls: ['./collection-detail.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
-  imports: [NgIf, SideNavCompanionBarComponent, CardActionablesComponent, NgStyle, ImageComponent, ReadMoreComponent, BulkOperationsComponent, CardDetailLayoutComponent, SeriesCardComponent, TranslocoDirective, NgbTooltip, SafeHtmlPipe, TranslocoDatePipe, DatePipe, DefaultDatePipe, ProviderImagePipe, ProviderNamePipe, AsyncPipe]
+  imports: [NgIf, SideNavCompanionBarComponent, CardActionablesComponent, NgStyle, ImageComponent, ReadMoreComponent, BulkOperationsComponent, CardDetailLayoutComponent, SeriesCardComponent, TranslocoDirective, NgbTooltip, SafeHtmlPipe, TranslocoDatePipe, DatePipe, DefaultDatePipe, ProviderImagePipe, ProviderNamePipe, AsyncPipe, PromotedIconComponent]
 })
 export class CollectionDetailComponent implements OnInit, AfterContentChecked {
 

--- a/UI/Web/src/app/collections/_components/collection-detail/collection-detail.component.ts
+++ b/UI/Web/src/app/collections/_components/collection-detail/collection-detail.component.ts
@@ -1,4 +1,4 @@
-import {AsyncPipe, DatePipe, DOCUMENT, NgIf, NgStyle} from '@angular/common';
+import {AsyncPipe, DatePipe, DOCUMENT, NgStyle} from '@angular/common';
 import {
   AfterContentChecked,
   ChangeDetectionStrategy,
@@ -15,7 +15,7 @@ import {
 } from '@angular/core';
 import {Title} from '@angular/platform-browser';
 import {ActivatedRoute, Router} from '@angular/router';
-import {NgbModal, NgbTooltip} from '@ng-bootstrap/ng-bootstrap';
+import {NgbModal, NgbOffcanvas, NgbTooltip} from '@ng-bootstrap/ng-bootstrap';
 import {ToastrService} from 'ngx-toastr';
 import {debounceTime, take} from 'rxjs/operators';
 import {BulkSelectionService} from 'src/app/cards/bulk-selection.service';
@@ -61,6 +61,9 @@ import {DefaultDatePipe} from "../../../_pipes/default-date.pipe";
 import {ProviderImagePipe} from "../../../_pipes/provider-image.pipe";
 import {ProviderNamePipe} from "../../../_pipes/provider-name.pipe";
 import {PromotedIconComponent} from "../../../shared/_components/promoted-icon/promoted-icon.component";
+import {
+  SmartCollectionDrawerComponent
+} from "../../../_single-module/smart-collection-drawer/smart-collection-drawer.component";
 
 @Component({
   selector: 'app-collection-detail',
@@ -68,7 +71,10 @@ import {PromotedIconComponent} from "../../../shared/_components/promoted-icon/p
   styleUrls: ['./collection-detail.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
-  imports: [NgIf, SideNavCompanionBarComponent, CardActionablesComponent, NgStyle, ImageComponent, ReadMoreComponent, BulkOperationsComponent, CardDetailLayoutComponent, SeriesCardComponent, TranslocoDirective, NgbTooltip, SafeHtmlPipe, TranslocoDatePipe, DatePipe, DefaultDatePipe, ProviderImagePipe, ProviderNamePipe, AsyncPipe, PromotedIconComponent]
+  imports: [SideNavCompanionBarComponent, CardActionablesComponent, NgStyle, ImageComponent, ReadMoreComponent,
+    BulkOperationsComponent, CardDetailLayoutComponent, SeriesCardComponent, TranslocoDirective, NgbTooltip,
+    SafeHtmlPipe, TranslocoDatePipe, DatePipe, DefaultDatePipe, ProviderImagePipe, ProviderNamePipe, AsyncPipe,
+    PromotedIconComponent]
 })
 export class CollectionDetailComponent implements OnInit, AfterContentChecked {
 
@@ -84,6 +90,7 @@ export class CollectionDetailComponent implements OnInit, AfterContentChecked {
   private readonly actionFactoryService = inject(ActionFactoryService);
   private readonly accountService = inject(AccountService);
   private readonly modalService = inject(NgbModal);
+  private readonly offcanvasService = inject(NgbOffcanvas);
   private readonly titleService = inject(Title);
   private readonly jumpbarService = inject(JumpbarService);
   private readonly actionService = inject(ActionService);
@@ -92,6 +99,9 @@ export class CollectionDetailComponent implements OnInit, AfterContentChecked {
   protected readonly utilityService = inject(UtilityService);
   private readonly cdRef = inject(ChangeDetectorRef);
   private readonly scrollService = inject(ScrollService);
+
+  protected readonly ScrobbleProvider = ScrobbleProvider;
+  protected readonly Breakpoint = Breakpoint;
 
   @ViewChild('scrollingBlock') scrollingBlock: ElementRef<HTMLDivElement> | undefined;
   @ViewChild('companionBar') companionBar: ElementRef<HTMLDivElement> | undefined;
@@ -328,6 +338,12 @@ export class CollectionDetailComponent implements OnInit, AfterContentChecked {
     });
   }
 
-  protected readonly ScrobbleProvider = ScrobbleProvider;
-  protected readonly Breakpoint = Breakpoint;
+  openSyncDetailDrawer() {
+
+    const ref = this.offcanvasService.open(SmartCollectionDrawerComponent, {position: 'end', panelClass: ''});
+    ref.componentInstance.collection = this.collectionTag;
+    ref.componentInstance.series = this.series;
+  }
+
+
 }

--- a/UI/Web/src/app/dashboard/_components/dashboard.component.ts
+++ b/UI/Web/src/app/dashboard/_components/dashboard.component.ts
@@ -163,7 +163,7 @@ export class DashboardComponent implements OnInit {
                 .pipe(map(d => d.result),tap(() => this.increment()), takeUntilDestroyed(this.destroyRef), shareReplay({bufferSize: 1, refCount: true}));
             break;
           case StreamType.MoreInGenre:
-            s.api = this.metadataService.getAllGenres().pipe(
+            s.api = this.metadataService.getAllGenres([], QueryContext.Dashboard).pipe(
                 map(genres => {
                   this.genre = genres[Math.floor(Math.random() * genres.length)];
                   return this.genre;

--- a/UI/Web/src/app/series-detail/_components/series-detail/series-detail.component.ts
+++ b/UI/Web/src/app/series-detail/_components/series-detail/series-detail.component.ts
@@ -699,7 +699,7 @@ export class SeriesDetailComponent implements OnInit, AfterContentChecked {
 
   loadSeries(seriesId: number, loadExternal: boolean = false) {
     this.seriesService.getMetadata(seriesId).subscribe(metadata => {
-      this.seriesMetadata = metadata;
+      this.seriesMetadata = {...metadata};
       this.cdRef.markForCheck();
 
       if (![PublicationStatus.Ended, PublicationStatus.OnGoing].includes(this.seriesMetadata.publicationStatus)) return;

--- a/UI/Web/src/app/shared/badge-expander/badge-expander.component.ts
+++ b/UI/Web/src/app/shared/badge-expander/badge-expander.component.ts
@@ -4,8 +4,8 @@ import {
   Component,
   ContentChild, EventEmitter,
   inject,
-  Input,
-  OnInit, Output,
+  Input, OnChanges,
+  OnInit, Output, SimpleChanges,
   TemplateRef
 } from '@angular/core';
 import {NgTemplateOutlet} from "@angular/common";
@@ -20,7 +20,7 @@ import {DefaultValuePipe} from "../../_pipes/default-value.pipe";
   styleUrls: ['./badge-expander.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class BadgeExpanderComponent implements OnInit {
+export class BadgeExpanderComponent implements OnInit, OnChanges {
 
   private readonly cdRef = inject(ChangeDetectorRef);
 
@@ -43,6 +43,11 @@ export class BadgeExpanderComponent implements OnInit {
   }
 
   ngOnInit(): void {
+    this.visibleItems = this.items.slice(0, this.itemsTillExpander);
+    this.cdRef.markForCheck();
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
     this.visibleItems = this.items.slice(0, this.itemsTillExpander);
     this.cdRef.markForCheck();
   }

--- a/UI/Web/src/app/sidenav/_components/customize-sidenav-streams/customize-sidenav-streams.component.html
+++ b/UI/Web/src/app/sidenav/_components/customize-sidenav-streams/customize-sidenav-streams.component.html
@@ -1,5 +1,7 @@
 <ng-container *transloco="let t; read: 'customize-sidenav-streams'">
   <form [formGroup]="listForm">
+    <app-bulk-operations [modalMode]="false" [actionCallback]="bulkActionCallback"></app-bulk-operations>
+
     @if (items.length > 3) {
       <div class="row g-0 mb-2">
         <label for="sidenav-stream-filter" class="form-label">{{t('filter')}}</label>
@@ -26,7 +28,7 @@
       </form>
     </div>
 
-    <app-bulk-operations [modalMode]="true" [topOffset]="0" [actionCallback]="bulkActionCallback"></app-bulk-operations>
+
     <div style="max-height: 500px; overflow-y: auto">
       <app-draggable-ordered-list [items]="items | filter: filterSideNavStreams" (orderUpdated)="orderUpdated($event)"
                                   [accessibilityMode]="pageOperationsForm.get('accessibilityMode')!.value"

--- a/UI/Web/src/app/volume-detail/volume-detail.component.ts
+++ b/UI/Web/src/app/volume-detail/volume-detail.component.ts
@@ -569,7 +569,7 @@ export class VolumeDetailComponent implements OnInit {
     }
   }
 
-  handleChapterActionCallback(action: ActionItem<Chapter>, chapter: Chapter) {
+  async handleChapterActionCallback(action: ActionItem<Chapter>, chapter: Chapter) {
     switch (action.action) {
       case(Action.MarkAsRead):
         this.actionService.markChapterAsRead(this.libraryId, this.seriesId, chapter, _ => this.setContinuePoint());
@@ -585,6 +585,12 @@ export class VolumeDetailComponent implements OnInit {
         break;
       case(Action.IncognitoRead):
         this.readerService.readChapter(this.libraryId, this.seriesId, chapter, true);
+        break;
+      case(Action.Delete):
+        await this.actionService.deleteChapter(chapter.id, (res) => {
+          if (!res) return;
+          this.navigateToSeries();
+        });
         break;
       case (Action.SendTo):
         const device = (action._extra!.data as Device);

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -1465,6 +1465,7 @@
         "select-all": "{{common.select-all}}",
         "filter-label": "{{common.filter}}",
         "last-sync-title": "Last Sync:",
+        "last-sync-tooltip": "Kavita syncs daily against upstream collection provider.",
         "source-url-title": "Source Url:",
         "total-series-title": "Total Series:",
         "missing-series-title": "Missing Series:"


### PR DESCRIPTION
# Added
- Added: (Kavita+) New Sync Details button on smart collections that shows an easier to digest view of Series and missing series. 

# Changed
- Changed: Changed Colorscape to use non-linear animation for transitioning between 2 colorscapes. 
- Changed: If the user somehow wrote bad cron notation for custom jobs, on startup, Kavita will detect and default to daily

# Fixed
- Fixed: Fixed a bug where when a card doesn't have a format, 22px was still beating taken up. 
- Fixed: Ensure More In Genre doesn't choose from a Genre that's not exposed to the dashboard (Fixes #2811 )
- Fixed: Fixed a bug where bulk mode on customize side nav wasn't laying out the bulk update well. (Fixes #3331 )
- Fixed: Fixed delete chapter not being hooked up from Volume details page (Fixes #3333 )
- Fixed: Fixed showing the default value on Book/LN library type for a single volume file (develop)
- Fixed: Fixed a bug where writers/tags/genres on series detail wasn't dynamically updating when new metadata came in
- Fixed: Fixed custom cron settings for tasks still not working in the browser (develop)
- Fixed: Fixed user rating filter not working at all. It was accepting a percentage, but should have been a number 0-5 for the star rating. (Fixes #3335)
