### PR TITLE
Rework person badges for consistency

### DIFF
--- a/UI/Web/src/app/person-detail/person-detail.component.html
+++ b/UI/Web/src/app/person-detail/person-detail.component.html
@@ -14,11 +14,19 @@
 
     <div class="main-container container-fluid pt-2 mb-5">
       <div class="row mb-0 mb-xl-3 info-container">
-        <div class="image-container col-5 col-sm-6 col-md-5 col-lg-5 col-xl-2 col-xxl-2 col-xxxl-2 d-none d-sm-block mt-2">
-          <app-image [styles]="{'background': 'none', 'max-height': '400px', 'height': '200px', 'width': '200px', 'border-radius': '50%'}"
-                     [imageUrl]="imageService.getPersonImage(person.id)"
-                     [errorImage]="imageService.noPersonImage"></app-image>
-        </div>
+        @if (HasCoverImage) {
+          <div class="image-container col-5 col-sm-6 col-md-5 col-lg-5 col-xl-2 col-xxl-2 col-xxxl-2 d-none d-sm-block mt-2">
+            <app-image [styles]="{'background': 'none', 'max-height': '400px', 'height': '200px', 'width': '200px', 'border-radius': '50%'}"
+                      [imageUrl]="imageService.getPersonImage(person.id)"
+                      [errorImage]="imageService.noPersonImage"></app-image>
+          </div>
+        } @else {
+          <div class="col-5 col-sm-6 col-md-5 col-lg-5 col-xl-2 col-xxl-2 col-xxxl-2 d-none d-sm-block mt-2">
+            <div style="background: var(--card-bg-color); max-height: 200px; height: 200px; width: 200px; border-radius: 50%" class="image-container d-flex align-items-center justify-content-center">
+              <i style="max-height: 128px; height: 128px; font-size: 8rem;" class="fas fa-user" aria-hidden="true"></i>
+            </div>
+          </div>
+        }
 
         <div class="col-xl-10 col-lg-7 col-md-12 col-xs-12 col-sm-12 mt-2">
           <div class="row g-0 mt-2">

--- a/UI/Web/src/app/person-detail/person-detail.component.html
+++ b/UI/Web/src/app/person-detail/person-detail.component.html
@@ -16,14 +16,19 @@
       <div class="row mb-0 mb-xl-3 info-container">
         @if (HasCoverImage) {
           <div class="image-container col-5 col-sm-6 col-md-5 col-lg-5 col-xl-2 col-xxl-2 col-xxxl-2 d-none d-sm-block mt-2">
-            <app-image [styles]="{'background': 'none', 'max-height': '400px', 'height': '200px', 'width': '200px', 'border-radius': '50%'}"
+            <div class="person-badge">
+              <app-image
+                      objectFit="cover"
+                      height="200px"
+                      width="200px"
                       [imageUrl]="imageService.getPersonImage(person.id)"
                       [errorImage]="imageService.noPersonImage"></app-image>
+            </div>
           </div>
         } @else {
-          <div class="col-5 col-sm-6 col-md-5 col-lg-5 col-xl-2 col-xxl-2 col-xxxl-2 d-none d-sm-block mt-2">
-            <div style="background: var(--card-bg-color); max-height: 200px; height: 200px; width: 200px; border-radius: 50%" class="image-container d-flex align-items-center justify-content-center">
-              <i style="max-height: 128px; height: 128px; font-size: 8rem;" class="fas fa-user" aria-hidden="true"></i>
+          <div class="image-container col-5 col-sm-6 col-md-5 col-lg-5 col-xl-2 col-xxl-2 col-xxxl-2 d-none d-sm-block mt-2">
+            <div class="person-badge d-flex align-items-center justify-content-center">
+              <i class="fas fa-user" aria-hidden="true"></i>
             </div>
           </div>
         }

--- a/UI/Web/src/app/person-detail/person-detail.component.scss
+++ b/UI/Web/src/app/person-detail/person-detail.component.scss
@@ -1,4 +1,19 @@
 .main-container {
   margin-top: 10px;
   padding: 0 0 0 10px;
+
+  .person-badge {
+    background: var(--card-bg-color);
+    max-height: 200px;
+    height: 200px;
+    width: 200px;
+    border-radius: 50%;
+    overflow: hidden;
+
+    i {
+      max-height: 128px;
+      height: 128px;
+      font-size: 8rem;
+    }
+  }
 }

--- a/UI/Web/src/app/person-detail/person-detail.component.ts
+++ b/UI/Web/src/app/person-detail/person-detail.component.ts
@@ -92,6 +92,10 @@ export class PersonDetailComponent {
   private readonly personSubject = new BehaviorSubject<Person | null>(null);
   protected readonly person$ = this.personSubject.asObservable();
 
+  get HasCoverImage() {
+    return (this.person as Person).coverImage;
+  }
+
   constructor() {
     this.route.paramMap.pipe(
       switchMap(params => {

--- a/UI/Web/src/app/shared/image/image.component.html
+++ b/UI/Web/src/app/shared/image/image.component.html
@@ -1,4 +1,5 @@
 <img class="img-placeholder fade-in"
+     [style]="{ 'object-fit': objectFit }"
      #img
      alt=""
      aria-hidden="true"

--- a/UI/Web/src/app/shared/image/image.component.ts
+++ b/UI/Web/src/app/shared/image/image.component.ts
@@ -65,6 +65,10 @@ export class ImageComponent implements OnChanges {
    * If the image load fails, instead of showing an error image, hide the image (visibility)
    */
   @Input() hideOnError: boolean = false;
+  /**
+   * Sets the object-fit property of the image. Default is 'fill'.
+   */
+  @Input() objectFit: 'fill' | 'contain' | 'cover' | 'none' | 'scale-down' = 'fill';
 
   @ViewChild('img', {static: true}) imgElem!: ElementRef<HTMLImageElement>;
 

--- a/UI/Web/src/app/shared/person-badge/person-badge.component.html
+++ b/UI/Web/src/app/shared/person-badge/person-badge.component.html
@@ -1,30 +1,30 @@
 @if (person !== undefined) {
-  <div class="tagbadge cursor clickable">
-    <div class="d-flex flex-column">
-      @if (HasCoverImage) {
-        <div class="mx-auto">
-          <a class="btn btn-icon p-0" routerLink="/person/{{person.name}}">
-            <app-image height="24px" width="24px" [styles]="{'background': 'none', 'max-height': '48px', 'height': '48px', 'width': '48px', 'border-radius': '50%'}"
-                       [imageUrl]="ImageUrl"
-                       [errorImage]="imageService.noPersonImage">
-            </app-image>
-          </a>
-        </div>
-      } @else {
-        <div style="background: none; max-height: 48px; height: 48px; width: 48px; border-radius: 50%" class="mx-auto">
-          <i class="fas fa-user" aria-hidden="true"></i>
-        </div>
-      }
-
-
-      <div class="flex-grow-1 text-center mt-2">
-        @if (isStaff) {
-          <span class="mt-1 mb-0">{{person.name}}</span>
+  <a class="btn btn-icon p-0" routerLink="/person/{{person.name}}">
+    <div class="tagbadge cursor clickable">
+      <div class="d-flex flex-column align-items-center justify-content-center">
+        @if (HasCoverImage) {
+          <div style="background: var(--card-bg-color); max-height: 96px; height: 96px; width: 96px; border-radius: 50%" class="image-container d-flex align-items-center justify-content-center">
+              <app-image height="96px" width="96px" [styles]="{'background': 'none', 'max-height': '96px', 'height': '96px', 'width': '96px', 'border-radius': '50%'}"
+                        [imageUrl]="ImageUrl"
+                        [errorImage]="imageService.noPersonImage">
+              </app-image>
+          </div>
         } @else {
-          <a class="btn btn-icon p-0" routerLink="/person/{{person.name}}">{{person.name}}</a>
+          <div style="background: var(--card-bg-color); max-height: 96px; height: 96px; width: 96px; border-radius: 50%" class="image-container d-flex align-items-center justify-content-center">
+            <i style="max-height: 48px; height: 48px; width: 48px;" class="fas fa-user" aria-hidden="true"></i>
+          </div>
         }
+
+
+        <div class="flex-grow-1 text-center mt-2">
+          @if (isStaff) {
+            <span class="mt-1 mb-0">{{person.name}}</span>
+          } @else {
+            <a class="btn btn-icon p-0" routerLink="/person/{{person.name}}">{{person.name}}</a>
+          }
+        </div>
       </div>
     </div>
-  </div>
+  </a>
 }
 

--- a/UI/Web/src/app/shared/person-badge/person-badge.component.html
+++ b/UI/Web/src/app/shared/person-badge/person-badge.component.html
@@ -2,26 +2,22 @@
   <a class="btn btn-icon p-0" routerLink="/person/{{person.name}}">
     <div class="tagbadge cursor clickable">
       <div class="d-flex flex-column align-items-center justify-content-center">
-        @if (HasCoverImage) {
-          <div style="background: var(--card-bg-color); max-height: 96px; height: 96px; width: 96px; border-radius: 50%" class="image-container d-flex align-items-center justify-content-center">
-              <app-image height="96px" width="96px" [styles]="{'background': 'none', 'max-height': '96px', 'height': '96px', 'width': '96px', 'border-radius': '50%'}"
-                        [imageUrl]="ImageUrl"
-                        [errorImage]="imageService.noPersonImage">
-              </app-image>
-          </div>
-        } @else {
-          <div style="background: var(--card-bg-color); max-height: 96px; height: 96px; width: 96px; border-radius: 50%" class="image-container d-flex align-items-center justify-content-center">
-            <i style="max-height: 48px; height: 48px; width: 48px;" class="fas fa-user" aria-hidden="true"></i>
-          </div>
-        }
-
+        <div class="image-container d-flex align-items-center justify-content-center">
+          @if (HasCoverImage) {
+            <app-image
+                      objectFit="cover" 
+                      height="96px"
+                      width="96px"
+                      [imageUrl]="ImageUrl"
+                      [errorImage]="imageService.noPersonImage">
+            </app-image>
+          } @else {
+              <i class="fas fa-user" aria-hidden="true"></i>
+          }
+        </div>
 
         <div class="flex-grow-1 text-center mt-2">
-          @if (isStaff) {
-            <span class="mt-1 mb-0">{{person.name}}</span>
-          } @else {
-            <a class="btn btn-icon p-0" routerLink="/person/{{person.name}}">{{person.name}}</a>
-          }
+          <span class="mt-1 mb-0">{{person.name}}</span>
         </div>
       </div>
     </div>

--- a/UI/Web/src/app/shared/person-badge/person-badge.component.scss
+++ b/UI/Web/src/app/shared/person-badge/person-badge.component.scss
@@ -1,18 +1,32 @@
 .tagbadge {
     background-color: var(--tagbadge-bg-color);
     transition: all .3s ease-out;
-    margin: 3px 5px 3px 0px;
-    padding: 2px 10px;
+    margin: 3px 10px 3px 0px;
     border-radius: 6px;
     font-size: .8rem;
     display: inline-block;
     cursor: pointer;
-    width: 120px;
+    width: 96px;
     word-break: break-word;
 
     i {
         font-size: 2.96rem;
         font-weight: bold;
         cursor: pointer;
+    }
+
+    image-container {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        width: 100%;
+        height: 100%;
+        border-radius: 50%;
+        overflow: hidden;
+        img {
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+        }
     }
 }

--- a/UI/Web/src/app/shared/person-badge/person-badge.component.scss
+++ b/UI/Web/src/app/shared/person-badge/person-badge.component.scss
@@ -1,3 +1,5 @@
+@import '../../../theme/_variables.scss';
+
 .tagbadge {
     background-color: var(--tagbadge-bg-color);
     transition: all .3s ease-out;
@@ -10,23 +12,20 @@
     word-break: break-word;
 
     i {
+        max-height: 48px;
+        height: 48px;
+        width: 48px;
         font-size: 2.96rem;
         font-weight: bold;
         cursor: pointer;
     }
 
-    image-container {
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        width: 100%;
-        height: 100%;
+    .image-container {
+        background: var(--card-bg-color);
+        max-height: 96px;
+        height: 96px;
+        width: 96px;
         border-radius: 50%;
         overflow: hidden;
-        img {
-            width: 100%;
-            height: 100%;
-            object-fit: cover;
-        }
     }
 }


### PR DESCRIPTION
# Changed

- Changed the user badges on the book details tab to properly aligned and have a background when no cover is set for the person
- Changed the user badge on the person details page to be consistent with the look of the book details tab and remove the use of the pixelated image

# Fixed

- Fixed the images of the user badges not being clickable

![image](https://github.com/user-attachments/assets/09fb1ec3-0320-4cf4-ae29-04cb818ce237)

![image](https://github.com/user-attachments/assets/e0aa7ef3-c4a1-4da3-aa73-d8510acdb4db)

---

First part of the UI/UX changes I'm looking at doing. There's still the errorImage to take care of, but I'm thinking we should leave that as-is and maybe replace it with an SVG or something to avoid the pixelation (Along with making sure images still have the new background to ensure that error image would have it).

Otherwise, if it's possible to somehow catch the error and set HasCoverImage to false, we can just remove it completely and fallback to the icon.

As an aside, I think it'd be beneficial in the long run to look at having an icon component that ensures the icon is square and all icons have readable names when relevant (For WCAG and all that). Maybe something like [this](https://github.com/FortAwesome/angular-fontawesome)? It's not for this PR anyway, but it would make consistency easier (and probably some code cleaner) across the UI, I think.