### PR TITLE
Fix Subfolders Scanner Issue

### DIFF
--- a/API.Tests/Services/ParseScannedFilesTests.cs
+++ b/API.Tests/Services/ParseScannedFilesTests.cs
@@ -489,7 +489,7 @@ public class ParseScannedFilesTests : AbstractDbTest
     }
 
     [Fact]
-    public async Task SubFoldersNoSubFolders_ScanAllAfterAdd()
+    public async Task SubFoldersNoSubFolders_ScanAllAfterAddInRoot()
     {
         const string testcase = "Subfolders and files at root - Manga.json";
         var infos = new Dictionary<string, ComicInfo>();
@@ -528,15 +528,47 @@ public class ParseScannedFilesTests : AbstractDbTest
             await _unitOfWork.SeriesRepository.GetFolderPathMap(postLib.Id), postLib);
         var changes = res.Count(sc => sc.HasChanged);
         Assert.Equal(2, changes);
+    }
+
+    [Fact]
+    public async Task SubFoldersNoSubFolders_ScanAllAfterAddInSubFolder()
+    {
+        const string testcase = "Subfolders and files at root - Manga.json";
+        var infos = new Dictionary<string, ComicInfo>();
+        var library = await _scannerHelper.GenerateScannerData(testcase, infos);
+        var testDirectoryPath = library.Folders.First().Path;
+
+        _unitOfWork.LibraryRepository.Update(library);
+        await _unitOfWork.CommitAsync();
+
+        var fs = new FileSystem();
+        var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), fs);
+        var psf = new ParseScannedFiles(Substitute.For<ILogger<ParseScannedFiles>>(), ds,
+            new MockReadingItemService(ds, Substitute.For<IBookService>()), Substitute.For<IEventHub>());
+
+        var scanner = _scannerHelper.CreateServices(ds, fs);
+        await scanner.ScanLibrary(library.Id);
+
+        var postLib = await _unitOfWork.LibraryRepository.GetLibraryForIdAsync(library.Id, LibraryIncludes.Series);
+        Assert.NotNull(postLib);
+        Assert.Single(postLib.Series);
+
+        var spiceAndWolf = postLib.Series.First(x => x.Name == "Spice and Wolf");
+        Assert.Equal(3, spiceAndWolf.Volumes.Count);
+        Assert.Equal(4, spiceAndWolf.Volumes.Sum(v => v.Chapters.Count));
+
+        spiceAndWolf.LastFolderScanned = DateTime.Now.Subtract(TimeSpan.FromMinutes(2));
+        _context.Series.Update(spiceAndWolf);
+        await _context.SaveChangesAsync();
 
         // Add file in subfolder
-        spiceAndWolfDir = Path.Join(spiceAndWolfDir, "Spice and Wolf Vol. 3");
+        var spiceAndWolfDir = Path.Join(Path.Join(testDirectoryPath, "Spice and Wolf"), "Spice and Wolf Vol. 3");
         File.Copy(Path.Join(spiceAndWolfDir, "Spice and Wolf Vol. 3 Ch. 0011.cbz"),
             Path.Join(spiceAndWolfDir, "Spice and Wolf Vol. 3 Ch. 0013.cbz"));
 
-        res = await psf.ScanFiles(testDirectoryPath, true,
+        var res = await psf.ScanFiles(testDirectoryPath, true,
             await _unitOfWork.SeriesRepository.GetFolderPathMap(postLib.Id), postLib);
-        changes = res.Count(sc => sc.HasChanged);
+        var changes = res.Count(sc => sc.HasChanged);
         Assert.Equal(2, changes);
     }
 }

--- a/API.Tests/Services/ParseScannedFilesTests.cs
+++ b/API.Tests/Services/ParseScannedFilesTests.cs
@@ -479,6 +479,8 @@ public class ParseScannedFilesTests : AbstractDbTest
         Assert.Equal(3, spiceAndWolf.Volumes.Count);
         Assert.Equal(4, spiceAndWolf.Volumes.Sum(v => v.Chapters.Count));
 
+        // Needs to be actual time as the write time is now, so if we set LastFolderChecked in the past
+        // it'll always a scan as it was changed since the last scan.
         Thread.Sleep(1100); // Ensure at least one second has passed since library scan
 
         var res = await psf.ScanFiles(testDirectoryPath, true,
@@ -513,8 +515,11 @@ public class ParseScannedFilesTests : AbstractDbTest
         Assert.Equal(3, spiceAndWolf.Volumes.Count);
         Assert.Equal(4, spiceAndWolf.Volumes.Sum(v => v.Chapters.Count));
 
-        Thread.Sleep(1100); // Ensure at least one second has passed since library scan
+        spiceAndWolf.LastFolderScanned = DateTime.Now.Subtract(TimeSpan.FromMinutes(2));
+        _context.Series.Update(spiceAndWolf);
+        await _context.SaveChangesAsync();
 
+        // Add file at series root
         var spiceAndWolfDir = Path.Join(testDirectoryPath, "Spice and Wolf");
         File.Copy(Path.Join(spiceAndWolfDir, "Spice and Wolf Vol. 1.cbz"),
             Path.Join(spiceAndWolfDir, "Spice and Wolf Vol. 4.cbz"));
@@ -522,6 +527,16 @@ public class ParseScannedFilesTests : AbstractDbTest
         var res = await psf.ScanFiles(testDirectoryPath, true,
             await _unitOfWork.SeriesRepository.GetFolderPathMap(postLib.Id), postLib);
         var changes = res.Count(sc => sc.HasChanged);
+        Assert.Equal(2, changes);
+
+        // Add file in subfolder
+        spiceAndWolfDir = Path.Join(spiceAndWolfDir, "Spice and Wolf Vol. 3");
+        File.Copy(Path.Join(spiceAndWolfDir, "Spice and Wolf Vol. 3 Ch. 0011.cbz"),
+            Path.Join(spiceAndWolfDir, "Spice and Wolf Vol. 3 Ch. 0013.cbz"));
+
+        res = await psf.ScanFiles(testDirectoryPath, true,
+            await _unitOfWork.SeriesRepository.GetFolderPathMap(postLib.Id), postLib);
+        changes = res.Count(sc => sc.HasChanged);
         Assert.Equal(2, changes);
     }
 }

--- a/API.Tests/Services/ParseScannedFilesTests.cs
+++ b/API.Tests/Services/ParseScannedFilesTests.cs
@@ -451,4 +451,77 @@ public class ParseScannedFilesTests : AbstractDbTest
         var changes = res.Count(sc => sc.HasChanged);
         Assert.Equal(1, changes);
     }
+
+    [Fact]
+    public async Task SubFoldersNoSubFolders_SkipAll()
+    {
+        const string testcase = "Subfolders and files at root - Manga.json";
+        var infos = new Dictionary<string, ComicInfo>();
+        var library = await _scannerHelper.GenerateScannerData(testcase, infos);
+        var testDirectoryPath = library.Folders.First().Path;
+
+        _unitOfWork.LibraryRepository.Update(library);
+        await _unitOfWork.CommitAsync();
+
+        var fs = new FileSystem();
+        var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), fs);
+        var psf = new ParseScannedFiles(Substitute.For<ILogger<ParseScannedFiles>>(), ds,
+            new MockReadingItemService(ds, Substitute.For<IBookService>()), Substitute.For<IEventHub>());
+
+        var scanner = _scannerHelper.CreateServices(ds, fs);
+        await scanner.ScanLibrary(library.Id);
+
+        var postLib = await _unitOfWork.LibraryRepository.GetLibraryForIdAsync(library.Id, LibraryIncludes.Series);
+        Assert.NotNull(postLib);
+        Assert.Single(postLib.Series);
+
+        var spiceAndWolf = postLib.Series.First(x => x.Name == "Spice and Wolf");
+        Assert.Equal(3, spiceAndWolf.Volumes.Count);
+        Assert.Equal(4, spiceAndWolf.Volumes.Sum(v => v.Chapters.Count));
+
+        Thread.Sleep(1100); // Ensure at least one second has passed since library scan
+
+        var res = await psf.ScanFiles(testDirectoryPath, true,
+            await _unitOfWork.SeriesRepository.GetFolderPathMap(postLib.Id), postLib);
+        Assert.DoesNotContain(res, sc => sc.HasChanged);
+    }
+
+    [Fact]
+    public async Task SubFoldersNoSubFolders_ScanAllAfterAdd()
+    {
+        const string testcase = "Subfolders and files at root - Manga.json";
+        var infos = new Dictionary<string, ComicInfo>();
+        var library = await _scannerHelper.GenerateScannerData(testcase, infos);
+        var testDirectoryPath = library.Folders.First().Path;
+
+        _unitOfWork.LibraryRepository.Update(library);
+        await _unitOfWork.CommitAsync();
+
+        var fs = new FileSystem();
+        var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), fs);
+        var psf = new ParseScannedFiles(Substitute.For<ILogger<ParseScannedFiles>>(), ds,
+            new MockReadingItemService(ds, Substitute.For<IBookService>()), Substitute.For<IEventHub>());
+
+        var scanner = _scannerHelper.CreateServices(ds, fs);
+        await scanner.ScanLibrary(library.Id);
+
+        var postLib = await _unitOfWork.LibraryRepository.GetLibraryForIdAsync(library.Id, LibraryIncludes.Series);
+        Assert.NotNull(postLib);
+        Assert.Single(postLib.Series);
+
+        var spiceAndWolf = postLib.Series.First(x => x.Name == "Spice and Wolf");
+        Assert.Equal(3, spiceAndWolf.Volumes.Count);
+        Assert.Equal(4, spiceAndWolf.Volumes.Sum(v => v.Chapters.Count));
+
+        Thread.Sleep(1100); // Ensure at least one second has passed since library scan
+
+        var spiceAndWolfDir = Path.Join(testDirectoryPath, "Spice and Wolf");
+        File.Copy(Path.Join(spiceAndWolfDir, "Spice and Wolf Vol. 1.cbz"),
+            Path.Join(spiceAndWolfDir, "Spice and Wolf Vol. 4.cbz"));
+
+        var res = await psf.ScanFiles(testDirectoryPath, true,
+            await _unitOfWork.SeriesRepository.GetFolderPathMap(postLib.Id), postLib);
+        var changes = res.Count(sc => sc.HasChanged);
+        Assert.Equal(2, changes);
+    }
 }

--- a/API.Tests/Services/ScannerServiceTests.cs
+++ b/API.Tests/Services/ScannerServiceTests.cs
@@ -55,6 +55,28 @@ public class ScannerServiceTests : AbstractDbTest
         await _context.SaveChangesAsync();
     }
 
+
+    protected async Task SetAllSeriesLastScannedInThePast(Library library, TimeSpan? duration = null)
+    {
+        foreach (var series in library.Series)
+        {
+            await SetLastScannedInThePast(series, duration, false);
+        }
+        await _context.SaveChangesAsync();
+    }
+
+    protected async Task SetLastScannedInThePast(Series series, TimeSpan? duration = null, bool save = true)
+    {
+        duration ??= TimeSpan.FromMinutes(2);
+        series.LastFolderScanned = DateTime.Now.Subtract(duration.Value);
+        _context.Series.Update(series);
+
+        if (save)
+        {
+            await _context.SaveChangesAsync();
+        }
+    }
+
     [Fact]
     public async Task ScanLibrary_ComicVine_PublisherFolder()
     {
@@ -611,9 +633,7 @@ public class ScannerServiceTests : AbstractDbTest
         File.Copy(Path.Join(root1PlushFolder, "Plush v02.cbz"), Path.Join(root1PlushFolder, "Plush v03.cbz"));
 
         // Emulate time passage by updating lastFolderScan to be a min in the past
-        s.LastFolderScanned = DateTime.Now.Subtract(TimeSpan.FromMinutes(1));
-        _context.Series.Update(s);
-        await _context.SaveChangesAsync();
+        await SetLastScannedInThePast(s);
 
         // Rescan to ensure nothing changes yet again
         await scanner.ScanLibrary(library.Id, false);
@@ -702,12 +722,7 @@ public class ScannerServiceTests : AbstractDbTest
         Assert.Contains(postLib.Series, s => s.Name == "Plush");
 
         // Emulate time passage by updating lastFolderScan to be a min in the past
-        foreach (var s in postLib.Series)
-        {
-            s.LastFolderScanned = DateTime.Now.Subtract(TimeSpan.FromMinutes(1));
-            _context.Series.Update(s);
-        }
-        await _context.SaveChangesAsync();
+        await SetAllSeriesLastScannedInThePast(postLib);
 
         // Fourth Scan: Run again to check stability (should not remove Accel)
         await scanner.ScanLibrary(library.Id);
@@ -794,7 +809,7 @@ public class ScannerServiceTests : AbstractDbTest
         Assert.Equal(2, executionerAndHerWayOfLife.Volumes.Count);
         Assert.Equal(2, executionerAndHerWayOfLife.Volumes.Sum(v => v.Chapters.Count));
 
-        Thread.Sleep(1100); // Ensure at least one second has passed since library scan
+        await SetAllSeriesLastScannedInThePast(postLib);
 
         // Add a new chapter to a volume of the series, and scan. Validate that no chapters were lost, and the new
         // chapter was added
@@ -845,11 +860,9 @@ public class ScannerServiceTests : AbstractDbTest
         Assert.Equal(3, spiceAndWolf.Volumes.Count);
         Assert.Equal(4, spiceAndWolf.Volumes.Sum(v => v.Chapters.Count));
 
-        spiceAndWolf.LastFolderScanned = DateTime.Now.Subtract(TimeSpan.FromMinutes(2));
-        _context.Series.Update(spiceAndWolf);
-        await _context.SaveChangesAsync();
+        await SetLastScannedInThePast(spiceAndWolf);
 
-        // Add file at series root
+        // Add volume to Spice and Wolf series directory
         var spiceAndWolfDir = Path.Join(testDirectoryPath, "Spice and Wolf");
         File.Copy(Path.Join(spiceAndWolfDir, "Spice and Wolf Vol. 1.cbz"),
             Path.Join(spiceAndWolfDir, "Spice and Wolf Vol. 4.cbz"));
@@ -864,9 +877,7 @@ public class ScannerServiceTests : AbstractDbTest
         Assert.Equal(4, spiceAndWolf.Volumes.Count);
         Assert.Equal(5, spiceAndWolf.Volumes.Sum(v => v.Chapters.Count));
 
-        spiceAndWolf.LastFolderScanned = DateTime.Now.Subtract(TimeSpan.FromMinutes(2));
-        _context.Series.Update(spiceAndWolf);
-        await _context.SaveChangesAsync();
+        await SetLastScannedInThePast(spiceAndWolf);
 
         // Add file in subfolder
         spiceAndWolfDir = Path.Join(spiceAndWolfDir, "Spice and Wolf Vol. 3");

--- a/API.Tests/Services/ScannerServiceTests.cs
+++ b/API.Tests/Services/ScannerServiceTests.cs
@@ -824,40 +824,7 @@ public class ScannerServiceTests : AbstractDbTest
     }
 
     [Fact]
-    public async Task SubFoldersNoSubFolders_SkipAll()
-    {
-        const string testcase = "Subfolders and files at root - Manga.json";
-        var infos = new Dictionary<string, ComicInfo>();
-        var library = await _scannerHelper.GenerateScannerData(testcase, infos);
-
-        _unitOfWork.LibraryRepository.Update(library);
-        await _unitOfWork.CommitAsync();
-
-        var scanner = _scannerHelper.CreateServices();
-        await scanner.ScanLibrary(library.Id);
-
-        var postLib = await _unitOfWork.LibraryRepository.GetLibraryForIdAsync(library.Id, LibraryIncludes.Series);
-        Assert.NotNull(postLib);
-        Assert.Single(postLib.Series);
-
-        var spiceAndWolf = postLib.Series.First(x => x.Name == "Spice and Wolf");
-        Assert.Equal(3, spiceAndWolf.Volumes.Count);
-        Assert.Equal(4, spiceAndWolf.Volumes.Sum(v => v.Chapters.Count));
-
-        Thread.Sleep(1100); // Ensure at least one second has passed since library scan
-
-        await scanner.ScanLibrary(library.Id);
-        postLib = await _unitOfWork.LibraryRepository.GetLibraryForIdAsync(library.Id, LibraryIncludes.Series);
-        Assert.NotNull(postLib);
-        Assert.Single(postLib.Series);
-
-        spiceAndWolf = postLib.Series.First(x => x.Name == "Spice and Wolf");
-        Assert.Equal(3, spiceAndWolf.Volumes.Count);
-        Assert.Equal(4, spiceAndWolf.Volumes.Sum(v => v.Chapters.Count));
-    }
-
-    [Fact]
-    public async Task SubFoldersNoSubFolders_ScanAllAfterAdd()
+    public async Task SubFoldersNoSubFolders_CorrectPickupAfterAdd()
     {
         const string testcase = "Subfolders and files at root - Manga.json";
         var infos = new Dictionary<string, ComicInfo>();
@@ -878,8 +845,11 @@ public class ScannerServiceTests : AbstractDbTest
         Assert.Equal(3, spiceAndWolf.Volumes.Count);
         Assert.Equal(4, spiceAndWolf.Volumes.Sum(v => v.Chapters.Count));
 
-        Thread.Sleep(1100); // Ensure at least one second has passed since library scan
+        spiceAndWolf.LastFolderScanned = DateTime.Now.Subtract(TimeSpan.FromMinutes(2));
+        _context.Series.Update(spiceAndWolf);
+        await _context.SaveChangesAsync();
 
+        // Add file at series root
         var spiceAndWolfDir = Path.Join(testDirectoryPath, "Spice and Wolf");
         File.Copy(Path.Join(spiceAndWolfDir, "Spice and Wolf Vol. 1.cbz"),
             Path.Join(spiceAndWolfDir, "Spice and Wolf Vol. 4.cbz"));
@@ -893,5 +863,25 @@ public class ScannerServiceTests : AbstractDbTest
         spiceAndWolf = postLib.Series.First(x => x.Name == "Spice and Wolf");
         Assert.Equal(4, spiceAndWolf.Volumes.Count);
         Assert.Equal(5, spiceAndWolf.Volumes.Sum(v => v.Chapters.Count));
+
+        spiceAndWolf.LastFolderScanned = DateTime.Now.Subtract(TimeSpan.FromMinutes(2));
+        _context.Series.Update(spiceAndWolf);
+        await _context.SaveChangesAsync();
+
+        // Add file in subfolder
+        spiceAndWolfDir = Path.Join(spiceAndWolfDir, "Spice and Wolf Vol. 3");
+        File.Copy(Path.Join(spiceAndWolfDir, "Spice and Wolf Vol. 3 Ch. 0012.cbz"),
+            Path.Join(spiceAndWolfDir, "Spice and Wolf Vol. 3 Ch. 0013.cbz"));
+
+        await scanner.ScanLibrary(library.Id);
+
+        postLib = await _unitOfWork.LibraryRepository.GetLibraryForIdAsync(library.Id, LibraryIncludes.Series);
+        Assert.NotNull(postLib);
+        Assert.Single(postLib.Series);
+
+        spiceAndWolf = postLib.Series.First(x => x.Name == "Spice and Wolf");
+        Assert.Equal(4, spiceAndWolf.Volumes.Count);
+        Assert.Equal(6, spiceAndWolf.Volumes.Sum(v => v.Chapters.Count));
+
     }
 }

--- a/API.Tests/Services/ScannerServiceTests.cs
+++ b/API.Tests/Services/ScannerServiceTests.cs
@@ -822,4 +822,76 @@ public class ScannerServiceTests : AbstractDbTest
         Assert.Equal(2, executionerAndHerWayOfLife.Volumes.Count);
         Assert.Equal(3, executionerAndHerWayOfLife.Volumes.Sum(v => v.Chapters.Count)); // Incremented by 1
     }
+
+    [Fact]
+    public async Task SubFoldersNoSubFolders_SkipAll()
+    {
+        const string testcase = "Subfolders and files at root - Manga.json";
+        var infos = new Dictionary<string, ComicInfo>();
+        var library = await _scannerHelper.GenerateScannerData(testcase, infos);
+
+        _unitOfWork.LibraryRepository.Update(library);
+        await _unitOfWork.CommitAsync();
+
+        var scanner = _scannerHelper.CreateServices();
+        await scanner.ScanLibrary(library.Id);
+
+        var postLib = await _unitOfWork.LibraryRepository.GetLibraryForIdAsync(library.Id, LibraryIncludes.Series);
+        Assert.NotNull(postLib);
+        Assert.Single(postLib.Series);
+
+        var spiceAndWolf = postLib.Series.First(x => x.Name == "Spice and Wolf");
+        Assert.Equal(3, spiceAndWolf.Volumes.Count);
+        Assert.Equal(4, spiceAndWolf.Volumes.Sum(v => v.Chapters.Count));
+
+        Thread.Sleep(1100); // Ensure at least one second has passed since library scan
+
+        await scanner.ScanLibrary(library.Id);
+        postLib = await _unitOfWork.LibraryRepository.GetLibraryForIdAsync(library.Id, LibraryIncludes.Series);
+        Assert.NotNull(postLib);
+        Assert.Single(postLib.Series);
+
+        spiceAndWolf = postLib.Series.First(x => x.Name == "Spice and Wolf");
+        Assert.Equal(3, spiceAndWolf.Volumes.Count);
+        Assert.Equal(4, spiceAndWolf.Volumes.Sum(v => v.Chapters.Count));
+    }
+
+    [Fact]
+    public async Task SubFoldersNoSubFolders_ScanAllAfterAdd()
+    {
+        const string testcase = "Subfolders and files at root - Manga.json";
+        var infos = new Dictionary<string, ComicInfo>();
+        var library = await _scannerHelper.GenerateScannerData(testcase, infos);
+        var testDirectoryPath = library.Folders.First().Path;
+
+        _unitOfWork.LibraryRepository.Update(library);
+        await _unitOfWork.CommitAsync();
+
+        var scanner = _scannerHelper.CreateServices();
+        await scanner.ScanLibrary(library.Id);
+
+        var postLib = await _unitOfWork.LibraryRepository.GetLibraryForIdAsync(library.Id, LibraryIncludes.Series);
+        Assert.NotNull(postLib);
+        Assert.Single(postLib.Series);
+
+        var spiceAndWolf = postLib.Series.First(x => x.Name == "Spice and Wolf");
+        Assert.Equal(3, spiceAndWolf.Volumes.Count);
+        Assert.Equal(4, spiceAndWolf.Volumes.Sum(v => v.Chapters.Count));
+
+        Thread.Sleep(1100); // Ensure at least one second has passed since library scan
+
+        var spiceAndWolfDir = Path.Join(testDirectoryPath, "Spice and Wolf");
+        File.Copy(Path.Join(spiceAndWolfDir, "Spice and Wolf Vol. 1.cbz"),
+            Path.Join(spiceAndWolfDir, "Spice and Wolf Vol. 4.cbz"));
+
+        await scanner.ScanLibrary(library.Id);
+
+        postLib = await _unitOfWork.LibraryRepository.GetLibraryForIdAsync(library.Id, LibraryIncludes.Series);
+        Assert.NotNull(postLib);
+        Assert.Single(postLib.Series);
+
+        spiceAndWolf = postLib.Series.First(x => x.Name == "Spice and Wolf");
+        Assert.Equal(4, spiceAndWolf.Volumes.Count);
+        Assert.Equal(5, spiceAndWolf.Volumes.Sum(v => v.Chapters.Count));
+    }
 }

--- a/API.Tests/Services/Test Data/ScannerService/TestCases/Subfolders and files at root - Manga.json
+++ b/API.Tests/Services/Test Data/ScannerService/TestCases/Subfolders and files at root - Manga.json
@@ -1,0 +1,6 @@
+[
+    "Spice and Wolf/Spice and Wolf Vol. 1.cbz",
+    "Spice and Wolf/Spice and Wolf Vol. 2.cbz",
+    "Spice and Wolf/Spice and Wolf Vol. 3/Spice and Wolf Vol. 3 Ch. 0011.cbz",
+    "Spice and Wolf/Spice and Wolf Vol. 3/Spice and Wolf Vol. 3 Ch. 0012.cbz"
+]

--- a/API/Services/Tasks/Scanner/ParseScannedFiles.cs
+++ b/API/Services/Tasks/Scanner/ParseScannedFiles.cs
@@ -164,10 +164,11 @@ public class ParseScannedFiles
         foreach (var directory in allDirectories)
         {
             // Don't process any folders where we've already scanned everything below
-            if (processedDirs.Any(d => d.StartsWith(directory + Path.AltDirectorySeparatorChar) || d.Equals(directory)))
+           if (processedDirs.Any(d => d.StartsWith(directory + Path.AltDirectorySeparatorChar) || d.Equals(directory)))
             {
+                var hasChanged = !HasSeriesFolderNotChangedSinceLastScan(library, seriesPaths, directory, forceCheck);
                 // Skip this directory as we've already processed a parent unless there are loose files at that directory
-                CheckSurfaceFiles(result, directory, folderPath, fileExtensions, matcher);
+                CheckSurfaceFiles(result, directory, folderPath, fileExtensions, matcher, hasChanged);
                 continue;
             }
 
@@ -290,14 +291,14 @@ public class ParseScannedFiles
     /// <summary>
     /// Performs a full scan of the directory and adds it to the result.
     /// </summary>
-    private void CheckSurfaceFiles(List<ScanResult> result, string directory, string folderPath, string fileExtensions, GlobMatcher matcher)
+    private void CheckSurfaceFiles(List<ScanResult> result, string directory, string folderPath, string fileExtensions, GlobMatcher matcher, bool hasChanged)
     {
         var files = _directoryService.ScanFiles(directory, fileExtensions, matcher, SearchOption.TopDirectoryOnly);
         if (files.Count == 0)
         {
             return;
         }
-        result.Add(CreateScanResult(directory, folderPath, true, files));
+        result.Add(CreateScanResult(directory, folderPath, hasChanged, files));
     }
 
     /// <summary>

--- a/API/Services/Tasks/Scanner/ParseScannedFiles.cs
+++ b/API/Services/Tasks/Scanner/ParseScannedFiles.cs
@@ -164,10 +164,11 @@ public class ParseScannedFiles
         foreach (var directory in allDirectories)
         {
             // Don't process any folders where we've already scanned everything below
-           if (processedDirs.Any(d => d.StartsWith(directory + Path.AltDirectorySeparatorChar) || d.Equals(directory)))
+            if (processedDirs.Any(d => d.StartsWith(directory + Path.AltDirectorySeparatorChar) || d.Equals(directory)))
             {
                 var hasChanged = !HasSeriesFolderNotChangedSinceLastScan(library, seriesPaths, directory, forceCheck);
                 // Skip this directory as we've already processed a parent unless there are loose files at that directory
+                // and they have changes
                 CheckSurfaceFiles(result, directory, folderPath, fileExtensions, matcher, hasChanged);
                 continue;
             }


### PR DESCRIPTION
# Fixed
- Fixed: Fixed a bug where a series with files at its root, and in subfolders would have the chapters in the subfolders removed after a scan (develop)