### PR TITLE
[skip ci] Fixed typo in scanner error message popover

### DIFF
--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -450,12 +450,12 @@ public class ScannerService : IScannerService
             // That way logging and UI informing is all in one place with full context
             _logger.LogError("[ScannerService] Some of the root folders for the library are empty. " +
                              "Either your mount has been disconnected or you are trying to delete all series in the library. " +
-                             "Scan has be aborted. " +
+                             "Scan has been aborted. " +
                              "Check that your mount is connected or change the library's root folder and rescan");
 
             await _eventHub.SendMessageAsync(MessageFactory.Error, MessageFactory.ErrorEvent( $"Some of the root folders for the library, {libraryName}, are empty.",
                 "Either your mount has been disconnected or you are trying to delete all series in the library. " +
-                "Scan has be aborted. " +
+                "Scan has been aborted. " +
                 "Check that your mount is connected or change the library's root folder and rescan"));
 
             return false;


### PR DESCRIPTION
# Fixed
- Fixed: Fixed a typo in the event widget error message that shows up when the scan returns an empty root folder for the particular library.