### PR TITLE
Fix: 3336 Ensure form uses correct keys

### DIFF
--- a/UI/Web/src/app/shared/edit-list/edit-list.component.ts
+++ b/UI/Web/src/app/shared/edit-list/edit-list.component.ts
@@ -83,6 +83,11 @@ export class EditListComponent implements OnInit {
       .map(key => this.form.get(key)?.value)
       .join(',');
 
+    // Recreate form to ensure index's match
+    this.form = new FormGroup({});
+    this.Items.forEach((item, index) => {
+      this.form.addControl('link' + index, new FormControl(item, []));
+    })
 
     this.emit();
     this.cdRef.markForCheck();


### PR DESCRIPTION
# Fixed
- Fixed: Fixed removing web links behaving wrongly when removing links in a specific order (Fixes #3336)

Note: The specific order is starting at the top, and then removing any link that was below it (higher index, so it got shifted). 
One below would not work at all, more than one below would remove the wrong one.

I do not know what the performance impact is of creating a new form object, but I didn't see a "delete all controls" method. Shouldn't be called enough to matter either way.