### PR TITLE
v0.8.5.3 - Hotfix

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -28,7 +28,7 @@ body:
       label: Kavita Version Number - If you don not see your version number listed, please update Kavita and see if your issue still persists.
       multiple: false
       options:
-        - 0.8.5 - Stable
+        - 0.8.5.3 - Stable
         - Nightly Testing Branch
     validations:
       required: true

--- a/Kavita.Common/Kavita.Common.csproj
+++ b/Kavita.Common/Kavita.Common.csproj
@@ -3,7 +3,7 @@
         <TargetFramework>net9.0</TargetFramework>
         <Company>kavitareader.com</Company>
         <Product>Kavita</Product>
-        <AssemblyVersion>0.8.5.2</AssemblyVersion>
+        <AssemblyVersion>0.8.5.3</AssemblyVersion>
         <NeutralLanguage>en</NeutralLanguage>
         <InvariantGlobalization>true</InvariantGlobalization>
         <TieredPGO>true</TieredPGO>


### PR DESCRIPTION
A small hotfix is needed due to the Don't fall behind modal showing incorrectly. 

The known issue of covers disappearing seems to be related to multi-root libraries and thus is likely to require a full release cycle to tackle. 

# Fixed
- Fixed: Fixed a bug where the Don't fall behind modal was opening constantly
- Fixed: Fixed a wiki link being wrong
