### PR TITLE
bugfix - remove hard 140px height limit for reading list items

### DIFF
--- a/UI/Web/src/app/reading-list/_components/reading-list-detail/reading-list-detail.component.scss
+++ b/UI/Web/src/app/reading-list/_components/reading-list-detail/reading-list-detail.component.scss
@@ -14,8 +14,6 @@
 
 .non-virtualized-container {
     width: 100%;
-    max-height: 140px;
-    height: 140px;
 }
 
 .dropdown-toggle-split {

--- a/UI/Web/src/app/reading-list/_components/reading-list-item/reading-list-item.component.scss
+++ b/UI/Web/src/app/reading-list/_components/reading-list-item/reading-list-item.component.scss
@@ -1,11 +1,6 @@
 $image-height: 125px;
 $clamp-lines: 3;
 
-.reading-list-item {
-  max-height: 140px;
-  height: 140px;
-}
-
 .progress-banner {
     height: 5px;
 


### PR DESCRIPTION
There was a bit of an issue with text overflowing the bounds of reading list items, this should fix it.

![before/after showing the 14px height limit was causing an overflow](https://github.com/user-attachments/assets/f8445a97-10c4-4de0-8a53-cf8fdfa878de)
