### PR TITLE
fix: fix login logo request to respect basepath

### DIFF
--- a/UI/Web/src/theme/themes/dark.scss
+++ b/UI/Web/src/theme/themes/dark.scss
@@ -414,7 +414,7 @@
 
     /** Login **/
     --login-card-bg-color: #212121;
-    --login-logo-image: url("/assets/images/logo.png");
+    --login-logo-image: url("../../assets/images/logo.png");
     --login-logo-height: 55px;
     --login-logo-width: 55px;
     --login-logo-bg-size: contain;


### PR DESCRIPTION
# Fixed
- Fixed: login page makes a malformed request to /assets/images/logo.png when basepath is set - fixed it to respect basepath

