### PR TITLE
Scanner Fixes

### DIFF
--- a/API.Tests/Helpers/ScannerHelper.cs
+++ b/API.Tests/Helpers/ScannerHelper.cs
@@ -63,10 +63,10 @@ public class ScannerHelper
         return library;
     }
 
-    public ScannerService CreateServices()
+    public ScannerService CreateServices(DirectoryService ds = null, IFileSystem fs = null)
     {
-        var fs = new FileSystem();
-        var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), fs);
+        fs ??= new FileSystem();
+        ds ??= new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), fs);
         var archiveService = new ArchiveService(Substitute.For<ILogger<ArchiveService>>(), ds,
             Substitute.For<IImageService>(), Substitute.For<IMediaErrorService>());
         var readingItemService = new ReadingItemService(archiveService, Substitute.For<IBookService>(),
@@ -133,7 +133,7 @@ public class ScannerHelper
 
         _testOutputHelper.WriteLine($"Test Directory Path: {testDirectory}");
 
-        return testDirectory;
+        return Path.GetFullPath(testDirectory);
     }
 
 

--- a/API.Tests/Services/ScannerServiceTests.cs
+++ b/API.Tests/Services/ScannerServiceTests.cs
@@ -626,11 +626,10 @@ public class ScannerServiceTests : AbstractDbTest
         Assert.Single(s2.Volumes);
     }
 
-    //[Fact]
+    [Fact]
     public async Task ScanLibrary_AlternatingRemoval_IssueReplication()
     {
         // https://github.com/Kareadita/Kavita/issues/3476#issuecomment-2661635558
-        // TODO: Come back to this, it's complicated
         const string testcase = "Alternating Removal - Manga.json";
 
         // Setup: Generate test library
@@ -665,6 +664,14 @@ public class ScannerServiceTests : AbstractDbTest
         _unitOfWork.LibraryRepository.Update(library);
         await _unitOfWork.CommitAsync();
 
+        // Emulate time passage by updating lastFolderScan to be a min in the past
+        foreach (var s in postLib.Series)
+        {
+            s.LastFolderScanned = DateTime.Now.Subtract(TimeSpan.FromMinutes(1));
+            _context.Series.Update(s);
+        }
+        await _context.SaveChangesAsync();
+
         await scanner.ScanLibrary(library.Id);
         postLib = await _unitOfWork.LibraryRepository.GetLibraryForIdAsync(library.Id, LibraryIncludes.Series);
 
@@ -680,11 +687,27 @@ public class ScannerServiceTests : AbstractDbTest
         _unitOfWork.LibraryRepository.Update(library);
         await _unitOfWork.CommitAsync();
 
+        // Emulate time passage by updating lastFolderScan to be a min in the past
+        foreach (var s in postLib.Series)
+        {
+            s.LastFolderScanned = DateTime.Now.Subtract(TimeSpan.FromMinutes(1));
+            _context.Series.Update(s);
+        }
+        await _context.SaveChangesAsync();
+
         await scanner.ScanLibrary(library.Id);
         postLib = await _unitOfWork.LibraryRepository.GetLibraryForIdAsync(library.Id, LibraryIncludes.Series);
 
         Assert.Contains(postLib.Series, s => s.Name == "Accel"); // Accel should be back
         Assert.Contains(postLib.Series, s => s.Name == "Plush");
+
+        // Emulate time passage by updating lastFolderScan to be a min in the past
+        foreach (var s in postLib.Series)
+        {
+            s.LastFolderScanned = DateTime.Now.Subtract(TimeSpan.FromMinutes(1));
+            _context.Series.Update(s);
+        }
+        await _context.SaveChangesAsync();
 
         // Fourth Scan: Run again to check stability (should not remove Accel)
         await scanner.ScanLibrary(library.Id);

--- a/API.Tests/Services/ScannerServiceTests.cs
+++ b/API.Tests/Services/ScannerServiceTests.cs
@@ -6,6 +6,7 @@ using System.IO.Compression;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.Serialization;
@@ -735,5 +736,64 @@ public class ScannerServiceTests : AbstractDbTest
 
         Assert.Contains(postLib.Series, s => s.Name == "Accel"); // Ensure Accel is gone
         Assert.Contains(postLib.Series, s => s.Name == "Plush");
+    }
+
+    [Fact]
+    public async Task SubFolders_NoRemovals_ChangesFound()
+    {
+        const string testcase = "Subfolders always scanning all series changes - Manga.json";
+        var infos = new Dictionary<string, ComicInfo>();
+        var library = await _scannerHelper.GenerateScannerData(testcase, infos);
+        var testDirectoryPath = library.Folders.First().Path;
+
+        _unitOfWork.LibraryRepository.Update(library);
+        await _unitOfWork.CommitAsync();
+
+        var scanner = _scannerHelper.CreateServices();
+        await scanner.ScanLibrary(library.Id);
+
+        var postLib = await _unitOfWork.LibraryRepository.GetLibraryForIdAsync(library.Id, LibraryIncludes.Series);
+        Assert.NotNull(postLib);
+        Assert.Equal(4, postLib.Series.Count);
+
+        var spiceAndWolf = postLib.Series.First(x => x.Name == "Spice and Wolf");
+        Assert.Equal(2, spiceAndWolf.Volumes.Count);
+        Assert.Equal(3, spiceAndWolf.Volumes.Sum(v => v.Chapters.Count));
+
+        var frieren = postLib.Series.First(x => x.Name == "Frieren - Beyond Journey's End");
+        Assert.Single(frieren.Volumes);
+        Assert.Equal(2, frieren.Volumes.Sum(v => v.Chapters.Count));
+
+        var executionerAndHerWayOfLife = postLib.Series.First(x => x.Name == "The Executioner and Her Way of Life");
+        Assert.Equal(2, executionerAndHerWayOfLife.Volumes.Count);
+        Assert.Equal(2, executionerAndHerWayOfLife.Volumes.Sum(v => v.Chapters.Count));
+
+        Thread.Sleep(1100); // Ensure at least one second has passed since library scan
+
+        // Add a new chapter to a volume of the series, and scan. Validate that no chapters were lost, and the new
+        // chapter was added
+        var executionerCopyDir = Path.Join(Path.Join(testDirectoryPath, "The Executioner and Her Way of Life"),
+            "The Executioner and Her Way of Life Vol. 1");
+        File.Copy(Path.Join(executionerCopyDir, "The Executioner and Her Way of Life Vol. 1 Ch. 0001.cbz"),
+            Path.Join(executionerCopyDir, "The Executioner and Her Way of Life Vol. 1 Ch. 0002.cbz"));
+
+        await scanner.ScanLibrary(library.Id);
+        await _unitOfWork.CommitAsync();
+
+        postLib = await _unitOfWork.LibraryRepository.GetLibraryForIdAsync(library.Id, LibraryIncludes.Series);
+        Assert.NotNull(postLib);
+        Assert.Equal(4, postLib.Series.Count);
+
+        spiceAndWolf = postLib.Series.First(x => x.Name == "Spice and Wolf");
+        Assert.Equal(2, spiceAndWolf.Volumes.Count);
+        Assert.Equal(3, spiceAndWolf.Volumes.Sum(v => v.Chapters.Count));
+
+        frieren = postLib.Series.First(x => x.Name == "Frieren - Beyond Journey's End");
+        Assert.Single(frieren.Volumes);
+        Assert.Equal(2, frieren.Volumes.Sum(v => v.Chapters.Count));
+
+        executionerAndHerWayOfLife = postLib.Series.First(x => x.Name == "The Executioner and Her Way of Life");
+        Assert.Equal(2, executionerAndHerWayOfLife.Volumes.Count);
+        Assert.Equal(3, executionerAndHerWayOfLife.Volumes.Sum(v => v.Chapters.Count)); // Incremented by 1
     }
 }

--- a/API.Tests/Services/ScannerServiceTests.cs
+++ b/API.Tests/Services/ScannerServiceTests.cs
@@ -519,7 +519,7 @@ public class ScannerServiceTests : AbstractDbTest
     }
 
     [Fact]
-    public async Task ScanLibrary_MultipleRoots_MultipleScans_DataPersists()
+    public async Task ScanLibrary_MultipleRoots_MultipleScans_DataPersists_Forced()
     {
         const string testcase = "Multiple Roots - Manga.json";
 
@@ -552,13 +552,70 @@ public class ScannerServiceTests : AbstractDbTest
         var s2 = postLib.Series.First(s => s.Name == "Accel");
         Assert.Single(s2.Volumes);
 
+        // Make a change (copy a file into only 1 root)
+        var root1PlushFolder = Path.Join(testDirectoryPath, "Root 1/Antarctic Press/Plush");
+        File.Copy(Path.Join(root1PlushFolder, "Plush v02.cbz"), Path.Join(root1PlushFolder, "Plush v03.cbz"));
+
         // Rescan to ensure nothing changes yet again
         await scanner.ScanLibrary(library.Id, true);
 
         postLib = await _unitOfWork.LibraryRepository.GetLibraryForIdAsync(library.Id, LibraryIncludes.Series);
         Assert.Equal(2, postLib.Series.Count);
         s = postLib.Series.First(s => s.Name == "Plush");
+        Assert.Equal(3, s.Volumes.Count);
+        s2 = postLib.Series.First(s => s.Name == "Accel");
+        Assert.Single(s2.Volumes);
+    }
+
+    /// <summary>
+    /// Regression bug appeared where multi-root and one root gets a new file, on next scan of library,
+    /// the series in the other root are deleted.
+    /// </summary>
+    [Fact]
+    public async Task ScanLibrary_MultipleRoots_MultipleScans_DataPersists_NonForced()
+    {
+        const string testcase = "Multiple Roots - Manga.json";
+
+        // Get the first file and generate a ComicInfo
+        var infos = new Dictionary<string, ComicInfo>();
+        var library = await _scannerHelper.GenerateScannerData(testcase, infos);
+
+        var testDirectoryPath =
+            Path.Join(
+                Path.Join(Directory.GetCurrentDirectory(), "../../../Services/Test Data/ScannerService/ScanTests"),
+                testcase.Replace(".json", string.Empty));
+        library.Folders =
+        [
+            new FolderPath() {Path = Path.Join(testDirectoryPath, "Root 1")},
+            new FolderPath() {Path = Path.Join(testDirectoryPath, "Root 2")}
+        ];
+
+        _unitOfWork.LibraryRepository.Update(library);
+        await _unitOfWork.CommitAsync();
+
+
+        var scanner = _scannerHelper.CreateServices();
+        await scanner.ScanLibrary(library.Id);
+        var postLib = await _unitOfWork.LibraryRepository.GetLibraryForIdAsync(library.Id, LibraryIncludes.Series);
+
+        Assert.NotNull(postLib);
+        Assert.Equal(2, postLib.Series.Count);
+        var s = postLib.Series.First(s => s.Name == "Plush");
         Assert.Equal(2, s.Volumes.Count);
+        var s2 = postLib.Series.First(s => s.Name == "Accel");
+        Assert.Single(s2.Volumes);
+
+        // Make a change (copy a file into only 1 root)
+        var root1PlushFolder = Path.Join(testDirectoryPath, "Root 1/Antarctic Press/Plush");
+        File.Copy(Path.Join(root1PlushFolder, "Plush v02.cbz"), Path.Join(root1PlushFolder, "Plush v03.cbz"));
+
+        // Rescan to ensure nothing changes yet again
+        await scanner.ScanLibrary(library.Id, false);
+
+        postLib = await _unitOfWork.LibraryRepository.GetLibraryForIdAsync(library.Id, LibraryIncludes.Series);
+        Assert.Equal(2, postLib.Series.Count);
+        s = postLib.Series.First(s => s.Name == "Plush");
+        Assert.Equal(3, s.Volumes.Count);
         s2 = postLib.Series.First(s => s.Name == "Accel");
         Assert.Single(s2.Volumes);
     }

--- a/API.Tests/Services/ScannerServiceTests.cs
+++ b/API.Tests/Services/ScannerServiceTests.cs
@@ -569,7 +569,7 @@ public class ScannerServiceTests : AbstractDbTest
 
     /// <summary>
     /// Regression bug appeared where multi-root and one root gets a new file, on next scan of library,
-    /// the series in the other root are deleted.
+    /// the series in the other root are deleted. (This is actually failing because the file in Root 1 isn't being detected)
     /// </summary>
     [Fact]
     public async Task ScanLibrary_MultipleRoots_MultipleScans_DataPersists_NonForced()

--- a/API.Tests/Services/ScannerServiceTests.cs
+++ b/API.Tests/Services/ScannerServiceTests.cs
@@ -610,7 +610,10 @@ public class ScannerServiceTests : AbstractDbTest
         var root1PlushFolder = Path.Join(testDirectoryPath, "Root 1/Antarctic Press/Plush");
         File.Copy(Path.Join(root1PlushFolder, "Plush v02.cbz"), Path.Join(root1PlushFolder, "Plush v03.cbz"));
 
-        await Task.Delay(1100);
+        // Emulate time passage by updating lastFolderScan to be a min in the past
+        s.LastFolderScanned = DateTime.Now.Subtract(TimeSpan.FromMinutes(1));
+        _context.Series.Update(s);
+        await _context.SaveChangesAsync();
 
         // Rescan to ensure nothing changes yet again
         await scanner.ScanLibrary(library.Id, false);

--- a/API.Tests/Services/ScannerServiceTests.cs
+++ b/API.Tests/Services/ScannerServiceTests.cs
@@ -609,6 +609,8 @@ public class ScannerServiceTests : AbstractDbTest
         var root1PlushFolder = Path.Join(testDirectoryPath, "Root 1/Antarctic Press/Plush");
         File.Copy(Path.Join(root1PlushFolder, "Plush v02.cbz"), Path.Join(root1PlushFolder, "Plush v03.cbz"));
 
+        await Task.Delay(1100);
+
         // Rescan to ensure nothing changes yet again
         await scanner.ScanLibrary(library.Id, false);
 

--- a/API.Tests/Services/Test Data/ScannerService/TestCases/Subfolder always scanning fix publisher layout - Comic.json
+++ b/API.Tests/Services/Test Data/ScannerService/TestCases/Subfolder always scanning fix publisher layout - Comic.json
@@ -1,0 +1,8 @@
+﻿[
+    "VizMedia/Frieren - Beyond Journey's End/Frieren - Beyond Journey's End Vol. 1.cbz",
+    "VizMedia/Frieren - Beyond Journey's End/Frieren - Beyond Journey's End Vol. 2.cbz",
+    "VizMedia/Seraph of the End/Seraph of the End Vol. 1.cbz",
+    "YenPress/Spice and Wolf/Spice and Wolf Vol. 1.cbz",
+    "YenPress/Spice and Wolf/Spice and Wolf Vol. 2.cbz",
+    "YenPress/The Executioner and Her Way of Life/The Executioner and Her Way of Life Vol. 1.cbz"
+]

--- a/API.Tests/Services/Test Data/ScannerService/TestCases/Subfolders always scanning all series changes - Manga.json
+++ b/API.Tests/Services/Test Data/ScannerService/TestCases/Subfolders always scanning all series changes - Manga.json
@@ -1,0 +1,11 @@
+﻿[
+    "Frieren - Beyond Journey's End/Frieren - Beyond Journey's End Vol. 1/Frieren - Beyond Journey's End Ch. 0001.cbz",
+    "Frieren - Beyond Journey's End/Frieren - Beyond Journey's End Vol. 1/Frieren - Beyond Journey's End Ch. 0002.cbz",
+    "Seraph of the End/Seraph of the End Vol. 1/Seraph of the End Ch. 0001.cbz",
+    "Spice and Wolf/Spice and Wolf Vol. 1/Spice and Wolf Vol. 1 Ch. 0001.cbz",
+    "Spice and Wolf/Spice and Wolf Vol. 1/Spice and Wolf Vol. 1 Ch. 0002.cbz",
+    "Spice and Wolf/Spice and Wolf Vol. 2/Spice and Wolf Vol. 2 Ch. 0003.cbz",
+    "The Executioner and Her Way of Life/The Executioner and Her Way of Life Vol. 1/The Executioner and Her Way of Life Vol. 1 Ch. 0001.cbz",
+    "The Executioner and Her Way of Life/The Executioner and Her Way of Life Vol. 2/The Executioner and Her Way of Life Vol. 2 Ch. 0003.cbz"
+]
+

--- a/API/Services/Tasks/Scanner/ParseScannedFiles.cs
+++ b/API/Services/Tasks/Scanner/ParseScannedFiles.cs
@@ -32,6 +32,10 @@ public class ParsedSeries
     /// Format of the Series
     /// </summary>
     public required MangaFormat Format { get; init; }
+    /// <summary>
+    /// Has this Series changed or not aka do we need to process it or not.
+    /// </summary>
+    public bool HasChanged { get; set; }
 }
 
 public class ScanResult

--- a/API/Services/Tasks/Scanner/ParseScannedFiles.cs
+++ b/API/Services/Tasks/Scanner/ParseScannedFiles.cs
@@ -182,7 +182,7 @@ public class ParseScannedFiles
             await _eventHub.SendMessageAsync(MessageFactory.NotificationProgress,
                 MessageFactory.FileScanProgressEvent(directory, library.Name, ProgressEventType.Updated));
 
-            if (HasSeriesFolderNotChangedSinceLastScan(seriesPaths, directory, forceCheck))
+            if (HasSeriesFolderNotChangedSinceLastScan(library, seriesPaths, directory, forceCheck))
             {
                 HandleUnchangedFolder(result, folderPath, directory);
             }
@@ -200,15 +200,21 @@ public class ParseScannedFiles
     /// <summary>
     /// Checks against all folder paths on file if the last scanned is >= the directory's last write time, down to the second
     /// </summary>
+    /// <param name="library"></param>
     /// <param name="seriesPaths"></param>
     /// <param name="directory">This should be normalized</param>
     /// <param name="forceCheck"></param>
     /// <returns></returns>
-    private bool HasSeriesFolderNotChangedSinceLastScan(IDictionary<string, IList<SeriesModified>> seriesPaths, string directory, bool forceCheck)
+    private bool HasSeriesFolderNotChangedSinceLastScan(Library library, IDictionary<string, IList<SeriesModified>> seriesPaths, string directory, bool forceCheck)
     {
-        // With the bottom-up approach, this can report a false positive where a nested folder will get scanned even though a parent is the series
-        // This can't really be avoided. This is more likely to happen on Image chapter folder library layouts.
-        if (forceCheck || !seriesPaths.TryGetValue(directory, out var seriesList))
+        if (forceCheck)
+        {
+            return false;
+        }
+
+        // TryGetSeriesList falls back to parent folders to match to seriesList
+        var seriesList = TryGetSeriesList(library, seriesPaths, directory);
+        if (seriesList == null)
         {
             return false;
         }
@@ -224,6 +230,31 @@ public class ParseScannedFiles
         }
 
         return true;
+    }
+
+    private IList<SeriesModified>? TryGetSeriesList(Library library, IDictionary<string, IList<SeriesModified>> seriesPaths, string directory)
+    {
+        if (seriesPaths.Count == 0)
+        {
+            return null;
+        }
+
+        if (string.IsNullOrEmpty(directory))
+        {
+            return null;
+        }
+
+        if (library.Folders.Any(fp => fp.Path.Equals(directory)))
+        {
+            return null;
+        }
+
+        if (seriesPaths.TryGetValue(directory, out var seriesList))
+        {
+            return seriesList;
+        }
+
+        return TryGetSeriesList(library, seriesPaths, _directoryService.GetParentDirectoryName(directory));
     }
 
     /// <summary>
@@ -284,7 +315,7 @@ public class ParseScannedFiles
         await _eventHub.SendMessageAsync(MessageFactory.NotificationProgress,
             MessageFactory.FileScanProgressEvent(normalizedPath, library.Name, ProgressEventType.Updated));
 
-        if (HasSeriesFolderNotChangedSinceLastScan(seriesPaths, normalizedPath, forceCheck))
+        if (HasSeriesFolderNotChangedSinceLastScan(library, seriesPaths, normalizedPath, forceCheck))
         {
             result.Add(CreateScanResult(folderPath, libraryRoot, false, ArraySegment<string>.Empty));
         }
@@ -725,7 +756,8 @@ public class ParseScannedFiles
         // If folder hasn't changed, generate fake ParserInfos
         if (!result.HasChanged)
         {
-            result.ParserInfos = seriesPaths[normalizedFolder]
+            // We are certain TryGetSeriesList will return a valid result here, if the series wasn't present yet. It will have been changed.
+            result.ParserInfos = TryGetSeriesList(library, seriesPaths, normalizedFolder)!
                 .Select(fp => new ParserInfo { Series = fp.SeriesName, Format = fp.Format })
                 .ToList();
 

--- a/API/Services/Tasks/Scanner/ProcessSeries.cs
+++ b/API/Services/Tasks/Scanner/ProcessSeries.cs
@@ -865,8 +865,11 @@ public class ProcessSeries : IProcessSeries
         var fileInfo = _directoryService.FileSystem.FileInfo.New(info.FullFilePath);
         if (existingFile != null)
         {
+            // TODO: I wonder if we can simplify this force check.
             existingFile.Format = info.Format;
+
             if (!forceUpdate && !_fileService.HasFileBeenModifiedSince(existingFile.FilePath, existingFile.LastModified) && existingFile.Pages != 0) return;
+
             existingFile.Pages = _readingItemService.GetNumberOfPages(info.FullFilePath, info.Format);
             existingFile.Extension = fileInfo.Extension.ToLowerInvariant();
             existingFile.FileName = Parser.Parser.RemoveExtensionIfSupported(existingFile.FilePath);


### PR DESCRIPTION
# Fixed
- Fixed: Fixed: Scanner scanning subfolders of a series when no changes have been made (Fixes #3557) (Thanks @Fesaa)
- Fixed: Fixed a bug where multi-root libraries would delete and recreate series in one of non-first folders (Fixes #3476)
