### PR TITLE
Remove redundant TieredPGO and TieredCompilation properties

### DIFF
--- a/API/API.csproj
+++ b/API/API.csproj
@@ -5,8 +5,6 @@
     <TargetFramework>net9.0</TargetFramework>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
-    <TieredPGO>true</TieredPGO>
-    <TieredCompilation>true</TieredCompilation>
     <ApplicationIcon>../favicon.ico</ApplicationIcon>
     <Nullable>warnings</Nullable>
     <LangVersion>latestmajor</LangVersion>

--- a/Kavita.Common/Kavita.Common.csproj
+++ b/Kavita.Common/Kavita.Common.csproj
@@ -5,7 +5,6 @@
         <Product>Kavita</Product>
         <AssemblyVersion>0.8.6.1</AssemblyVersion>
         <NeutralLanguage>en</NeutralLanguage>
-        <TieredPGO>true</TieredPGO>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
# Changed
- Changed: Removed TieredPGO and TieredCompilation

Looks like these options are redundant for .net 9. 
TieredCompilation is enabled by default starting from .net core 3.0:
https://learn.microsoft.com/en-us/dotnet/core/runtime-config/compilation#tiered-compilation

Dynamic PGO (TieredPGO) is enabled by default in .net 8.