### PR TITLE
[skip ci] Fix GitHub actions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,9 +48,10 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - name: Install Swashbuckle CLI
-      shell: bash
-      run: dotnet tool install -g Swashbuckle.AspNetCore.Cli
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 9.0.x
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/openapi-gen.yml
+++ b/.github/workflows/openapi-gen.yml
@@ -14,15 +14,11 @@ jobs:
   generate-openapi:
     runs-on: ubuntu-latest
     # Only run on direct pushes to develop, not PRs
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-    if: github.repository_owner == 'Kareadita'
+    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.repository_owner == 'Kareadita'
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.REPO_GHA_PAT }}
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
@@ -62,11 +58,11 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
 
+          git commit -m "Update OpenAPI documentation" openapi.json
+
           # Pull latest changes with rebase to avoid merge commits
           git pull --rebase origin develop
 
-          # Commit and push
-          git commit -m "Update OpenAPI documentation" openapi.json
           git push
         env:
           GITHUB_TOKEN: ${{ secrets.REPO_GHA_PAT }}

--- a/.github/workflows/openapi-gen.yml
+++ b/.github/workflows/openapi-gen.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     # Only run on direct pushes to develop, not PRs
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    if: github.repository_owner == 'Kareadita'
 
     steps:
       - name: Checkout code
@@ -60,10 +61,10 @@ jobs:
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          
+
           # Pull latest changes with rebase to avoid merge commits
           git pull --rebase origin develop
-          
+
           # Commit and push
           git commit -m "Update OpenAPI documentation" openapi.json
           git push

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,8 +1,6 @@
 name: Validate PR Body
 
 on:
-    push:
-        branches: '**'
     pull_request:
         branches: [ main, develop, canary ]
         types: [synchronize]


### PR DESCRIPTION
# Changed
- Stops the PR action from running outside of PRs
- Only runs the OpenAPI action in the main repo

# Fixed
- Fixes the OpenAPI documentation action
- Fixes the codeql action(s)


# Notes

I did change `secrets.REPO_GHA_PAT` to `secrets.GITHUB_TOKEN` during my testing, but I assume the REPO_GHA_PAT is setup in the main repo, so that should be fine?

Swashbuckle.AspNetCore.Cli isn't needed in the codeql anymore as it's not ran at the end of building the project.