### PR TITLE
Remove unused NReco.Logging.File

### DIFF
--- a/API/API.csproj
+++ b/API/API.csproj
@@ -80,7 +80,6 @@
     <PackageReference Include="Nager.ArticleNumber" Version="1.0.7" />
     <PackageReference Include="NetVips" Version="3.0.0" />
     <PackageReference Include="NetVips.Native" Version="8.16.1" />
-    <PackageReference Include="NReco.Logging.File" Version="1.2.2" />
     <PackageReference Include="Serilog" Version="4.2.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />


### PR DESCRIPTION
# Changed
- Changed: Removed unused NReco.Logging.File

I don't see any reference, looks like it was replaced by Serilog.