### PR TITLE
Make white reader theme respect book CSS

### DIFF
--- a/UI/Web/src/app/book-reader/_models/book-white-theme.ts
+++ b/UI/Web/src/app/book-reader/_models/book-white-theme.ts
@@ -103,7 +103,7 @@ export const BookWhiteTheme = `
 
 
 .book-content *:not(input), .book-content *:not(select), .book-content *:not(code), .book-content *:not(:link), .book-content *:not(.ngx-toastr) {
-  color: black !important;
+  color: black;
 }
 
 .book-content code {
@@ -116,17 +116,15 @@ export const BookWhiteTheme = `
 
 .book-content img, .book-content img[src] {
 z-index: 1;
-filter: brightness(0.85) !important;
 background-color: initial !important;
 }
 
 
 .book-content *:not(code), .book-content *:not(a) {
-    background-color: white;
     box-shadow: none;
     text-shadow: none;
     border-radius: unset;
-    color: #dcdcdc !important;
+    color: #dcdcdc;
 }
 
 .book-content :visited, .book-content :visited *, .book-content :visited *[class] {color: rgb(240, 50, 50) !important}


### PR DESCRIPTION
# Fixed
- Fixed: Removes unneeded lines from the book-white-theme.ts so that is now displays colored text from the ebook (Fixes #3467)
