### PR TITLE
Enforce a readable line length for Read More

### DIFF
--- a/UI/Web/src/app/_single-module/review-card/review-card.component.html
+++ b/UI/Web/src/app/_single-module/review-card/review-card.component.html
@@ -16,7 +16,7 @@
             {{review.isExternal ? t('external-review') : t('local-review')}}
           </h6>-->
           <p class="card-text no-images">
-            <app-read-more [text]="(review.isExternal ? review.bodyJustText : review.body) || ''" [maxLength]="150" [showToggle]="false"></app-read-more>
+            <app-read-more [text]="(review.isExternal ? review.bodyJustText : review.body) || ''" [maxLength]="140" [showToggle]="false"></app-read-more>
           </p>
         </div>
       </div>

--- a/UI/Web/src/app/chapter-detail/chapter-detail.component.html
+++ b/UI/Web/src/app/chapter-detail/chapter-detail.component.html
@@ -85,7 +85,7 @@
           </div>
 
           <div class="mt-2 mb-3">
-            <app-read-more [text]="chapter.summary || ''" [maxLength]="utilityService.getActiveBreakpoint() >= Breakpoint.Desktop ? 585 : 250"></app-read-more>
+            <app-read-more [text]="chapter.summary || ''" [maxLength]="utilityService.getActiveBreakpoint() >= Breakpoint.Desktop ? 170 : 200"></app-read-more>
           </div>
 
           <div class="mt-2">

--- a/UI/Web/src/app/collections/_components/collection-detail/collection-detail.component.html
+++ b/UI/Web/src/app/collections/_components/collection-detail/collection-detail.component.html
@@ -41,7 +41,7 @@
             <div class="col-md-10 col-xs-8 col-sm-6 mt-2">
               @if (summary.length > 0) {
                 <div class="mb-2">
-                  <app-read-more [text]="summary" [maxLength]="(utilityService.activeBreakpoint$ | async)! >= Breakpoint.Desktop ? 585 : 200"></app-read-more>
+                  <app-read-more [text]="summary" [maxLength]="(utilityService.activeBreakpoint$ | async)! >= Breakpoint.Desktop ? 170 : 200"></app-read-more>
                 </div>
 
                 @if (collectionTag.source !== ScrobbleProvider.Kavita) {

--- a/UI/Web/src/app/reading-list/_components/reading-list-detail/reading-list-detail.component.html
+++ b/UI/Web/src/app/reading-list/_components/reading-list-detail/reading-list-detail.component.html
@@ -124,8 +124,8 @@
 
 
             <!-- Summary row-->
-            <div class="row g-0 mt-2">
-              <app-read-more [text]="readingListSummary" [maxLength]="(utilityService.activeBreakpoint$ | async)! >= Breakpoint.Desktop ? 585 : 200"></app-read-more>
+            <div class="row g-0 my-2">
+              <app-read-more [text]="readingListSummary" [maxLength]="(utilityService.activeBreakpoint$ | async)! >= Breakpoint.Desktop ? 170 : 200"></app-read-more>
             </div>
 
             @if (characters$ | async; as characters) {

--- a/UI/Web/src/app/series-detail/_components/series-detail/series-detail.component.html
+++ b/UI/Web/src/app/series-detail/_components/series-detail/series-detail.component.html
@@ -109,7 +109,7 @@
           </div>
 
           <div class="mt-2 mb-3">
-            <app-read-more [text]="seriesMetadata.summary || ''" [maxLength]="(utilityService.activeBreakpoint$ | async)! >= Breakpoint.Desktop ? 585 : 200"></app-read-more>
+            <app-read-more [text]="seriesMetadata.summary || ''" [maxLength]="(utilityService.activeBreakpoint$ | async)! >= Breakpoint.Desktop ? 170 : 200"></app-read-more>
           </div>
 
           <div class="mt-2 upper-details">

--- a/UI/Web/src/app/shared/read-more/read-more.component.scss
+++ b/UI/Web/src/app/shared/read-more/read-more.component.scss
@@ -1,3 +1,5 @@
+@import "../../../theme/variables";
+
 .blur-text {
   color: transparent;
   text-shadow: 0 0 5px var(--body-text-color);
@@ -8,5 +10,10 @@
 
   div {
     word-break: break-word;
+    max-width: 75ch;
+    
+    @media (max-width: $grid-breakpoints-sm) {
+      max-width: 50ch;
+    }
   }
 }

--- a/UI/Web/src/app/volume-detail/volume-detail.component.html
+++ b/UI/Web/src/app/volume-detail/volume-detail.component.html
@@ -89,7 +89,7 @@
           </div>
 
           <div class="mt-2 mb-3">
-            <app-read-more [text]="volume.chapters[0].summary || ''" [maxLength]="utilityService.getActiveBreakpoint() >= Breakpoint.Desktop ? 585 : 250"></app-read-more>
+            <app-read-more [text]="volume.chapters[0].summary || ''" [maxLength]="utilityService.getActiveBreakpoint() >= Breakpoint.Desktop ? 170 : 200"></app-read-more>
           </div>
 
           <div class="mt-2">


### PR DESCRIPTION
# Changed
- Changed: Changed the maximum line length of text inside of expandable blocks of text to a readable value

---

Before:
![image](https://github.com/user-attachments/assets/4c68df11-dad9-45d0-b11b-7836a4672fac)

After (Ignore the slight differences in metadata, my prod server has Kavita+ and Komf alimenting it):
![image](https://github.com/user-attachments/assets/4c47fd33-df60-4de5-a167-175ca264966b)

Review cards:
![image](https://github.com/user-attachments/assets/b0f59ab0-c223-421d-a840-dfcdfd7b031e)

Usually, for longer texts, readability suffers with lines over 75 characters on desktop (On mobile, that's around 50 characters).

To make sure descriptions stay readable, the contents of the read-more component are now capped to a line length of 75 characters on larger breakpoints and 50 characters on smaller breakpoints.

I'm keeping this PR as a draft for now, because I need to adjust the cutoff limits for the various uses of the component. I'm generally trying to keep the number of lines similar to the current one, to not break design. It sacrifices the amount of content that's readable without expanding, but I feel like preserving alignment is much better than having 5+ lines of text shown on load.

Edit: Forgot a source for the length thing: https://baymard.com/blog/line-length-readability

Edit 2: This is now ready for review.

One thing I noticed while adjusting the cutoff, there's often an overflow on the review cards when reviews have line returns. I lowered the cutoff a bit (The max-width doesn't do anything for these, so I can omit this if you prefer), which fixes the overflow in some cases, but there should probably be some server-size cleanup of empty lines and such (Especially since we'll likely want to let clients decide how to display them, including the distance between paragraphs, so returning straight paragraphs separated by one \n seems like the best solution). In any case, that's for another PR some day, but I figured I'd raise it while I'm seeing it.