### PR TITLE
Polish 5

### DIFF
--- a/.github/workflows/openapi-gen.yml
+++ b/.github/workflows/openapi-gen.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.REPO_GHA_PAT }}
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
@@ -59,6 +60,11 @@ jobs:
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
+          
+          # Pull latest changes with rebase to avoid merge commits
+          git pull --rebase origin develop
+          
+          # Commit and push
           git commit -m "Update OpenAPI documentation" openapi.json
           git push
         env:

--- a/API.Tests/Services/ScannerServiceTests.cs
+++ b/API.Tests/Services/ScannerServiceTests.cs
@@ -298,38 +298,38 @@ public class ScannerServiceTests : AbstractDbTest
     }
 
 
-    [Fact]
-    public async Task ScanLibrary_PublishersInheritFromChapters()
-    {
-        const string testcase = "Flat Special - Manga.json";
-
-        var infos = new Dictionary<string, ComicInfo>();
-        infos.Add("Uzaki-chan Wants to Hang Out! v01 (2019) (Digital) (danke-Empire).cbz", new ComicInfo()
+        [Fact]
+        public async Task ScanLibrary_PublishersInheritFromChapters()
         {
-            Publisher = "Correct Publisher"
-        });
-        infos.Add("Uzaki-chan Wants to Hang Out! - 2022 New Years Special SP01.cbz", new ComicInfo()
-        {
-            Publisher = "Special Publisher"
-        });
-        infos.Add("Uzaki-chan Wants to Hang Out! - Ch. 103 - Kouhai and Control.cbz", new ComicInfo()
-        {
-            Publisher = "Chapter Publisher"
-        });
+            const string testcase = "Flat Special - Manga.json";
 
-        var library = await _scannerHelper.GenerateScannerData(testcase, infos);
+            var infos = new Dictionary<string, ComicInfo>();
+            infos.Add("Uzaki-chan Wants to Hang Out! v01 (2019) (Digital) (danke-Empire).cbz", new ComicInfo()
+            {
+                Publisher = "Correct Publisher"
+            });
+            infos.Add("Uzaki-chan Wants to Hang Out! - 2022 New Years Special SP01.cbz", new ComicInfo()
+            {
+                Publisher = "Special Publisher"
+            });
+            infos.Add("Uzaki-chan Wants to Hang Out! - Ch. 103 - Kouhai and Control.cbz", new ComicInfo()
+            {
+                Publisher = "Chapter Publisher"
+            });
+
+            var library = await _scannerHelper.GenerateScannerData(testcase, infos);
 
 
-        var scanner = _scannerHelper.CreateServices();
-        await scanner.ScanLibrary(library.Id);
-        var postLib = await _unitOfWork.LibraryRepository.GetLibraryForIdAsync(library.Id, LibraryIncludes.Series);
+            var scanner = _scannerHelper.CreateServices();
+            await scanner.ScanLibrary(library.Id);
+            var postLib = await _unitOfWork.LibraryRepository.GetLibraryForIdAsync(library.Id, LibraryIncludes.Series);
 
-        Assert.NotNull(postLib);
-        Assert.Single(postLib.Series);
-        var publishers = postLib.Series.First().Metadata.People
-            .Where(p => p.Role == PersonRole.Publisher);
-        Assert.Equal(3, publishers.Count());
-    }
+            Assert.NotNull(postLib);
+            Assert.Single(postLib.Series);
+            var publishers = postLib.Series.First().Metadata.People
+                .Where(p => p.Role == PersonRole.Publisher);
+            Assert.Equal(3, publishers.Count());
+        }
 
 
     /// <summary>

--- a/API/API.csproj
+++ b/API/API.csproj
@@ -12,11 +12,6 @@
     <LangVersion>latestmajor</LangVersion>
   </PropertyGroup>
 
-  <!-- Moved to GA -->
-<!--  <Target Name="PostBuild" AfterTargets="Build" Condition=" '$(Configuration)' == 'Debug' ">-->
-<!--      <Delete Files="../openapi.json" />-->
-<!--      <Exec Command="swagger tofile &#45;&#45;output ../openapi.json bin/$(Configuration)/$(TargetFramework)/$(AssemblyName).dll v1" />-->
-<!--  </Target>-->
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DebugSymbols>false</DebugSymbols>

--- a/API/Entities/Metadata/SeriesMetadata.cs
+++ b/API/Entities/Metadata/SeriesMetadata.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Linq;
 using API.Entities.Enums;
 using API.Entities.Interfaces;
 using Microsoft.EntityFrameworkCore;
@@ -100,5 +101,15 @@ public class SeriesMetadata : IHasConcurrencyToken
     public void OnSavingChanges()
     {
         RowVersion++;
+    }
+
+    /// <summary>
+    /// Are all instances of the role from Kavita+
+    /// </summary>
+    /// <param name="role"></param>
+    /// <returns></returns>
+    public bool AllKavitaPlus(PersonRole role)
+    {
+        return People.Where(p => p.Role == role).All(p => p.KavitaPlusConnection);
     }
 }

--- a/API/Entities/Metadata/SeriesMetadata.cs
+++ b/API/Entities/Metadata/SeriesMetadata.cs
@@ -104,6 +104,16 @@ public class SeriesMetadata : IHasConcurrencyToken
     }
 
     /// <summary>
+    /// Any People in this Role present
+    /// </summary>
+    /// <param name="role"></param>
+    /// <returns></returns>
+    public bool AnyOfRole(PersonRole role)
+    {
+        return People.Any(p => p.Role == role);
+    }
+
+    /// <summary>
     /// Are all instances of the role from Kavita+
     /// </summary>
     /// <param name="role"></param>

--- a/API/Services/Plus/ExternalMetadataService.cs
+++ b/API/Services/Plus/ExternalMetadataService.cs
@@ -1082,10 +1082,18 @@ public class ExternalMetadataService : IExternalMetadataService
             var aniListId = ScrobblingService.ExtractId<int?>(staff.Url, ScrobblingService.AniListStaffWebsite);
             if (aniListId is null or <= 0) continue;
             var person = await _unitOfWork.PersonRepository.GetPersonByAniListId(aniListId.Value);
-            if (person != null && !string.IsNullOrEmpty(staff.ImageUrl) && string.IsNullOrEmpty(person.CoverImage) && !staff.ImageUrl.EndsWith("default.jpg"))
+            if (person == null || string.IsNullOrEmpty(staff.ImageUrl) ||
+                !string.IsNullOrEmpty(person.CoverImage) || staff.ImageUrl.EndsWith("default.jpg")) continue;
+
+            try
             {
                 await _coverDbService.SetPersonCoverByUrl(person, staff.ImageUrl, false, true);
             }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "There was an exception saving cover image for Person {PersonName} ({PersonId})", person.Name, person.Id);
+            }
+
         }
     }
 

--- a/API/Services/Plus/ExternalMetadataService.cs
+++ b/API/Services/Plus/ExternalMetadataService.cs
@@ -383,7 +383,10 @@ public class ExternalMetadataService : IExternalMetadataService
     {
 
         var series = await _unitOfWork.SeriesRepository.GetSeriesByIdAsync(seriesId, SeriesIncludes.Library);
-        if (series == null) return _defaultReturn;
+        if (series == null)
+        {
+            return _defaultReturn;
+        }
 
         try
         {
@@ -1079,7 +1082,7 @@ public class ExternalMetadataService : IExternalMetadataService
             var aniListId = ScrobblingService.ExtractId<int?>(staff.Url, ScrobblingService.AniListStaffWebsite);
             if (aniListId is null or <= 0) continue;
             var person = await _unitOfWork.PersonRepository.GetPersonByAniListId(aniListId.Value);
-            if (person != null && !string.IsNullOrEmpty(staff.ImageUrl) && string.IsNullOrEmpty(person.CoverImage))
+            if (person != null && !string.IsNullOrEmpty(staff.ImageUrl) && string.IsNullOrEmpty(person.CoverImage) && !staff.ImageUrl.EndsWith("default.jpg"))
             {
                 await _coverDbService.SetPersonCoverByUrl(person, staff.ImageUrl, false, true);
             }

--- a/API/Services/Plus/ExternalMetadataService.cs
+++ b/API/Services/Plus/ExternalMetadataService.cs
@@ -460,11 +460,19 @@ public class ExternalMetadataService : IExternalMetadataService
             {
                 externalSeriesMetadata.Series = await _unitOfWork.SeriesRepository.GetSeriesByIdAsync(seriesId);
 
-                madeMetadataModification = await WriteExternalMetadataToSeries(result.Series, seriesId);
-                if (madeMetadataModification)
+                try
                 {
-                    _unitOfWork.SeriesRepository.Update(series);
+                    madeMetadataModification = await WriteExternalMetadataToSeries(result.Series, seriesId);
+                    if (madeMetadataModification)
+                    {
+                        _unitOfWork.SeriesRepository.Update(series);
+                    }
                 }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "There was an exception when trying to write Series metadata from Kavita+");
+                }
+
             }
 
             // WriteExternalMetadataToSeries will commit but not always

--- a/API/Services/Plus/ExternalMetadataService.cs
+++ b/API/Services/Plus/ExternalMetadataService.cs
@@ -295,7 +295,16 @@ public class ExternalMetadataService : IExternalMetadataService
         if (data == null) return _defaultReturn;
 
         // Get from Kavita+ API the Full Series metadata with rec/rev and cache to ExternalMetadata tables
-        return await FetchExternalMetadataForSeries(seriesId, libraryType, data);
+        try
+        {
+            return await FetchExternalMetadataForSeries(seriesId, libraryType, data);
+        }
+        catch (KavitaException ex)
+        {
+            _logger.LogError(ex, "Rate limit hit fetching metadata");
+            // This can happen when we hit rate limit
+            return _defaultReturn;
+        }
     }
 
     /// <summary>
@@ -314,38 +323,49 @@ public class ExternalMetadataService : IExternalMetadataService
         _unitOfWork.SeriesRepository.Update(series);
 
         // Refetch metadata with a Direct lookup
-        var metadata = await FetchExternalMetadataForSeries(seriesId, series.Library.Type, new PlusSeriesRequestDto()
+        try
         {
-            AniListId = anilistId,
-            MalId = malId,
-            SeriesName = series.Name // Required field, not used since AniList/Mal Id are passed
-        });
+            var metadata = await FetchExternalMetadataForSeries(seriesId, series.Library.Type,
+                new PlusSeriesRequestDto()
+                {
+                    AniListId = anilistId,
+                    MalId = malId,
+                    SeriesName = series.Name // Required field, not used since AniList/Mal Id are passed
+                });
 
-        if (metadata.Series == null)
-        {
-            _logger.LogError("Unable to Match {SeriesName} with Kavita+ Series AniList Id: {AniListId}", series.Name, anilistId);
-            return;
+            if (metadata.Series == null)
+            {
+                _logger.LogError("Unable to Match {SeriesName} with Kavita+ Series AniList Id: {AniListId}",
+                    series.Name, anilistId);
+                return;
+            }
+
+            // Find all scrobble events and rewrite them to be the correct
+            var events = await _unitOfWork.ScrobbleRepository.GetAllEventsForSeries(seriesId);
+            _unitOfWork.ScrobbleRepository.Remove(events);
+
+            // Find all scrobble errors and remove them
+            var errors = await _unitOfWork.ScrobbleRepository.GetAllScrobbleErrorsForSeries(seriesId);
+            _unitOfWork.ScrobbleRepository.Remove(errors);
+
+            await _unitOfWork.CommitAsync();
+
+            // Regenerate all events for the series for all users
+            BackgroundJob.Enqueue(() => _scrobblingService.CreateEventsFromExistingHistoryForSeries(seriesId));
+
+            // Name can be null on Series even with a direct match
+            _logger.LogInformation("Matched {SeriesName} with Kavita+ Series {MatchSeriesName}", series.Name,
+                metadata.Series.Name);
         }
-
-        // Find all scrobble events and rewrite them to be the correct
-        var events = await _unitOfWork.ScrobbleRepository.GetAllEventsForSeries(seriesId);
-        _unitOfWork.ScrobbleRepository.Remove(events);
-
-        // Find all scrobble errors and remove them
-        var errors = await _unitOfWork.ScrobbleRepository.GetAllScrobbleErrorsForSeries(seriesId);
-        _unitOfWork.ScrobbleRepository.Remove(errors);
-
-        await _unitOfWork.CommitAsync();
-
-        // Regenerate all events for the series for all users
-        BackgroundJob.Enqueue(() => _scrobblingService.CreateEventsFromExistingHistoryForSeries(seriesId));
-
-        // Name can be null on Series even with a direct match
-        _logger.LogInformation("Matched {SeriesName} with Kavita+ Series {MatchSeriesName}", series.Name, metadata.Series.Name);
+        catch (KavitaException ex)
+        {
+            // We can't rethrow because Fix match is done in a background thread and Hangfire will requeue multiple times
+            _logger.LogInformation(ex, "Rate limit hit for matching {SeriesName} with Kavita+", series.Name);
+        }
     }
 
     /// <summary>
-    /// Sets a series to Dont Match and removes all previously cached
+    /// Sets a series to Don't Match and removes all previously cached
     /// </summary>
     /// <param name="seriesId"></param>
     public async Task UpdateSeriesDontMatch(int seriesId, bool dontMatch)
@@ -420,7 +440,7 @@ public class ExternalMetadataService : IExternalMetadataService
 
 
             // Recommendations
-            externalSeriesMetadata.ExternalRecommendations ??= new List<ExternalRecommendation>();
+            externalSeriesMetadata.ExternalRecommendations ??= [];
             var recs = await ProcessRecommendations(libraryType, result.Recommendations, externalSeriesMetadata);
 
             var extRatings = externalSeriesMetadata.ExternalRatings
@@ -469,13 +489,27 @@ public class ExternalMetadataService : IExternalMetadataService
         }
         catch (FlurlHttpException ex)
         {
+            var errorMessage = await ex.GetResponseStringAsync();
+            // Trim quotes if the response is a JSON string
+            errorMessage = errorMessage.Trim('"');
+
             if (ex.StatusCode == 500)
             {
                 return _defaultReturn;
             }
+
+            if (ex.StatusCode == 400 && errorMessage.Contains("Too many Requests"))
+            {
+                throw new KavitaException("Too many requests, slow down");
+            }
         }
         catch (Exception ex)
         {
+            if (ex.Message.Contains("Too Many Requests"))
+            {
+                throw new KavitaException("Too many requests, slow down");
+            }
+
             _logger.LogError(ex, "Unable to fetch external series metadata from Kavita+");
         }
 

--- a/API/Services/Plus/LicenseService.cs
+++ b/API/Services/Plus/LicenseService.cs
@@ -44,7 +44,10 @@ public class LicenseService(
 {
     private readonly TimeSpan _licenseCacheTimeout = TimeSpan.FromHours(8);
     public const string Cron = "0 */9 * * *";
-    private const string CacheKey = "license";
+    /// <summary>
+    /// Cache key for if license is valid or not
+    /// </summary>
+    public const string CacheKey = "license";
     private const string LicenseInfoCacheKey = "license-info";
 
 

--- a/API/Services/Tasks/Scanner/ProcessSeries.cs
+++ b/API/Services/Tasks/Scanner/ProcessSeries.cs
@@ -331,84 +331,123 @@ public class ProcessSeries : IProcessSeries
         }
 
         #region PeopleAndTagsAndGenres
-        if (!series.Metadata.WriterLocked && !series.Metadata.AllKavitaPlus(PersonRole.Writer))
-        {
-            var personSw = Stopwatch.StartNew();
-            var chapterPeople = chapters.SelectMany(c => c.People.Where(p => p.Role == PersonRole.Writer)).ToList();
-            await UpdateSeriesMetadataPeople(series.Metadata, series.Metadata.People, chapterPeople, PersonRole.Writer);
-            _logger.LogTrace("[TIME] Kavita took {Time} ms to process writer on Series: {File} for {Count} people", personSw.ElapsedMilliseconds, series.Name, chapterPeople.Count);
-        }
+            if (!series.Metadata.WriterLocked)
+            {
+                var personSw = Stopwatch.StartNew();
+                var chapterPeople = chapters.SelectMany(c => c.People.Where(p => p.Role == PersonRole.Writer)).ToList();
+                if (ShouldUpdatePeopleForRole(series, chapterPeople, PersonRole.Writer))
+                {
+                    await UpdateSeriesMetadataPeople(series.Metadata, series.Metadata.People, chapterPeople, PersonRole.Writer);
+                }
+                _logger.LogTrace("[TIME] Kavita took {Time} ms to process writer on Series: {File} for {Count} people", personSw.ElapsedMilliseconds, series.Name, chapterPeople.Count);
+            }
 
-        if (!series.Metadata.ColoristLocked && !series.Metadata.AllKavitaPlus(PersonRole.Colorist))
+        if (!series.Metadata.ColoristLocked)
         {
             var chapterPeople = chapters.SelectMany(c => c.People.Where(p => p.Role == PersonRole.Colorist)).ToList();
-            await UpdateSeriesMetadataPeople(series.Metadata, series.Metadata.People, chapterPeople, PersonRole.Colorist);
+            if (ShouldUpdatePeopleForRole(series, chapterPeople, PersonRole.Colorist))
+            {
+                await UpdateSeriesMetadataPeople(series.Metadata, series.Metadata.People, chapterPeople, PersonRole.Colorist);
+            }
         }
 
-        if (!series.Metadata.PublisherLocked && !series.Metadata.AllKavitaPlus(PersonRole.Publisher))
+        if (!series.Metadata.PublisherLocked)
         {
             var chapterPeople = chapters.SelectMany(c => c.People.Where(p => p.Role == PersonRole.Publisher)).ToList();
-            await UpdateSeriesMetadataPeople(series.Metadata, series.Metadata.People, chapterPeople, PersonRole.Publisher);
+            if (ShouldUpdatePeopleForRole(series, chapterPeople, PersonRole.Publisher))
+            {
+                await UpdateSeriesMetadataPeople(series.Metadata, series.Metadata.People, chapterPeople, PersonRole.Publisher);
+            }
         }
 
-        if (!series.Metadata.CoverArtistLocked && !series.Metadata.AllKavitaPlus(PersonRole.CoverArtist))
+        if (!series.Metadata.CoverArtistLocked)
         {
             var chapterPeople = chapters.SelectMany(c => c.People.Where(p => p.Role == PersonRole.CoverArtist)).ToList();
-            await UpdateSeriesMetadataPeople(series.Metadata, series.Metadata.People, chapterPeople, PersonRole.CoverArtist);
+            if (ShouldUpdatePeopleForRole(series, chapterPeople, PersonRole.CoverArtist))
+            {
+                await UpdateSeriesMetadataPeople(series.Metadata, series.Metadata.People, chapterPeople, PersonRole.CoverArtist);
+            }
         }
 
-        if (!series.Metadata.CharacterLocked && !series.Metadata.AllKavitaPlus(PersonRole.Character))
+        if (!series.Metadata.CharacterLocked)
         {
             var chapterPeople = chapters.SelectMany(c => c.People.Where(p => p.Role == PersonRole.Character)).ToList();
-            await UpdateSeriesMetadataPeople(series.Metadata, series.Metadata.People, chapterPeople, PersonRole.Character);
+            if (ShouldUpdatePeopleForRole(series, chapterPeople, PersonRole.Character))
+            {
+                await UpdateSeriesMetadataPeople(series.Metadata, series.Metadata.People, chapterPeople, PersonRole.Character);
+            }
         }
 
-        if (!series.Metadata.EditorLocked && !series.Metadata.AllKavitaPlus(PersonRole.Editor))
+        if (!series.Metadata.EditorLocked)
         {
             var chapterPeople = chapters.SelectMany(c => c.People.Where(p => p.Role == PersonRole.Editor)).ToList();
-            await UpdateSeriesMetadataPeople(series.Metadata, series.Metadata.People, chapterPeople, PersonRole.Editor);
+            if (ShouldUpdatePeopleForRole(series, chapterPeople, PersonRole.Editor))
+            {
+                await UpdateSeriesMetadataPeople(series.Metadata, series.Metadata.People, chapterPeople, PersonRole.Editor);
+            }
         }
 
-        if (!series.Metadata.InkerLocked && !series.Metadata.AllKavitaPlus(PersonRole.Inker))
+        if (!series.Metadata.InkerLocked)
         {
             var chapterPeople = chapters.SelectMany(c => c.People.Where(p => p.Role == PersonRole.Inker)).ToList();
-            await UpdateSeriesMetadataPeople(series.Metadata, series.Metadata.People, chapterPeople, PersonRole.Inker);
+            if (ShouldUpdatePeopleForRole(series, chapterPeople, PersonRole.Inker))
+            {
+                await UpdateSeriesMetadataPeople(series.Metadata, series.Metadata.People, chapterPeople, PersonRole.Inker);
+            }
         }
 
-        if (!series.Metadata.ImprintLocked && !series.Metadata.AllKavitaPlus(PersonRole.Imprint))
+        if (!series.Metadata.ImprintLocked)
         {
             var chapterPeople = chapters.SelectMany(c => c.People.Where(p => p.Role == PersonRole.Imprint)).ToList();
-            await UpdateSeriesMetadataPeople(series.Metadata, series.Metadata.People, chapterPeople, PersonRole.Imprint);
+            if (ShouldUpdatePeopleForRole(series, chapterPeople, PersonRole.Imprint))
+            {
+                await UpdateSeriesMetadataPeople(series.Metadata, series.Metadata.People, chapterPeople, PersonRole.Imprint);
+            }
         }
 
-        if (!series.Metadata.TeamLocked && !series.Metadata.AllKavitaPlus(PersonRole.Team))
+        if (!series.Metadata.TeamLocked)
         {
             var chapterPeople = chapters.SelectMany(c => c.People.Where(p => p.Role == PersonRole.Team)).ToList();
-            await UpdateSeriesMetadataPeople(series.Metadata, series.Metadata.People, chapterPeople, PersonRole.Team);
+            if (ShouldUpdatePeopleForRole(series, chapterPeople, PersonRole.Team))
+            {
+                await UpdateSeriesMetadataPeople(series.Metadata, series.Metadata.People, chapterPeople, PersonRole.Team);
+            }
         }
 
         if (!series.Metadata.LocationLocked && !series.Metadata.AllKavitaPlus(PersonRole.Location))
         {
             var chapterPeople = chapters.SelectMany(c => c.People.Where(p => p.Role == PersonRole.Location)).ToList();
-            await UpdateSeriesMetadataPeople(series.Metadata, series.Metadata.People, chapterPeople, PersonRole.Location);
+            if (ShouldUpdatePeopleForRole(series, chapterPeople, PersonRole.Location))
+            {
+                await UpdateSeriesMetadataPeople(series.Metadata, series.Metadata.People, chapterPeople, PersonRole.Location);
+            }
         }
 
         if (!series.Metadata.LettererLocked && !series.Metadata.AllKavitaPlus(PersonRole.Letterer))
         {
             var chapterPeople = chapters.SelectMany(c => c.People.Where(p => p.Role == PersonRole.Letterer)).ToList();
-            await UpdateSeriesMetadataPeople(series.Metadata, series.Metadata.People, chapterPeople, PersonRole.Letterer);
+            if (ShouldUpdatePeopleForRole(series, chapterPeople, PersonRole.Location))
+            {
+                await UpdateSeriesMetadataPeople(series.Metadata, series.Metadata.People, chapterPeople, PersonRole.Letterer);
+            }
         }
 
         if (!series.Metadata.PencillerLocked && !series.Metadata.AllKavitaPlus(PersonRole.Penciller))
         {
             var chapterPeople = chapters.SelectMany(c => c.People.Where(p => p.Role == PersonRole.Penciller)).ToList();
-            await UpdateSeriesMetadataPeople(series.Metadata, series.Metadata.People, chapterPeople, PersonRole.Penciller);
+            if (ShouldUpdatePeopleForRole(series, chapterPeople, PersonRole.Penciller))
+            {
+                await UpdateSeriesMetadataPeople(series.Metadata, series.Metadata.People, chapterPeople, PersonRole.Penciller);
+            }
         }
 
         if (!series.Metadata.TranslatorLocked && !series.Metadata.AllKavitaPlus(PersonRole.Translator))
         {
             var chapterPeople = chapters.SelectMany(c => c.People.Where(p => p.Role == PersonRole.Translator)).ToList();
-            await UpdateSeriesMetadataPeople(series.Metadata, series.Metadata.People, chapterPeople, PersonRole.Translator);
+            if (ShouldUpdatePeopleForRole(series, chapterPeople, PersonRole.Translator))
+            {
+                await UpdateSeriesMetadataPeople(series.Metadata, series.Metadata.People, chapterPeople, PersonRole.Translator);
+            }
         }
 
 
@@ -426,6 +465,34 @@ public class ProcessSeries : IProcessSeries
 
         #endregion
 
+    }
+
+    /// <summary>
+    /// Ensure that we don't overwrite Person metadata when all metadata is coming from Kavita+ metadata match functionality
+    /// </summary>
+    /// <param name="series"></param>
+    /// <param name="chapterPeople"></param>
+    /// <param name="role"></param>
+    /// <returns></returns>
+    private static bool ShouldUpdatePeopleForRole(Series series, List<ChapterPeople> chapterPeople, PersonRole role)
+    {
+        if (chapterPeople.Count == 0) return false;
+
+        // If metadata already has this role, but all entries are from KavitaPlus, we should retain them
+        if (series.Metadata.AnyOfRole(role))
+        {
+            var existingPeople = series.Metadata.People.Where(p => p.Role == role);
+
+            // If all existing people are KavitaPlus but new chapter people exist, we should still update
+            if (existingPeople.All(p => p.KavitaPlusConnection))
+            {
+                return false; // Ensure we don't remove KavitaPlus people
+            }
+
+            return true; // Default case: metadata exists, and it's okay to update
+        }
+
+        return true;
     }
 
     private async Task UpdateCollectionTags(Series series, Chapter firstChapter)
@@ -553,8 +620,8 @@ public class ProcessSeries : IProcessSeries
                 .Where(v => v.MaxNumber.IsNot(Parser.Parser.SpecialVolumeNumber))
                 .ToList();
 
-            var maxVolume = (int) (nonSpecialVolumes.Any() ? nonSpecialVolumes.Max(v => v.MaxNumber) : 0);
-            var maxChapter = (int) chapters.Max(c => c.MaxNumber);
+            var maxVolume = (int)(nonSpecialVolumes.Any() ? nonSpecialVolumes.Max(v => v.MaxNumber) : 0);
+            var maxChapter = (int)chapters.Max(c => c.MaxNumber);
 
             // Single books usually don't have a number in their Range (filename)
             if (series.Format == MangaFormat.Epub || series.Format == MangaFormat.Pdf && chapters.Count == 1)

--- a/API/Services/Tasks/Scanner/ProcessSeries.cs
+++ b/API/Services/Tasks/Scanner/ProcessSeries.cs
@@ -331,7 +331,7 @@ public class ProcessSeries : IProcessSeries
         }
 
         #region PeopleAndTagsAndGenres
-        if (!series.Metadata.WriterLocked)
+        if (!series.Metadata.WriterLocked && !series.Metadata.AllKavitaPlus(PersonRole.Writer))
         {
             var personSw = Stopwatch.StartNew();
             var chapterPeople = chapters.SelectMany(c => c.People.Where(p => p.Role == PersonRole.Writer)).ToList();
@@ -339,73 +339,73 @@ public class ProcessSeries : IProcessSeries
             _logger.LogTrace("[TIME] Kavita took {Time} ms to process writer on Series: {File} for {Count} people", personSw.ElapsedMilliseconds, series.Name, chapterPeople.Count);
         }
 
-        if (!series.Metadata.ColoristLocked)
+        if (!series.Metadata.ColoristLocked && !series.Metadata.AllKavitaPlus(PersonRole.Colorist))
         {
             var chapterPeople = chapters.SelectMany(c => c.People.Where(p => p.Role == PersonRole.Colorist)).ToList();
             await UpdateSeriesMetadataPeople(series.Metadata, series.Metadata.People, chapterPeople, PersonRole.Colorist);
         }
 
-        if (!series.Metadata.PublisherLocked)
+        if (!series.Metadata.PublisherLocked && !series.Metadata.AllKavitaPlus(PersonRole.Publisher))
         {
             var chapterPeople = chapters.SelectMany(c => c.People.Where(p => p.Role == PersonRole.Publisher)).ToList();
             await UpdateSeriesMetadataPeople(series.Metadata, series.Metadata.People, chapterPeople, PersonRole.Publisher);
         }
 
-        if (!series.Metadata.CoverArtistLocked)
+        if (!series.Metadata.CoverArtistLocked && !series.Metadata.AllKavitaPlus(PersonRole.CoverArtist))
         {
             var chapterPeople = chapters.SelectMany(c => c.People.Where(p => p.Role == PersonRole.CoverArtist)).ToList();
             await UpdateSeriesMetadataPeople(series.Metadata, series.Metadata.People, chapterPeople, PersonRole.CoverArtist);
         }
 
-        if (!series.Metadata.CharacterLocked)
+        if (!series.Metadata.CharacterLocked && !series.Metadata.AllKavitaPlus(PersonRole.Character))
         {
             var chapterPeople = chapters.SelectMany(c => c.People.Where(p => p.Role == PersonRole.Character)).ToList();
             await UpdateSeriesMetadataPeople(series.Metadata, series.Metadata.People, chapterPeople, PersonRole.Character);
         }
 
-        if (!series.Metadata.EditorLocked)
+        if (!series.Metadata.EditorLocked && !series.Metadata.AllKavitaPlus(PersonRole.Editor))
         {
             var chapterPeople = chapters.SelectMany(c => c.People.Where(p => p.Role == PersonRole.Editor)).ToList();
             await UpdateSeriesMetadataPeople(series.Metadata, series.Metadata.People, chapterPeople, PersonRole.Editor);
         }
 
-        if (!series.Metadata.InkerLocked)
+        if (!series.Metadata.InkerLocked && !series.Metadata.AllKavitaPlus(PersonRole.Inker))
         {
             var chapterPeople = chapters.SelectMany(c => c.People.Where(p => p.Role == PersonRole.Inker)).ToList();
             await UpdateSeriesMetadataPeople(series.Metadata, series.Metadata.People, chapterPeople, PersonRole.Inker);
         }
 
-        if (!series.Metadata.ImprintLocked)
+        if (!series.Metadata.ImprintLocked && !series.Metadata.AllKavitaPlus(PersonRole.Imprint))
         {
             var chapterPeople = chapters.SelectMany(c => c.People.Where(p => p.Role == PersonRole.Imprint)).ToList();
             await UpdateSeriesMetadataPeople(series.Metadata, series.Metadata.People, chapterPeople, PersonRole.Imprint);
         }
 
-        if (!series.Metadata.TeamLocked)
+        if (!series.Metadata.TeamLocked && !series.Metadata.AllKavitaPlus(PersonRole.Team))
         {
             var chapterPeople = chapters.SelectMany(c => c.People.Where(p => p.Role == PersonRole.Team)).ToList();
             await UpdateSeriesMetadataPeople(series.Metadata, series.Metadata.People, chapterPeople, PersonRole.Team);
         }
 
-        if (!series.Metadata.LocationLocked)
+        if (!series.Metadata.LocationLocked && !series.Metadata.AllKavitaPlus(PersonRole.Location))
         {
             var chapterPeople = chapters.SelectMany(c => c.People.Where(p => p.Role == PersonRole.Location)).ToList();
             await UpdateSeriesMetadataPeople(series.Metadata, series.Metadata.People, chapterPeople, PersonRole.Location);
         }
 
-        if (!series.Metadata.LettererLocked)
+        if (!series.Metadata.LettererLocked && !series.Metadata.AllKavitaPlus(PersonRole.Letterer))
         {
             var chapterPeople = chapters.SelectMany(c => c.People.Where(p => p.Role == PersonRole.Letterer)).ToList();
             await UpdateSeriesMetadataPeople(series.Metadata, series.Metadata.People, chapterPeople, PersonRole.Letterer);
         }
 
-        if (!series.Metadata.PencillerLocked)
+        if (!series.Metadata.PencillerLocked && !series.Metadata.AllKavitaPlus(PersonRole.Penciller))
         {
             var chapterPeople = chapters.SelectMany(c => c.People.Where(p => p.Role == PersonRole.Penciller)).ToList();
             await UpdateSeriesMetadataPeople(series.Metadata, series.Metadata.People, chapterPeople, PersonRole.Penciller);
         }
 
-        if (!series.Metadata.TranslatorLocked)
+        if (!series.Metadata.TranslatorLocked && !series.Metadata.AllKavitaPlus(PersonRole.Translator))
         {
             var chapterPeople = chapters.SelectMany(c => c.People.Where(p => p.Role == PersonRole.Translator)).ToList();
             await UpdateSeriesMetadataPeople(series.Metadata, series.Metadata.People, chapterPeople, PersonRole.Translator);


### PR DESCRIPTION
# Changed
- Changed: General polish around matching and handling rate limit issues or failures (develop)

# Fixed
- Fixed: Fixed a bug where webp could fail when staff image url is default (aka no cover) (develop)
- Fixed: Don't overwrite people metadata after matching with Kavita+ then performing a scan (develop)
- Fixed: Fixed a bug that was calling unneeded checks on Kavita+ license validation each refresh

Fixed #3426 from an earlier PR. 