### PR TITLE
v0.8.5.11 - Hotfix 2

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -25,7 +25,7 @@ body:
   - type: dropdown
     id: version
     attributes:
-      label: Kavita Version Number - If you don not see your version number listed, please update Kavita and see if your issue still persists.
+      label: Kavita Version Number - If you don't see your version number listed, please update Kavita and see if your issue still persists.
       multiple: false
       options:
         - 0.8.5.11 - Stable

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -28,7 +28,7 @@ body:
       label: Kavita Version Number - If you don not see your version number listed, please update Kavita and see if your issue still persists.
       multiple: false
       options:
-        - 0.8.5.3 - Stable
+        - 0.8.5.11 - Stable
         - Nightly Testing Branch
     validations:
       required: true

--- a/Kavita.Common/Kavita.Common.csproj
+++ b/Kavita.Common/Kavita.Common.csproj
@@ -3,7 +3,7 @@
         <TargetFramework>net9.0</TargetFramework>
         <Company>kavitareader.com</Company>
         <Product>Kavita</Product>
-        <AssemblyVersion>0.8.5.10</AssemblyVersion>
+        <AssemblyVersion>0.8.5.11</AssemblyVersion>
         <NeutralLanguage>en</NeutralLanguage>
         <InvariantGlobalization>true</InvariantGlobalization>
         <TieredPGO>true</TieredPGO>


### PR DESCRIPTION
I decided to do one more hotfix as there was an annoying bug for multi-root libraries that causes flip-flopping (the same issue as covers disappearing). This also contains some fixes around scrobbling and misc other bugs reported that are a good fit. 

v0.8.6 is still planned to focus on the Scanner and finishing off the Kavita+ Polish. 

# Changed
- Changed: Locale selection now shows the total percentage of completion of the locale.
- Changed: Cleaned up some code around localization as a way to hopefully fight the keys showing in the UI on new versions.
- Changed: (Kavita+) When a user removes the Kavita+ license from their instance, stop doing all K+ Background tasks instead of waiting for the next restart.
- Changed: (Kavita+) Kavita will now clean up old scrobble events for users that don't have an anilist token on their account, so that events that will never get processed get cleaned up.
- Changed: (Kavita+) When sourcing descriptions from Kavita+, remove the (Source: X).

# Fixed
- Fixed: Fixed a bug where a signature on an API was wrong 
- Fixed: (Kavita+) Fixed a length issue for reviews from Kavita+ that could break metadata matching 
- Fixed: (Kavita+) Fixed some edge case handling of want to read scrobbling and potentially some issues around events that never get processed.
- Fixed: Fixed unable to start Kavita for the first time on DD/MM/YYYY locales (Thanks @Fesaa )
- Fixed: Fixed a bug where multi-root libraries would delete and recreate series in one of non-first folders
- Fixed: Fixed reading list not respecting age restrictions (Thanks @Fesaa )

# API
- Updated the ReadHistoryEvent to expose ReadDateUtc instead of just the server timezone date. (Thanks @0xGingi)

# Known Issues
- Docker images aren't showing Locale names correctly (this will be fixed v0.8.6)