### PR TITLE
[skip ci] Fix unit tests on macOS (And probably Unix)

### DIFF
--- a/API.Tests/AbstractDbTest.cs
+++ b/API.Tests/AbstractDbTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data.Common;
+using System.IO;
 using System.IO.Abstractions.TestingHelpers;
 using System.Linq;
 using System.Threading.Tasks;
@@ -29,15 +30,16 @@ public abstract class AbstractDbTest : IDisposable
     protected readonly IMapper _mapper;
 
 
-    protected const string CacheDirectory = "C:/kavita/config/cache/";
-    protected const string CacheLongDirectory = "C:/kavita/config/cache-long/";
-    protected const string CoverImageDirectory = "C:/kavita/config/covers/";
-    protected const string BackupDirectory = "C:/kavita/config/backups/";
-    protected const string LogDirectory = "C:/kavita/config/logs/";
-    protected const string BookmarkDirectory = "C:/kavita/config/bookmarks/";
-    protected const string SiteThemeDirectory = "C:/kavita/config/themes/";
-    protected const string TempDirectory = "C:/kavita/config/temp/";
-    protected const string DataDirectory = "C:/data/";
+    protected static readonly string Root = Path.GetPathRoot(Directory.GetCurrentDirectory());
+    protected static readonly string CacheDirectory = Root + "kavita/config/cache/";
+    protected static readonly string CacheLongDirectory = Root + "kavita/config/cache-long/";
+    protected static readonly string CoverImageDirectory = Root + "kavita/config/covers/";
+    protected static readonly string BackupDirectory = Root + "kavita/config/backups/";
+    protected static readonly string LogDirectory = Root + "kavita/config/logs/";
+    protected static readonly string BookmarkDirectory = Root + "kavita/config/bookmarks/";
+    protected static readonly string SiteThemeDirectory = Root + "kavita/config/themes/";
+    protected static readonly string TempDirectory = Root + "kavita/config/temp/";
+    protected static readonly string DataDirectory = Root + "data/";
 
     protected AbstractDbTest()
     {
@@ -116,8 +118,8 @@ public abstract class AbstractDbTest : IDisposable
     protected static MockFileSystem CreateFileSystem()
     {
         var fileSystem = new MockFileSystem();
-        fileSystem.Directory.SetCurrentDirectory("C:/kavita/");
-        fileSystem.AddDirectory("C:/kavita/config/");
+        fileSystem.Directory.SetCurrentDirectory(Root + "kavita/");
+        fileSystem.AddDirectory(Root + "kavita/config/");
         fileSystem.AddDirectory(CacheDirectory);
         fileSystem.AddDirectory(CacheLongDirectory);
         fileSystem.AddDirectory(CoverImageDirectory);

--- a/API.Tests/AbstractDbTest.cs
+++ b/API.Tests/AbstractDbTest.cs
@@ -22,24 +22,12 @@ using NSubstitute;
 
 namespace API.Tests;
 
-public abstract class AbstractDbTest : IDisposable
+public abstract class AbstractDbTest : AbstractFsTest , IDisposable
 {
     protected readonly DbConnection _connection;
     protected readonly DataContext _context;
     protected readonly IUnitOfWork _unitOfWork;
     protected readonly IMapper _mapper;
-
-
-    protected static readonly string Root = Path.GetPathRoot(Directory.GetCurrentDirectory());
-    protected static readonly string CacheDirectory = Root + "kavita/config/cache/";
-    protected static readonly string CacheLongDirectory = Root + "kavita/config/cache-long/";
-    protected static readonly string CoverImageDirectory = Root + "kavita/config/covers/";
-    protected static readonly string BackupDirectory = Root + "kavita/config/backups/";
-    protected static readonly string LogDirectory = Root + "kavita/config/logs/";
-    protected static readonly string BookmarkDirectory = Root + "kavita/config/bookmarks/";
-    protected static readonly string SiteThemeDirectory = Root + "kavita/config/themes/";
-    protected static readonly string TempDirectory = Root + "kavita/config/temp/";
-    protected static readonly string DataDirectory = Root + "data/";
 
     protected AbstractDbTest()
     {
@@ -114,24 +102,6 @@ public abstract class AbstractDbTest : IDisposable
     }
 
     protected abstract Task ResetDb();
-
-    protected static MockFileSystem CreateFileSystem()
-    {
-        var fileSystem = new MockFileSystem();
-        fileSystem.Directory.SetCurrentDirectory(Root + "kavita/");
-        fileSystem.AddDirectory(Root + "kavita/config/");
-        fileSystem.AddDirectory(CacheDirectory);
-        fileSystem.AddDirectory(CacheLongDirectory);
-        fileSystem.AddDirectory(CoverImageDirectory);
-        fileSystem.AddDirectory(BackupDirectory);
-        fileSystem.AddDirectory(BookmarkDirectory);
-        fileSystem.AddDirectory(SiteThemeDirectory);
-        fileSystem.AddDirectory(LogDirectory);
-        fileSystem.AddDirectory(TempDirectory);
-        fileSystem.AddDirectory(DataDirectory);
-
-        return fileSystem;
-    }
 
     public void Dispose()
     {

--- a/API.Tests/AbstractFsTest.cs
+++ b/API.Tests/AbstractFsTest.cs
@@ -2,13 +2,14 @@
 
 using System.IO;
 using System.IO.Abstractions.TestingHelpers;
+using API.Services.Tasks.Scanner.Parser;
 
 namespace API.Tests;
 
 public abstract class AbstractFsTest
 {
 
-    protected static readonly string Root = Path.GetPathRoot(Directory.GetCurrentDirectory());
+    protected static readonly string Root = Parser.NormalizePath(Path.GetPathRoot(Directory.GetCurrentDirectory()));
     protected static readonly string ConfigDirectory = Root + "kavita/config/";
     protected static readonly string CacheDirectory = ConfigDirectory + "cache/";
     protected static readonly string CacheLongDirectory = ConfigDirectory + "cache-long/";

--- a/API.Tests/AbstractFsTest.cs
+++ b/API.Tests/AbstractFsTest.cs
@@ -1,0 +1,42 @@
+
+
+using System.IO;
+using System.IO.Abstractions.TestingHelpers;
+
+namespace API.Tests;
+
+public abstract class AbstractFsTest
+{
+
+    protected static readonly string Root = Path.GetPathRoot(Directory.GetCurrentDirectory());
+    protected static readonly string ConfigDirectory = Root + "kavita/config/";
+    protected static readonly string CacheDirectory = ConfigDirectory + "cache/";
+    protected static readonly string CacheLongDirectory = ConfigDirectory + "cache-long/";
+    protected static readonly string CoverImageDirectory = ConfigDirectory + "covers/";
+    protected static readonly string BackupDirectory = ConfigDirectory + "backups/";
+    protected static readonly string LogDirectory = ConfigDirectory + "logs/";
+    protected static readonly string BookmarkDirectory = ConfigDirectory + "bookmarks/";
+    protected static readonly string SiteThemeDirectory = ConfigDirectory + "themes/";
+    protected static readonly string TempDirectory = ConfigDirectory + "temp/";
+    protected static readonly string ThemesDirectory = ConfigDirectory + "theme";
+    protected static readonly string DataDirectory = Root + "data/";
+
+    protected static MockFileSystem CreateFileSystem()
+    {
+        var fileSystem = new MockFileSystem();
+        fileSystem.Directory.SetCurrentDirectory(Root + "kavita/");
+        fileSystem.AddDirectory(Root + "kavita/config/");
+        fileSystem.AddDirectory(CacheDirectory);
+        fileSystem.AddDirectory(CacheLongDirectory);
+        fileSystem.AddDirectory(CoverImageDirectory);
+        fileSystem.AddDirectory(BackupDirectory);
+        fileSystem.AddDirectory(BookmarkDirectory);
+        fileSystem.AddDirectory(SiteThemeDirectory);
+        fileSystem.AddDirectory(LogDirectory);
+        fileSystem.AddDirectory(TempDirectory);
+        fileSystem.AddDirectory(DataDirectory);
+        fileSystem.AddDirectory(ThemesDirectory);
+
+        return fileSystem;
+    }
+}

--- a/API.Tests/Helpers/CacheHelperTests.cs
+++ b/API.Tests/Helpers/CacheHelperTests.cs
@@ -14,7 +14,7 @@ namespace API.Tests.Helpers;
 
 public class CacheHelperTests: AbstractFsTest
 {
-    private static readonly string TestCoverImageDirectory = Path.GetPathRoot(Directory.GetCurrentDirectory());
+    private static readonly string TestCoverImageDirectory = Root;
     private const string TestCoverImageFile = "thumbnail.jpg";
     private readonly string _testCoverPath = Path.Join(TestCoverImageDirectory, TestCoverImageFile);
     private const string TestCoverArchive = @"file in folder.zip";
@@ -38,7 +38,6 @@ public class CacheHelperTests: AbstractFsTest
 
     [Theory]
     [InlineData("", false)]
-    [InlineData("C:/", false)]
     [InlineData(null, false)]
     public void CoverImageExists_DoesFileExist(string coverImage, bool exists)
     {
@@ -46,16 +45,22 @@ public class CacheHelperTests: AbstractFsTest
     }
 
     [Fact]
+    public void CoverImageExists_DoesFileExistRoot()
+    {
+        Assert.False(_cacheHelper.CoverImageExists(Root));
+    }
+
+    [Fact]
     public void CoverImageExists_FileExists()
     {
-        Assert.True(_cacheHelper.CoverImageExists(TestCoverArchive));
+        Assert.True(_cacheHelper.CoverImageExists(Path.Join(TestCoverImageDirectory, TestCoverArchive)));
     }
 
     [Fact]
     public void ShouldUpdateCoverImage_OnFirstRun()
     {
 
-        var file = new MangaFileBuilder(TestCoverArchive, MangaFormat.Archive)
+        var file = new MangaFileBuilder(Path.Join(TestCoverImageDirectory, TestCoverArchive), MangaFormat.Archive)
             .WithLastModified(DateTime.Now)
             .Build();
         Assert.True(_cacheHelper.ShouldUpdateCoverImage(null, file, DateTime.Now.Subtract(TimeSpan.FromMinutes(1)),
@@ -66,7 +71,7 @@ public class CacheHelperTests: AbstractFsTest
     public void ShouldUpdateCoverImage_ShouldNotUpdateOnSecondRunWithCoverImageSetNotLocked()
     {
         // Represents first run
-        var file = new MangaFileBuilder(TestCoverArchive, MangaFormat.Archive)
+        var file = new MangaFileBuilder(Path.Join(TestCoverImageDirectory, TestCoverArchive), MangaFormat.Archive)
             .WithLastModified(DateTime.Now)
             .Build();
         Assert.False(_cacheHelper.ShouldUpdateCoverImage(_testCoverPath, file, DateTime.Now.Subtract(TimeSpan.FromMinutes(1)),
@@ -77,7 +82,7 @@ public class CacheHelperTests: AbstractFsTest
     public void ShouldUpdateCoverImage_ShouldNotUpdateOnSecondRunWithCoverImageSetNotLocked_2()
     {
         // Represents first run
-        var file = new MangaFileBuilder(TestCoverArchive, MangaFormat.Archive)
+        var file = new MangaFileBuilder(Path.Join(TestCoverImageDirectory, TestCoverArchive), MangaFormat.Archive)
             .WithLastModified(DateTime.Now)
             .Build();
         Assert.False(_cacheHelper.ShouldUpdateCoverImage(_testCoverPath, file, DateTime.Now,
@@ -88,7 +93,7 @@ public class CacheHelperTests: AbstractFsTest
     public void ShouldUpdateCoverImage_ShouldNotUpdateOnSecondRunWithCoverImageSetLocked()
     {
         // Represents first run
-        var file = new MangaFileBuilder(TestCoverArchive, MangaFormat.Archive)
+        var file = new MangaFileBuilder(Path.Join(TestCoverImageDirectory, TestCoverArchive), MangaFormat.Archive)
             .WithLastModified(DateTime.Now)
             .Build();
         Assert.False(_cacheHelper.ShouldUpdateCoverImage(_testCoverPath, file, DateTime.Now.Subtract(TimeSpan.FromMinutes(1)),
@@ -99,7 +104,7 @@ public class CacheHelperTests: AbstractFsTest
     public void ShouldUpdateCoverImage_ShouldNotUpdateOnSecondRunWithCoverImageSetLocked_Modified()
     {
         // Represents first run
-        var file = new MangaFileBuilder(TestCoverArchive, MangaFormat.Archive)
+        var file = new MangaFileBuilder(Path.Join(TestCoverImageDirectory, TestCoverArchive), MangaFormat.Archive)
             .WithLastModified(DateTime.Now)
             .Build();
         Assert.False(_cacheHelper.ShouldUpdateCoverImage(_testCoverPath, file, DateTime.Now.Subtract(TimeSpan.FromMinutes(1)),
@@ -123,7 +128,7 @@ public class CacheHelperTests: AbstractFsTest
         var cacheHelper = new CacheHelper(fileService);
 
         var created = DateTime.Now.Subtract(TimeSpan.FromHours(1));
-        var file = new MangaFileBuilder(TestCoverArchive, MangaFormat.Archive)
+        var file = new MangaFileBuilder(Path.Join(TestCoverImageDirectory, TestCoverArchive), MangaFormat.Archive)
             .WithLastModified(DateTime.Now.Subtract(TimeSpan.FromMinutes(1)))
             .Build();
 
@@ -153,7 +158,7 @@ public class CacheHelperTests: AbstractFsTest
             .WithCreated(now.DateTime)
             .Build();
 
-        var file = new MangaFileBuilder(TestCoverArchive, MangaFormat.Archive)
+        var file = new MangaFileBuilder(Path.Join(TestCoverImageDirectory, TestCoverArchive), MangaFormat.Archive)
             .WithLastModified(now.DateTime)
             .Build();
         Assert.True(cacheHelper.IsFileUnmodifiedSinceCreationOrLastScan(chapter, false, file));
@@ -181,7 +186,7 @@ public class CacheHelperTests: AbstractFsTest
             .WithCreated(now.DateTime)
             .Build();
 
-        var file = new MangaFileBuilder(TestCoverArchive, MangaFormat.Archive)
+        var file = new MangaFileBuilder(Path.Join(TestCoverImageDirectory, TestCoverArchive), MangaFormat.Archive)
             .WithLastModified(now.DateTime)
             .Build();
 
@@ -191,9 +196,10 @@ public class CacheHelperTests: AbstractFsTest
     [Fact]
     public void HasFileNotChangedSinceCreationOrLastScan_NotChangedSinceLastModified_ForceUpdate()
     {
+        var now = DateTimeOffset.Now;
         var filesystemFile = new MockFileData("")
         {
-            LastWriteTime = DateTimeOffset.Now
+            LastWriteTime = now.DateTime,
         };
         var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
         {
@@ -205,12 +211,12 @@ public class CacheHelperTests: AbstractFsTest
         var cacheHelper = new CacheHelper(fileService);
 
         var chapter = new ChapterBuilder("1")
-            .WithLastModified(filesystemFile.LastWriteTime.DateTime)
-            .WithCreated(filesystemFile.LastWriteTime.DateTime)
+            .WithLastModified(now.DateTime)
+            .WithCreated(now.DateTime)
             .Build();
 
-        var file = new MangaFileBuilder(TestCoverArchive, MangaFormat.Archive)
-            .WithLastModified(filesystemFile.LastWriteTime.DateTime)
+        var file = new MangaFileBuilder(Path.Join(TestCoverImageDirectory, TestCoverArchive), MangaFormat.Archive)
+            .WithLastModified(now.DateTime)
             .Build();
         Assert.False(cacheHelper.IsFileUnmodifiedSinceCreationOrLastScan(chapter, true, file));
     }
@@ -218,10 +224,11 @@ public class CacheHelperTests: AbstractFsTest
     [Fact]
     public void IsFileUnmodifiedSinceCreationOrLastScan_ModifiedSinceLastScan()
     {
+        var now = DateTimeOffset.Now;
         var filesystemFile = new MockFileData("")
         {
-            LastWriteTime = DateTimeOffset.Now,
-            CreationTime = DateTimeOffset.Now
+            LastWriteTime = now.DateTime,
+            CreationTime = now.DateTime
         };
         var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
         {
@@ -237,8 +244,8 @@ public class CacheHelperTests: AbstractFsTest
             .WithCreated(DateTime.Now.Subtract(TimeSpan.FromMinutes(10)))
             .Build();
 
-        var file = new MangaFileBuilder(TestCoverArchive, MangaFormat.Archive)
-            .WithLastModified(filesystemFile.LastWriteTime.DateTime)
+        var file = new MangaFileBuilder(Path.Join(TestCoverImageDirectory, TestCoverArchive), MangaFormat.Archive)
+            .WithLastModified(now.DateTime)
             .Build();
         Assert.False(cacheHelper.IsFileUnmodifiedSinceCreationOrLastScan(chapter, false, file));
     }
@@ -246,9 +253,10 @@ public class CacheHelperTests: AbstractFsTest
     [Fact]
     public void HasFileNotChangedSinceCreationOrLastScan_ModifiedSinceLastScan_ButLastModifiedSame()
     {
+        var now = DateTimeOffset.Now;
         var filesystemFile = new MockFileData("")
         {
-            LastWriteTime = DateTimeOffset.Now
+            LastWriteTime =now.DateTime
         };
         var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
         {
@@ -265,7 +273,7 @@ public class CacheHelperTests: AbstractFsTest
             .Build();
 
         var file = new MangaFileBuilder(Path.Join(TestCoverImageDirectory, TestCoverArchive), MangaFormat.Archive)
-            .WithLastModified(filesystemFile.LastWriteTime.DateTime)
+            .WithLastModified(now.DateTime)
             .Build();
 
         Assert.False(cacheHelper.IsFileUnmodifiedSinceCreationOrLastScan(chapter, false, file));

--- a/API.Tests/Helpers/CacheHelperTests.cs
+++ b/API.Tests/Helpers/CacheHelperTests.cs
@@ -14,7 +14,7 @@ namespace API.Tests.Helpers;
 
 public class CacheHelperTests: AbstractFsTest
 {
-    private static readonly string TestCoverImageDirectory = Root;
+    private static readonly string TestCoverImageDirectory = Path.GetPathRoot(Directory.GetCurrentDirectory());
     private const string TestCoverImageFile = "thumbnail.jpg";
     private readonly string _testCoverPath = Path.Join(TestCoverImageDirectory, TestCoverImageFile);
     private const string TestCoverArchive = @"file in folder.zip";

--- a/API.Tests/Helpers/CacheHelperTests.cs
+++ b/API.Tests/Helpers/CacheHelperTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Abstractions.TestingHelpers;
+using System.Threading;
 using API.Entities;
 using API.Entities.Enums;
 using API.Helpers;
@@ -13,7 +14,7 @@ namespace API.Tests.Helpers;
 
 public class CacheHelperTests
 {
-    private const string TestCoverImageDirectory = @"c:\";
+    private static readonly string TestCoverImageDirectory = Path.GetPathRoot(Directory.GetCurrentDirectory());
     private const string TestCoverImageFile = "thumbnail.jpg";
     private readonly string _testCoverPath = Path.Join(TestCoverImageDirectory, TestCoverImageFile);
     private const string TestCoverArchive = @"file in folder.zip";
@@ -133,9 +134,10 @@ public class CacheHelperTests
     [Fact]
     public void HasFileNotChangedSinceCreationOrLastScan_NotChangedSinceCreated()
     {
+        var now = DateTimeOffset.Now;
         var filesystemFile = new MockFileData("")
         {
-            LastWriteTime = DateTimeOffset.Now
+            LastWriteTime =now,
         };
         var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
         {
@@ -147,12 +149,12 @@ public class CacheHelperTests
         var cacheHelper = new CacheHelper(fileService);
 
         var chapter = new ChapterBuilder("1")
-            .WithLastModified(filesystemFile.LastWriteTime.DateTime)
-            .WithCreated(filesystemFile.LastWriteTime.DateTime)
+            .WithLastModified(now.DateTime)
+            .WithCreated(now.DateTime)
             .Build();
 
         var file = new MangaFileBuilder(TestCoverArchive, MangaFormat.Archive)
-            .WithLastModified(filesystemFile.LastWriteTime.DateTime)
+            .WithLastModified(now.DateTime)
             .Build();
         Assert.True(cacheHelper.IsFileUnmodifiedSinceCreationOrLastScan(chapter, false, file));
     }
@@ -160,9 +162,10 @@ public class CacheHelperTests
     [Fact]
     public void HasFileNotChangedSinceCreationOrLastScan_NotChangedSinceLastModified()
     {
+        var now = DateTimeOffset.Now;
         var filesystemFile = new MockFileData("")
         {
-            LastWriteTime = DateTimeOffset.Now
+            LastWriteTime = now,
         };
         var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
         {
@@ -174,12 +177,12 @@ public class CacheHelperTests
         var cacheHelper = new CacheHelper(fileService);
 
         var chapter = new ChapterBuilder("1")
-            .WithLastModified(filesystemFile.LastWriteTime.DateTime)
-            .WithCreated(filesystemFile.LastWriteTime.DateTime)
+            .WithLastModified(now.DateTime)
+            .WithCreated(now.DateTime)
             .Build();
 
         var file = new MangaFileBuilder(TestCoverArchive, MangaFormat.Archive)
-            .WithLastModified(filesystemFile.LastWriteTime.DateTime)
+            .WithLastModified(now.DateTime)
             .Build();
 
         Assert.True(cacheHelper.IsFileUnmodifiedSinceCreationOrLastScan(chapter, false, file));

--- a/API.Tests/Helpers/CacheHelperTests.cs
+++ b/API.Tests/Helpers/CacheHelperTests.cs
@@ -12,9 +12,9 @@ using Xunit;
 
 namespace API.Tests.Helpers;
 
-public class CacheHelperTests
+public class CacheHelperTests: AbstractFsTest
 {
-    private static readonly string TestCoverImageDirectory = Path.GetPathRoot(Directory.GetCurrentDirectory());
+    private static readonly string TestCoverImageDirectory = Root;
     private const string TestCoverImageFile = "thumbnail.jpg";
     private readonly string _testCoverPath = Path.Join(TestCoverImageDirectory, TestCoverImageFile);
     private const string TestCoverArchive = @"file in folder.zip";

--- a/API.Tests/Parsing/ParsingTests.cs
+++ b/API.Tests/Parsing/ParsingTests.cs
@@ -11,8 +11,12 @@ public class ParsingTests
     [Fact]
     public void ShouldWork()
     {
-        var s = 6.5f + "";
+        var s = 6.5f.ToString(CultureInfo.InvariantCulture);
         var a = float.Parse(s, CultureInfo.InvariantCulture);
+        Assert.Equal(6.5f, a);
+
+        s = 6.5f + "";
+        a = float.Parse(s, CultureInfo.CurrentCulture);
         Assert.Equal(6.5f, a);
     }
 

--- a/API.Tests/Services/BackupServiceTests.cs
+++ b/API.Tests/Services/BackupServiceTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Data.Common;
+using System.IO;
 using System.IO.Abstractions.TestingHelpers;
 using System.Linq;
 using System.Threading.Tasks;
@@ -31,13 +32,14 @@ public class BackupServiceTests
     private readonly DbConnection _connection;
     private readonly DataContext _context;
 
-    private const string CacheDirectory = "C:/kavita/config/cache/";
-    private const string CoverImageDirectory = "C:/kavita/config/covers/";
-    private const string BackupDirectory = "C:/kavita/config/backups/";
-    private const string LogDirectory = "C:/kavita/config/logs/";
-    private const string ConfigDirectory = "C:/kavita/config/";
-    private const string BookmarkDirectory = "C:/kavita/config/bookmarks";
-    private const string ThemesDirectory = "C:/kavita/config/theme";
+    private static readonly string Root = Path.GetPathRoot(Directory.GetCurrentDirectory());
+    private static readonly string CacheDirectory = Root + "kavita/config/cache/";
+    private static readonly string CoverImageDirectory = Root + "kavita/config/covers/";
+    private static readonly string BackupDirectory = Root + "kavita/config/backups/";
+    private static readonly string LogDirectory = Root + "kavita/config/logs/";
+    private static readonly string ConfigDirectory = Root + "kavita/config/";
+    private static readonly string BookmarkDirectory = Root + "kavita/config/bookmarks";
+    private static readonly string ThemesDirectory = Root + "kavita/config/theme";
 
     public BackupServiceTests()
     {
@@ -82,7 +84,7 @@ public class BackupServiceTests
 
         _context.ServerSetting.Update(setting);
         _context.Library.Add(new LibraryBuilder("Manga")
-            .WithFolderPath(new FolderPathBuilder("C:/data/").Build())
+            .WithFolderPath(new FolderPathBuilder(Root + "data/").Build())
             .Build());
         return await _context.SaveChangesAsync() > 0;
     }
@@ -97,15 +99,15 @@ public class BackupServiceTests
     private static MockFileSystem CreateFileSystem()
     {
         var fileSystem = new MockFileSystem();
-        fileSystem.Directory.SetCurrentDirectory("C:/kavita/");
-        fileSystem.AddDirectory("C:/kavita/config/");
+        fileSystem.Directory.SetCurrentDirectory(Root + "kavita/");
+        fileSystem.AddDirectory(Root + "kavita/config/");
         fileSystem.AddDirectory(CacheDirectory);
         fileSystem.AddDirectory(CoverImageDirectory);
         fileSystem.AddDirectory(BackupDirectory);
         fileSystem.AddDirectory(LogDirectory);
         fileSystem.AddDirectory(ThemesDirectory);
         fileSystem.AddDirectory(BookmarkDirectory);
-        fileSystem.AddDirectory("C:/data/");
+        fileSystem.AddDirectory(Root + "data/");
 
         return fileSystem;
     }

--- a/API.Tests/Services/BackupServiceTests.cs
+++ b/API.Tests/Services/BackupServiceTests.cs
@@ -22,7 +22,7 @@ using Xunit;
 
 namespace API.Tests.Services;
 
-public class BackupServiceTests
+public class BackupServiceTests: AbstractFsTest
 {
     private readonly ILogger<BackupService> _logger = Substitute.For<ILogger<BackupService>>();
     private readonly IUnitOfWork _unitOfWork;
@@ -32,14 +32,6 @@ public class BackupServiceTests
     private readonly DbConnection _connection;
     private readonly DataContext _context;
 
-    private static readonly string Root = Path.GetPathRoot(Directory.GetCurrentDirectory());
-    private static readonly string CacheDirectory = Root + "kavita/config/cache/";
-    private static readonly string CoverImageDirectory = Root + "kavita/config/covers/";
-    private static readonly string BackupDirectory = Root + "kavita/config/backups/";
-    private static readonly string LogDirectory = Root + "kavita/config/logs/";
-    private static readonly string ConfigDirectory = Root + "kavita/config/";
-    private static readonly string BookmarkDirectory = Root + "kavita/config/bookmarks";
-    private static readonly string ThemesDirectory = Root + "kavita/config/theme";
 
     public BackupServiceTests()
     {
@@ -94,22 +86,6 @@ public class BackupServiceTests
         _context.Series.RemoveRange(_context.Series.ToList());
 
         await _context.SaveChangesAsync();
-    }
-
-    private static MockFileSystem CreateFileSystem()
-    {
-        var fileSystem = new MockFileSystem();
-        fileSystem.Directory.SetCurrentDirectory(Root + "kavita/");
-        fileSystem.AddDirectory(Root + "kavita/config/");
-        fileSystem.AddDirectory(CacheDirectory);
-        fileSystem.AddDirectory(CoverImageDirectory);
-        fileSystem.AddDirectory(BackupDirectory);
-        fileSystem.AddDirectory(LogDirectory);
-        fileSystem.AddDirectory(ThemesDirectory);
-        fileSystem.AddDirectory(BookmarkDirectory);
-        fileSystem.AddDirectory(Root + "data/");
-
-        return fileSystem;
     }
 
     #endregion

--- a/API.Tests/Services/BookmarkServiceTests.cs
+++ b/API.Tests/Services/BookmarkServiceTests.cs
@@ -25,17 +25,11 @@ using Xunit;
 
 namespace API.Tests.Services;
 
-public class BookmarkServiceTests
+public class BookmarkServiceTests: AbstractFsTest
 {
     private readonly IUnitOfWork _unitOfWork;
     private readonly DbConnection _connection;
     private readonly DataContext _context;
-
-    private static readonly string Root = Path.GetPathRoot(Directory.GetCurrentDirectory());
-    private static readonly string CacheDirectory = Root + "kavita/config/cache/";
-    private static readonly string CoverImageDirectory = Root + "kavita/config/covers/";
-    private static readonly string BackupDirectory = Root + "kavita/config/backups/";
-    private static readonly string BookmarkDirectory = Root + "kavita/config/bookmarks/";
 
 
     public BookmarkServiceTests()
@@ -101,20 +95,6 @@ Substitute.For<IMediaConversionService>());
         _context.AppUserBookmark.RemoveRange(_context.AppUserBookmark.ToList());
 
         await _context.SaveChangesAsync();
-    }
-
-    private static MockFileSystem CreateFileSystem()
-    {
-        var fileSystem = new MockFileSystem();
-        fileSystem.Directory.SetCurrentDirectory(Root + "kavita/");
-        fileSystem.AddDirectory(Root + "kavita/config/");
-        fileSystem.AddDirectory(CacheDirectory);
-        fileSystem.AddDirectory(CoverImageDirectory);
-        fileSystem.AddDirectory(BackupDirectory);
-        fileSystem.AddDirectory(BookmarkDirectory);
-        fileSystem.AddDirectory(Root + "data/");
-
-        return fileSystem;
     }
 
     #endregion

--- a/API.Tests/Services/BookmarkServiceTests.cs
+++ b/API.Tests/Services/BookmarkServiceTests.cs
@@ -31,10 +31,11 @@ public class BookmarkServiceTests
     private readonly DbConnection _connection;
     private readonly DataContext _context;
 
-    private const string CacheDirectory = "C:/kavita/config/cache/";
-    private const string CoverImageDirectory = "C:/kavita/config/covers/";
-    private const string BackupDirectory = "C:/kavita/config/backups/";
-    private const string BookmarkDirectory = "C:/kavita/config/bookmarks/";
+    private static readonly string Root = Path.GetPathRoot(Directory.GetCurrentDirectory());
+    private static readonly string CacheDirectory = Root + "kavita/config/cache/";
+    private static readonly string CoverImageDirectory = Root + "kavita/config/covers/";
+    private static readonly string BackupDirectory = Root + "kavita/config/backups/";
+    private static readonly string BookmarkDirectory = Root + "kavita/config/bookmarks/";
 
 
     public BookmarkServiceTests()
@@ -88,7 +89,7 @@ Substitute.For<IMediaConversionService>());
         _context.ServerSetting.Update(setting);
 
         _context.Library.Add(new LibraryBuilder("Manga")
-            .WithFolderPath(new FolderPathBuilder("C:/data/").Build())
+            .WithFolderPath(new FolderPathBuilder(Root + "data/").Build())
             .Build());
         return await _context.SaveChangesAsync() > 0;
     }
@@ -105,13 +106,13 @@ Substitute.For<IMediaConversionService>());
     private static MockFileSystem CreateFileSystem()
     {
         var fileSystem = new MockFileSystem();
-        fileSystem.Directory.SetCurrentDirectory("C:/kavita/");
-        fileSystem.AddDirectory("C:/kavita/config/");
+        fileSystem.Directory.SetCurrentDirectory(Root + "kavita/");
+        fileSystem.AddDirectory(Root + "kavita/config/");
         fileSystem.AddDirectory(CacheDirectory);
         fileSystem.AddDirectory(CoverImageDirectory);
         fileSystem.AddDirectory(BackupDirectory);
         fileSystem.AddDirectory(BookmarkDirectory);
-        fileSystem.AddDirectory("C:/data/");
+        fileSystem.AddDirectory(Root + "data/");
 
         return fileSystem;
     }

--- a/API.Tests/Services/CacheServiceTests.cs
+++ b/API.Tests/Services/CacheServiceTests.cs
@@ -71,10 +71,11 @@ public class CacheServiceTests
     private readonly DbConnection _connection;
     private readonly DataContext _context;
 
-    private const string CacheDirectory = "C:/kavita/config/cache/";
-    private const string CoverImageDirectory = "C:/kavita/config/covers/";
-    private const string BackupDirectory = "C:/kavita/config/backups/";
-    private const string DataDirectory = "C:/data/";
+    private static readonly string Root = Path.GetPathRoot(Directory.GetCurrentDirectory());
+    private static readonly string CacheDirectory = Root + "kavita/config/cache/";
+    private static readonly string CoverImageDirectory = Root + "kavita/config/covers/";
+    private static readonly string BackupDirectory = Root + "kavita/config/backups/";
+    private static readonly string DataDirectory = Root + "kavita/data/";
 
     public CacheServiceTests()
     {
@@ -118,7 +119,7 @@ public class CacheServiceTests
         _context.ServerSetting.Update(setting);
 
         _context.Library.Add(new LibraryBuilder("Manga")
-            .WithFolderPath(new FolderPathBuilder("C:/data/").Build())
+            .WithFolderPath(new FolderPathBuilder(Root + "data/").Build())
             .Build());
         return await _context.SaveChangesAsync() > 0;
     }
@@ -133,8 +134,8 @@ public class CacheServiceTests
     private static MockFileSystem CreateFileSystem()
     {
         var fileSystem = new MockFileSystem();
-        fileSystem.Directory.SetCurrentDirectory("C:/kavita/");
-        fileSystem.AddDirectory("C:/kavita/config/");
+        fileSystem.Directory.SetCurrentDirectory(Root + "kavita/");
+        fileSystem.AddDirectory(Root + "kavita/config/");
         fileSystem.AddDirectory(CacheDirectory);
         fileSystem.AddDirectory(CoverImageDirectory);
         fileSystem.AddDirectory(BackupDirectory);

--- a/API.Tests/Services/CacheServiceTests.cs
+++ b/API.Tests/Services/CacheServiceTests.cs
@@ -62,7 +62,7 @@ internal class MockReadingItemServiceForCacheService : IReadingItemService
         throw new System.NotImplementedException();
     }
 }
-public class CacheServiceTests
+public class CacheServiceTests: AbstractFsTest
 {
     private readonly ILogger<CacheService> _logger = Substitute.For<ILogger<CacheService>>();
     private readonly IUnitOfWork _unitOfWork;
@@ -70,12 +70,6 @@ public class CacheServiceTests
 
     private readonly DbConnection _connection;
     private readonly DataContext _context;
-
-    private static readonly string Root = Path.GetPathRoot(Directory.GetCurrentDirectory());
-    private static readonly string CacheDirectory = Root + "kavita/config/cache/";
-    private static readonly string CoverImageDirectory = Root + "kavita/config/covers/";
-    private static readonly string BackupDirectory = Root + "kavita/config/backups/";
-    private static readonly string DataDirectory = Root + "kavita/data/";
 
     public CacheServiceTests()
     {
@@ -129,19 +123,6 @@ public class CacheServiceTests
         _context.Series.RemoveRange(_context.Series.ToList());
 
         await _context.SaveChangesAsync();
-    }
-
-    private static MockFileSystem CreateFileSystem()
-    {
-        var fileSystem = new MockFileSystem();
-        fileSystem.Directory.SetCurrentDirectory(Root + "kavita/");
-        fileSystem.AddDirectory(Root + "kavita/config/");
-        fileSystem.AddDirectory(CacheDirectory);
-        fileSystem.AddDirectory(CoverImageDirectory);
-        fileSystem.AddDirectory(BackupDirectory);
-        fileSystem.AddDirectory(DataDirectory);
-
-        return fileSystem;
     }
 
     #endregion
@@ -264,7 +245,7 @@ public class CacheServiceTests
             .WithFile(new MangaFileBuilder($"{DataDirectory}2.epub", MangaFormat.Epub).Build())
             .Build();
         cs.GetCachedFile(c);
-        Assert.Same($"{DataDirectory}1.epub", cs.GetCachedFile(c));
+        Assert.Equal($"{DataDirectory}1.epub", cs.GetCachedFile(c));
     }
 
     #endregion

--- a/API.Tests/Services/CleanupServiceTests.cs
+++ b/API.Tests/Services/CleanupServiceTests.cs
@@ -29,12 +29,12 @@ public class CleanupServiceTests : AbstractDbTest
     private readonly ILogger<CleanupService> _logger = Substitute.For<ILogger<CleanupService>>();
     private readonly IEventHub _messageHub = Substitute.For<IEventHub>();
     private readonly IReaderService _readerService;
-
+    private static readonly string Root = Path.GetPathRoot(Directory.GetCurrentDirectory());
 
     public CleanupServiceTests() : base()
     {
         _context.Library.Add(new LibraryBuilder("Manga")
-            .WithFolderPath(new FolderPathBuilder("C:/data/").Build())
+            .WithFolderPath(new FolderPathBuilder(Root + "data/").Build())
             .Build());
 
         _readerService = new ReaderService(_unitOfWork, Substitute.For<ILogger<ReaderService>>(), Substitute.For<IEventHub>(),

--- a/API.Tests/Services/CleanupServiceTests.cs
+++ b/API.Tests/Services/CleanupServiceTests.cs
@@ -29,7 +29,6 @@ public class CleanupServiceTests : AbstractDbTest
     private readonly ILogger<CleanupService> _logger = Substitute.For<ILogger<CleanupService>>();
     private readonly IEventHub _messageHub = Substitute.For<IEventHub>();
     private readonly IReaderService _readerService;
-    private static readonly string Root = Path.GetPathRoot(Directory.GetCurrentDirectory());
 
     public CleanupServiceTests() : base()
     {

--- a/API.Tests/Services/DirectoryServiceTests.cs
+++ b/API.Tests/Services/DirectoryServiceTests.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.IO;
 using System.IO.Abstractions.TestingHelpers;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 using API.Services;
@@ -14,7 +15,7 @@ using Xunit;
 
 namespace API.Tests.Services;
 
-public class DirectoryServiceTests
+public class DirectoryServiceTests: AbstractFsTest
 {
     private readonly ILogger<DirectoryService> _logger = Substitute.For<ILogger<DirectoryService>>();
 
@@ -374,9 +375,15 @@ public class DirectoryServiceTests
     #endregion
 
     #region IsDriveMounted
+    // The root directory (/) is always mounted on non windows
     [Fact]
     public void IsDriveMounted_DriveIsNotMounted()
     {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return;
+        }
+
         const string testDirectory = "c:/manga/";
         var fileSystem = new MockFileSystem();
         fileSystem.AddFile($"{testDirectory}data-0.txt", new MockFileData("abc"));
@@ -388,6 +395,11 @@ public class DirectoryServiceTests
     [Fact]
     public void IsDriveMounted_DriveIsMounted()
     {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return;
+        }
+
         const string testDirectory = "c:/manga/";
         var fileSystem = new MockFileSystem();
         fileSystem.AddFile($"{testDirectory}data-0.txt", new MockFileData("abc"));
@@ -1044,11 +1056,14 @@ public class DirectoryServiceTests
     #region GetParentDirectory
 
     [Theory]
-    [InlineData(@"C:/file.txt", "C:/")]
-    [InlineData(@"C:/folder/file.txt", "C:/folder")]
-    [InlineData(@"C:/folder/subfolder/file.txt", "C:/folder/subfolder")]
+    [InlineData(@"file.txt", "")]
+    [InlineData(@"folder/file.txt", "folder")]
+    [InlineData(@"folder/subfolder/file.txt", "folder/subfolder")]
     public void GetParentDirectoryName_ShouldFindParentOfFiles(string path, string expected)
     {
+        path = Root + path;
+        expected = Root + expected;
+
         var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
         {
             { path, new MockFileData(string.Empty)}
@@ -1058,11 +1073,14 @@ public class DirectoryServiceTests
         Assert.Equal(expected, ds.GetParentDirectoryName(path));
     }
     [Theory]
-    [InlineData(@"C:/folder", "C:/")]
-    [InlineData(@"C:/folder/subfolder", "C:/folder")]
-    [InlineData(@"C:/folder/subfolder/another", "C:/folder/subfolder")]
+    [InlineData(@"folder", "")]
+    [InlineData(@"folder/subfolder", "folder")]
+    [InlineData(@"folder/subfolder/another", "folder/subfolder")]
     public void GetParentDirectoryName_ShouldFindParentOfDirectories(string path, string expected)
     {
+        path = Root + path;
+        expected = Root + expected;
+
         var fileSystem = new MockFileSystem();
         fileSystem.AddDirectory(path);
 

--- a/API.Tests/Services/DirectoryServiceTests.cs
+++ b/API.Tests/Services/DirectoryServiceTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.IO.Abstractions.TestingHelpers;
 using System.Linq;
@@ -900,12 +901,14 @@ public class DirectoryServiceTests
     #region GetHumanReadableBytes
 
     [Theory]
-    [InlineData(1200, "1.17 KB")]
-    [InlineData(1, "1 B")]
-    [InlineData(10000000, "9.54 MB")]
-    [InlineData(10000000000, "9.31 GB")]
-    public void GetHumanReadableBytesTest(long bytes, string expected)
+    [InlineData(1200, 1.17, " KB")]
+    [InlineData(1, 1, " B")]
+    [InlineData(10000000, 9.54, " MB")]
+    [InlineData(10000000000, 9.31, " GB")]
+    public void GetHumanReadableBytesTest(long bytes, float number, string suffix)
     {
+        // GetHumanReadableBytes is user facing, should be in CultureInfo.CurrentCulture
+        var expected = number.ToString(CultureInfo.CurrentCulture) + suffix;
         Assert.Equal(expected, DirectoryService.GetHumanReadableBytes(bytes));
     }
     #endregion

--- a/API.Tests/Services/DirectoryServiceTests.cs
+++ b/API.Tests/Services/DirectoryServiceTests.cs
@@ -12,12 +12,19 @@ using Kavita.Common.Helpers;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace API.Tests.Services;
 
 public class DirectoryServiceTests: AbstractFsTest
 {
     private readonly ILogger<DirectoryService> _logger = Substitute.For<ILogger<DirectoryService>>();
+    private readonly ITestOutputHelper _testOutputHelper;
+
+    public DirectoryServiceTests(ITestOutputHelper testOutputHelper)
+    {
+        _testOutputHelper = testOutputHelper;
+    }
 
 
     #region TraverseTreeParallelForEach
@@ -381,6 +388,7 @@ public class DirectoryServiceTests: AbstractFsTest
     {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
+            _testOutputHelper.WriteLine("Skipping test on non Windows platform");
             return;
         }
 
@@ -397,6 +405,7 @@ public class DirectoryServiceTests: AbstractFsTest
     {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
+            _testOutputHelper.WriteLine("Skipping test on non Windows platform");
             return;
         }
 

--- a/API.Tests/Services/ParseScannedFilesTests.cs
+++ b/API.Tests/Services/ParseScannedFilesTests.cs
@@ -204,11 +204,11 @@ public class ParseScannedFilesTests : AbstractDbTest
     public async Task ScanLibrariesForSeries_ShouldFindFiles()
     {
         var fileSystem = new MockFileSystem();
-        fileSystem.AddDirectory("C:/Data/");
-        fileSystem.AddFile("C:/Data/Accel World v1.cbz", new MockFileData(string.Empty));
-        fileSystem.AddFile("C:/Data/Accel World v2.cbz", new MockFileData(string.Empty));
-        fileSystem.AddFile("C:/Data/Accel World v2.pdf", new MockFileData(string.Empty));
-        fileSystem.AddFile("C:/Data/Nothing.pdf", new MockFileData(string.Empty));
+        fileSystem.AddDirectory(Root + "Data/");
+        fileSystem.AddFile(Root + "Data/Accel World v1.cbz", new MockFileData(string.Empty));
+        fileSystem.AddFile(Root + "Data/Accel World v2.cbz", new MockFileData(string.Empty));
+        fileSystem.AddFile(Root + "Data/Accel World v2.pdf", new MockFileData(string.Empty));
+        fileSystem.AddFile(Root + "Data/Nothing.pdf", new MockFileData(string.Empty));
 
         var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), fileSystem);
         var psf = new ParseScannedFiles(Substitute.For<ILogger<ParseScannedFiles>>(), ds,
@@ -221,7 +221,7 @@ public class ParseScannedFilesTests : AbstractDbTest
         Assert.NotNull(library);
 
         library.Type = LibraryType.Manga;
-        var parsedSeries = await psf.ScanLibrariesForSeries(library, new List<string>() {"C:/Data/"}, false,
+        var parsedSeries = await psf.ScanLibrariesForSeries(library, new List<string>() {Root + "Data/"}, false,
             await _unitOfWork.SeriesRepository.GetFolderPathMap(1));
 
 

--- a/API.Tests/Services/ReaderServiceTests.cs
+++ b/API.Tests/Services/ReaderServiceTests.cs
@@ -32,17 +32,12 @@ using Xunit.Abstractions;
 
 namespace API.Tests.Services;
 
-public class ReaderServiceTests
+public class ReaderServiceTests: AbstractFsTest
 {
     private readonly ITestOutputHelper _testOutputHelper;
     private readonly IUnitOfWork _unitOfWork;
     private readonly DataContext _context;
     private readonly ReaderService _readerService;
-
-    private const string CacheDirectory = "C:/kavita/config/cache/";
-    private const string CoverImageDirectory = "C:/kavita/config/covers/";
-    private const string BackupDirectory = "C:/kavita/config/backups/";
-    private const string DataDirectory = "C:/data/";
 
     public ReaderServiceTests(ITestOutputHelper testOutputHelper)
     {
@@ -99,19 +94,6 @@ public class ReaderServiceTests
         _context.Series.RemoveRange(_context.Series.ToList());
 
         await _context.SaveChangesAsync();
-    }
-
-    private static MockFileSystem CreateFileSystem()
-    {
-        var fileSystem = new MockFileSystem();
-        fileSystem.Directory.SetCurrentDirectory("C:/kavita/");
-        fileSystem.AddDirectory("C:/kavita/config/");
-        fileSystem.AddDirectory(CacheDirectory);
-        fileSystem.AddDirectory(CoverImageDirectory);
-        fileSystem.AddDirectory(BackupDirectory);
-        fileSystem.AddDirectory(DataDirectory);
-
-        return fileSystem;
     }
 
     #endregion

--- a/API.Tests/Services/Test Data/ScannerService/TestCases/Flat Special - Manga.json
+++ b/API.Tests/Services/Test Data/ScannerService/TestCases/Flat Special - Manga.json
@@ -1,5 +1,5 @@
 [
-    "Uzaki-chan Wants to Hang Out!\\Uzaki-chan Wants to Hang Out! - 2022 New Years Special SP01.cbz",
-    "Uzaki-chan Wants to Hang Out!\\Uzaki-chan Wants to Hang Out! - Ch. 103 - Kouhai and Control.cbz",
-    "Uzaki-chan Wants to Hang Out!\\Uzaki-chan Wants to Hang Out! v01 (2019) (Digital) (danke-Empire).cbz"
+    "Uzaki-chan Wants to Hang Out!/Uzaki-chan Wants to Hang Out! - 2022 New Years Special SP01.cbz",
+    "Uzaki-chan Wants to Hang Out!/Uzaki-chan Wants to Hang Out! - Ch. 103 - Kouhai and Control.cbz",
+    "Uzaki-chan Wants to Hang Out!/Uzaki-chan Wants to Hang Out! v01 (2019) (Digital) (danke-Empire).cbz"
 ]


### PR DESCRIPTION
This PR fixes all but 7 tests on macOS. The remaining tests are in DirectoryServiceTest

<img width="1323" alt="image" src="https://github.com/user-attachments/assets/c34b4b7d-154d-45b4-9170-a0ef34ddbea7" />

Top one fails because `\` is valid in a filename. And the othesr fails because `C:/` is hardcoded, I could change them to construct it from Root +, but the test already has them mixed; so I think that would  change the test too much. 
Unsure what to do with them.


# Fixed
- Fixed several tests not running on macOS/Unix because of `C:/` as root
- Fixed a test involving time not passing on timezones > UTC because of how the setter works in the MockFileData

# Changed
- Unified several test classes to use the new AbstractFsTest to simplify setup
- Skip the IsDriveMounted tests on macOS/Unix as the root `/` is always mounted, and `C:/` will throw
- Change some tests to test against the CurrentLocale instead as the result is user facing


### Notes
I've had a friend run the tests on their Windows PC, and everything passes for them. However, they're on the same timezone as me. So would probably need to have someone tests whose on a timezone "earlier" than UTC.
