### PR TITLE
Update browserslist to support more versions

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -8,10 +8,4 @@
 # You can see what browsers were selected by your queries by running:
 #   npx browserslist
 
-last 1 Chrome version
-last 1 Firefox version
-last 2 Edge major versions
-last 2 Safari major versions
-last 2 iOS major versions
-Firefox ESR
-not IE 11 # Angular supports IE 11 only as an opt-in. To opt-in, remove the 'not' prefix on this line.
+defaults


### PR DESCRIPTION
# Changed
- Changed: .browserslistrc file to not be so strict around what browsers it supports. The old config only had a global browser audience coverage of 23.8 % vs the defaults setting of 89.6 %.

This should let mobile browsers load the page much faster based on the testing that was done with a small sample group.