### PR TITLE
Polish 7 - Code Freeze

### DIFF
--- a/API/Data/ManualMigrations/v0.8.5/ManualMigrateNeedsManualMatch.cs
+++ b/API/Data/ManualMigrations/v0.8.5/ManualMigrateNeedsManualMatch.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using API.DTOs.KavitaPlus.Manage;
+using API.Entities.History;
+using API.Entities.Metadata;
+using API.Extensions.QueryExtensions;
+using Kavita.Common.EnvironmentInfo;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace API.Data.ManualMigrations;
+
+/// <summary>
+/// v0.8.5 - After user testing, the needs manual match has some edge cases from migrations and for best user experience,
+/// should be reset to allow the upgraded system to process better.
+/// </summary>
+public static class ManualMigrateNeedsManualMatch
+{
+    public static async Task Migrate(DataContext context, ILogger<Program> logger)
+    {
+        if (await context.ManualMigrationHistory.AnyAsync(m => m.Name == "ManualMigrateNeedsManualMatch"))
+        {
+            return;
+        }
+
+        logger.LogCritical("Running ManualMigrateNeedsManualMatch migration - Please be patient, this may take some time. This is not an error");
+
+        // Get all series in the Blacklist table and set their IsBlacklist = true
+        var series = await context.Series
+            .FilterMatchState(MatchStateOption.Error)
+            .ToListAsync();
+
+        foreach (var seriesEntry in series)
+        {
+            seriesEntry.IsBlacklisted = false;
+            context.Series.Update(seriesEntry);
+        }
+
+        if (context.ChangeTracker.HasChanges())
+        {
+            await context.SaveChangesAsync();
+        }
+
+        await context.ManualMigrationHistory.AddAsync(new ManualMigrationHistory()
+        {
+            Name = "ManualMigrateNeedsManualMatch",
+            ProductVersion = BuildInfo.Version.ToString(),
+            RanAt = DateTime.UtcNow
+        });
+        await context.SaveChangesAsync();
+
+        logger.LogCritical("Running ManualMigrateNeedsManualMatch migration - Completed. This is not an error");
+    }
+}

--- a/API/Data/ManualMigrations/v0.8.5/ManualMigrateScrobbleErrors.cs
+++ b/API/Data/ManualMigrations/v0.8.5/ManualMigrateScrobbleErrors.cs
@@ -38,7 +38,7 @@ public static class ManualMigrateScrobbleErrors
 
         await context.ManualMigrationHistory.AddAsync(new ManualMigrationHistory()
         {
-            Name = "ManualMigrateInvalidBlacklistSeries",
+            Name = "ManualMigrateScrobbleErrors",
             ProductVersion = BuildInfo.Version.ToString(),
             RanAt = DateTime.UtcNow
         });

--- a/API/Startup.cs
+++ b/API/Startup.cs
@@ -281,6 +281,7 @@ public class Startup
                     await ManualMigrateBlacklistTableToSeries.Migrate(dataContext, logger);
                     await ManualMigrateInvalidBlacklistSeries.Migrate(dataContext, logger);
                     await ManualMigrateScrobbleErrors.Migrate(dataContext, logger);
+                    await ManualMigrateNeedsManualMatch.Migrate(dataContext, logger);
 
                     //  Update the version in the DB after all migrations are run
                     var installVersion = await unitOfWork.SettingsRepository.GetSettingAsync(ServerSettingKey.InstallVersion);


### PR DESCRIPTION
I reset the Needs Manual Match data based on user feedback. 

# Changed
- Changed: (Kavita+) Reset all blacklisted external series metadata to allow fresh start with the much upgraded code. 
