### PR TITLE
Only show last 6 version updates on admin settings screen

### DIFF
--- a/UI/Web/src/app/announcements/_components/changelog/changelog.component.ts
+++ b/UI/Web/src/app/announcements/_components/changelog/changelog.component.ts
@@ -26,6 +26,7 @@ export class ChangelogComponent implements OnInit {
 
   ngOnInit(): void {
     this.serverService.getChangelog().subscribe(updates => {
+      updates = updates.slice(0, 6);
       this.updates = updates;
       this.isLoading = false;
       this.cdRef.markForCheck();


### PR DESCRIPTION
# Changed
- Changed: Show only the last 6 updates in the `settings#admin-system` screen. This stops the page from trying to load 20+ versions going back well over 2 years.

Honestly even 6 feels like a lot. We could lower it since going back that far brings us to pretty old versions that aren't relevant anymore. 

