### PR TITLE
fix: duplicate images in cache folder

### DIFF
--- a/API/Services/Tasks/Scanner/Parser/Parser.cs
+++ b/API/Services/Tasks/Scanner/Parser/Parser.cs
@@ -24,7 +24,7 @@ public static partial class Parser
 
     public static readonly TimeSpan RegexTimeout = TimeSpan.FromMilliseconds(500);
 
-    public const string ImageFileExtensions = @"^(\.png|\.jpeg|\.jpg|\.webp|\.gif|\.avif)"; // Don't forget to update CoverChooser
+    public const string ImageFileExtensions = @"(\.png|\.jpeg|\.jpg|\.webp|\.gif|\.avif)$"; // Don't forget to update CoverChooser
     public const string ArchiveFileExtensions = @"\.cbz|\.zip|\.rar|\.cbr|\.tar.gz|\.7zip|\.7z|\.cb7|\.cbt";
     public const string EpubFileExtension = @"\.epub";
     public const string PdfFileExtension = @"\.pdf";


### PR DESCRIPTION
# Fixed
- Fixed: Fixed images being repeatedly copied into cache folder causing display duplicate images on Mihon.

# Explanation

When you call `/api/Reader/image` with `extractPdf = true` (which is default for Mihon extension), it will call the `Ensure()` function in `CacheService`. The function will check if the images exist in the directory if `extractPdfToImages = true`. 
https://github.com/Kareadita/Kavita/blob/cbb97208b820a25339aa67ebbaf698f53a60e803/API/Services/CacheService.cs#L175-L191
The `GetFiles()` function accepts a regex to check if filenames match the regex. If the `GetFiles()` function does not return any files, it will try to copy the images to the cache folder with auto renaming. 

In the `GetFiles()` function, it will use the **whole filename** to match the regex
https://github.com/Kareadita/Kavita/blob/cbb97208b820a25339aa67ebbaf698f53a60e803/API/Services/DirectoryService.cs#L263

However, the regex requires the first character to be extensions.
https://github.com/Kareadita/Kavita/blob/cbb97208b820a25339aa67ebbaf698f53a60e803/API/Services/Tasks/Scanner/Parser/Parser.cs#L27

This makes the regex matching failed, resulting nothing being returned to the `Ensure()` function, making it think the cache does not exist, and copying the image again.

The easiest solution will be updating the image extension regex. I am actually a little bit confused of the original regex, which has the extra first character check compared to other regexes, is that still needed now? Anyway, my fix is changing the first character check to the last character check, which should serve the same purpose.
