### PR TITLE
v0.8.5 - Metadata Downloading & PDF Metadata!

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -28,7 +28,7 @@ body:
       label: Kavita Version Number - If you don not see your version number listed, please update Kavita and see if your issue still persists.
       multiple: false
       options:
-        - 0.8.4.2 - Stable
+        - 0.8.5 - Stable
         - Nightly Testing Branch
     validations:
       required: true

--- a/API/Data/ManualMigrations/v0.8.5/MigrateProgressExport.cs
+++ b/API/Data/ManualMigrations/v0.8.5/MigrateProgressExport.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using API.Entities;
+using API.Entities.History;
+using API.Services;
+using CsvHelper;
+using CsvHelper.Configuration.Attributes;
+using Kavita.Common.EnvironmentInfo;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace API.Data.ManualMigrations;
+
+
+/// <summary>
+/// v0.8.5 - Progress is extracted and saved in a csv since PDF parser has massive changes
+/// </summary>
+public static class MigrateProgressExportForV085
+{
+    public static async Task Migrate(DataContext dataContext, IDirectoryService directoryService, ILogger<Program> logger)
+    {
+        try
+        {
+            if (await dataContext.ManualMigrationHistory.AnyAsync(m => m.Name == "MigrateProgressExportForV085"))
+            {
+                return;
+            }
+
+            logger.LogCritical(
+                "Running MigrateProgressExportForV085 migration - Please be patient, this may take some time. This is not an error");
+
+            var data = await dataContext.AppUserProgresses
+                .Join(dataContext.Series, progress => progress.SeriesId, series => series.Id, (progress, series) => new { progress, series })
+                .Join(dataContext.Volume, ps => ps.progress.VolumeId, volume => volume.Id, (ps, volume) => new { ps.progress, ps.series, volume })
+                .Join(dataContext.Chapter, psv => psv.progress.ChapterId, chapter => chapter.Id, (psv, chapter) => new { psv.progress, psv.series, psv.volume, chapter })
+                .Join(dataContext.MangaFile, psvc => psvc.chapter.Id, mangaFile => mangaFile.ChapterId, (psvc, mangaFile) => new { psvc.progress, psvc.series, psvc.volume, psvc.chapter, mangaFile })
+                .Join(dataContext.AppUser, psvcm => psvcm.progress.AppUserId, appUser => appUser.Id, (psvcm, appUser) => new
+                {
+                    LibraryId = psvcm.series.LibraryId,
+                    LibraryName = psvcm.series.Library.Name,
+                    SeriesName = psvcm.series.Name,
+                    VolumeRange = psvcm.volume.MinNumber + "-" + psvcm.volume.MaxNumber,
+                    VolumeLookupName = psvcm.volume.Name,
+                    ChapterRange = psvcm.chapter.Range,
+                    MangaFileName = psvcm.mangaFile.FileName,
+                    MangaFilePath = psvcm.mangaFile.FilePath,
+                    AppUserName = appUser.UserName,
+                    AppUserId = appUser.Id,
+                    PagesRead = psvcm.progress.PagesRead,
+                    BookScrollId = psvcm.progress.BookScrollId,
+                    ProgressCreated = psvcm.progress.Created,
+                    ProgressLastModified = psvcm.progress.LastModified
+                }).ToListAsync();
+
+
+            // Write the mapped data to a CSV file
+            await using var writer = new StreamWriter(Path.Join(directoryService.ConfigDirectory, "progress_export-v0.8.5.csv"));
+            await using var csv = new CsvWriter(writer, CultureInfo.InvariantCulture);
+            await csv.WriteRecordsAsync(data);
+
+            logger.LogCritical(
+                "Running MigrateProgressExportForV085 migration - Completed. This is not an error");
+        }
+        catch (Exception ex)
+        {
+            // On new installs, the db isn't setup yet, so this has nothing to do
+        }
+
+        dataContext.ManualMigrationHistory.Add(new ManualMigrationHistory()
+        {
+            Name = "MigrateProgressExportForV085",
+            ProductVersion = BuildInfo.Version.ToString(),
+            RanAt = DateTime.UtcNow
+        });
+        await dataContext.SaveChangesAsync();
+    }
+}

--- a/API/Startup.cs
+++ b/API/Startup.cs
@@ -282,6 +282,7 @@ public class Startup
                     await ManualMigrateInvalidBlacklistSeries.Migrate(dataContext, logger);
                     await ManualMigrateScrobbleErrors.Migrate(dataContext, logger);
                     await ManualMigrateNeedsManualMatch.Migrate(dataContext, logger);
+                    await MigrateProgressExportForV085.Migrate(dataContext, directoryService, logger);
 
                     //  Update the version in the DB after all migrations are run
                     var installVersion = await unitOfWork.SettingsRepository.GetSettingAsync(ServerSettingKey.InstallVersion);

--- a/Kavita.Common/Kavita.Common.csproj
+++ b/Kavita.Common/Kavita.Common.csproj
@@ -3,7 +3,7 @@
         <TargetFramework>net9.0</TargetFramework>
         <Company>kavitareader.com</Company>
         <Product>Kavita</Product>
-        <AssemblyVersion>0.8.5.1</AssemblyVersion>
+        <AssemblyVersion>0.8.5.0</AssemblyVersion>
         <NeutralLanguage>en</NeutralLanguage>
         <InvariantGlobalization>true</InvariantGlobalization>
         <TieredPGO>true</TieredPGO>


### PR DESCRIPTION
It's been some time since the last release and this one is hefty! The goal of this release is to overhaul Kavita+ experience within Kavita, but I sneaked in metadata downloading, something I originally envisioned for Kavita, as well. This release is packed with a lot of goodies, from the ability to download metadata, greatly improving the PDF experience, to decreasing the scrobble window from 4 hours to 1 hour, and much more. 


### Metadata Downloading (Kavita+)
When I first started Kavita, I talked about wanting to build a plugin system to support metadata downloading, so I could have a true Plex experience. As the application and user base grew, the Plugin system was too much scope for me to handle and I said goodbye to the idea. Luckily, Kavita+ is here to provide that opportunity to build it out and all of last year, I have been slowly laying the foundation to make it a reality. 

Kavita can now automatically download metadata and apply it to your Series. It currently supports 12 different fields, including Cover Image, People, Genres, Tags, Age Ratings, and Relationships to name a few. I wanted to build a system that was functional but simple. Kavita offers a few controls that should allow enough flexibility to work for most users. I want to also thank the community for the overwhelming testing and feedback. The nightly testers and community really brought a lot of great ideas to polish this feature off. 

With that said, I want to set expectations. I'm not looking to build a komf replacement. This will currently just use metadata from AniList/MAL and Hardcover once I get around to it. 

So how does it work? 


### PDF Metadata
The pains of PDF may finally be over! Kavita now can read PDF metadata when tagged with Calibre (there is no real metadata format). Thanks to @microtherion writing a custom PDF parser, Kavita can now extract Series, title, volume, genres, etc from your files and bring a good experience for people forced to use PDFs. 

### New Stats API
This release also sees the release of an overhauled stat system. The Stats API is mainly for understanding how many servers are running Kavita, but there is also a lot of benefit in collecting anonymous data about the users of Kavita. On multiple occasions, I base decisions for features or bugs based on that data. However, the original stats API was quite out of date with what was important, so I overhauled it drastically. Like always, the code is Open source and nothing is logged that can identify you. You can take a look at the stat record [here](https://github.com/Kareadita/KavitaStats/pull/67). Thank you to all that continue to report statistics. 

### Misc
I wanted to shout out a few extra features that are included in this release. First off, Automatic Webtoon mode switching. This is a very common issue for users that read by comics and webtoons and also a discovery issue for new users. While I had architected out a grand solution for this, due to time constraints it never came. This is a good hold over until that time comes. When Kavita opens a comic that is likely a webtoon, it will switch into the mode for you automatically. It's not 100%, but a best guess. 

Another new feature is bringing Bionic Reading mode to Kavita's epub reader via a new font. A few users asked for this and thankfully a font made it possible. 

### Docker Fix
In the last release, docker users reported the scanner breaking. You can fix this with the following. The wiki reflects this as well.
> Add `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true` to your docker compose

### This Year
With that said, let's talk about what I want to deliver this year. I have to preface this by saying that this year my time is extremely constrained. But as always, I have lots of ideas that I want to try and accomplish. Since my time is limited, I've scaled down my goals to 2 main features:
1. **Journal-style Progress** will allow for a much richer stats experience and allow for some new functionalities in reading history. I've already validated this architecture in another project so it shouldn't be too complex porting back to Kavita. 

3. **Kobo Sync** was on my list last year but due to the new scanner, got pushed away. With the news of Kindle, it seems like a great time to prioritize it to the front of the list. 

These two features are a blend of user wants and my own wants to enable much richer statistics in the application. I'm sure I'll get side tracked along the way and deliver something cool. As always, a big thank you to our users and community. Kavita would not be where it is without your comments, feedback, and ideas. I'm really grateful that I have a great community, looking forward to working with you this year. 

**Note: AniList API is currently degraded and stuck at 30 requests / min. I've tried to build out the cache to avoid having to hit them for the release. Please be patient, I will be continuing my work on Kavita+ to work around these API limits.** 

**With metadata being available for PDF, you may loose progress. When v0.8.5 starts, it will export all progress to config/progress_export-v0.8.5.csv**

![image](https://github.com/user-attachments/assets/942d0640-eb36-4523-93bc-d3f882ae29cc)

![image](https://github.com/user-attachments/assets/7b6ade48-8036-4d0b-b473-bddaf6b10bc2)

![image](https://github.com/user-attachments/assets/419955c1-9557-44e2-b329-dba43fb2b050)

![image](https://github.com/user-attachments/assets/4133c843-cc74-4cb6-96b0-5d1c43fa1d61)



# Added
- Added: Added Fast Font to Book Reader. Fast Font is an open source Bionic Font alternative (FR #1268)
- Added: Added the ability to read embedded metadata from PDFs that conform to Calibre's embedding. (FR #3103)
- Added: Added a new stat for if the server uses metadata matching
- Added: (Manga Reader) When most of the file dimensions look like webtoon images, switch into the Webtoon reader on behalf of the user.
- Added: Series related tab will now show if there are bookmarks
- Added: Added the ability to see release notes of nightly releases in the changelog/announcements screens.
- Added: The UI will now check for new versions of Kavita (server-level) and prompt the user with the changelog and force them to refresh to get the latest UI code. This also takes care of any transloco hacks to clear the cache. This should help on update day for non-admin users to get the latest UI code files.
- Added: Added a new long term cache directory (cache-long). Currently storing Github release history information.
- Added: (Kavita+) Complete overhaul to the Kavita+ license page. Not only will you have the main license flow, but Kavita will pull down information about your subscription, including the registered email, total sub length, when the expiration will be, and if you're on a valid Kavita install version. Surfaced some of the actionable buttons with descriptions to hopefully help drive more management through the software instead of emailing me.
- Added: Added long term caching for Publisher/Favicon fallback so CoversDb doesn't have to service more requests than needed.
- Added: (Kavita+) There is now a manual match flow in Kavita to match a series (or fix a match) to AniList (currently the only upstream provider till Hardcover). Kavita still tries to match automatically, but via this new action from Series detail page, you can either provide another search name or Anilist/Mal urls directly to direct match. Likewise, you can select 'Do Not Match' which will delete any previously matched data, drop all scrobble events, and prevent matching/scrobbling in the future.
- Added: (Kavita+) Removed the previous error/matched bar from license screen and broke into it's own page called Matched Metadata. You can now filter by matched state (either not yet matched, needs manual match, don't match) and perform said flows from this screen. This should result in a much easier time navigating your metadata.
- Added: (Kavita+) New screen to see your users and if their AniList tokens are set or expired.
- Added: (Kavita+) Kavita will now email you (assuming email is setup and using a real email) whenever your scrobble tokens are about to expire (5 days out) and the day of, urging you to renew them to avoid scrobbling issues.
- Added: Kavita now has an email history table for admins to see which emails were sent out
- Added: (Kavita+) Kavita now implements the feature request to sync your 'planned' read lists from AniList/MAL into Kavita's Want to Read (FR #3153)
- Added: New button to download a person's image from CoverDB. I am still working out how to approach an automated solution. CoverDB is open for new entries.
- Added: (Kavita+) Added the ability for individual users to turn on/off scrobbling to anilist and the want to read sync.
- Added: (Kavita+) Kavita can now download metadata upon add and via the Match action. Metadata includes series cover image, summary, age rating, publication status, relationships (assuming already owned), release year, people (writer, artist, character) - including cover images, genres, and tags. Provides a flexible system to customize to your needs or disable altogether.
- Added: (Kavita+) New Library setting to opt a whole library out of being matched.
- Added: (Kavita+) Ability to override locked fields when performing a match to update metadata
- Added: Users can now press enter to close (and save) the setting items that are text inputs 

# Changed
- Changed: Changed the maximum line length of text inside of expandable blocks of text to a readable value (Thanks @heyhippari)
- Changed: Allow admins to change non-admin's email accounts on file. Will automatically assume it's valid.
- Changed: Docker builds will now have extra metadata (Thanks @halkeye)
- Changed:  Cleaned up the person image components to be a better experience in different states (Thanks @heyhippari )
- Changed: Known for on person page shouldn't show for Translator/Team/Location.
- Changed: Updated docker build scripts to include docker labels
- Changed: Massive overhaul to the data collection aspect of Kavita to ship more helpful information that is more up to date with the functionalities of Kavita. Stat collection can still be disabled and will still run after the first 12 hours to give time to opt-out.
- Changed: ReadOnly role is now more inline with the name. Any user with this role will only be able to rate series and update their want to read.
- Changed: Added a new mix mode for Colorscape to darken the colors
- Changed: Reworked handling of an exception for there being 2 progress entries for a given chapter. This previously would take the first and set as the new progress, but now it will take the newest and also take the highest page.
- Changed: Don't show the number of images under a chapter card for images.
- Changed: Rewrote the changelog/announcement to now be limited to 10 releases and have a better rendering experience.
- Changed: [TIME] profiling logs from last release is now on Trace as it's no longer needed anymore.
- Changed: Updated to .NET 9 which brings performance improvements and patches some security vulnerabilities
- Changed: (Kavita+) When registering a license that was previously bound to another instance, Kavita will now prompt you to override that old binding. This is usually the case and thus Kavita can perform the reset and registration in one flow for you (rather than you using Reset button then Saving again).
- Changed: (Kavita+) After registering your license a popup will open to inform you of how Scrobbling works and the next steps you should take.
- Changed: (Kavita+) After adding your Anilist token, Kavita now prompts you if you want to backfill scrobble events now or later (from Scrobbling page). This first time generation is important to sync your history/want to read/ratings from before you added the token. Giving the user time to setup Series Holds will ensure only data they want exposed is.
- Changed: (Kavita+) Scrobbling window is decreased from 4 hours to 1 hour
- Changed: If anilist id is set, will add an AL weblink on person page
- Changed: (Kavita+) Age Rating mappings from Kavita+ Metadata settings will apply when scanning in series.
- Changed: (Kavita+) When using edit series modal, also recalculate age rating based on tags/genres
- Changed: (Kavita+) Characters are now ordered based on their role in the Series (Main, Supporting, Background)
- Changed: (Kavita+) Sleep a little longer for background fetching to respect AL's new rate limit.
- Changed: (Kavita+) Reset all blacklisted external series metadata to allow fresh start with the much upgraded code. 

# Fixed
- Fixed: Fixed the way the sidebar closes (both on large screens and on mobile) to prevent text and icons jumping around during the animation. (Thanks @heyhippari)
- Fixed: Fixed a bug where if an age restricted user tried to load a person that they have partial access to, the backend would restrict the load 
- Fixed: Fixed a bug where double tap on an image in manga reader no longer triggers the bookmark flow. 
- Fixed: Fixed the UI using the wrong localization key for On Deck descriptions 
- Fixed: Fixed a bug where updating Team, it would actually write to Characters for edit series modal.
- Fixed: Fixed a typo in the event widget error message that shows up when the scan returns an empty root folder for the particular library. (Thanks @midhun3301 )
- Fixed: (Kavita+) Fixed a long standing bug where background series processing (fetching metadata for K+) wasn't pulling anything more than the first 25 series over and over.
- Fixed: Fixed add device button being broken
- Fixed: Fixed a bug where an admin editing a user was unable to save the form without a valid email, even though non-valid emails are allowed. 
- Fixed: Fixed a bug where person links wouldn't be url encoded
- Fixed: Fixed a bug where characters weren't being saved on the backend
- Fixed: Fixed a bug where progress tooltips would be behind the card title overlay 
- Fixed: Fixed a bug where when the filename and the series name/localized name are the same, Kavita would get confused and skip the file.
- Fixed: Fixed a bug where reading a pdf on Kavita then switching to reading over OPDS, the cache wouldn't work as the images weren't cached, only the pdf. (Thanks @m-amazirh for the help)
- Fixed: When downloading image series/chapters, zip them up and use the folder names on disk for inside the archive
- Fixed: (Manga Reader) Fixed up/down arrow key not scrolling on manga reader with original layout 
- Fixed: Sanitize OPDS feeds in case the user has characters that are invalid
- Fixed: (Epub Reader) White book theme was unnecessarily overriding some book styles (Thanks @Redst0neFlux)
- Fixed: Don't darken images on white/paper book themes
- Fixed: Fixed a bug when bulk selecting cards, the read button overlay shouldn't be present
- Fixed: Confirmation modals didn't have localized strings.
- Fixed: (Kavita+) Fixed a bug where want to read was scrobbling from libraries where AllowScrobbling is off. 
- Fixed: (Kavita+) Fixed a bug where Want to Read scrobbling was not respecting library rules 
- Fixed: Fixed Characters field not being wired up in the Save API.
- Fixed: Fixed location locked field not being wired up in the Save API.
- Fixed: Fixed a weird issue where Host name would eat keys when typing on General settings.
- Fixed: Fixed a bug where clicking a person from Volume/Chapter detail pages wouldn't load the person profile
- Fixed: Fixed a bug that was calling unneeded checks on Kavita+ license validation each refresh
- Fixed: Fixed spacing issue on the edit chapter modal (and aligned all modals to have the same spacing)
- Fixed: Fixed a bug where a progress check on the DB was being handled which logged a warning to logger.
- Fixed: Fixed the overlay title on cards extending past the card boundary when in a carousel (Thanks @Zeoic)
- Fixed: Fixed a bug where the background job to fill out metadata was constantly pulling the same blacklisted series over and over again, thus making no progress.
- Fixed: Fixed a bug where epub images that were hotlinked weren't loading correctly in the reader.
- Fixed: Fixed removing web links behaving wrongly when removing links in a specific order  (Thanks @Fesaa)
- Fixed: Fixed default cache being 50MB when it should be 75MB
- Fixed: Fixed a bug when a metadata refresh event comes int, the active tab could get stuck on series detail
- Fixed: Fixed not being able to update general server settings 
- Fixed: (Kavita+) New migration to cleanup super old scrobble events that might be side-effects of version updates. 


# Feature Requests
- Added Fast Font to Book Reader. Fast Font is an open source Bionic Font alternative (FR #1268)
- Added the ability to read embedded metadata from PDFs that conform to Calibre's embedding. (FR #3103)
- (Kavita+) Kavita now implements the feature request to sync your 'planned' read lists from AniList/MAL into Kavita's Want to Read (FR #3153)

# Known Issues
- Some covers will disappear after being added to Kavita (rare). If I can reproduce, I will hotfix.
- Match modal may sometimes appear like there are no results but there should be. This is due to rate issues, this will be addressed in v0.8.6. You just need to wait a few minutes for it to be searchable again. 
