### PR TITLE
A few reading list bug fixes

### DIFF
--- a/API.Tests/Extensions/SeriesFilterTests.cs
+++ b/API.Tests/Extensions/SeriesFilterTests.cs
@@ -932,7 +932,8 @@ public class SeriesFilterTests : AbstractDbTest
 
         var seriesService = new SeriesService(_unitOfWork, Substitute.For<IEventHub>(),
             Substitute.For<ITaskScheduler>(), Substitute.For<ILogger<SeriesService>>(),
-            Substitute.For<IScrobblingService>(), Substitute.For<ILocalizationService>());
+            Substitute.For<IScrobblingService>(), Substitute.For<ILocalizationService>(),
+            Substitute.For<IReadingListService>());
 
         // Select 0 Rating
         var zeroRating = await _unitOfWork.SeriesRepository.GetSeriesByIdAsync(2);

--- a/API.Tests/Services/SeriesServiceTests.cs
+++ b/API.Tests/Services/SeriesServiceTests.cs
@@ -57,7 +57,7 @@ public class SeriesServiceTests : AbstractDbTest
 
         _seriesService = new SeriesService(_unitOfWork, Substitute.For<IEventHub>(),
             Substitute.For<ITaskScheduler>(), Substitute.For<ILogger<SeriesService>>(),
-            Substitute.For<IScrobblingService>(), locService);
+            Substitute.For<IScrobblingService>(), locService, Substitute.For<IReadingListService>());
     }
     #region Setup
 

--- a/API/Controllers/OPDSController.cs
+++ b/API/Controllers/OPDSController.cs
@@ -585,19 +585,27 @@ public class OpdsController : BaseApiController
         var userId = await GetUser(apiKey);
 
         if (!(await _unitOfWork.SettingsRepository.GetSettingsDtoAsync()).EnableOpds)
+        {
             return BadRequest(await _localizationService.Translate(userId, "opds-disabled"));
+        }
 
         var user = await _unitOfWork.UserRepository.GetUserByIdAsync(userId);
         if (user == null)
+        {
             return Unauthorized();
+        }
 
         var readingLists = await _unitOfWork.ReadingListRepository.GetReadingListDtosForUserAsync(user.Id, true, GetUserParams(pageNumber), false);
         if (readingLists == null)
+        {
             return Unauthorized();
+        }
 
-        var readingList = readingLists.SingleOrDefault(rl => rl.Id == readingListId);
+        var readingList = readingLists.FirstOrDefault(rl => rl.Id == readingListId);
         if (readingList == null)
+        {
             return BadRequest(await _localizationService.Translate(userId, "reading-list-restricted"));
+        }
 
         var (baseUrl, prefix) = await GetPrefix();
         var feed = CreateFeed(readingList.Title + " " + await _localizationService.Translate(userId, "reading-list"), $"{apiKey}/reading-list/{readingListId}", apiKey, prefix);

--- a/API/Controllers/OPDSController.cs
+++ b/API/Controllers/OPDSController.cs
@@ -27,6 +27,7 @@ using AutoMapper;
 using Kavita.Common;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 using MimeTypes;
 
 namespace API.Controllers;
@@ -36,6 +37,7 @@ namespace API.Controllers;
 [AllowAnonymous]
 public class OpdsController : BaseApiController
 {
+    private readonly ILogger<OpdsController> _logger;
     private readonly IUnitOfWork _unitOfWork;
     private readonly IDownloadService _downloadService;
     private readonly IDirectoryService _directoryService;
@@ -82,7 +84,7 @@ public class OpdsController : BaseApiController
         IDirectoryService directoryService, ICacheService cacheService,
         IReaderService readerService, ISeriesService seriesService,
         IAccountService accountService, ILocalizationService localizationService,
-        IMapper mapper)
+        IMapper mapper, ILogger<OpdsController> logger)
     {
         _unitOfWork = unitOfWork;
         _downloadService = downloadService;
@@ -93,6 +95,7 @@ public class OpdsController : BaseApiController
         _accountService = accountService;
         _localizationService = localizationService;
         _mapper = mapper;
+        _logger = logger;
 
         _xmlSerializer = new XmlSerializer(typeof(Feed));
         _xmlOpenSearchSerializer = new XmlSerializer(typeof(OpenSearchDescription));
@@ -580,19 +583,23 @@ public class OpdsController : BaseApiController
     public async Task<IActionResult> GetReadingListItems(int readingListId, string apiKey, [FromQuery] int pageNumber = 0)
     {
         var userId = await GetUser(apiKey);
+
         if (!(await _unitOfWork.SettingsRepository.GetSettingsDtoAsync()).EnableOpds)
             return BadRequest(await _localizationService.Translate(userId, "opds-disabled"));
-        var (baseUrl, prefix) = await GetPrefix();
+
         var user = await _unitOfWork.UserRepository.GetUserByIdAsync(userId);
+        if (user == null)
+            return Unauthorized();
 
-        var userWithLists = await _unitOfWork.UserRepository.GetUserByUsernameAsync(user!.UserName!, AppUserIncludes.ReadingListsWithItems);
-        if (userWithLists == null) return Unauthorized();
-        var readingList = userWithLists.ReadingLists.SingleOrDefault(t => t.Id == readingListId);
+        var readingLists = await _unitOfWork.ReadingListRepository.GetReadingListDtosForUserAsync(user.Id, true, GetUserParams(pageNumber), false);
+        if (readingLists == null)
+            return Unauthorized();
+
+        var readingList = readingLists.SingleOrDefault(rl => rl.Id == readingListId);
         if (readingList == null)
-        {
             return BadRequest(await _localizationService.Translate(userId, "reading-list-restricted"));
-        }
 
+        var (baseUrl, prefix) = await GetPrefix();
         var feed = CreateFeed(readingList.Title + " " + await _localizationService.Translate(userId, "reading-list"), $"{apiKey}/reading-list/{readingListId}", apiKey, prefix);
         SetFeedId(feed, $"reading-list-{readingListId}");
 

--- a/API/Data/Repositories/ReadingListRepository.cs
+++ b/API/Data/Repositories/ReadingListRepository.cs
@@ -53,6 +53,7 @@ public interface IReadingListRepository
     Task<int> RemoveReadingListsWithoutSeries();
     Task<ReadingList?> GetReadingListByTitleAsync(string name, int userId, ReadingListIncludes includes = ReadingListIncludes.Items);
     Task<IEnumerable<ReadingList>> GetReadingListsByIds(IList<int> ids, ReadingListIncludes includes = ReadingListIncludes.Items);
+    Task<IEnumerable<ReadingList>> GetReadingListsBySeriesId(int seriesId, ReadingListIncludes includes = ReadingListIncludes.Items);
 }
 
 public class ReadingListRepository : IReadingListRepository
@@ -170,7 +171,14 @@ public class ReadingListRepository : IReadingListRepository
             .AsSplitQuery()
             .ToListAsync();
     }
-
+    public async Task<IEnumerable<ReadingList>> GetReadingListsBySeriesId(int seriesId, ReadingListIncludes includes = ReadingListIncludes.Items)
+    {
+        return await _context.ReadingList
+            .Where(rl => rl.Items.Any(rli => rli.SeriesId == seriesId))
+            .Includes(includes)
+            .AsSplitQuery()
+            .ToListAsync();
+    }
 
 
     public void Remove(ReadingListItem item)

--- a/API/Services/ReadingListService.cs
+++ b/API/Services/ReadingListService.cs
@@ -104,7 +104,13 @@ public class ReadingListService : IReadingListService
                 {
                     title = $"Volume {Parser.CleanSpecialTitle(item.VolumeNumber)}";
                 }
-            } else {
+            }
+            else if (item.VolumeNumber == Parser.SpecialVolume)
+            {
+                title = specialTitle;
+            }
+            else
+            {
                 title = $"Volume {specialTitle}";
             }
         }

--- a/API/Services/ReadingListService.cs
+++ b/API/Services/ReadingListService.cs
@@ -50,6 +50,14 @@ public interface IReadingListService
 
     Task CreateReadingListsFromSeries(int libraryId, int seriesId);
     Task<string> GenerateReadingListCoverImage(int readingListId);
+    /// <summary>
+    /// Check, and update if needed, all reading lists' AgeRating who contain the passed series
+    /// </summary>
+    /// <param name="seriesId">The series whose age rating is being updated</param>
+    /// <param name="ageRating">The new (uncommited) age rating of the series</param>
+    /// <returns></returns>
+    /// <remarks>This method does not commit changes</remarks>
+    Task UpdateReadingListAgeRatingForSeries(int seriesId, AgeRating ageRating);
 }
 
 /// <summary>
@@ -843,5 +851,20 @@ public class ReadingListService : IReadingListService
         // TODO: Refactor this so that reading lists have a dedicated cover image so we can calculate primary/secondary colors
 
         return !_directoryService.FileSystem.File.Exists(destFile) ? string.Empty : destFile;
+    }
+    public async Task UpdateReadingListAgeRatingForSeries(int seriesId, AgeRating ageRating)
+    {
+        var readingLists = await _unitOfWork.ReadingListRepository.GetReadingListsBySeriesId(seriesId);
+        foreach (var readingList in readingLists)
+        {
+            var seriesIds = readingList.Items.Select(item => item.SeriesId).ToList();
+            seriesIds.Remove(seriesId); // Don't get AgeRating from database
+
+            var maxAgeRating = await _unitOfWork.SeriesRepository.GetMaxAgeRatingFromSeriesAsync(seriesIds);
+            if (ageRating > maxAgeRating)
+                maxAgeRating = ageRating;
+
+            readingList.AgeRating = maxAgeRating;
+        }
     }
 }

--- a/API/Services/ReadingListService.cs
+++ b/API/Services/ReadingListService.cs
@@ -858,6 +858,7 @@ public class ReadingListService : IReadingListService
 
         return !_directoryService.FileSystem.File.Exists(destFile) ? string.Empty : destFile;
     }
+
     public async Task UpdateReadingListAgeRatingForSeries(int seriesId, AgeRating ageRating)
     {
         var readingLists = await _unitOfWork.ReadingListRepository.GetReadingListsBySeriesId(seriesId);
@@ -868,7 +869,9 @@ public class ReadingListService : IReadingListService
 
             var maxAgeRating = await _unitOfWork.SeriesRepository.GetMaxAgeRatingFromSeriesAsync(seriesIds);
             if (ageRating > maxAgeRating)
+            {
                 maxAgeRating = ageRating;
+            }
 
             readingList.AgeRating = maxAgeRating;
         }

--- a/API/Services/SeriesService.cs
+++ b/API/Services/SeriesService.cs
@@ -50,6 +50,7 @@ public class SeriesService : ISeriesService
     private readonly ILogger<SeriesService> _logger;
     private readonly IScrobblingService _scrobblingService;
     private readonly ILocalizationService _localizationService;
+    private readonly IReadingListService _readingListService;
 
     private readonly NextExpectedChapterDto _emptyExpectedChapter = new NextExpectedChapterDto
     {
@@ -59,7 +60,8 @@ public class SeriesService : ISeriesService
     };
 
     public SeriesService(IUnitOfWork unitOfWork, IEventHub eventHub, ITaskScheduler taskScheduler,
-        ILogger<SeriesService> logger, IScrobblingService scrobblingService, ILocalizationService localizationService)
+        ILogger<SeriesService> logger, IScrobblingService scrobblingService, ILocalizationService localizationService,
+        IReadingListService readingListService)
     {
         _unitOfWork = unitOfWork;
         _eventHub = eventHub;
@@ -67,6 +69,7 @@ public class SeriesService : ISeriesService
         _logger = logger;
         _scrobblingService = scrobblingService;
         _localizationService = localizationService;
+        _readingListService = readingListService;
     }
 
     /// <summary>
@@ -191,6 +194,7 @@ public class SeriesService : ISeriesService
             {
                 series.Metadata.AgeRating = updateSeriesMetadataDto.SeriesMetadata?.AgeRating ?? AgeRating.Unknown;
                 series.Metadata.AgeRatingLocked = true;
+                await _readingListService.UpdateReadingListAgeRatingForSeries(series.Id, series.Metadata.AgeRating);
             }
             else
             {

--- a/UI/Web/src/app/reading-list/_components/reading-list-item/reading-list-item.component.html
+++ b/UI/Web/src/app/reading-list/_components/reading-list-item/reading-list-item.component.html
@@ -42,7 +42,7 @@
 
         @if (item.releaseDate !== '0001-01-01T00:00:00') {
           <div class="ps-1 mt-2">
-            {{t('released')}}{{item.releaseDate | date:'longDate'}}
+            {{t('released-label', {date: item.releaseDate | date:'longDate'})}}
           </div>
         }
       </div>

--- a/UI/Web/src/app/reading-list/_components/reading-list-item/reading-list-item.component.html
+++ b/UI/Web/src/app/reading-list/_components/reading-list-item/reading-list-item.component.html
@@ -42,7 +42,7 @@
 
         @if (item.releaseDate !== '0001-01-01T00:00:00') {
           <div class="ps-1 mt-2">
-            Released: {{item.releaseDate | date:'longDate'}}
+            {{t('released')}}{{item.releaseDate | date:'longDate'}}
           </div>
         }
       </div>

--- a/UI/Web/src/app/volume-detail/volume-detail.component.ts
+++ b/UI/Web/src/app/volume-detail/volume-detail.component.ts
@@ -613,6 +613,7 @@ export class VolumeDetailComponent implements OnInit {
         });
         break;
       case Action.AddToReadingList:
+        this.actionService.addVolumeToReadingList(this.volume!, this.seriesId, () => {/* No Operation */ });
         break;
       case Action.Download:
         if (this.downloadInProgress) return;

--- a/UI/Web/src/app/volume-detail/volume-detail.component.ts
+++ b/UI/Web/src/app/volume-detail/volume-detail.component.ts
@@ -613,7 +613,7 @@ export class VolumeDetailComponent implements OnInit {
         });
         break;
       case Action.AddToReadingList:
-        this.actionService.addVolumeToReadingList(this.volume!, this.seriesId, () => {/* No Operation */ });
+        this.actionService.addVolumeToReadingList(this.volume!, this.seriesId);
         break;
       case Action.Download:
         if (this.downloadInProgress) return;

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -1731,7 +1731,8 @@
 
     "reading-list-item": {
         "remove": "{{common.remove}}",
-        "read": "{{common.read}}"
+        "read": "{{common.read}}",
+        "released": "Released: "
     },
 
     "stream-list-item": {

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -1732,7 +1732,7 @@
     "reading-list-item": {
         "remove": "{{common.remove}}",
         "read": "{{common.read}}",
-        "released": "Released: "
+        "released-label": "Released: {{date}}"
     },
 
     "stream-list-item": {


### PR DESCRIPTION
# Changed
- Changed: Reading lists' age rating will now update when a series age rating is updated via the UI

# Fixed
- Fixed: Fixed 'add to reading list' not working in volume detail
- Fixed: Fixed users being unable to open promoted reading lists via OPDS (Fixes #3651)
- Fixed: Fixed reading lists, adding an unnecessary volume marker for EPUB specials (Fixes #3654)


I'm waiting with it updating age ratings after a library scan till after we've done the scanner rework.