### PR TITLE
Metadata Fixes

### DIFF
--- a/API/Data/DataContext.cs
+++ b/API/Data/DataContext.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using API.DTOs.KavitaPlus.Metadata;
 using API.Entities;
 using API.Entities.Enums;
 using API.Entities.Enums.UserPreferences;
@@ -217,6 +218,12 @@ public sealed class DataContext : IdentityDbContext<AppUser, AppRole, int,
                 v => JsonSerializer.Serialize(v, JsonSerializerOptions.Default),
                 v => JsonSerializer.Deserialize<List<string>>(v, JsonSerializerOptions.Default)
             );
+        builder.Entity<MetadataSettings>()
+            .Property(x => x.Whitelist)
+            .HasConversion(
+                v => JsonSerializer.Serialize(v, JsonSerializerOptions.Default),
+                v => JsonSerializer.Deserialize<List<string>>(v, JsonSerializerOptions.Default)
+            );
 
         // Configure one-to-many relationship
         builder.Entity<MetadataSettings>()
@@ -224,6 +231,7 @@ public sealed class DataContext : IdentityDbContext<AppUser, AppRole, int,
             .WithOne(x => x.MetadataSettings)
             .HasForeignKey(x => x.MetadataSettingsId)
             .OnDelete(DeleteBehavior.Cascade);
+
         builder.Entity<MetadataSettings>()
             .Property(b => b.Enabled)
             .HasDefaultValue(true);

--- a/API/Data/Repositories/ExternalSeriesMetadataRepository.cs
+++ b/API/Data/Repositories/ExternalSeriesMetadataRepository.cs
@@ -224,6 +224,7 @@ public class ExternalSeriesMetadataRepository : IExternalSeriesMetadataRepositor
     public async Task<IList<ManageMatchSeriesDto>> GetAllSeries(ManageMatchFilterDto filter)
     {
         return await _context.Series
+            .Include(s => s.Library)
             .Where(s => !ExternalMetadataService.NonEligibleLibraryTypes.Contains(s.Library.Type))
             .FilterMatchState(filter.MatchStateOption)
             .OrderBy(s => s.NormalizedName)

--- a/API/Data/Repositories/ExternalSeriesMetadataRepository.cs
+++ b/API/Data/Repositories/ExternalSeriesMetadataRepository.cs
@@ -223,6 +223,7 @@ public class ExternalSeriesMetadataRepository : IExternalSeriesMetadataRepositor
 
     public async Task<IList<ManageMatchSeriesDto>> GetAllSeries(ManageMatchFilterDto filter)
     {
+        // BUG: Diesel had a weird bug from this, can't reproduce
         return await _context.Series
             .Include(s => s.Library)
             .Where(s => !ExternalMetadataService.NonEligibleLibraryTypes.Contains(s.Library.Type))

--- a/API/Data/Repositories/ExternalSeriesMetadataRepository.cs
+++ b/API/Data/Repositories/ExternalSeriesMetadataRepository.cs
@@ -223,7 +223,6 @@ public class ExternalSeriesMetadataRepository : IExternalSeriesMetadataRepositor
 
     public async Task<IList<ManageMatchSeriesDto>> GetAllSeries(ManageMatchFilterDto filter)
     {
-        // BUG: Diesel had a weird bug from this, can't reproduce
         return await _context.Series
             .Include(s => s.Library)
             .Where(s => !ExternalMetadataService.NonEligibleLibraryTypes.Contains(s.Library.Type))

--- a/API/Data/Seed.cs
+++ b/API/Data/Seed.cs
@@ -308,7 +308,7 @@ public static class Seed
                 EnableTags = false,
                 EnableGenres = true,
                 EnableLocalizedName = false,
-                FirstLastPeopleNaming = false,
+                FirstLastPeopleNaming = true,
                 PersonRoles = [PersonRole.Writer, PersonRole.CoverArtist, PersonRole.Character]
             };
             await context.MetadataSettings.AddAsync(existing);

--- a/API/Extensions/QueryExtensions/QueryableExtensions.cs
+++ b/API/Extensions/QueryExtensions/QueryableExtensions.cs
@@ -288,11 +288,15 @@ public static class QueryableExtensions
         return stateOption switch
         {
             MatchStateOption.All => query,
-            MatchStateOption.Matched => query.Where(s => s.ExternalSeriesMetadata != null && s.ExternalSeriesMetadata.ValidUntilUtc > DateTime.MinValue && !s.IsBlacklisted),
-            MatchStateOption.NotMatched => query.Where(s => (s.ExternalSeriesMetadata == null || s.ExternalSeriesMetadata.ValidUntilUtc == DateTime.MinValue) && !s.IsBlacklisted),
+            MatchStateOption.Matched => query
+                .Include(s => s.ExternalSeriesMetadata)
+                .Where(s => s.ExternalSeriesMetadata != null && s.ExternalSeriesMetadata.ValidUntilUtc > DateTime.MinValue && !s.IsBlacklisted),
+            MatchStateOption.NotMatched => query.
+                Include(s => s.ExternalSeriesMetadata)
+                .Where(s => (s.ExternalSeriesMetadata == null || s.ExternalSeriesMetadata.ValidUntilUtc == DateTime.MinValue) && !s.IsBlacklisted),
             MatchStateOption.Error => query.Where(s => s.IsBlacklisted),
             MatchStateOption.DontMatch => query.Where(s => s.DontMatch),
-            _ => throw new ArgumentOutOfRangeException(nameof(stateOption), stateOption, null)
+            _ => query
         };
     }
 }

--- a/API/Helpers/AutoMapperProfiles.cs
+++ b/API/Helpers/AutoMapperProfiles.cs
@@ -361,10 +361,14 @@ public class AutoMapperProfiles : Profile
             .ForMember(dest => dest.LibraryId, opt => opt.MapFrom(src => src.Volume.Series.LibraryId))
             .ForMember(dest => dest.LibraryType, opt => opt.MapFrom(src => src.Volume.Series.Library.Type));
 
+        CreateMap<MetadataFieldMapping, MetadataFieldMappingDto>();
+
         CreateMap<MetadataSettings, MetadataSettingsDto>()
             .ForMember(dest => dest.Blacklist, opt => opt.MapFrom(src => src.Blacklist ?? new List<string>()))
-            .ForMember(dest => dest.Whitelist, opt => opt.MapFrom(src => src.Whitelist ?? new List<string>()));
-        CreateMap<MetadataFieldMapping, MetadataFieldMappingDto>();
+            .ForMember(dest => dest.Whitelist, opt => opt.MapFrom(src => src.Whitelist ?? new List<string>()))
+            .ForMember(dest => dest.AgeRatingMappings, opt => opt.MapFrom(src => src.AgeRatingMappings ?? new Dictionary<string, AgeRating>()));
+
+
 
     }
 }

--- a/API/Helpers/AutoMapperProfiles.cs
+++ b/API/Helpers/AutoMapperProfiles.cs
@@ -345,10 +345,13 @@ public class AutoMapperProfiles : Profile
                     opt.MapFrom(src => src))
             .ForMember(dest => dest.IsMatched,
                 opt =>
-                    opt.MapFrom(src => src.ExternalSeriesMetadata != null && src.ExternalSeriesMetadata.AniListId != 0 && src.ExternalSeriesMetadata.ValidUntilUtc > DateTime.MinValue))
+                    opt.MapFrom(src => src.ExternalSeriesMetadata != null && src.ExternalSeriesMetadata.AniListId != 0
+                                                                          && src.ExternalSeriesMetadata.ValidUntilUtc > DateTime.MinValue))
             .ForMember(dest => dest.ValidUntilUtc,
-                opt =>
-                    opt.MapFrom(src => src.ExternalSeriesMetadata.ValidUntilUtc));
+                opt => opt.MapFrom(src =>
+                    src.ExternalSeriesMetadata != null
+                        ? src.ExternalSeriesMetadata.ValidUntilUtc
+                        : DateTime.MinValue));
 
 
         CreateMap<MangaFile, FileExtensionExportDto>();

--- a/API/Services/Plus/ExternalMetadataService.cs
+++ b/API/Services/Plus/ExternalMetadataService.cs
@@ -513,7 +513,7 @@ public class ExternalMetadataService : IExternalMetadataService
             madeModification = true;
         }
 
-        if (settings.EnableStartDate && externalMetadata.StartDate.HasValue)
+        if (settings.EnableStartDate && !series.Metadata.ReleaseYearLocked && externalMetadata.StartDate.HasValue)
         {
             series.Metadata.ReleaseYear = externalMetadata.StartDate.Value.Year;
             madeModification = true;
@@ -949,6 +949,7 @@ public class ExternalMetadataService : IExternalMetadataService
         };
         series.ExternalSeriesMetadata = externalSeriesMetadata;
         _unitOfWork.ExternalSeriesMetadataRepository.Attach(externalSeriesMetadata);
+
         return externalSeriesMetadata;
     }
 

--- a/API/Services/Plus/ExternalMetadataService.cs
+++ b/API/Services/Plus/ExternalMetadataService.cs
@@ -601,7 +601,11 @@ public class ExternalMetadataService : IExternalMetadataService
             try
             {
                 // Determine Age Rating
-                var ageRating = DetermineAgeRating(processedGenres.Concat(processedTags), settings.AgeRatingMappings);
+                var totalTags = processedGenres
+                    .Concat(processedTags)
+                    .Concat(series.Metadata.Genres.Select(g => g.Title))
+                    .Concat(series.Metadata.Tags.Select(g => g.Title));
+                var ageRating = DetermineAgeRating(totalTags, settings.AgeRatingMappings);
                 if (!series.Metadata.AgeRatingLocked && series.Metadata.AgeRating <= ageRating)
                 {
                     series.Metadata.AgeRating = ageRating;

--- a/API/Services/Plus/ExternalMetadataService.cs
+++ b/API/Services/Plus/ExternalMetadataService.cs
@@ -592,7 +592,7 @@ public class ExternalMetadataService : IExternalMetadataService
         #region Age Rating
 
         // Determine Age Rating
-        var ageRating = DetermineAgeRating([.. processedGenres, .. processedTags], settings.AgeRatingMappings);
+        var ageRating = DetermineAgeRating(processedGenres.Concat(processedTags), settings.AgeRatingMappings);
         if (!series.Metadata.AgeRatingLocked && series.Metadata.AgeRating <= ageRating)
         {
             series.Metadata.AgeRating = ageRating;
@@ -886,10 +886,10 @@ public class ExternalMetadataService : IExternalMetadataService
         return mapping.DestinationValue ?? (mapping.ExcludeFromSource ? null : value);
     }
 
-    private static AgeRating DetermineAgeRating(IList<string> values, Dictionary<string, AgeRating> mappings)
+    private static AgeRating DetermineAgeRating(IEnumerable<string> values, Dictionary<string, AgeRating> mappings)
     {
         // Find highest age rating from mappings
-        if (values.Count == 0) return AgeRating.Unknown;
+        mappings ??= new Dictionary<string, AgeRating>();
 
         return values
             .Select(v => mappings.TryGetValue(v, out var mapping) ? mapping : AgeRating.Unknown)

--- a/API/Services/Plus/ExternalMetadataService.cs
+++ b/API/Services/Plus/ExternalMetadataService.cs
@@ -540,7 +540,7 @@ public class ExternalMetadataService : IExternalMetadataService
             // Strip blacklisted items from processedGenres
             processedGenres = processedGenres.Distinct().Where(g => !settings.Blacklist.Contains(g)).ToList();
 
-            if (settings.EnableGenres && processedGenres.Count > 0)
+            if (settings.EnableGenres && !series.Metadata.GenresLocked && processedGenres.Count > 0)
             {
                 _logger.LogDebug("Found {GenreCount} genres for {SeriesName}", processedGenres.Count, series.Name);
                 var allGenres = (await _unitOfWork.GenreRepository.GetAllGenresByNamesAsync(processedGenres.Select(Parser.Normalize))).ToList();
@@ -574,7 +574,7 @@ public class ExternalMetadataService : IExternalMetadataService
                 .ToList();
 
             // Set the tags for the series and ensure they are in the DB
-            if (settings.EnableTags && processedTags.Count > 0)
+            if (settings.EnableTags && !series.Metadata.TagsLocked && processedTags.Count > 0)
             {
                 _logger.LogDebug("Found {TagCount} tags for {SeriesName}", processedTags.Count, series.Name);
                 var allTags = (await _unitOfWork.TagRepository.GetAllTagsByNameAsync(processedTags.Select(Parser.Normalize)))
@@ -592,16 +592,24 @@ public class ExternalMetadataService : IExternalMetadataService
 
         #region Age Rating
 
-        // TODO: Try-catchify all this code
-        // Determine Age Rating
-        var ageRating = DetermineAgeRating(processedGenres.Concat(processedTags), settings.AgeRatingMappings);
-        if (!series.Metadata.AgeRatingLocked && series.Metadata.AgeRating <= ageRating)
+        if (!series.Metadata.AgeRatingLocked)
         {
-            series.Metadata.AgeRating = ageRating;
-            _unitOfWork.SeriesRepository.Update(series);
-            madeModification = true;
+            try
+            {
+                // Determine Age Rating
+                var ageRating = DetermineAgeRating(processedGenres.Concat(processedTags), settings.AgeRatingMappings);
+                if (!series.Metadata.AgeRatingLocked && series.Metadata.AgeRating <= ageRating)
+                {
+                    series.Metadata.AgeRating = ageRating;
+                    _unitOfWork.SeriesRepository.Update(series);
+                    madeModification = true;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "There was an issue determining Age Rating for Series {SeriesName} ({SeriesId})", series.Name, series.Id);
+            }
         }
-
         #endregion
 
         #region People

--- a/API/Services/Plus/ExternalMetadataService.cs
+++ b/API/Services/Plus/ExternalMetadataService.cs
@@ -527,7 +527,7 @@ public class ExternalMetadataService : IExternalMetadataService
         // Process Genres
         if (externalMetadata.Genres != null)
         {
-            foreach (var genre in externalMetadata.Genres.Where(g => !settings.Blacklist.Contains(g)))
+            foreach (var genre in externalMetadata.Genres)
             {
                 // Apply field mappings
                 var mappedGenre = ApplyFieldMapping(genre, MetadataFieldType.Genre, settings.FieldMappings);
@@ -538,7 +538,10 @@ public class ExternalMetadataService : IExternalMetadataService
             }
 
             // Strip blacklisted items from processedGenres
-            processedGenres = processedGenres.Distinct().Where(g => !settings.Blacklist.Contains(g)).ToList();
+            processedGenres = processedGenres
+                .Distinct()
+                .Where(g => !settings.Blacklist.Contains(g))
+                .ToList();
 
             if (settings.EnableGenres && !series.Metadata.GenresLocked && processedGenres.Count > 0)
             {
@@ -568,7 +571,8 @@ public class ExternalMetadataService : IExternalMetadataService
             }
 
             // Strip blacklisted items from processedTags
-            processedTags = processedTags.Distinct()
+            processedTags = processedTags
+                .Distinct()
                 .Where(g => !settings.Blacklist.Contains(g))
                 .Where(g => settings.Whitelist.Count == 0 || settings.Whitelist.Contains(g))
                 .ToList();
@@ -616,7 +620,7 @@ public class ExternalMetadataService : IExternalMetadataService
 
         if (settings.EnablePeople)
         {
-            series.Metadata.People ??= new List<SeriesMetadataPeople>();
+            series.Metadata.People ??= [];
 
             // Ensure all people are named correctly
             externalMetadata.Staff = externalMetadata.Staff.Select(s =>
@@ -723,13 +727,27 @@ public class ExternalMetadataService : IExternalMetadataService
 
         #endregion
 
+        #region Publication Status
+
         if (!series.Metadata.PublicationStatusLocked && settings.EnablePublicationStatus)
         {
-            var chapters = (await _unitOfWork.SeriesRepository.GetSeriesByIdAsync(series.Id, SeriesIncludes.Chapters))!.Volumes.SelectMany(v => v.Chapters).ToList();
-            var wasChanged = DeterminePublicationStatus(series, chapters, externalMetadata);
-            _unitOfWork.SeriesRepository.Update(series);
-            madeModification = madeModification || wasChanged;
+            try
+            {
+                var chapters =
+                    (await _unitOfWork.SeriesRepository.GetSeriesByIdAsync(series.Id, SeriesIncludes.Chapters))!.Volumes
+                    .SelectMany(v => v.Chapters).ToList();
+                var wasChanged = DeterminePublicationStatus(series, chapters, externalMetadata);
+                _unitOfWork.SeriesRepository.Update(series);
+                madeModification = madeModification || wasChanged;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "There was an issue determining Publication Status for Series {SeriesName} ({SeriesId})", series.Name, series.Id);
+            }
         }
+        #endregion
+
+        #region Relationships
 
         if (settings.EnableRelationships && externalMetadata.Relations != null && defaultAdmin != null)
         {
@@ -783,6 +801,7 @@ public class ExternalMetadataService : IExternalMetadataService
                 madeModification = true;
             }
         }
+        #endregion
 
         return madeModification;
     }

--- a/API/Services/Plus/ExternalMetadataService.cs
+++ b/API/Services/Plus/ExternalMetadataService.cs
@@ -654,7 +654,10 @@ public class ExternalMetadataService : IExternalMetadataService
                     Name = w.Name,
                     AniListId = ScrobblingService.ExtractId<int>(w.Url, ScrobblingService.AniListStaffWebsite),
                     Description = CleanSummary(w.Description),
-                }).ToList();
+                })
+                .Concat(series.Metadata.People.Where(p => p.Role == PersonRole.Writer).Select(p => _mapper.Map<PersonDto>(p)))
+                .DistinctBy(p => Parser.Normalize(p.Name))
+                .ToList();
 
 
             // NOTE: PersonRoles can be a hashset
@@ -680,7 +683,10 @@ public class ExternalMetadataService : IExternalMetadataService
                     Name = w.Name,
                     AniListId = ScrobblingService.ExtractId<int>(w.Url, ScrobblingService.AniListStaffWebsite),
                     Description = CleanSummary(w.Description),
-                }).ToList();
+                })
+                .Concat(series.Metadata.People.Where(p => p.Role == PersonRole.CoverArtist).Select(p => _mapper.Map<PersonDto>(p)))
+                .DistinctBy(p => Parser.Normalize(p.Name))
+                .ToList();
 
             if (!series.Metadata.CoverArtistLocked && artists.Count > 0 &&  settings.PersonRoles.Contains(PersonRole.CoverArtist))
             {
@@ -703,7 +709,10 @@ public class ExternalMetadataService : IExternalMetadataService
                         Name = w.Name,
                         AniListId = ScrobblingService.ExtractId<int>(w.Url, ScrobblingService.AniListCharacterWebsite),
                         Description = CleanSummary(w.Description),
-                    }).ToList();
+                    })
+                    .Concat(series.Metadata.People.Where(p => p.Role == PersonRole.Character).Select(p => _mapper.Map<PersonDto>(p)))
+                    .DistinctBy(p => Parser.Normalize(p.Name))
+                    .ToList();
 
 
                 if (!series.Metadata.CharacterLocked && characters.Count > 0)

--- a/API/Services/Plus/ExternalMetadataService.cs
+++ b/API/Services/Plus/ExternalMetadataService.cs
@@ -195,6 +195,7 @@ public class ExternalMetadataService : IExternalMetadataService
         var license = (await _unitOfWork.SettingsRepository.GetSettingAsync(ServerSettingKey.LicenseKey)).Value;
         var series = await _unitOfWork.SeriesRepository.GetSeriesByIdAsync(dto.SeriesId,
             SeriesIncludes.Metadata | SeriesIncludes.ExternalMetadata);
+        if (series == null) return [];
 
         var potentialAnilistId = ScrobblingService.ExtractId<int?>(dto.Query, ScrobblingService.AniListWeblinkWebsite);
         var potentialMalId = ScrobblingService.ExtractId<long?>(dto.Query, ScrobblingService.MalWeblinkWebsite);
@@ -591,6 +592,7 @@ public class ExternalMetadataService : IExternalMetadataService
 
         #region Age Rating
 
+        // TODO: Try-catchify all this code
         // Determine Age Rating
         var ageRating = DetermineAgeRating(processedGenres.Concat(processedTags), settings.AgeRatingMappings);
         if (!series.Metadata.AgeRatingLocked && series.Metadata.AgeRating <= ageRating)

--- a/API/Services/Plus/ExternalMetadataService.cs
+++ b/API/Services/Plus/ExternalMetadataService.cs
@@ -605,6 +605,7 @@ public class ExternalMetadataService : IExternalMetadataService
                     .Concat(processedTags)
                     .Concat(series.Metadata.Genres.Select(g => g.Title))
                     .Concat(series.Metadata.Tags.Select(g => g.Title));
+
                 var ageRating = DetermineAgeRating(totalTags, settings.AgeRatingMappings);
                 if (!series.Metadata.AgeRatingLocked && series.Metadata.AgeRating <= ageRating)
                 {

--- a/API/Services/Plus/ExternalMetadataService.cs
+++ b/API/Services/Plus/ExternalMetadataService.cs
@@ -592,7 +592,7 @@ public class ExternalMetadataService : IExternalMetadataService
         #region Age Rating
 
         // Determine Age Rating
-        var ageRating = DetermineAgeRating(processedGenres.Concat(processedTags), settings.AgeRatingMappings);
+        var ageRating = DetermineAgeRating([.. processedGenres, .. processedTags], settings.AgeRatingMappings);
         if (!series.Metadata.AgeRatingLocked && series.Metadata.AgeRating <= ageRating)
         {
             series.Metadata.AgeRating = ageRating;
@@ -886,9 +886,11 @@ public class ExternalMetadataService : IExternalMetadataService
         return mapping.DestinationValue ?? (mapping.ExcludeFromSource ? null : value);
     }
 
-    private static AgeRating DetermineAgeRating(IEnumerable<string> values, Dictionary<string, AgeRating> mappings)
+    private static AgeRating DetermineAgeRating(IList<string> values, Dictionary<string, AgeRating> mappings)
     {
         // Find highest age rating from mappings
+        if (values.Count == 0) return AgeRating.Unknown;
+
         return values
             .Select(v => mappings.TryGetValue(v, out var mapping) ? mapping : AgeRating.Unknown)
             .DefaultIfEmpty(AgeRating.Unknown)

--- a/API/Services/SeriesService.cs
+++ b/API/Services/SeriesService.cs
@@ -349,7 +349,8 @@ public class SeriesService : ISeriesService
         var existingPeople = await unitOfWork.PersonRepository.GetPeopleByNames(normalizedNames);
 
         // Use a dictionary for quick lookups
-        var existingPeopleDictionary = existingPeople.DistinctBy(p => p.NormalizedName).ToDictionary(p => p.NormalizedName, p => p);
+        var existingPeopleDictionary = existingPeople.DistinctBy(p => p.NormalizedName)
+            .ToDictionary(p => p.NormalizedName, p => p);
 
         // List to track people that will be added to the metadata
         var peopleToAdd = new List<Person>();

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -450,12 +450,12 @@ public class ScannerService : IScannerService
             // That way logging and UI informing is all in one place with full context
             _logger.LogError("[ScannerService] Some of the root folders for the library are empty. " +
                              "Either your mount has been disconnected or you are trying to delete all series in the library. " +
-                             "Scan has be aborted. " +
+                             "Scan has been aborted. " +
                              "Check that your mount is connected or change the library's root folder and rescan");
 
             await _eventHub.SendMessageAsync(MessageFactory.Error, MessageFactory.ErrorEvent( $"Some of the root folders for the library, {libraryName}, are empty.",
                 "Either your mount has been disconnected or you are trying to delete all series in the library. " +
-                "Scan has be aborted. " +
+                "Scan has been aborted. " +
                 "Check that your mount is connected or change the library's root folder and rescan"));
 
             return false;

--- a/API/Services/Tasks/VersionUpdaterService.cs
+++ b/API/Services/Tasks/VersionUpdaterService.cs
@@ -114,6 +114,7 @@ public partial class VersionUpdaterService : IVersionUpdaterService
 
                 var nightlyDto = new UpdateNotificationDto
                 {
+                    // TODO: I should pass Title to the FE so that Nightly Release can be localized
                     UpdateTitle = $"Nightly Release {nightly.Version} - {prInfo.Title}",
                     UpdateVersion = nightly.Version,
                     CurrentVersion = dto.CurrentVersion,
@@ -446,7 +447,7 @@ public partial class VersionUpdaterService : IVersionUpdaterService
     {
         var sections = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
         var lines = body.Split('\n');
-        string currentSection = null;
+        string? currentSection = null;
 
         foreach (var line in lines)
         {

--- a/UI/Web/src/app/_models/series-detail/external-series-detail.ts
+++ b/UI/Web/src/app/_models/series-detail/external-series-detail.ts
@@ -37,6 +37,11 @@ export interface ExternalSeriesDetail {
   summary?: string;
   volumeCount?: number;
   chapterCount?: number;
+  /**
+   * These are duplicated with volumeCount based on where it's being invoked.
+   */
+  volumes?: number;
+  chapters?: number;
   staff: Array<SeriesStaff>;
   tags: Array<MetadataTagDto>;
   provider: ScrobbleProvider;

--- a/UI/Web/src/app/_single-module/details-tab/details-tab.component.html
+++ b/UI/Web/src/app/_single-module/details-tab/details-tab.component.html
@@ -63,7 +63,7 @@
   <div class="mb-3">
     <app-carousel-reel [items]="webLinks" [title]="t('weblinks-title')">
       <ng-template #carouselItem let-item>
-        <a class="me-1" [href]="item | safeHtml"  target="_blank" rel="noopener noreferrer" [title]="item">
+        <a class="me-1" [href]="item | safeUrl"  target="_blank" rel="noopener noreferrer" [title]="item">
           <app-image height="24px" width="24px" aria-hidden="true" [imageUrl]="imageService.getWebLinkImage(item)"
                      [errorImage]="imageService.errorWebLinkImage"></app-image>
         </a>

--- a/UI/Web/src/app/_single-module/details-tab/details-tab.component.ts
+++ b/UI/Web/src/app/_single-module/details-tab/details-tab.component.ts
@@ -22,6 +22,7 @@ import {SeriesFormatComponent} from "../../shared/series-format/series-format.co
 import {MangaFormatPipe} from "../../_pipes/manga-format.pipe";
 import {LanguageNamePipe} from "../../_pipes/language-name.pipe";
 import {AsyncPipe} from "@angular/common";
+import {SafeUrlPipe} from "../../_pipes/safe-url.pipe";
 
 @Component({
   selector: 'app-details-tab',
@@ -39,7 +40,8 @@ import {AsyncPipe} from "@angular/common";
     SeriesFormatComponent,
     MangaFormatPipe,
     LanguageNamePipe,
-    AsyncPipe
+    AsyncPipe,
+    SafeUrlPipe
   ],
   templateUrl: './details-tab.component.html',
   styleUrl: './details-tab.component.scss',

--- a/UI/Web/src/app/_single-module/match-series-result-item/match-series-result-item.component.html
+++ b/UI/Web/src/app/_single-module/match-series-result-item/match-series-result-item.component.html
@@ -32,9 +32,9 @@
   } @else {
     <div class="d-flex p-1 justify-content-between">
       <span class="me-1"><a (click)="$event.stopPropagation()" [href]="item.series.siteUrl" rel="noreferrer noopener" target="_blank">{{t('details')}}</a></span>
-      @if ((item.series.volumeCount || 0) > 0 || (item.series.chapterCount || 0) > 0) {
-        <span class="me-1">{{t('volume-count', {num: item.series.volumeCount})}}</span>
-        <span class="me-1">{{t('chapter-count', {num: item.series.chapterCount})}}</span>
+      @if ((item.series.volumes || 0) > 0 || (item.series.chapters || 0) > 0) {
+        <span class="me-1">{{t('volume-count', {num: item.series.volumes})}}</span>
+        <span class="me-1">{{t('chapter-count', {num: item.series.chapters})}}</span>
       } @else {
         <span class="me-1">{{t('releasing')}}</span>
       }

--- a/UI/Web/src/app/admin/license/license.component.html
+++ b/UI/Web/src/app/admin/license/license.component.html
@@ -4,7 +4,7 @@
     <a class="position-absolute custom-position btn btn-primary-outline" [href]="WikiLink.KavitaPlusFAQ" target="_blank" rel="noreferrer nofollow">{{t('faq-title')}}</a>
   </div>
 
-  <div class="container-fluid">
+  <div>
     <p>{{t('kavita+-desc-part-1')}} <a [href]="WikiLink.KavitaPlus" target="_blank" rel="noreferrer nofollow">{{t('kavita+-desc-part-2')}}</a> {{t('kavita+-desc-part-3')}}</p>
 
     <form [formGroup]="formGroup">

--- a/UI/Web/src/app/admin/manage-logs/manage-logs.component.ts
+++ b/UI/Web/src/app/admin/manage-logs/manage-logs.component.ts
@@ -31,6 +31,7 @@ export class ManageLogsComponent implements OnInit, OnDestroy {
   constructor(private accountService: AccountService) { }
 
   ngOnInit(): void {
+    // TODO: Come back and implement this one day
     this.accountService.currentUser$.pipe(take(1)).subscribe(user => {
       if (user) {
         this.hubConnection = new HubConnectionBuilder()

--- a/UI/Web/src/app/admin/manage-settings/manage-settings.component.ts
+++ b/UI/Web/src/app/admin/manage-settings/manage-settings.component.ts
@@ -25,7 +25,7 @@ const ValidIpAddress = /^(\s*((([12]?\d{1,2}\.){3}[12]?\d{1,2})|(([\da-f]{0,4}\:
   styleUrls: ['./manage-settings.component.scss'],
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [ReactiveFormsModule, NgbTooltip, TitleCasePipe, TranslocoModule, NgTemplateOutlet, PageLayoutModePipe, SettingItemComponent, SettingSwitchComponent, SafeHtmlPipe]
+  imports: [ReactiveFormsModule, TitleCasePipe, TranslocoModule, SettingItemComponent, SettingSwitchComponent]
 })
 export class ManageSettingsComponent implements OnInit {
 

--- a/UI/Web/src/app/admin/manage-tasks-settings/manage-tasks-settings.component.ts
+++ b/UI/Web/src/app/admin/manage-tasks-settings/manage-tasks-settings.component.ts
@@ -18,7 +18,6 @@ import {UtcToLocalTimePipe} from "../../_pipes/utc-to-local-time.pipe";
 
 import {takeUntilDestroyed} from "@angular/core/rxjs-interop";
 import {SettingItemComponent} from "../../settings/_components/setting-item/setting-item.component";
-import {ConfirmService} from "../../shared/confirm.service";
 import {SettingButtonComponent} from "../../settings/_components/setting-button/setting-button.component";
 import {DefaultModalOptions} from "../../_models/default-modal-options";
 import {ColumnMode, NgxDatatableModule} from "@siemens/ngx-datatable";
@@ -38,7 +37,8 @@ interface AdhocTask {
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
     imports: [ReactiveFormsModule, AsyncPipe, TitleCasePipe, DefaultValuePipe,
-        TranslocoModule, TranslocoLocaleModule, UtcToLocalTimePipe, SettingItemComponent, SettingButtonComponent, NgxDatatableModule]
+        TranslocoModule, TranslocoLocaleModule, UtcToLocalTimePipe, SettingItemComponent,
+      SettingButtonComponent, NgxDatatableModule]
 })
 export class ManageTasksSettingsComponent implements OnInit {
 

--- a/UI/Web/src/app/announcements/_components/changelog-update-item/changelog-update-item.component.scss
+++ b/UI/Web/src/app/announcements/_components/changelog-update-item/changelog-update-item.component.scss
@@ -2,7 +2,7 @@
   border-radius: 0.5rem;
 }
 
-.blog-content {
+:host ::ng-deep .blog-content {
   margin-bottom: 1.5rem;
   line-height: 1.6;
   word-wrap: break-word;

--- a/UI/Web/src/app/announcements/_components/changelog-update-item/changelog-update-item.component.ts
+++ b/UI/Web/src/app/announcements/_components/changelog-update-item/changelog-update-item.component.ts
@@ -27,4 +27,5 @@ export class ChangelogUpdateItemComponent {
   @Input({required:true}) update: UpdateVersionEvent | null = null;
   @Input() index: number = 0;
   @Input() showExtras: boolean = true;
+
 }

--- a/UI/Web/src/app/cards/_modals/edit-series-modal/edit-series-modal.component.ts
+++ b/UI/Web/src/app/cards/_modals/edit-series-modal/edit-series-modal.component.ts
@@ -103,9 +103,7 @@ const blackList = [Action.Edit, Action.Info, Action.IncognitoRead, Action.Read, 
     MangaFormatPipe,
     DefaultDatePipe,
     TimeAgoPipe,
-    TagBadgeComponent,
     PublicationStatusPipe,
-    NgbTooltip,
     BytesPipe,
     ImageComponent,
     NgbCollapse,
@@ -117,7 +115,6 @@ const blackList = [Action.Edit, Action.Info, Action.IncognitoRead, Action.Read, 
     EditListComponent,
     SettingButtonComponent,
     SettingItemComponent,
-    ReadTimePipe,
   ],
   templateUrl: './edit-series-modal.component.html',
   styleUrls: ['./edit-series-modal.component.scss'],
@@ -654,6 +651,11 @@ export class EditSeriesModalComponent implements OnInit {
         break;
       case Action.Download:
         this.downloadService.download('series', this.series);
+        break;
+      case Action.Match:
+        this.actionService.matchSeries(this.series, _ => {
+          this.modal.close({success: true, series: this.series, coverImageUpdate: false, updateExternal: true});
+        });
         break;
     }
   }

--- a/UI/Web/src/app/person-detail/person-detail.component.html
+++ b/UI/Web/src/app/person-detail/person-detail.component.html
@@ -7,6 +7,13 @@
           <h2 class="title text-break">
             <app-card-actionables (actionHandler)="performAction($event)" [actions]="personActions" [labelBy]="person.name" iconClass="fa-ellipsis-v"></app-card-actionables>
             <span>{{person.name}}</span>
+
+            @if (person.aniListId) {
+              <a class="ms-1" [href]="anilistUrl | safeUrl"  target="_blank" rel="noopener noreferrer">
+                <app-image height="24px" width="24px" aria-hidden="true" [imageUrl]="imageService.getWebLinkImage(anilistUrl)"
+                           [errorImage]="imageService.errorWebLinkImage"></app-image>
+              </a>
+            }
           </h2>
         </ng-container>
       </app-side-nav-companion-bar>
@@ -45,6 +52,7 @@
                 }
               </div>
             }
+
           </div>
         </div>
       </div>

--- a/UI/Web/src/app/person-detail/person-detail.component.ts
+++ b/UI/Web/src/app/person-detail/person-detail.component.ts
@@ -41,6 +41,7 @@ import {ThemeService} from "../_services/theme.service";
 import {DefaultModalOptions} from "../_models/default-modal-options";
 import {ToastrService} from "ngx-toastr";
 import {LicenseService} from "../_services/license.service";
+import {SafeUrlPipe} from "../_pipes/safe-url.pipe";
 
 @Component({
   selector: 'app-person-detail',
@@ -49,16 +50,15 @@ import {LicenseService} from "../_services/license.service";
     AsyncPipe,
     ImageComponent,
     SideNavCompanionBarComponent,
-    NgStyle,
     ReadMoreComponent,
     TagBadgeComponent,
     PersonRolePipe,
     CarouselReelComponent,
-    SeriesCardComponent,
     CardItemComponent,
     CardActionablesComponent,
     TranslocoDirective,
-    ChapterCardComponent
+    ChapterCardComponent,
+    SafeUrlPipe
   ],
   templateUrl: './person-detail.component.html',
   styleUrl: './person-detail.component.scss',
@@ -93,8 +93,14 @@ export class PersonDetailComponent {
   filter: SeriesFilterV2 | null = null;
   personActions: Array<ActionItem<Person>> = this.actionService.getPersonActions(this.handleAction.bind(this));
   chaptersByRole: any = {};
+  anilistUrl: string = '';
   private readonly personSubject = new BehaviorSubject<Person | null>(null);
-  protected readonly person$ = this.personSubject.asObservable();
+  protected readonly person$ = this.personSubject.asObservable().pipe(tap(p => {
+    if (p?.aniListId) {
+      this.anilistUrl = translate('person-detail.anilist-url').replace('{AniListId}', p!.aniListId! + '');
+      this.cdRef.markForCheck();
+    }
+  }));
 
   get HasCoverImage() {
     return (this.person as Person).coverImage;

--- a/UI/Web/src/app/settings/_components/settings/settings.component.html
+++ b/UI/Web/src/app/settings/_components/settings/settings.component.html
@@ -1,11 +1,11 @@
 <div class="main-container container-fluid">
   <ng-container *transloco="let t; read:'settings'">
     <app-side-nav-companion-bar>
-      <h2 title>
+      <h2 class="container-fluid" title>
         {{fragment | settingFragment}}
       </h2>
     </app-side-nav-companion-bar>
-    <div class="row col-me-4 pb-3">
+    <div class="container-fluid row col-me-4 pb-3">
 
       @if (accountService.currentUser$ | async; as user) {
         @if (accountService.hasAdminRole(user)) {

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -763,6 +763,7 @@
         "matched-status-label": "Matched",
         "unmatched-status-label": "Not Matched",
         "blacklist-status-label": "Needs Manual Match",
+        "dont-match-status-label": "{{dont-match-label}}",
         "all-status-label": "All",
         "dont-match-label": "Don't Match",
         "no-data": "{{common.no-data}}"

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -2677,7 +2677,7 @@
         "title": "Actions",
         "copy-settings": "Copy Settings From",
         "match": "Match",
-        "match-description": "Match Series with Kavita+ manually"
+        "match-tooltip": "Match Series with Kavita+ manually"
     },
 
     "preferences": {

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -1072,7 +1072,8 @@
         "individual-role-title": "As a {{role}}",
         "browse-person-title": "All Works of {{name}}",
         "browse-person-by-role-title": "All Works of {{name}} as a {{role}}",
-        "all-roles": "Roles"
+        "all-roles": "Roles",
+        "anilist-url": "{{edit-person-modal.anilist-tooltip}}"
     },
 
     "library-settings-modal": {

--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.1",
   "info": {
     "title": "Kavita",
-    "description": "Kavita provides a set of APIs that are authenticated by JWT. JWT token can be copied from local storage. Assume all fields of a payload are required. Built against v0.8.4.9",
+    "description": "Kavita provides a set of APIs that are authenticated by JWT. JWT token can be copied from local storage. Assume all fields of a payload are required. Built against v0.8.4.10",
     "license": {
       "name": "GPL-3.0",
       "url": "https://github.com/Kareadita/Kavita/blob/develop/LICENSE"


### PR DESCRIPTION
A quick set of fixes based on the feedback from yesterday. This is just a bit to give me more time to tackle more of the bugs and some of the great suggestions that came out of the first day of testing. Looking forward to more suggestions. 

# Changed
- Changed: Allow existing genres/tags to contribute to the Age Rating mapping
- Changed: If anilist id is set, will add an AL weblink on person page
- Changed: Default to First Last naming convention as that is what Manga Manager and AniList use by default. (develop). 

# Fixed
- Fixed: Fixed an issue that caused breakage when Field Mappings was not set (develop)
- Fixed: Fixed the images in the changelog modal to be styled correctly
- Fixed: Fixed a lot of cases where locked fields weren't being respected (develop). I plan to add a new field to allow overwriting locked fields. 
- Fixed: Fixed match button in Edit Series modal (develop)
- Fixed: Fixed Dont Match on manage matched throwing an nullable exception during mapping. (develop)
- Fixed: Fixed a typo in the event widget error message that shows up when the scan returns an empty root folder for the particular library. (Thanks @midhun3301)
- Fixed: When processing people from upstream, ensure we keep the existing metadata on hand for processing. (develop)
- Fixed: Fixed match series item not showing chapter/volume count when series was ended. 