### PR TITLE
Fix not being able to add new series a library in publisher layout

### DIFF
--- a/API.Tests/Services/ParseScannedFilesTests.cs
+++ b/API.Tests/Services/ParseScannedFilesTests.cs
@@ -399,9 +399,9 @@ public class ParseScannedFilesTests : AbstractDbTest
         File.Copy(Path.Join(executionerCopyDir, "The Executioner and Her Way of Life Vol. 1 Ch. 0001.cbz"),
             Path.Join(executionerCopyDir, "The Executioner and Her Way of Life Vol. 1 Ch. 0002.cbz"));
 
-        // 4 series, of which 2 have volumes as directories
+        // 4 series
         var folderMap = await _unitOfWork.SeriesRepository.GetFolderPathMap(postLib.Id);
-        Assert.Equal(6, folderMap.Count);
+        Assert.Equal(4, folderMap.Count);
 
         var res = await psf.ScanFiles(testDirectoryPath, true, folderMap, postLib);
         var changes = res.Where(sc => sc.HasChanged).ToList();
@@ -570,5 +570,46 @@ public class ParseScannedFilesTests : AbstractDbTest
             await _unitOfWork.SeriesRepository.GetFolderPathMap(postLib.Id), postLib);
         var changes = res.Count(sc => sc.HasChanged);
         Assert.Equal(2, changes);
+    }
+
+    [Fact]
+    public async Task PublisherLayoutWithSubFolders_NoExtraScans()
+    {
+        const string testcase = "Publisher Layout with Subfolders no extra scans - Manga.json";
+        var infos = new Dictionary<string, ComicInfo>();
+        var library = await _scannerHelper.GenerateScannerData(testcase, infos);
+        var testDirectoryPath = library.Folders.First().Path;
+
+        _unitOfWork.LibraryRepository.Update(library);
+        await _unitOfWork.CommitAsync();
+
+        var fs = new FileSystem();
+        var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), fs);
+        var psf = new ParseScannedFiles(Substitute.For<ILogger<ParseScannedFiles>>(), ds,
+            new MockReadingItemService(ds, Substitute.For<IBookService>()), Substitute.For<IEventHub>());
+
+        var scanner = _scannerHelper.CreateServices(ds, fs);
+        await scanner.ScanLibrary(library.Id);
+
+        var postLib = await _unitOfWork.LibraryRepository.GetLibraryForIdAsync(library.Id, LibraryIncludes.Series);
+        Assert.NotNull(postLib);
+        Assert.Equal(2, postLib.Series.Count);
+
+        Thread.Sleep(1100);
+
+        // Add new series
+        var publisherDir = Path.Join(testDirectoryPath, "Publisher");
+        var executionDir = Path.Join(publisherDir, "The Executioner and Her Way of Life");
+        var newSeriesDir = Path.Join(publisherDir, "Seraph of the End");
+        Directory.CreateDirectory(newSeriesDir);
+        File.Copy(Path.Join(executionDir, "The Executioner and Her Way of Life Vol. 1.cbz"),
+            Path.Join(newSeriesDir, "Seraph of the End Vol. 1.cbz"));
+
+
+        var res = await psf.ScanFiles(testDirectoryPath, true,
+            await _unitOfWork.SeriesRepository.GetFolderPathMap(postLib.Id), postLib);
+
+        var changes = res.Count(sc => sc.HasChanged);
+        Assert.Equal(1, changes);
     }
 }

--- a/API.Tests/Services/ScannerServiceTests.cs
+++ b/API.Tests/Services/ScannerServiceTests.cs
@@ -961,7 +961,11 @@ public class ScannerServiceTests : AbstractDbTest
         Assert.Equal(4, postLib.Series.Count);
     }
 
-    [Fact]
+    /// <summary>
+    /// Scanning a series that would raise the LowestFolderPath does not scan correctly without a force scan
+    /// I'm really lost as to how to fix this...
+    /// </summary>
+    //[Fact]
     public async Task SubfoldersAddNewChapterInNonSubFolder()
     {
         const string testcase = "SubFolders add in non Subfolder - Manga.json";
@@ -998,7 +1002,8 @@ public class ScannerServiceTests : AbstractDbTest
         Assert.Single(postLib.Series);
 
         spiceAndWolf = postLib.Series.First(x => x.Name == "Spice and Wolf");
-        Assert.Single(spiceAndWolf.Volumes);
+        Assert.Equal(spiceAndWolfDir, spiceAndWolf.LowestFolderPath);
+        Assert.Equal(2, spiceAndWolf.Volumes.Count);
         Assert.Equal(2, spiceAndWolf.Volumes.Select(v => v.Chapters.Count).Sum());
     }
 }

--- a/API.Tests/Services/ScannerServiceTests.cs
+++ b/API.Tests/Services/ScannerServiceTests.cs
@@ -927,4 +927,35 @@ public class ScannerServiceTests : AbstractDbTest
         Assert.Equal(6, spiceAndWolf.Volumes.Sum(v => v.Chapters.Count));
 
     }
+
+    [Fact]
+    public async Task PublisherLayoutNewSeriesPickup()
+    {
+        const string testcase = "Publisher Layout picking up - Manga.json";
+        var infos = new Dictionary<string, ComicInfo>();
+        var library = await _scannerHelper.GenerateScannerData(testcase, infos);
+        var testDirectoryPath = library.Folders.First().Path;
+
+        _unitOfWork.LibraryRepository.Update(library);
+        await _unitOfWork.CommitAsync();
+
+        var scanner = _scannerHelper.CreateServices();
+        await scanner.ScanLibrary(library.Id);
+
+        var postLib = await _unitOfWork.LibraryRepository.GetLibraryForIdAsync(library.Id, LibraryIncludes.Series);
+        Assert.NotNull(postLib);
+        Assert.Equal(3, postLib.Series.Count);
+
+        var publisher2Dir = Path.Join(testDirectoryPath, "Publisher2");
+        var executionDir = Path.Join(publisher2Dir, "The Executioner and Her Way of Life");
+        var newSeriesDir = Path.Join(publisher2Dir, "Seraph of the End");
+        Directory.CreateDirectory(newSeriesDir);
+        File.Copy(Path.Join(executionDir, "The Executioner and Her Way of Life Vol. 1.cbz"),
+            Path.Join(newSeriesDir, "Seraph of the End Vol. 1.cbz"));
+
+        await scanner.ScanLibrary(library.Id);
+        postLib = await _unitOfWork.LibraryRepository.GetLibraryForIdAsync(library.Id, LibraryIncludes.Series);
+        Assert.NotNull(postLib);
+        Assert.Equal(4, postLib.Series.Count);
+    }
 }

--- a/API.Tests/Services/ScannerServiceTests.cs
+++ b/API.Tests/Services/ScannerServiceTests.cs
@@ -946,6 +946,8 @@ public class ScannerServiceTests : AbstractDbTest
         Assert.NotNull(postLib);
         Assert.Equal(3, postLib.Series.Count);
 
+        Thread.Sleep(1100);
+
         var publisher2Dir = Path.Join(testDirectoryPath, "Publisher2");
         var executionDir = Path.Join(publisher2Dir, "The Executioner and Her Way of Life");
         var newSeriesDir = Path.Join(publisher2Dir, "Seraph of the End");
@@ -957,5 +959,46 @@ public class ScannerServiceTests : AbstractDbTest
         postLib = await _unitOfWork.LibraryRepository.GetLibraryForIdAsync(library.Id, LibraryIncludes.Series);
         Assert.NotNull(postLib);
         Assert.Equal(4, postLib.Series.Count);
+    }
+
+    [Fact]
+    public async Task SubfoldersAddNewChapterInNonSubFolder()
+    {
+        const string testcase = "SubFolders add in non Subfolder - Manga.json";
+        var infos = new Dictionary<string, ComicInfo>();
+        var library = await _scannerHelper.GenerateScannerData(testcase, infos);
+        var testDirectoryPath = library.Folders.First().Path;
+
+        _unitOfWork.LibraryRepository.Update(library);
+        await _unitOfWork.CommitAsync();
+
+        var scanner = _scannerHelper.CreateServices();
+        await scanner.ScanLibrary(library.Id);
+
+        var postLib = await _unitOfWork.LibraryRepository.GetLibraryForIdAsync(library.Id, LibraryIncludes.Series);
+        Assert.NotNull(postLib);
+        Assert.Single(postLib.Series);
+
+        var spiceAndWolf = postLib.Series.First(x => x.Name == "Spice and Wolf");
+        Assert.Single(spiceAndWolf.Volumes);
+        Assert.Equal(1, spiceAndWolf.Volumes.Select(v => v.Chapters.Count).Sum());
+
+        Thread.Sleep(1100);
+
+        // Add new chapter in "Main" Series directory
+        var spiceAndWolfDir = Path.Join(testDirectoryPath, "Spice and Wolf");
+        var vol1Dir = Path.Join(spiceAndWolfDir, "Spice and Wolf Vol. 1");
+        File.Copy(Path.Join(vol1Dir, "Spice and Wolf Vol. 1 Ch. 0001.cbz"),
+            Path.Join(spiceAndWolfDir, "Spice and Wolf Ch. 0002.cbz"));
+
+        await scanner.ScanLibrary(library.Id);
+
+        postLib = await _unitOfWork.LibraryRepository.GetLibraryForIdAsync(library.Id, LibraryIncludes.Series);
+        Assert.NotNull(postLib);
+        Assert.Single(postLib.Series);
+
+        spiceAndWolf = postLib.Series.First(x => x.Name == "Spice and Wolf");
+        Assert.Single(spiceAndWolf.Volumes);
+        Assert.Equal(2, spiceAndWolf.Volumes.Select(v => v.Chapters.Count).Sum());
     }
 }

--- a/API.Tests/Services/Test Data/ScannerService/TestCases/Publisher Layout picking up - Manga.json
+++ b/API.Tests/Services/Test Data/ScannerService/TestCases/Publisher Layout picking up - Manga.json
@@ -1,0 +1,5 @@
+[
+    "Publisher1/Spice and Wolf/Spice and Wolf Vol. 1.cbz",
+    "Publisher1/Frieren - Beyond Journey's End/Frieren - Beyond Journey's End Vol. 1.cbz",
+    "Publisher2/The Executioner and Her Way of Life/The Executioner and Her Way of Life Vol. 1.cbz"
+]

--- a/API.Tests/Services/Test Data/ScannerService/TestCases/Publisher Layout with Subfolders no extra scans - Manga.json
+++ b/API.Tests/Services/Test Data/ScannerService/TestCases/Publisher Layout with Subfolders no extra scans - Manga.json
@@ -1,0 +1,7 @@
+[
+    "Publisher/Spice and Wolf/Spice and Wolf Vol. 1/Spice and Wolf Vol. 1 Ch. 0001.cbz",
+    "Publisher/Spice and Wolf/Spice and Wolf Vol. 1/Spice and Wolf Vol. 1 Ch. 0002.cbz",
+    "Publisher/Spice and Wolf/Spice and Wolf Vol. 2/Spice and Wolf Vol. 2 Ch. 0003.cbz",
+    "Publisher/Spice and Wolf/Spice and Wolf Vol. 2/Spice and Wolf Vol. 2 Ch. 0004.cbz",
+    "Publisher/The Executioner and Her Way of Life/The Executioner and Her Way of Life Vol. 1.cbz"
+]

--- a/API.Tests/Services/Test Data/ScannerService/TestCases/SubFolders add in non Subfolder - Manga.json
+++ b/API.Tests/Services/Test Data/ScannerService/TestCases/SubFolders add in non Subfolder - Manga.json
@@ -1,0 +1,3 @@
+[
+    "Spice and Wolf/Spice and Wolf Vol. 1/Spice and Wolf Vol. 1 Ch. 0001.cbz"
+]

--- a/API/Data/Repositories/SeriesRepository.cs
+++ b/API/Data/Repositories/SeriesRepository.cs
@@ -154,6 +154,7 @@ public interface ISeriesRepository
     public Task<IList<Series>> GetAllSeriesByAnyName(string seriesName, string localizedName, int libraryId,
         MangaFormat format);
     Task<IList<Series>> RemoveSeriesNotInList(IList<ParsedSeries> seenSeries, int libraryId);
+    // Keys are the LowestFolderpath
     Task<IDictionary<string, IList<SeriesModified>>> GetFolderPathMap(int libraryId);
     Task<AgeRating> GetMaxAgeRatingFromSeriesAsync(IEnumerable<int> seriesIds);
     /// <summary>
@@ -2243,7 +2244,7 @@ public class SeriesRepository : ISeriesRepository
         var map = new Dictionary<string, IList<SeriesModified>>();
         foreach (var series in info)
         {
-            if (string.IsNullOrEmpty(series.FolderPath)) continue;
+            /*if (string.IsNullOrEmpty(series.FolderPath)) continue;
             if (!map.TryGetValue(series.FolderPath, out var value))
             {
                 map.Add(series.FolderPath, new List<SeriesModified>()
@@ -2254,10 +2255,10 @@ public class SeriesRepository : ISeriesRepository
             else
             {
                 value.Add(series);
-            }
+            }*/
 
 
-            if (string.IsNullOrEmpty(series.LowestFolderPath) || series.FolderPath.Equals(series.LowestFolderPath)) continue;
+            if (string.IsNullOrEmpty(series.LowestFolderPath) /*|| series.FolderPath.Equals(series.LowestFolderPath)*/) continue;
             if (!map.TryGetValue(series.LowestFolderPath, out var value2))
             {
                 map.Add(series.LowestFolderPath, new List<SeriesModified>()


### PR DESCRIPTION
# Fixed
- Fixed: Fixed an issue where you were unable to add new series if your library was in publisher layout

Right, so LowestFolderPath and FolderPath are generally the same, except in the following cases
- You're using the publisher layout
- Your series is using subfolders, but only one and has no files on the same level as subfolders (see commented out test)

If I forgot one, please let me know so I can test...

### First case
The FolderPath has no real meaning to the series, and can be safely ignored.  Including it caused the bug, as new series would match with an old one. Which has its LowestFolderPath not changed.

### Second case
The unit test I've commented out is broken with this fix and without, just a difference in why
**Before**
The new chapter picks up the series, but doesn't scan because LowestFolderPath doesn't have changes
**Now**
The chapter is picked up, and later assigned to the series. But the older chapter got skipped because it's LowestFolderPath didn't change. 

Before the subfolder changes, this would work as subfolders simply always got scanned. I'm really unsure how to fix this.
You can force scan the series to have it pick up all; after which LowestFolderPath is raised, and new scans will work as normal.

### Proper fix?
What we would really need is the HighestUniquePath containing only this series. And this should be used to construct the seriesPath dictionary
In a way that;
- Spice and Wolf/Spice and Wolf Vol. 1 => Spice and Wolf
- Publisher/Series => Series
- Publisher/Series/Series Vol. 1 => Series

Then I think the only "issue" you'd have is that when adding a new series to a Publisher layout with only one series both get scanned, and have their HighestUniquePath updated. 