### PR TITLE
Rework sidebar to avoid jump when collapsing

### DIFF
--- a/UI/Web/src/app/_single-module/card-actionables/card-actionables.component.html
+++ b/UI/Web/src/app/_single-module/card-actionables/card-actionables.component.html
@@ -1,14 +1,14 @@
 <ng-container *transloco="let t; read: 'actionable'">
   @if (actions.length > 0) {
     @if ((utilityService.activeBreakpoint$ | async)! <= Breakpoint.Tablet) {
-      <button [disabled]="disabled" class="btn {{btnClass}}" id="actions-{{labelBy}}"
+      <button [disabled]="disabled" class="btn {{btnClass}} px-3" id="actions-{{labelBy}}"
               (click)="openMobileActionableMenu($event)">
         {{label}}
         <i class="fa {{iconClass}}" aria-hidden="true"></i>
       </button>
     } @else {
       <div ngbDropdown container="body" class="d-inline-block">
-        <button [disabled]="disabled" class="btn {{btnClass}}" id="actions-{{labelBy}}" ngbDropdownToggle
+        <button [disabled]="disabled" class="btn {{btnClass}} px-3" id="actions-{{labelBy}}" ngbDropdownToggle
                 (click)="preventEvent($event)">
           {{label}}
           <i class="fa {{iconClass}}" aria-hidden="true"></i>

--- a/UI/Web/src/app/app.component.scss
+++ b/UI/Web/src/app/app.component.scss
@@ -7,7 +7,7 @@
 
 .companion-bar {
     transition: all var(--side-nav-companion-bar-transistion);
-    margin-left: 60px;
+    margin-left: 45px;
     overflow-y: hidden;
     overflow-x: hidden;
     height: calc(var(--vh)* 100 - var(--nav-mobile-offset));

--- a/UI/Web/src/theme/components/_sidenav.scss
+++ b/UI/Web/src/theme/components/_sidenav.scss
@@ -12,6 +12,7 @@
   border-radius: var(--side-nav-border-radius);
   transition: width var(--side-nav-openclose-transition), background-color var(--side-nav-bg-color-transition), border-color var(--side-nav-border-transition);
   border: var(--side-nav-border);
+  overflow: hidden;
 
   &::-webkit-scrollbar {
     visibility: hidden;
@@ -27,7 +28,7 @@
   }
   //START closed state of the sidebar
   &.closed {
-    width: 4.0625rem;
+    width: 2.825rem;
     overflow-x: hidden;
     overflow-y: hidden;
     background-color: var(--side-nav-closed-bg-color);
@@ -49,11 +50,6 @@
           opacity: 0;
         }
 
-        .side-nav-text {
-          opacity: 0;
-          display: none;
-        }
-
         .card-actions {
           opacity: 0;
           display: none;
@@ -64,7 +60,7 @@
   //END closed state of the sidebar
   //START sidebar
   .side-nav {
-    overflow-y: hidden;
+    overflow: hidden;
     height: 100%;
     scrollbar-gutter: stable;
     scrollbar-width: thin;
@@ -73,7 +69,7 @@
       position: relative;
       align-items: center;
       display: flex;
-      justify-content: space-between;
+      justify-content: start;
       width: 100%;
       height: auto;
       min-height: 2.6rem;
@@ -89,6 +85,7 @@
         &:first-of-type {
           text-align: center;
           width: 2.5rem;
+          min-width: 2.5rem;
           margin-left: 0.3rem;
         }
 
@@ -101,7 +98,7 @@
           align-items: center;
           height: 100%;
           justify-content: inherit;
-          width: 100%;
+          padding: 0 0.625rem;
 
           i {
             font-size: var(--side-nav-icon-size);
@@ -291,10 +288,6 @@
     .side-nav-item {
       width: 100%;
       padding: 0;
-      display: block;
-      line-height: 2.5rem;
-      text-align: center;
-      min-height: unset;
       color: var(--side-nav-item-closed-color);
 
       &:hover {
@@ -317,11 +310,13 @@
     margin: 0;
     left: 0;
     top: 0;
-    transition: width var(--side-nav-openclose-transition);
+    transition: width var(--side-nav-openclose-transition), visibility var(--side-nav-openclose-transition);
     z-index: 1050;
+    overflow-x: hidden;
     overflow-y: auto;
     border: var(--side-nav-mobile-border);
     border-radius: 0rem;
+    visibility: visible;
 
     &.preference {
         background-color: unset;
@@ -349,8 +344,10 @@
 
     &.closed {
       width: 0;
+      background-color: var(--side-nav-mobile-bg-color);
       overflow: hidden;
       box-shadow: none;
+      visibility: hidden;
     }
 
     .side-nav {
@@ -383,9 +380,13 @@
         left: 0;
         top: 0;
         z-index: 1041;
+        visibility: visible;
+        opacity: 1;
+        transition: visibility var(--side-nav-openclose-transition), opacity var(--side-nav-openclose-transition);
 
         &.closed {
-            display: none;
+          visibility: hidden;
+          opacity: 0;
         }
     }
 }


### PR DESCRIPTION
# Fixed
- Fixed: Fixed the way the sidebar closes (both on large screens and on mobile) to prevent text and icons jumping around during the animation.

Desktop:
https://github.com/user-attachments/assets/9da3367f-57b4-4bd9-b34e-8b58cb8e53e3

Mobile:
https://github.com/user-attachments/assets/7cfc911b-0f2b-4513-bdbb-a940375dfcaa

