### PR TITLE
Revert Subfolder Optimization

### DIFF
--- a/API.Tests/Services/ParseScannedFilesTests.cs
+++ b/API.Tests/Services/ParseScannedFilesTests.cs
@@ -358,7 +358,8 @@ public class ParseScannedFilesTests : AbstractDbTest
 
     #endregion
 
-    [Fact]
+    // TODO: Add back in (removed for Hotfix v0.8.5.x)
+    //[Fact]
     public async Task HasSeriesFolderNotChangedSinceLastScan_AllSeriesFoldersHaveChanges()
     {
         const string testcase = "Subfolders always scanning all series changes - Manga.json";
@@ -452,7 +453,8 @@ public class ParseScannedFilesTests : AbstractDbTest
         Assert.Equal(1, changes);
     }
 
-    [Fact]
+    // TODO: Add back in (removed for Hotfix v0.8.5.x)
+    //[Fact]
     public async Task SubFoldersNoSubFolders_SkipAll()
     {
         const string testcase = "Subfolders and files at root - Manga.json";


### PR DESCRIPTION
# Changed
- Changed: Revert all optimizations around subfolder scanning. This will be taken care of with the larger work in v0.8.6. (Reopens #3557)
