### PR TITLE
[skip ci] Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Password: Demouser64
 ## Setup
 The easiest way to get started is to visit our Wiki which has up-to-date information on a variety of
 install methods and platforms.
-[https://wiki.kavitareader.com/installation/getting-started](https://wiki.kavitareader.com/installation/getting-started)
+[https://wiki.kavitareader.com/getting-started](https://wiki.kavitareader.com/getting-started)
 
 ## Feature Requests
 Got a great idea? Throw it up on [Discussions](https://github.com/Kareadita/Kavita/discussions/2529) or vote on another idea. Many great features in Kavita are driven by our community. 


### PR DESCRIPTION
# Changed
update https://wiki.kavitareader.com/installation/getting-started/ to https://wiki.kavitareader.com/getting-started/, reflecting changes in the wiki's layout so users don't get a 404 error upon clicking on the page. No issues addressed.