### PR TITLE
fix(i18n): equals is not equitable in the filter context

### DIFF
--- a/UI/Web/src/assets/langs/de.json
+++ b/UI/Web/src/assets/langs/de.json
@@ -2054,7 +2054,7 @@
     "filter-comparison-pipe": {
         "begins-with": "Beginnt mit",
         "contains": "Enthält",
-        "equal": "Gleichberechtigt",
+        "equal": "Ist gleich",
         "greater-than": "Größer als",
         "greater-than-or-equal": "Größer als oder gleich",
         "less-than": "Weniger als",


### PR DESCRIPTION
# Fixed
- Fixed: Fixed german translation of equal in the filter context