### PR TITLE
preference sidebar incorrect render fix + badge center alignment

### DIFF
--- a/UI/Web/src/app/sidenav/preference-nav/preference-nav.component.html
+++ b/UI/Web/src/app/sidenav/preference-nav/preference-nav.component.html
@@ -9,7 +9,7 @@
 
           @for(section of sections; track section.title + section.children.length; let idx = $index;) {
             @if (hasAnyChildren(user, section)) {
-              <h5 class="side-nav-header mb-2 ms-3" [ngClass]="{'mt-4': idx > 0}">{{t(section.title)}}</h5>
+              <h5 class="side-nav-header mb-2" [ngClass]="{'mt-4': idx > 0}">{{t(section.title)}}</h5>
               @for(item of section.children; track item.fragment) {
                 @if (accountService.hasAnyRole(user, item.roles, item.restrictRoles)) {
                   <app-side-nav-item [id]="'nav-item-' + item.fragment" [noIcon]="true" link="/settings" [fragment]="item.fragment" [title]="item.fragment | settingFragment" [badgeCount]="item.badgeCount$ | async"></app-side-nav-item>

--- a/UI/Web/src/theme/components/_sidenav.scss
+++ b/UI/Web/src/theme/components/_sidenav.scss
@@ -193,10 +193,12 @@
     .side-nav {
       overflow-x: hidden;
       padding-bottom: 0.625rem;
+      padding-left: 1.125rem;
 
       .side-nav-header {
         color: #ffffff;
         font-size: 1rem;
+        margin-left: unset;
 
         &:first-of-type {
           margin-top: 0.7rem;
@@ -207,7 +209,6 @@
         font-size: 1rem;
         min-height: 1.875rem;
         justify-content: unset;
-        margin-left: 1.125rem;
 
         &.active {
           .side-nav-text {
@@ -220,6 +221,14 @@
           margin-left: 0.75rem;
           font-size: 0.9rem;
           color: #999999;
+          
+          div {
+            display: flex;
+            
+            .badge {
+              align-self: center;
+            }
+          }
         }
 
         .card-actions {

--- a/UI/Web/src/theme/components/_sidenav.scss
+++ b/UI/Web/src/theme/components/_sidenav.scss
@@ -28,13 +28,18 @@
   }
   //START closed state of the sidebar
   &.closed {
-    width: 2.825rem;
+    width: 3.125rem;
     overflow-x: hidden;
     overflow-y: hidden;
     background-color: var(--side-nav-closed-bg-color);
     border: var(--side-nav-border-closed);
     height: calc((var(--vh) * 100) - 6.5rem);
     border-radius: unset;
+
+    // For Firefox
+    @supports (-moz-appearance: none) {
+      width: 2.5rem;
+    }
 
     .side-nav {
       .side-nav-item {
@@ -44,6 +49,10 @@
           &.active {
             color: var(--side-nav-item-active-text-color);
           }
+        }
+
+        .phone-hidden:first-of-type {
+          margin-left: unset;
         }
 
         .active-highlight {
@@ -83,10 +92,10 @@
         display: flex;
 
         &:first-of-type {
-          text-align: center;
           width: 2.5rem;
           min-width: 2.5rem;
           margin-left: 0.3rem;
+          justify-content: center;
         }
 
         &:last-child {
@@ -95,9 +104,7 @@
         }
 
         div {
-          align-items: center;
           height: 100%;
-          justify-content: inherit;
           padding: 0 0.625rem;
 
           i {
@@ -287,9 +294,9 @@
       }
     }
   }
-  //START sidebar closed
+  //START sidebar bottom closed
   &.closed {
-    width: 3.4375rem;
+    width: 2.5rem;
     overflow-x: hidden;
     overflow-y: auto;
     background-color: unset;
@@ -304,7 +311,7 @@
       }
     }
   }
-  //END sidebar closed
+  //END sidebar bottom closed
 }
 //END kavita+ subscription bottom heart button
 


### PR DESCRIPTION
# Fixed
- Fixed: Fixed the preference sidebar not rendering correctly at all in Firefox and Chrome.
- Fixed: Fixed the alignment of the badge on the sidebar not being centered with the text
- Fixed Homepage sidebar tabs were not sized properly for when the sidebar was closed

# Chrome
![chrome_QyW5ZhM7lM](https://github.com/user-attachments/assets/49110ead-4bdc-4fdc-a77a-98d8477f4cc3)

# Firefox
![firefox_MCE3fMSFFO](https://github.com/user-attachments/assets/8255de5f-f80e-4443-b69f-ea3c8188e028)

# Sidebar tabs sizing fix
<img width="137" alt="chrome_a2t8neQhAS" src="https://github.com/user-attachments/assets/4534e0bf-61bc-4bd1-b32b-b744594b3b0c" /> <img width="109" alt="MYLr94sj1Q" src="https://github.com/user-attachments/assets/c73bf722-97da-4a8f-831c-3b1be2426f33" />


