### PR TITLE
First OIDC fixes and feedback

### DIFF
--- a/API.Tests/Services/AccountServiceTests.cs
+++ b/API.Tests/Services/AccountServiceTests.cs
@@ -23,6 +23,19 @@ namespace API.Tests.Services;
 public class AccountServiceTests: AbstractDbTest
 {
 
+    [Theory]
+    [InlineData("admin", true)]
+    [InlineData("^^$SomeBadChars", false)]
+    [InlineData("Lisa2003", true)]
+    [InlineData("Kraft Lawrance", false)]
+    public async Task ValidateUsername_Regex(string username, bool valid)
+    {
+        await ResetDb();
+        var (_, accountService, _, _) = await Setup();
+
+        Assert.Equal(valid, !(await accountService.ValidateUsername(username)).Any());
+    }
+
     [Fact]
     public async Task ChangeIdentityProvider_Throws_WhenDefaultAdminUser()
     {

--- a/API.Tests/Services/OidcServiceTests.cs
+++ b/API.Tests/Services/OidcServiceTests.cs
@@ -36,7 +36,7 @@ public class OidcServiceTests: AbstractDbTest
         var claims = new List<Claim>()
         {
             new (ClaimTypes.Name, "amelia"),
-            new (ClaimTypes.GivenName, "Kraft Lawrence"),
+            new (ClaimTypes.GivenName, "Lawrence"),
         };
         var identity = new ClaimsIdentity(claims);
         var principal = new ClaimsPrincipal(identity);
@@ -50,13 +50,13 @@ public class OidcServiceTests: AbstractDbTest
         await oidcService.SyncUserSettings(null!, settings, principal, user);
         var dbUser = await UnitOfWork.UserRepository.GetUserByIdAsync(user.Id);
         Assert.NotNull(dbUser);
-        Assert.Equal("Kraft Lawrence", user.UserName);
+        Assert.Equal("Lawrence", user.UserName);
 
         claims = new List<Claim>()
         {
             new (ClaimTypes.Name, "amelia"),
-            new (ClaimTypes.GivenName, "Kraft Lawrence"),
-            new (ClaimTypes.Surname, "Norah Arendt"),
+            new (ClaimTypes.GivenName, "Lawrence"),
+            new (ClaimTypes.Surname, "Norah"),
         };
         identity = new ClaimsIdentity(claims);
         principal = new ClaimsPrincipal(identity);
@@ -65,7 +65,7 @@ public class OidcServiceTests: AbstractDbTest
         await oidcService.SyncUserSettings(null!, settings, principal, user);
         dbUser = await UnitOfWork.UserRepository.GetUserByIdAsync(user.Id);
         Assert.NotNull(dbUser);
-        Assert.Equal("Kraft Lawrence", user.UserName);
+        Assert.Equal("Lawrence", user.UserName);
     }
 
     [Fact]

--- a/API.Tests/Services/OidcServiceTests.cs
+++ b/API.Tests/Services/OidcServiceTests.cs
@@ -383,17 +383,18 @@ public class OidcServiceTests: AbstractDbTest
 
         var dbUser = await UnitOfWork.UserRepository.GetUserByIdAsync(user.Id);
         Assert.NotNull(dbUser);
-        Assert.Equal(AgeRating.RatingPending,  dbUser.AgeRestriction);
-        Assert.False(dbUser.AgeRestrictionIncludeUnknowns);
+        Assert.Equal(AgeRating.NotApplicable,  dbUser.AgeRestriction);
+        Assert.True(dbUser.AgeRestrictionIncludeUnknowns);
 
-        identity = new ClaimsIdentity([new (ClaimTypes.Role, OidcService.AgeRestrictionPrefix + OidcService.IncludeUnknowns)]);
+        // Also default to no restrictions when only include unknowns is present
+        identity = new ClaimsIdentity([new Claim(ClaimTypes.Role, OidcService.AgeRestrictionPrefix + OidcService.IncludeUnknowns)]);
         principal = new ClaimsPrincipal(identity);
 
         await oidcService.SyncUserSettings(null!, settings, principal, user);
 
         dbUser = await UnitOfWork.UserRepository.GetUserByIdAsync(user.Id);
         Assert.NotNull(dbUser);
-        Assert.Equal(AgeRating.RatingPending,  dbUser.AgeRestriction);
+        Assert.Equal(AgeRating.NotApplicable,  dbUser.AgeRestriction);
         Assert.True(dbUser.AgeRestrictionIncludeUnknowns);
     }
 

--- a/API.Tests/Services/OidcServiceTests.cs
+++ b/API.Tests/Services/OidcServiceTests.cs
@@ -23,6 +23,52 @@ public class OidcServiceTests: AbstractDbTest
 {
 
     [Fact]
+    public async Task UserSync_Username()
+    {
+        await ResetDb();
+        var (oidcService, _, _, userManager) = await Setup();
+
+        var user = new AppUserBuilder("holo", "holo@localhost").Build();
+        var res = await userManager.CreateAsync(user);
+        Assert.Empty(res.Errors);
+        Assert.True(res.Succeeded);
+
+        var claims = new List<Claim>()
+        {
+            new (ClaimTypes.Name, "amelia"),
+            new (ClaimTypes.GivenName, "Kraft Lawrence"),
+        };
+        var identity = new ClaimsIdentity(claims);
+        var principal = new ClaimsPrincipal(identity);
+
+        var settings = new OidcConfigDto
+        {
+            SyncUserSettings = true,
+        };
+
+        // name is updated as the current username is not found, amelia is skipped as it is alredy in use
+        await oidcService.SyncUserSettings(null!, settings, principal, user);
+        var dbUser = await UnitOfWork.UserRepository.GetUserByIdAsync(user.Id);
+        Assert.NotNull(dbUser);
+        Assert.Equal("Kraft Lawrence", user.UserName);
+
+        claims = new List<Claim>()
+        {
+            new (ClaimTypes.Name, "amelia"),
+            new (ClaimTypes.GivenName, "Kraft Lawrence"),
+            new (ClaimTypes.Surname, "Norah Arendt"),
+        };
+        identity = new ClaimsIdentity(claims);
+        principal = new ClaimsPrincipal(identity);
+
+        // Ensure a name longer down the list isn't picked if the current username is found
+        await oidcService.SyncUserSettings(null!, settings, principal, user);
+        dbUser = await UnitOfWork.UserRepository.GetUserByIdAsync(user.Id);
+        Assert.NotNull(dbUser);
+        Assert.Equal("Kraft Lawrence", user.UserName);
+    }
+
+    [Fact]
     public async Task UserSync_CustomClaim()
     {
         await ResetDb();

--- a/API.Tests/Services/OidcServiceTests.cs
+++ b/API.Tests/Services/OidcServiceTests.cs
@@ -54,7 +54,7 @@ public class OidcServiceTests: AbstractDbTest
             RolesClaim = claim,
         };
 
-        await oidcService.SyncUserSettings(settings, principal, user);
+        await oidcService.SyncUserSettings(null!, settings, principal, user);
 
         // Check correct roles assigned
         var userRoles = await UnitOfWork.UserRepository.GetRoles(user.Id);
@@ -107,7 +107,7 @@ public class OidcServiceTests: AbstractDbTest
             RolesPrefix = prefix,
         };
 
-        await oidcService.SyncUserSettings(settings, principal, user);
+        await oidcService.SyncUserSettings(null!, settings, principal, user);
 
         // Check correct roles assigned
         var userRoles = await UnitOfWork.UserRepository.GetRoles(user.Id);
@@ -147,7 +147,7 @@ public class OidcServiceTests: AbstractDbTest
             SyncUserSettings = true,
         };
 
-        await oidcService.SyncUserSettings(settings, principal, user);
+        await oidcService.SyncUserSettings(null!, settings, principal, user);
 
         var userRoles = await UnitOfWork.UserRepository.GetRoles(user.Id);
         Assert.Contains(PolicyConstants.LoginRole, userRoles);
@@ -158,7 +158,7 @@ public class OidcServiceTests: AbstractDbTest
         identity = new ClaimsIdentity(claims);
         principal = new ClaimsPrincipal(identity);
 
-        await oidcService.SyncUserSettings(settings, principal, user);
+        await oidcService.SyncUserSettings(null!, settings, principal, user);
 
         userRoles = await UnitOfWork.UserRepository.GetRoles(user.Id);
         Assert.Contains(PolicyConstants.LoginRole, userRoles);
@@ -190,7 +190,7 @@ public class OidcServiceTests: AbstractDbTest
             SyncUserSettings = true,
         };
 
-        await oidcService.SyncUserSettings(settings, principal, user);
+        await oidcService.SyncUserSettings(null!, settings, principal, user);
 
         var libraries = (await UnitOfWork.LibraryRepository.GetLibrariesForUserIdAsync(user.Id)).Select(l => l.Name).ToList();
         Assert.Single(libraries);
@@ -202,7 +202,7 @@ public class OidcServiceTests: AbstractDbTest
         identity = new ClaimsIdentity(claims);
         principal = new ClaimsPrincipal(identity);
 
-        await oidcService.SyncUserSettings(settings, principal, user);
+        await oidcService.SyncUserSettings(null!, settings, principal, user);
 
         // Check access has swicthed
         libraries = (await UnitOfWork.LibraryRepository.GetLibrariesForUserIdAsync(user.Id)).Select(l => l.Name).ToList();
@@ -230,7 +230,7 @@ public class OidcServiceTests: AbstractDbTest
             SyncUserSettings = true,
         };
 
-        await oidcService.SyncUserSettings(settings, principal, user);
+        await oidcService.SyncUserSettings(null!, settings, principal, user);
 
         var dbUser = await UnitOfWork.UserRepository.GetUserByIdAsync(user.Id);
         Assert.NotNull(dbUser);
@@ -257,7 +257,7 @@ public class OidcServiceTests: AbstractDbTest
             SyncUserSettings = true,
         };
 
-        await oidcService.SyncUserSettings(settings, principal, user);
+        await oidcService.SyncUserSettings(null!, settings, principal, user);
 
         var dbUser = await UnitOfWork.UserRepository.GetUserByIdAsync(user.Id);
         Assert.NotNull(dbUser);
@@ -284,7 +284,7 @@ public class OidcServiceTests: AbstractDbTest
             SyncUserSettings = true,
         };
 
-        await oidcService.SyncUserSettings(settings, principal, user);
+        await oidcService.SyncUserSettings(null!, settings, principal, user);
 
         var dbUser = await UnitOfWork.UserRepository.GetUserByIdAsync(user.Id);
         Assert.NotNull(dbUser);
@@ -312,7 +312,7 @@ public class OidcServiceTests: AbstractDbTest
         };
 
 
-        await oidcService.SyncUserSettings(settings, principal, user);
+        await oidcService.SyncUserSettings(null!, settings, principal, user);
 
         var dbUser = await UnitOfWork.UserRepository.GetUserByIdAsync(user.Id);
         Assert.NotNull(dbUser);
@@ -333,7 +333,7 @@ public class OidcServiceTests: AbstractDbTest
             SyncUserSettings = true,
         };
 
-        await oidcService.SyncUserSettings(settings, principal, user);
+        await oidcService.SyncUserSettings(null!, settings, principal, user);
 
         var dbUser = await UnitOfWork.UserRepository.GetUserByIdAsync(user.Id);
         Assert.NotNull(dbUser);
@@ -343,7 +343,7 @@ public class OidcServiceTests: AbstractDbTest
         identity = new ClaimsIdentity([new (ClaimTypes.Role, OidcService.AgeRestrictionPrefix + OidcService.IncludeUnknowns)]);
         principal = new ClaimsPrincipal(identity);
 
-        await oidcService.SyncUserSettings(settings, principal, user);
+        await oidcService.SyncUserSettings(null!, settings, principal, user);
 
         dbUser = await UnitOfWork.UserRepository.GetUserByIdAsync(user.Id);
         Assert.NotNull(dbUser);
@@ -373,7 +373,7 @@ public class OidcServiceTests: AbstractDbTest
         var identity = new ClaimsIdentity(claims);
         var principal = new ClaimsPrincipal(identity);
 
-        await oidcService.SyncUserSettings(settings, principal, user);
+        await oidcService.SyncUserSettings(null!, settings, principal, user);
 
         var userFromDb = await UnitOfWork.UserRepository.GetUserByIdAsync(user.Id);
         Assert.NotNull(userFromDb);
@@ -384,7 +384,7 @@ public class OidcServiceTests: AbstractDbTest
         Assert.Empty(res.Errors);
         Assert.True(res.Succeeded);
 
-        await oidcService.SyncUserSettings(settings, principal, newUser);
+        await oidcService.SyncUserSettings(null!, settings, principal, newUser);
         userFromDb = await UnitOfWork.UserRepository.GetUserByIdAsync(newUser.Id);
         Assert.NotNull(userFromDb);
         Assert.True(await userManager.IsInRoleAsync(newUser, PolicyConstants.ChangePasswordRole));
@@ -522,7 +522,7 @@ public class OidcServiceTests: AbstractDbTest
         await userManager.CreateAsync(defaultAdmin);
 
         var accountService = new AccountService(userManager, Substitute.For<ILogger<AccountService>>(), UnitOfWork, Mapper, Substitute.For<ILocalizationService>());
-        var oidcService = new OidcService(Substitute.For<ILogger<OidcService>>(), userManager, UnitOfWork, accountService);
+        var oidcService = new OidcService(Substitute.For<ILogger<OidcService>>(), userManager, UnitOfWork, accountService, Substitute.For<IEmailService>());
         return (oidcService, user, accountService, userManager);
     }
 

--- a/API.Tests/Services/OidcServiceTests.cs
+++ b/API.Tests/Services/OidcServiceTests.cs
@@ -23,6 +23,112 @@ public class OidcServiceTests: AbstractDbTest
 {
 
     [Fact]
+    public async Task UserSync_CustomClaim()
+    {
+        await ResetDb();
+        var (oidcService, user, _, _) = await Setup();
+
+        var mangaLib = new LibraryBuilder("Manga", LibraryType.Manga).Build();
+        var lightNovelsLib = new LibraryBuilder("Light Novels", LibraryType.LightNovel).Build();
+
+        UnitOfWork.LibraryRepository.Add(mangaLib);
+        UnitOfWork.LibraryRepository.Add(lightNovelsLib);
+        await UnitOfWork.CommitAsync();
+
+        const string claim = "groups";
+        var claims = new List<Claim>()
+        {
+            new (claim, PolicyConstants.LoginRole),
+            new (claim, PolicyConstants.DownloadRole),
+            new (ClaimTypes.Role, PolicyConstants.PromoteRole),
+            new (claim, OidcService.AgeRestrictionPrefix + "M"),
+            new (claim, OidcService.LibraryAccessPrefix + "Manga"),
+            new (ClaimTypes.Role, OidcService.LibraryAccessPrefix + "Light Novels"),
+        };
+        var identity = new ClaimsIdentity(claims);
+        var principal = new ClaimsPrincipal(identity);
+
+        var settings = new OidcConfigDto
+        {
+            SyncUserSettings = true,
+            RolesClaim = claim,
+        };
+
+        await oidcService.SyncUserSettings(settings, principal, user);
+
+        // Check correct roles assigned
+        var userRoles = await UnitOfWork.UserRepository.GetRoles(user.Id);
+        Assert.Contains(PolicyConstants.LoginRole, userRoles);
+        Assert.Contains(PolicyConstants.DownloadRole, userRoles);
+        Assert.DoesNotContain(PolicyConstants.PromoteRole, userRoles);
+
+        // Check correct libraries
+        var libraries = (await UnitOfWork.LibraryRepository.GetLibrariesForUserIdAsync(user.Id)).Select(l => l.Name).ToList();
+        Assert.Single(libraries);
+        Assert.Contains(mangaLib.Name, libraries);
+        Assert.DoesNotContain(lightNovelsLib.Name, libraries);
+
+        // Check correct age restrictions
+        var dbUser = await UnitOfWork.UserRepository.GetUserByIdAsync(user.Id);
+        Assert.NotNull(dbUser);
+        Assert.Equal(AgeRating.Mature,  dbUser.AgeRestriction);
+        Assert.False(dbUser.AgeRestrictionIncludeUnknowns);
+    }
+
+    [Fact]
+    public async Task UserSync_CustomPrefix()
+    {
+        await ResetDb();
+        var (oidcService, user, _, _) = await Setup();
+
+        var mangaLib = new LibraryBuilder("Manga", LibraryType.Manga).Build();
+        var lightNovelsLib = new LibraryBuilder("Light Novels", LibraryType.LightNovel).Build();
+
+        UnitOfWork.LibraryRepository.Add(mangaLib);
+        UnitOfWork.LibraryRepository.Add(lightNovelsLib);
+        await UnitOfWork.CommitAsync();
+
+        const string prefix = "kavita-";
+        var claims = new List<Claim>()
+        {
+            new (ClaimTypes.Role, prefix + PolicyConstants.LoginRole),
+            new (ClaimTypes.Role, prefix + PolicyConstants.DownloadRole),
+            new (ClaimTypes.Role, PolicyConstants.PromoteRole),
+            new (ClaimTypes.Role, prefix + OidcService.AgeRestrictionPrefix + "M"),
+            new (ClaimTypes.Role, prefix + OidcService.LibraryAccessPrefix + "Manga"),
+            new (ClaimTypes.Role, OidcService.LibraryAccessPrefix + "Light Novels"),
+        };
+        var identity = new ClaimsIdentity(claims);
+        var principal = new ClaimsPrincipal(identity);
+
+        var settings = new OidcConfigDto
+        {
+            SyncUserSettings = true,
+            RolesPrefix = prefix,
+        };
+
+        await oidcService.SyncUserSettings(settings, principal, user);
+
+        // Check correct roles assigned
+        var userRoles = await UnitOfWork.UserRepository.GetRoles(user.Id);
+        Assert.Contains(PolicyConstants.LoginRole, userRoles);
+        Assert.Contains(PolicyConstants.DownloadRole, userRoles);
+        Assert.DoesNotContain(PolicyConstants.PromoteRole, userRoles);
+
+        // Check correct libraries
+        var libraries = (await UnitOfWork.LibraryRepository.GetLibrariesForUserIdAsync(user.Id)).Select(l => l.Name).ToList();
+        Assert.Single(libraries);
+        Assert.Contains(mangaLib.Name, libraries);
+        Assert.DoesNotContain(lightNovelsLib.Name, libraries);
+
+        // Check correct age restrictions
+        var dbUser = await UnitOfWork.UserRepository.GetUserByIdAsync(user.Id);
+        Assert.NotNull(dbUser);
+        Assert.Equal(AgeRating.Mature,  dbUser.AgeRestriction);
+        Assert.False(dbUser.AgeRestrictionIncludeUnknowns);
+    }
+
+    [Fact]
     public async Task SyncRoles()
     {
         await ResetDb();
@@ -106,16 +212,15 @@ public class OidcServiceTests: AbstractDbTest
     }
 
     [Fact]
-    public async Task SyncAgeRestrictions_IncludeUnknowns()
+    public async Task SyncAgeRestrictions_NoRestrictions()
     {
         await ResetDb();
         var (oidcService, user, _, _) = await Setup();
 
         var claims = new List<Claim>()
         {
-            new (ClaimTypes.Role, PolicyConstants.AdminRole),
-            new (ClaimTypes.Role, OidcService.AgeRestrictionPrefix + "M"),
-            new(ClaimTypes.Role, OidcService.IncludeUnknowns)
+            new (ClaimTypes.Role, OidcService.AgeRestrictionPrefix + "Not Applicable"),
+            new(ClaimTypes.Role, OidcService.AgeRestrictionPrefix + OidcService.IncludeUnknowns),
         };
         var identity = new ClaimsIdentity(claims);
         var principal = new ClaimsPrincipal(identity);
@@ -130,6 +235,33 @@ public class OidcServiceTests: AbstractDbTest
         var dbUser = await UnitOfWork.UserRepository.GetUserByIdAsync(user.Id);
         Assert.NotNull(dbUser);
         Assert.Equal(AgeRating.NotApplicable,  dbUser.AgeRestriction);
+        Assert.True(dbUser.AgeRestrictionIncludeUnknowns);
+    }
+
+    [Fact]
+    public async Task SyncAgeRestrictions_IncludeUnknowns()
+    {
+        await ResetDb();
+        var (oidcService, user, _, _) = await Setup();
+
+        var claims = new List<Claim>()
+        {
+            new (ClaimTypes.Role, OidcService.AgeRestrictionPrefix + "M"),
+            new(ClaimTypes.Role, OidcService.AgeRestrictionPrefix + OidcService.IncludeUnknowns),
+        };
+        var identity = new ClaimsIdentity(claims);
+        var principal = new ClaimsPrincipal(identity);
+
+        var settings = new OidcConfigDto
+        {
+            SyncUserSettings = true,
+        };
+
+        await oidcService.SyncUserSettings(settings, principal, user);
+
+        var dbUser = await UnitOfWork.UserRepository.GetUserByIdAsync(user.Id);
+        Assert.NotNull(dbUser);
+        Assert.Equal(AgeRating.Mature,  dbUser.AgeRestriction);
         Assert.True(dbUser.AgeRestrictionIncludeUnknowns);
     }
 
@@ -185,6 +317,38 @@ public class OidcServiceTests: AbstractDbTest
         var dbUser = await UnitOfWork.UserRepository.GetUserByIdAsync(user.Id);
         Assert.NotNull(dbUser);
         Assert.Equal(AgeRating.Mature,  dbUser.AgeRestriction);
+    }
+
+    [Fact]
+    public async Task SyncAgeRestriction_NoAgeRestrictionClaims()
+    {
+        await ResetDb();
+        var (oidcService, user, _, _) = await Setup();
+
+        var identity = new ClaimsIdentity([]);
+        var principal = new ClaimsPrincipal(identity);
+
+        var settings = new OidcConfigDto
+        {
+            SyncUserSettings = true,
+        };
+
+        await oidcService.SyncUserSettings(settings, principal, user);
+
+        var dbUser = await UnitOfWork.UserRepository.GetUserByIdAsync(user.Id);
+        Assert.NotNull(dbUser);
+        Assert.Equal(AgeRating.RatingPending,  dbUser.AgeRestriction);
+        Assert.False(dbUser.AgeRestrictionIncludeUnknowns);
+
+        identity = new ClaimsIdentity([new (ClaimTypes.Role, OidcService.AgeRestrictionPrefix + OidcService.IncludeUnknowns)]);
+        principal = new ClaimsPrincipal(identity);
+
+        await oidcService.SyncUserSettings(settings, principal, user);
+
+        dbUser = await UnitOfWork.UserRepository.GetUserByIdAsync(user.Id);
+        Assert.NotNull(dbUser);
+        Assert.Equal(AgeRating.RatingPending,  dbUser.AgeRestriction);
+        Assert.True(dbUser.AgeRestrictionIncludeUnknowns);
     }
 
     [Fact]

--- a/API/Controllers/AccountController.cs
+++ b/API/Controllers/AccountController.cs
@@ -94,7 +94,16 @@ public class AccountController : BaseApiController
         if (user.IdentityProvider == IdentityProvider.OpenIdConnect)
         {
             var oidcSettings = (await _unitOfWork.SettingsRepository.GetSettingsDtoAsync()).OidcConfig;
-            await _oidcService.SyncUserSettings(HttpContext.Request, oidcSettings, User, user);
+
+            try
+            {
+                await _oidcService.SyncUserSettings(HttpContext.Request, oidcSettings, User, user);
+            }
+            catch (KavitaException ex)
+            {
+                // Log the user out if syncing fails
+                return Unauthorized(ex.Message);
+            }
         }
 
         var roles = await _userManager.GetRolesAsync(user);

--- a/API/Controllers/AccountController.cs
+++ b/API/Controllers/AccountController.cs
@@ -94,7 +94,7 @@ public class AccountController : BaseApiController
         if (user.IdentityProvider == IdentityProvider.OpenIdConnect)
         {
             var oidcSettings = (await _unitOfWork.SettingsRepository.GetSettingsDtoAsync()).OidcConfig;
-            await _oidcService.SyncUserSettings(oidcSettings, User, user);
+            await _oidcService.SyncUserSettings(HttpContext.Request, oidcSettings, User, user);
         }
 
         var roles = await _userManager.GetRolesAsync(user);

--- a/API/DTOs/Settings/OidcConfigDto.cs
+++ b/API/DTOs/Settings/OidcConfigDto.cs
@@ -24,7 +24,7 @@ public sealed record OidcConfigDto: OidcPublicConfigDto
     /// </summary>
     public bool SyncUserSettings { get; set; }
     /// <summary>
-    /// A prefix that all roles Kavita check for during sync must have
+    /// A prefix that all roles Kavita checks for during sync must have
     /// </summary>
     public string RolesPrefix { get; set; } = string.Empty;
     /// <summary>

--- a/API/DTOs/Settings/OidcConfigDto.cs
+++ b/API/DTOs/Settings/OidcConfigDto.cs
@@ -1,6 +1,7 @@
 ﻿#nullable enable
 
 using System.Collections.Generic;
+using System.Security.Claims;
 using API.Entities.Enums;
 
 namespace API.DTOs.Settings;
@@ -22,6 +23,14 @@ public sealed record OidcConfigDto: OidcPublicConfigDto
     /// Overwrite Kavita roles, libraries and age rating with OpenIDConnect provided roles on log in.
     /// </summary>
     public bool SyncUserSettings { get; set; }
+    /// <summary>
+    /// A prefix that all roles Kavita check for during sync must have
+    /// </summary>
+    public string RolesPrefix { get; set; } = string.Empty;
+    /// <summary>
+    /// The JWT claim roles are mapped under, defaults to <see cref="ClaimTypes.Role"/>
+    /// </summary>
+    public string RolesClaim { get; set; } = ClaimTypes.Role;
 
     // Default values used when SyncUserSettings is false
     #region Default user settings

--- a/API/DTOs/Settings/OidcPublicConfigDto.cs
+++ b/API/DTOs/Settings/OidcPublicConfigDto.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System.Collections.Generic;
 using API.Entities.Enums;
 
 namespace API.DTOs.Settings;
@@ -25,4 +26,9 @@ public record OidcPublicConfigDto
     /// </summary>
     /// <remarks>Default to OpenID Connect</remarks>
     public string ProviderName { get; set; } = "OpenID Connect";
+    /// <summary>
+    /// Custom scopes Kavita should request from your OIDC provider
+    /// </summary>
+    /// <remarks>Advanced setting</remarks>
+    public IList<string> CustomScopes { get; set; } = [];
 }

--- a/API/Extensions/ClaimsPrincipalExtensions.cs
+++ b/API/Extensions/ClaimsPrincipalExtensions.cs
@@ -45,11 +45,12 @@ public static class ClaimsPrincipalExtensions
         return true;
     }
 
-    public static List<string> GetAccessRoles(this ClaimsPrincipal claimsPrincipal)
+    public static IList<string> GetClaimsWithPrefix(this ClaimsPrincipal claimsPrincipal, string claimType, string prefix)
     {
-        return claimsPrincipal.FindAll(ClaimTypes.Role)
-            .Select(r => r.Value)
-            .Where(r => PolicyConstants.ValidRoles.Contains(r))
+        return claimsPrincipal
+            .FindAll(claimType)
+            .Where(c => c.Value.StartsWith(prefix))
+            .Select(c => c.Value.TrimPrefix(prefix))
             .ToList();
     }
 }

--- a/API/Extensions/IdentityServiceExtensions.cs
+++ b/API/Extensions/IdentityServiceExtensions.cs
@@ -156,7 +156,7 @@ public static class IdentityServiceExtensions
         if (ctx.Principal == null) return;
 
         var oidcService = ctx.HttpContext.RequestServices.GetRequiredService<IOidcService>();
-        var user = await oidcService.LoginOrCreate(ctx.Principal);
+        var user = await oidcService.LoginOrCreate(ctx.Request, ctx.Principal);
         if (user == null)
         {
             ctx.Principal = null;

--- a/API/I18N/en.json
+++ b/API/I18N/en.json
@@ -45,6 +45,8 @@
     "email-not-enabled": "Email is not enabled on this server. You cannot perform this action.",
     "account-email-invalid": "The email on file for the admin account is not a valid email. Cannot send test email.",
     "email-settings-invalid": "Email settings missing information. Ensure all email settings are saved.",
+    "oidc-invalid-authority": "Oidc Authority is not valid",
+    "reserved-client-id": "Kavita is a reserved ClientId and cannot be used for OIDC",
 
     "chapter-doesnt-exist": "Chapter does not exist",
     "file-missing": "File was not found in book",

--- a/API/I18N/en.json
+++ b/API/I18N/en.json
@@ -45,6 +45,7 @@
     "email-not-enabled": "Email is not enabled on this server. You cannot perform this action.",
     "account-email-invalid": "The email on file for the admin account is not a valid email. Cannot send test email.",
     "email-settings-invalid": "Email settings missing information. Ensure all email settings are saved.",
+    "oidc-invalid-authority": "OIDC authority is invalid",
 
     "chapter-doesnt-exist": "Chapter does not exist",
     "file-missing": "File was not found in book",

--- a/API/I18N/en.json
+++ b/API/I18N/en.json
@@ -45,8 +45,6 @@
     "email-not-enabled": "Email is not enabled on this server. You cannot perform this action.",
     "account-email-invalid": "The email on file for the admin account is not a valid email. Cannot send test email.",
     "email-settings-invalid": "Email settings missing information. Ensure all email settings are saved.",
-    "oidc-invalid-authority": "Oidc Authority is not valid",
-    "reserved-client-id": "Kavita is a reserved ClientId and cannot be used for OIDC",
 
     "chapter-doesnt-exist": "Chapter does not exist",
     "file-missing": "File was not found in book",

--- a/API/Services/AccountService.cs
+++ b/API/Services/AccountService.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using API.Constants;
 using API.Data;
@@ -26,7 +27,7 @@ public interface IAccountService
 {
     Task<IEnumerable<ApiException>> ChangeUserPassword(AppUser user, string newPassword);
     Task<IEnumerable<ApiException>> ValidatePassword(AppUser user, string password);
-    Task<IEnumerable<ApiException>> ValidateUsername(string username);
+    Task<IEnumerable<ApiException>> ValidateUsername(string? username);
     Task<IEnumerable<ApiException>> ValidateEmail(string email);
     Task<bool> HasBookmarkPermission(AppUser? user);
     Task<bool> HasDownloadPermission(AppUser? user);
@@ -57,7 +58,7 @@ public interface IAccountService
     Task AddDefaultReadingProfileToUser(AppUser user);
 }
 
-public class AccountService : IAccountService
+public partial class AccountService : IAccountService
 {
     private readonly ILocalizationService _localizationService;
     private readonly UserManager<AppUser> _userManager;
@@ -65,6 +66,8 @@ public class AccountService : IAccountService
     private readonly IUnitOfWork _unitOfWork;
     private readonly IMapper _mapper;
     public const string DefaultPassword = "[k.2@RZ!mxCQkJzE";
+    public static readonly Regex AllowedUsernameRegex = AllowedUsernameRegexAttr();
+
 
     public AccountService(UserManager<AppUser> userManager, ILogger<AccountService> logger, IUnitOfWork unitOfWork,
         IMapper mapper, ILocalizationService localizationService)
@@ -108,8 +111,13 @@ public class AccountService : IAccountService
 
         return Array.Empty<ApiException>();
     }
-    public async Task<IEnumerable<ApiException>> ValidateUsername(string username)
+    public async Task<IEnumerable<ApiException>> ValidateUsername(string? username)
     {
+        if (string.IsNullOrWhiteSpace(username) || !AllowedUsernameRegex.IsMatch(username))
+        {
+            return [new ApiException(400, "Invalid username")];
+        }
+
         // Reverted because of https://go.microsoft.com/fwlink/?linkid=2129535
         if (await _userManager.Users.AnyAsync(x => x.NormalizedUserName != null
                                                    && x.NormalizedUserName == username.ToUpper()))
@@ -280,4 +288,7 @@ public class AccountService : IAccountService
         _unitOfWork.AppUserReadingProfileRepository.Add(profile);
         await _unitOfWork.CommitAsync();
     }
+
+    [GeneratedRegex(@"^[a-zA-Z0-9\-._@+/]*$")]
+    private static partial Regex AllowedUsernameRegexAttr();
 }

--- a/API/Services/OidcService.cs
+++ b/API/Services/OidcService.cs
@@ -394,7 +394,7 @@ public class OidcService(ILogger<OidcService> logger, UserManager<AppUser> userM
             logger.LogDebug("No age restriction found in roles, setting to RatingPending");
 
             user.AgeRestriction = AgeRating.NotApplicable;
-            user.AgeRestrictionIncludeUnknowns = ageRatings.Count == 0 || ageRatings.Contains(IncludeUnknowns);
+            user.AgeRestrictionIncludeUnknowns = true;
             return;
         }
 

--- a/API/Services/OidcService.cs
+++ b/API/Services/OidcService.cs
@@ -164,9 +164,7 @@ public class OidcService(ILogger<OidcService> logger, UserManager<AppUser> userM
 
     private async Task<bool> IsNameAvailable(string? name)
     {
-        if (string.IsNullOrEmpty(name)) return false;
-
-        return await userManager.FindByNameAsync(name) == null;
+        return !(await accountService.ValidateUsername(name)).Any();
     }
 
     private async Task<AppUser?> NewUserFromOpenIdConnect(HttpRequest request, OidcConfigDto settings, ClaimsPrincipal claimsPrincipal, string externalId)
@@ -261,7 +259,7 @@ public class OidcService(ILogger<OidcService> logger, UserManager<AppUser> userM
         {
             logger.LogError(ex, "Failed to sync user {UserName} from OIDC", user.UserName);
             await unitOfWork.RollbackAsync();
-            throw new KavitaException("errors.oidc.syncing-user");
+            throw new KavitaException("errors.oidc.syncing-user", ex);
         }
     }
 

--- a/API/Services/OidcService.cs
+++ b/API/Services/OidcService.cs
@@ -284,7 +284,16 @@ public class OidcService(ILogger<OidcService> logger, UserManager<AppUser> userM
         var ageRatings = claimsPrincipal.GetClaimsWithPrefix(settings.RolesClaim, ageRatingPrefix);
         logger.LogDebug("Syncing age restriction for user {UserName}, found restrictions {Restrictions}", user.UserName, ageRatings);
 
-        var highestAgeRating = AgeRating.Unknown;
+        if (ageRatings.Count == 0 || (ageRatings.Count == 1 && ageRatings.Contains(IncludeUnknowns)))
+        {
+            logger.LogDebug("No age restriction found in roles, setting to RatingPending");
+
+            user.AgeRestriction = AgeRating.RatingPending;
+            user.AgeRestrictionIncludeUnknowns = ageRatings.Contains(IncludeUnknowns);
+            return;
+        }
+
+        var highestAgeRestriction = AgeRating.NotApplicable;
 
         foreach (var ar in ageRatings)
         {
@@ -294,17 +303,17 @@ public class OidcService(ILogger<OidcService> logger, UserManager<AppUser> userM
                 continue;
             }
 
-            if (ageRating > highestAgeRating)
+            if (ageRating > highestAgeRestriction)
             {
-                highestAgeRating = ageRating;
+                highestAgeRestriction = ageRating;
             }
         }
 
-        user.AgeRestriction = highestAgeRating;
+        user.AgeRestriction = highestAgeRestriction;
         user.AgeRestrictionIncludeUnknowns = ageRatings.Contains(IncludeUnknowns);
 
         logger.LogDebug("Synced age restriction for user {UserName}, AgeRestriction {AgeRestriction}, IncludeUnknowns: {IncludeUnknowns}",
-            user.UserName, ageRatings, user.AgeRestrictionIncludeUnknowns);
+            user.UserName, user.AgeRestriction, user.AgeRestrictionIncludeUnknowns);
     }
 
 }

--- a/API/Services/OidcService.cs
+++ b/API/Services/OidcService.cs
@@ -261,6 +261,7 @@ public class OidcService(ILogger<OidcService> logger, UserManager<AppUser> userM
         {
             logger.LogError(ex, "Failed to sync user {UserName} from OIDC", user.UserName);
             await unitOfWork.RollbackAsync();
+            throw new KavitaException("errors.oidc.syncing-user");
         }
     }
 

--- a/API/Services/OidcService.cs
+++ b/API/Services/OidcService.cs
@@ -1,5 +1,6 @@
 ﻿#nullable enable
 using System;
+using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
 using System.Security.Claims;
@@ -46,7 +47,7 @@ public class OidcService(ILogger<OidcService> logger, UserManager<AppUser> userM
 {
     public const string LibraryAccessPrefix = "library-";
     public const string AgeRestrictionPrefix = "age-restriction-";
-    public const string IncludeUnknowns = AgeRestrictionPrefix + "include-unknowns";
+    public const string IncludeUnknowns = "include-unknowns";
 
     public async Task<AppUser?> LoginOrCreate(ClaimsPrincipal principal)
     {
@@ -84,7 +85,9 @@ public class OidcService(ILogger<OidcService> logger, UserManager<AppUser> userM
         }
 
         // Cannot match on native account, try and create new one
-        if (settings.SyncUserSettings && principal.GetAccessRoles().Count == 0)
+        var accessRoles = principal.GetClaimsWithPrefix(settings.RolesClaim, settings.RolesPrefix)
+            .Where(s => PolicyConstants.ValidRoles.Contains(s)).ToList();
+        if (settings.SyncUserSettings && accessRoles.Count == 0)
         {
             throw new KavitaException("errors.oidc.role-not-assigned");
         }
@@ -226,9 +229,9 @@ public class OidcService(ILogger<OidcService> logger, UserManager<AppUser> userM
         logger.LogDebug("Syncing user {UserName} from OIDC", user.UserName);
         try
         {
-            await SyncRoles(claimsPrincipal, user);
-            await SyncLibraries(claimsPrincipal, user);
-            await SyncAgeRestriction(claimsPrincipal, user);
+            await SyncRoles(settings, claimsPrincipal, user);
+            await SyncLibraries(settings, claimsPrincipal, user);
+            await SyncAgeRestriction(settings, claimsPrincipal, user);
 
             if (unitOfWork.HasChanges())
             {
@@ -242,22 +245,20 @@ public class OidcService(ILogger<OidcService> logger, UserManager<AppUser> userM
         }
     }
 
-    private async Task SyncRoles(ClaimsPrincipal claimsPrincipal, AppUser user)
+    private async Task SyncRoles(OidcConfigDto settings, ClaimsPrincipal claimsPrincipal, AppUser user)
     {
-        var roles = claimsPrincipal.GetAccessRoles();
+        var roles = claimsPrincipal.GetClaimsWithPrefix(settings.RolesClaim, settings.RolesPrefix)
+            .Where(s => PolicyConstants.ValidRoles.Contains(s)).ToList();
         logger.LogDebug("Syncing access roles for user {UserName}, found roles {Roles}", user.UserName, roles);
 
         var errors = await accountService.UpdateRolesForUser(user, roles);
         if (errors.Any()) throw new KavitaException("errors.oidc.syncing-user");
     }
 
-    private async Task SyncLibraries(ClaimsPrincipal claimsPrincipal, AppUser user)
+    private async Task SyncLibraries(OidcConfigDto settings, ClaimsPrincipal claimsPrincipal, AppUser user)
     {
-        var libraryAccess = claimsPrincipal
-            .FindAll(ClaimTypes.Role)
-            .Where(r => r.Value.StartsWith(LibraryAccessPrefix))
-            .Select(r => r.Value.TrimPrefix(LibraryAccessPrefix))
-            .ToList();
+        var libraryAccessPrefix = settings.RolesPrefix + LibraryAccessPrefix;
+        var libraryAccess = claimsPrincipal.GetClaimsWithPrefix(settings.RolesClaim, libraryAccessPrefix);
 
         logger.LogDebug("Syncing libraries for user {UserName}, found library roles {Roles}", user.UserName, libraryAccess);
 
@@ -269,7 +270,7 @@ public class OidcService(ILogger<OidcService> logger, UserManager<AppUser> userM
         await accountService.UpdateLibrariesForUser(user, librariesIds, hasAdminRole);
     }
 
-    private async Task SyncAgeRestriction(ClaimsPrincipal claimsPrincipal, AppUser user)
+    private async Task SyncAgeRestriction(OidcConfigDto settings, ClaimsPrincipal claimsPrincipal, AppUser user)
     {
         if (await userManager.IsInRoleAsync(user, PolicyConstants.AdminRole))
         {
@@ -279,11 +280,8 @@ public class OidcService(ILogger<OidcService> logger, UserManager<AppUser> userM
             return;
         }
 
-        var ageRatings = claimsPrincipal
-            .FindAll(ClaimTypes.Role)
-            .Where(r => r.Value.StartsWith(AgeRestrictionPrefix))
-            .Select(r => r.Value.TrimPrefix(AgeRestrictionPrefix))
-            .ToList();
+        var ageRatingPrefix = settings.RolesPrefix + AgeRestrictionPrefix;
+        var ageRatings = claimsPrincipal.GetClaimsWithPrefix(settings.RolesClaim, ageRatingPrefix);
         logger.LogDebug("Syncing age restriction for user {UserName}, found restrictions {Restrictions}", user.UserName, ageRatings);
 
         var highestAgeRating = AgeRating.Unknown;

--- a/API/Services/OidcService.cs
+++ b/API/Services/OidcService.cs
@@ -83,7 +83,7 @@ public class OidcService(ILogger<OidcService> logger, UserManager<AppUser> userM
         {
             // Don't allow taking over accounts
             // This could happen if the user changes their email in OIDC, and then someone else uses the old one
-            if (user.OidcId is not (null or ""))
+            if (!string.IsNullOrEmpty(user.OidcId))
             {
                 throw new KavitaException("errors.oidc.email-in-use");
             }
@@ -273,7 +273,7 @@ public class OidcService(ILogger<OidcService> logger, UserManager<AppUser> userM
             throw new KavitaException("errors.oidc.email-not-verified");
         }
 
-        // Ensure no other user, uses this email
+        // Ensure no other user uses this email
         var other = await userManager.FindByEmailAsync(email);
         if (other != null)
         {
@@ -305,7 +305,7 @@ public class OidcService(ILogger<OidcService> logger, UserManager<AppUser> userM
         await userManager.UpdateAsync(user);
 
         var emailLink = await emailService.GenerateEmailLink(request, user.ConfirmationToken, "confirm-email-update", email);
-        logger.LogCritical("[Update Email]: Email Link for {UserName}: {Link}", user.UserName, emailLink);
+        logger.LogCritical("[Update Email]: Automatic email update after OIDC sync, email Link for {UserName}: {Link}", user.UserName, emailLink);
 
         if (!shouldEmailUser)
         {
@@ -393,8 +393,8 @@ public class OidcService(ILogger<OidcService> logger, UserManager<AppUser> userM
         {
             logger.LogDebug("No age restriction found in roles, setting to RatingPending");
 
-            user.AgeRestriction = AgeRating.RatingPending;
-            user.AgeRestrictionIncludeUnknowns = ageRatings.Contains(IncludeUnknowns);
+            user.AgeRestriction = AgeRating.NotApplicable;
+            user.AgeRestrictionIncludeUnknowns = ageRatings.Count == 0 || ageRatings.Contains(IncludeUnknowns);
             return;
         }
 

--- a/API/Services/OidcService.cs
+++ b/API/Services/OidcService.cs
@@ -8,12 +8,16 @@ using System.Threading.Tasks;
 using API.Constants;
 using API.Data;
 using API.Data.Repositories;
+using API.DTOs.Email;
 using API.DTOs.Settings;
 using API.Entities;
 using API.Entities.Enums;
 using API.Extensions;
 using API.Helpers.Builders;
+using Hangfire;
 using Kavita.Common;
+using Kavita.Common.EnvironmentInfo;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Logging;
 
@@ -27,14 +31,14 @@ public interface IOidcService
     /// <param name="principal"></param>
     /// <returns></returns>
     /// <exception cref="KavitaException">if any requirements aren't met</exception>
-    Task<AppUser?> LoginOrCreate(ClaimsPrincipal principal);
+    Task<AppUser?> LoginOrCreate(HttpRequest request, ClaimsPrincipal principal);
     /// <summary>
     /// Updates roles, library access and age rating restriction. Will not modify the default admin
     /// </summary>
     /// <param name="settings"></param>
     /// <param name="claimsPrincipal"></param>
     /// <param name="user"></param>
-    Task SyncUserSettings(OidcConfigDto settings, ClaimsPrincipal claimsPrincipal, AppUser user);
+    Task SyncUserSettings(HttpRequest request, OidcConfigDto settings, ClaimsPrincipal claimsPrincipal, AppUser user);
     /// <summary>
     /// Remove <see cref="AppUser.OidcId"/> from all users
     /// </summary>
@@ -43,13 +47,13 @@ public interface IOidcService
 }
 
 public class OidcService(ILogger<OidcService> logger, UserManager<AppUser> userManager,
-    IUnitOfWork unitOfWork, IAccountService accountService): IOidcService
+    IUnitOfWork unitOfWork, IAccountService accountService, IEmailService emailService): IOidcService
 {
     public const string LibraryAccessPrefix = "library-";
     public const string AgeRestrictionPrefix = "age-restriction-";
     public const string IncludeUnknowns = "include-unknowns";
 
-    public async Task<AppUser?> LoginOrCreate(ClaimsPrincipal principal)
+    public async Task<AppUser?> LoginOrCreate(HttpRequest request, ClaimsPrincipal principal)
     {
         var settings = (await unitOfWork.SettingsRepository.GetSettingsDtoAsync()).OidcConfig;
 
@@ -77,6 +81,13 @@ public class OidcService(ILogger<OidcService> logger, UserManager<AppUser> userM
         user = await unitOfWork.UserRepository.GetUserByEmailAsync(email, AppUserIncludes.UserPreferences | AppUserIncludes.SideNavStreams);
         if (user != null)
         {
+            // Don't allow taking over accounts
+            // This could happen if the user changes their email in OIDC, and then someone else uses the old one
+            if (user.OidcId is not (null or ""))
+            {
+                throw new KavitaException("errors.oidc.email-in-use");
+            }
+
             logger.LogDebug("User {UserName} has matched on email to {OidcId}", user.Id, oidcId);
             user.OidcId = oidcId;
             await unitOfWork.CommitAsync();
@@ -94,7 +105,7 @@ public class OidcService(ILogger<OidcService> logger, UserManager<AppUser> userM
 
         try
         {
-            user = await NewUserFromOpenIdConnect(settings, principal, oidcId);
+            user = await NewUserFromOpenIdConnect(request, settings, principal, oidcId);
         }
         catch (KavitaException e)
         {
@@ -128,19 +139,25 @@ public class OidcService(ILogger<OidcService> logger, UserManager<AppUser> userM
         await unitOfWork.CommitAsync();
     }
 
-    public async Task<string?> FindBestAvailableName(ClaimsPrincipal claimsPrincipal)
+    /// <summary>
+    /// Find the best available name from claims
+    /// </summary>
+    /// <param name="claimsPrincipal"></param>
+    /// <param name="orEqualTo">Also return if the claim is equal to this value</param>
+    /// <returns></returns>
+    public async Task<string?> FindBestAvailableName(ClaimsPrincipal claimsPrincipal, string? orEqualTo = null)
     {
         var name = claimsPrincipal.FindFirstValue(JwtRegisteredClaimNames.PreferredUsername);
-        if (await IsNameAvailable(name)) return name;
+        if (orEqualTo == name || await IsNameAvailable(name)) return name;
 
         name = claimsPrincipal.FindFirstValue(ClaimTypes.Name);
-        if (await IsNameAvailable(name)) return name;
+        if (orEqualTo == name || await IsNameAvailable(name)) return name;
 
         name = claimsPrincipal.FindFirstValue(ClaimTypes.GivenName);
-        if (await IsNameAvailable(name)) return name;
+        if (orEqualTo == name || await IsNameAvailable(name)) return name;
 
         name = claimsPrincipal.FindFirstValue(ClaimTypes.Surname);
-        if (await IsNameAvailable(name)) return name;
+        if (orEqualTo == name || await IsNameAvailable(name)) return name;
 
         return null;
     }
@@ -152,7 +169,7 @@ public class OidcService(ILogger<OidcService> logger, UserManager<AppUser> userM
         return await userManager.FindByNameAsync(name) == null;
     }
 
-    private async Task<AppUser?> NewUserFromOpenIdConnect(OidcConfigDto settings, ClaimsPrincipal claimsPrincipal, string externalId)
+    private async Task<AppUser?> NewUserFromOpenIdConnect(HttpRequest request, OidcConfigDto settings, ClaimsPrincipal claimsPrincipal, string externalId)
     {
         if (!settings.ProvisionAccounts) return null;
 
@@ -173,9 +190,8 @@ public class OidcService(ILogger<OidcService> logger, UserManager<AppUser> userM
             throw new KavitaException("errors.oidc.creating-user");
         }
 
-        if (settings.RequireVerifiedEmail)
+        if (claimsPrincipal.HasVerifiedEmail())
         {
-            // Email has been verified by OpenID Connect provider
             var token = await userManager.GenerateEmailConfirmationTokenAsync(user);
             await userManager.ConfirmEmailAsync(user, token);
         }
@@ -186,7 +202,7 @@ public class OidcService(ILogger<OidcService> logger, UserManager<AppUser> userM
         accountService.AddDefaultStreamsToUser(user);
         await accountService.AddDefaultReadingProfileToUser(user);
 
-        await SyncUserSettings(settings, claimsPrincipal, user);
+        await SyncUserSettings(request, settings, claimsPrincipal, user);
         await SetDefaults(settings, user);
 
         await unitOfWork.CommitAsync();
@@ -218,7 +234,7 @@ public class OidcService(ILogger<OidcService> logger, UserManager<AppUser> userM
         await unitOfWork.CommitAsync();
     }
 
-    public async Task SyncUserSettings(OidcConfigDto settings, ClaimsPrincipal claimsPrincipal, AppUser user)
+    public async Task SyncUserSettings(HttpRequest request, OidcConfigDto settings, ClaimsPrincipal claimsPrincipal, AppUser user)
     {
         if (!settings.SyncUserSettings) return;
 
@@ -229,6 +245,9 @@ public class OidcService(ILogger<OidcService> logger, UserManager<AppUser> userM
         logger.LogDebug("Syncing user {UserName} from OIDC", user.UserName);
         try
         {
+
+            await SyncEmail(request, settings, claimsPrincipal, user);
+            await SyncUsername(claimsPrincipal, user);
             await SyncRoles(settings, claimsPrincipal, user);
             await SyncLibraries(settings, claimsPrincipal, user);
             await SyncAgeRestriction(settings, claimsPrincipal, user);
@@ -242,6 +261,93 @@ public class OidcService(ILogger<OidcService> logger, UserManager<AppUser> userM
         {
             logger.LogError(ex, "Failed to sync user {UserName} from OIDC", user.UserName);
             await unitOfWork.RollbackAsync();
+        }
+    }
+
+    private async Task SyncEmail(HttpRequest request, OidcConfigDto settings, ClaimsPrincipal claimsPrincipal, AppUser user)
+    {
+        var email = claimsPrincipal.FindFirstValue(ClaimTypes.Email);
+        if (string.IsNullOrEmpty(email) || user.Email == email) return;
+
+        if (settings.RequireVerifiedEmail && !claimsPrincipal.HasVerifiedEmail())
+        {
+            throw new KavitaException("errors.oidc.email-not-verified");
+        }
+
+        // Ensure no other user, uses this email
+        var other = await userManager.FindByEmailAsync(email);
+        if (other != null)
+        {
+            throw new KavitaException("errors.oidc.email-in-use");
+        }
+
+        // The email is verified, we can go ahead and change & confirm it
+        if (claimsPrincipal.HasVerifiedEmail())
+        {
+            var res = await userManager.SetEmailAsync(user, email);
+            if (!res.Succeeded)
+            {
+                logger.LogError("Failed to update email for user {UserName} from OIDC {Errors}", user.UserName, res.Errors.Select(x => x.Description).ToList());
+                throw new KavitaException("errors.oidc.failed-to-update-email");
+            }
+
+            user.EmailConfirmed = true;
+            await userManager.UpdateAsync(user);
+            return;
+        }
+
+        var token = await userManager.GenerateEmailConfirmationTokenAsync(user);
+        var isValidEmailAddress = !string.IsNullOrEmpty(user.Email) && emailService.IsValidEmail(user.Email);
+        var isEmailSetup = (await unitOfWork.SettingsRepository.GetSettingsDtoAsync()).IsEmailSetup();
+        var shouldEmailUser = isEmailSetup || !isValidEmailAddress;
+
+        user.EmailConfirmed = !shouldEmailUser;
+        user.ConfirmationToken = token;
+        await userManager.UpdateAsync(user);
+
+        var emailLink = await emailService.GenerateEmailLink(request, user.ConfirmationToken, "confirm-email-update", email);
+        logger.LogCritical("[Update Email]: Email Link for {UserName}: {Link}", user.UserName, emailLink);
+
+        if (!shouldEmailUser)
+        {
+            logger.LogInformation("Cannot email admin, email not setup or admin email invalid");
+            return;
+        }
+
+        if (!isValidEmailAddress)
+        {
+            logger.LogCritical("[Update Email]: User is trying to update their email, but their existing email ({Email}) isn't valid. No email will be send", user.Email);
+            return;
+        }
+
+        try
+        {
+            var invitingUser = await unitOfWork.UserRepository.GetDefaultAdminUser();
+            BackgroundJob.Enqueue(() => emailService.SendEmailChangeEmail(new ConfirmationEmailDto()
+            {
+                EmailAddress = string.IsNullOrEmpty(user.Email) ? email : user.Email,
+                InstallId = BuildInfo.Version.ToString(),
+                InvitingUser = invitingUser.UserName,
+                ServerConfirmationLink = emailLink,
+            }));
+        }
+        catch (Exception)
+        {
+            /* Swallow exception */
+        }
+
+    }
+
+    private async Task SyncUsername(ClaimsPrincipal claimsPrincipal, AppUser user)
+    {
+        var bestName = await FindBestAvailableName(claimsPrincipal, user.UserName);
+        if (bestName == null || bestName == user.UserName) return;
+
+        var res = await userManager.SetUserNameAsync(user, bestName);
+        if (!res.Succeeded)
+        {
+            logger.LogError("Failed to update username for user {UserName} to {NewUserName} from OIDC {Errors}", user.UserName, bestName,  res.Errors.Select(x => x.Description).ToList());
+            throw new KavitaException("errors.oidc.failed-to-update-username");
         }
     }
 

--- a/API/Services/SettingsService.cs
+++ b/API/Services/SettingsService.cs
@@ -364,8 +364,7 @@ public class SettingsService : ISettingsService
             return false;
         }
 
-        var hasTrailingSlash = authority.EndsWith('/');
-        var url = authority + (hasTrailingSlash ? "" : "/") + ".well-known/openid-configuration";
+        var url = authority + "/.well-known/openid-configuration";
         try
         {
             var json = await url.GetStringAsync();
@@ -433,12 +432,6 @@ public class SettingsService : ISettingsService
 
         if (setting.Key == ServerSettingKey.OidcClientId && setting.Value != updateSettingsDto.OidcConfig.ClientId)
         {
-
-            if (updateSettingsDto.OidcConfig.ClientId == "Kavita")
-            {
-                throw new KavitaException("reserved-client-id");
-            }
-
             setting.Value = updateSettingsDto.OidcConfig.ClientId;
             Configuration.OidcClientId = updateSettingsDto.OidcConfig.ClientId;
             _unitOfWork.SettingsRepository.Update(setting);

--- a/API/Services/SettingsService.cs
+++ b/API/Services/SettingsService.cs
@@ -365,7 +365,7 @@ public class SettingsService : ISettingsService
         }
 
         var hasTrailingSlash = authority.EndsWith('/');
-        var url = authority + (hasTrailingSlash ? "" : "/") + ".well-known/openid-configuration";
+        var url = authority + (hasTrailingSlash ? string.Empty : "/") + ".well-known/openid-configuration";
         try
         {
             var json = await url.GetStringAsync();

--- a/API/Services/SettingsService.cs
+++ b/API/Services/SettingsService.cs
@@ -363,7 +363,8 @@ public class SettingsService : ISettingsService
             return false;
         }
 
-        var url = authority + "/.well-known/openid-configuration";
+        var hasTrailingSlash = authority.EndsWith('/');
+        var url = authority + (hasTrailingSlash ? "" : "/") + ".well-known/openid-configuration";
         try
         {
             var json = await url.GetStringAsync();
@@ -431,6 +432,12 @@ public class SettingsService : ISettingsService
 
         if (setting.Key == ServerSettingKey.OidcClientId && setting.Value != updateSettingsDto.OidcConfig.ClientId)
         {
+
+            if (updateSettingsDto.OidcConfig.ClientId == "Kavita")
+            {
+                throw new KavitaException("reserved-client-id");
+            }
+
             setting.Value = updateSettingsDto.OidcConfig.ClientId;
             Configuration.OidcClientId = updateSettingsDto.OidcConfig.ClientId;
             _unitOfWork.SettingsRepository.Update(setting);

--- a/API/Services/SettingsService.cs
+++ b/API/Services/SettingsService.cs
@@ -364,7 +364,8 @@ public class SettingsService : ISettingsService
             return false;
         }
 
-        var url = authority + "/.well-known/openid-configuration";
+        var hasTrailingSlash = authority.EndsWith('/');
+        var url = authority + (hasTrailingSlash ? "" : "/") + ".well-known/openid-configuration";
         try
         {
             var json = await url.GetStringAsync();

--- a/API/Services/SettingsService.cs
+++ b/API/Services/SettingsService.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Net;
+using System.Security.Claims;
 using System.Text.Json;
 using System.Threading.Tasks;
 using API.Data;
@@ -445,6 +446,11 @@ public class SettingsService : ISettingsService
         }
 
         if (setting.Key != ServerSettingKey.OidcConfiguration) return;
+
+        if (updateSettingsDto.OidcConfig.RolesClaim.Trim() == string.Empty)
+        {
+            updateSettingsDto.OidcConfig.RolesClaim = ClaimTypes.Role;
+        }
 
         var newValue = JsonSerializer.Serialize(updateSettingsDto.OidcConfig);
         if (setting.Value == newValue) return;

--- a/UI/Web/src/app/_interceptors/error.interceptor.ts
+++ b/UI/Web/src/app/_interceptors/error.interceptor.ts
@@ -131,17 +131,19 @@ export class ErrorInterceptor implements HttpInterceptor {
     }
 
     if (error.error && error.error !== 'Unauthorized') {
-      this.toastr.error(error.error);
+      this.toast(error.error);
     }
 
     // NOTE: Signin has error.error or error.statusText available.
     // if statement is due to http/2 spec issue: https://github.com/angular/angular/issues/23334
+
+    // Ensure AutoLogin is skipped when the OIDC endpoint is called
     this.accountService.logout(req.method === 'GET' && req.url.endsWith('/api/account'));
   }
 
   // Assume the title is already translated
   private toast(message: string, title?: string) {
-    if (message.startsWith('errors.')) {
+    if ((message+'').startsWith('errors.')) {
       this.toastr.error(this.translocoService.translate(message), title);
     } else {
       this.toastr.error(message, title);

--- a/UI/Web/src/app/_interceptors/error.interceptor.ts
+++ b/UI/Web/src/app/_interceptors/error.interceptor.ts
@@ -31,7 +31,7 @@ export class ErrorInterceptor implements HttpInterceptor {
             this.handleValidationError(error);
             break;
           case 401:
-            this.handleAuthError(error);
+            this.handleAuthError(request, error);
             break;
           case 404:
             this.handleNotFound(error);
@@ -119,7 +119,7 @@ export class ErrorInterceptor implements HttpInterceptor {
     console.error('500 error:', error);
   }
 
-  private handleAuthError(error: any) {
+  private handleAuthError(req: HttpRequest<unknown>, error: any) {
     // Special hack for register url, to not care about auth
     if (location.href.includes('/registration/confirm-email?token=')) {
       return;
@@ -130,9 +130,13 @@ export class ErrorInterceptor implements HttpInterceptor {
       localStorage.setItem(AuthGuard.urlKey, path);
     }
 
+    if (error.error && error.error !== 'Unauthorized') {
+      this.toastr.error(error.error);
+    }
+
     // NOTE: Signin has error.error or error.statusText available.
     // if statement is due to http/2 spec issue: https://github.com/angular/angular/issues/23334
-    this.accountService.logout();
+    this.accountService.logout(req.method === 'GET' && req.url.endsWith('/api/account'));
   }
 
   // Assume the title is already translated

--- a/UI/Web/src/app/_resolvers/oidc.resolver.ts
+++ b/UI/Web/src/app/_resolvers/oidc.resolver.ts
@@ -3,6 +3,7 @@ import {inject, Injectable} from "@angular/core";
 import {catchError, filter, Observable, of, take, timeout} from "rxjs";
 import {OidcService} from "../_services/oidc.service";
 import {ToastrService} from "ngx-toastr";
+import {translate} from "@jsverse/transloco";
 
 @Injectable({
   providedIn: 'root'
@@ -19,7 +20,7 @@ export class OidcResolver implements Resolve<any> {
       timeout(5000),
       catchError(err => {
         console.log(err);
-        this.toastR.error("oidc.timeout");
+        this.toastR.error(translate("oidc.timeout"));
         return of(true);
     }));
   }

--- a/UI/Web/src/app/_resolvers/oidc.resolver.ts
+++ b/UI/Web/src/app/_resolvers/oidc.resolver.ts
@@ -11,7 +11,7 @@ import {translate} from "@jsverse/transloco";
 export class OidcResolver implements Resolve<any> {
 
   private oidcService = inject(OidcService);
-  private toastR = inject(ToastrService);
+  private toastr = inject(ToastrService);
 
   resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<any> {
     return this.oidcService.loaded$.pipe(
@@ -20,7 +20,7 @@ export class OidcResolver implements Resolve<any> {
       timeout(5000),
       catchError(err => {
         console.log(err);
-        this.toastR.error(translate("oidc.timeout"));
+        this.toastr.error(translate("oidc.timeout"));
         return of(true);
     }));
   }

--- a/UI/Web/src/app/_services/account.service.ts
+++ b/UI/Web/src/app/_services/account.service.ts
@@ -266,14 +266,16 @@ export class AccountService {
     }
   }
 
-  logout() {
+  logout(skipAutoLogin: boolean = false) {
     localStorage.removeItem(this.userKey);
     this.currentUserSource.next(undefined);
     this.currentUser = undefined;
     this.stopRefreshTokenTimer();
     this.messageHub.stopHubConnection();
     // Upon logout, perform redirection
-    this.router.navigateByUrl('/login');
+    this.router.navigate(['/login'], {
+      queryParams: {skipAutoLogin: skipAutoLogin}
+    });
   }
 
 

--- a/UI/Web/src/app/_services/oidc.service.ts
+++ b/UI/Web/src/app/_services/oidc.service.ts
@@ -84,6 +84,8 @@ export class OidcService {
         return
       }
 
+      const scopes = "openid profile email roles offline_access " + oidcSetting.customScopes.join(" ");
+
       this.oauth2.configure({
         issuer: oidcSetting.authority,
         clientId: oidcSetting.clientId,
@@ -93,7 +95,7 @@ export class OidcService {
         postLogoutRedirectUri: window.location.origin + this.baseUrl + "login",
         showDebugInformation: !environment.production,
         responseType: 'code',
-        scope: "openid profile email roles offline_access",
+        scope: scopes.trim(),
         // Not all OIDC providers follow this nicely
         strictDiscoveryDocumentValidation: false,
       });

--- a/UI/Web/src/app/_services/oidc.service.ts
+++ b/UI/Web/src/app/_services/oidc.service.ts
@@ -53,6 +53,9 @@ export class OidcService {
   private readonly _settings = signal<OidcPublicConfig | undefined>(undefined);
   public readonly settings = this._settings.asReadonly();
 
+  private readonly _isLoggingOut = signal(false);
+  public readonly isLoggingOut = this._isLoggingOut.asReadonly();
+
   constructor() {
     window.addEventListener('online', () => {
       if (!this.oauth2.hasValidAccessToken() && this.oauth2.getRefreshToken()) {
@@ -119,6 +122,7 @@ export class OidcService {
 
   logout() {
     if (this.token()) {
+      this._isLoggingOut.set(true);
       this.oauth2.logOut();
     }
   }

--- a/UI/Web/src/app/admin/_models/oidc-config.ts
+++ b/UI/Web/src/app/admin/_models/oidc-config.ts
@@ -12,6 +12,8 @@ export interface OidcConfig extends OidcPublicConfig {
   provisionAccounts: boolean;
   requireVerifiedEmail: boolean;
   syncUserSettings: boolean;
+  rolesPrefix: string;
+  rolesClaim: string;
   defaultRoles: string[];
   defaultLibraries: number[];
   defaultAgeRestriction: AgeRating;

--- a/UI/Web/src/app/admin/_models/oidc-config.ts
+++ b/UI/Web/src/app/admin/_models/oidc-config.ts
@@ -6,6 +6,7 @@ export interface OidcPublicConfig {
   autoLogin: boolean;
   disablePasswordAuthentication: boolean;
   providerName: string;
+  customScopes: string[];
 }
 
 export interface OidcConfig extends OidcPublicConfig {

--- a/UI/Web/src/app/admin/edit-user/edit-user.component.ts
+++ b/UI/Web/src/app/admin/edit-user/edit-user.component.ts
@@ -27,7 +27,7 @@ import {ServerSettings} from "../_models/server-settings";
 import {IdentityProvider, IdentityProviders} from "../../_models/user";
 import {IdentityProviderPipePipe} from "../../_pipes/identity-provider.pipe";
 
-const AllowedUsernameCharacters = /^[\sa-zA-Z0-9\-._@+/\s]*$/;
+const AllowedUsernameCharacters = /^[a-zA-Z0-9\-._@+/]*$/;
 const EmailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 @Component({

--- a/UI/Web/src/app/admin/manage-open-idconnect/manage-open-idconnect.component.html
+++ b/UI/Web/src/app/admin/manage-open-idconnect/manage-open-idconnect.component.html
@@ -239,7 +239,7 @@
             </ng-template>
 
             <ng-template #edit>
-              <textarea rows="3" id="blacklist" class="form-control"  formControlName="customScopes"></textarea>
+              <textarea rows="3" id="custom-scopes" class="form-control"  formControlName="customScopes"></textarea>
             </ng-template>
 
           </app-setting-item>

--- a/UI/Web/src/app/admin/manage-open-idconnect/manage-open-idconnect.component.html
+++ b/UI/Web/src/app/admin/manage-open-idconnect/manage-open-idconnect.component.html
@@ -224,6 +224,29 @@
           </app-setting-item>
         }
       </div>
+
+      <div class="row g-0 mt-4 mb-4">
+        @if (settingsForm.get('customScopes'); as formControl) {
+          <app-setting-item [title]="t('custom-scopes-label')" [subtitle]="t('custom-scopes-tooltip')">
+            <ng-template #view>
+              @let val = breakString(formControl.value);
+
+              @for(opt of val; track opt) {
+                <app-tag-badge>{{opt.trim()}}</app-tag-badge>
+              } @empty {
+                {{null | defaultValue}}
+              }
+            </ng-template>
+
+            <ng-template #edit>
+              <textarea rows="3" id="blacklist" class="form-control"  formControlName="customScopes"></textarea>
+            </ng-template>
+
+          </app-setting-item>
+
+        }
+      </div>
+
     </ng-container>
 
   </form>

--- a/UI/Web/src/app/admin/manage-open-idconnect/manage-open-idconnect.component.html
+++ b/UI/Web/src/app/admin/manage-open-idconnect/manage-open-idconnect.component.html
@@ -51,9 +51,6 @@
                   @if (formControl.errors && formControl.errors.requiredIf) {
                     <div>{{t('other-field-required', {name: 'clientId', other: formControl.errors.requiredIf.other})}}</div>
                   }
-                  @if (formControl.errors && formControl.errors.pattern) {
-                    <div>{{t('reserved-client-id')}}</div>
-                  }
                 </div>
               }
 

--- a/UI/Web/src/app/admin/manage-open-idconnect/manage-open-idconnect.component.html
+++ b/UI/Web/src/app/admin/manage-open-idconnect/manage-open-idconnect.component.html
@@ -51,6 +51,9 @@
                   @if (formControl.errors && formControl.errors.requiredIf) {
                     <div>{{t('other-field-required', {name: 'clientId', other: formControl.errors.requiredIf.other})}}</div>
                   }
+                  @if (formControl.errors && formControl.errors.pattern) {
+                    <div>{{t('reserved-client-id')}}</div>
+                  }
                 </div>
               }
 

--- a/UI/Web/src/app/admin/manage-open-idconnect/manage-open-idconnect.component.html
+++ b/UI/Web/src/app/admin/manage-open-idconnect/manage-open-idconnect.component.html
@@ -1,7 +1,7 @@
 <ng-container *transloco="let t; prefix:'manage-oidc-connect'">
 
   <div class="position-relative">
-    <button type="button" class="btn btn-primary position-absolute custom-position" (click)="save()">{{t('save')}}</button>
+    <button type="button" class="btn btn-primary position-absolute custom-position" (click)="save(true)">{{t('save')}}</button>
   </div>
 
   <form [formGroup]="settingsForm">
@@ -9,8 +9,8 @@
       <strong>{{t('notice')}}</strong> {{t('restart-required')}}
     </div>
 
-    <h4>{{t('provider')}}</h4>
-    <div class="text-muted">{{t('manual-save-label')}}</div>
+    <h4>{{t('provider-title')}}</h4>
+    <div class="text-muted" [innerHtml]="t('provider-tooltip') | safeHtml"></div>
     <ng-container>
       <div class="row g-0 mt-4 mb-4">
         @if (settingsForm.get('authority'); as formControl) {
@@ -191,6 +191,42 @@
         </div>
       }
 
+    </ng-container>
+
+    <div class="setting-section-break"></div>
+    <h4>{{t('advanced-title')}}</h4>
+    <div class="text-muted">{{t('advanced-tooltip')}}</div>
+
+    <ng-container>
+      <div class="row g-0 mt-4 mb-4">
+        @if (settingsForm.get('rolesPrefix'); as formControl) {
+          <app-setting-item [title]="t('roles-prefix-label')" [subtitle]="t('roles-prefix-tooltip')">
+            <ng-template #view>
+              {{formControl.value}}
+            </ng-template>
+            <ng-template #edit>
+              <input id="oidc-roles-prefix" class="form-control"
+                     formControlName="rolesPrefix" type="text"
+                     [class.is-invalid]="formControl.invalid && !formControl.untouched">
+            </ng-template>
+          </app-setting-item>
+        }
+      </div>
+
+      <div class="row g-0 mt-4 mb-4">
+        @if (settingsForm.get('rolesClaim'); as formControl) {
+          <app-setting-item [title]="t('roles-claim-label')" [subtitle]="t('roles-claim-tooltip')">
+            <ng-template #view>
+              {{formControl.value}}
+            </ng-template>
+            <ng-template #edit>
+              <input id="oidc-roles-claim" class="form-control"
+                     formControlName="rolesClaim" type="text"
+                     [class.is-invalid]="formControl.invalid && !formControl.untouched">
+            </ng-template>
+          </app-setting-item>
+        }
+      </div>
     </ng-container>
 
   </form>

--- a/UI/Web/src/app/admin/manage-open-idconnect/manage-open-idconnect.component.ts
+++ b/UI/Web/src/app/admin/manage-open-idconnect/manage-open-idconnect.component.ts
@@ -37,6 +37,8 @@ import {LibrarySelectorComponent} from "../library-selector/library-selector.com
 import {RoleSelectorComponent} from "../role-selector/role-selector.component";
 import {ToastrService} from "ngx-toastr";
 import {SafeHtmlPipe} from "../../_pipes/safe-html.pipe";
+import {DefaultValuePipe} from "../../_pipes/default-value.pipe";
+import {TagBadgeComponent} from "../../shared/tag-badge/tag-badge.component";
 
 @Component({
   selector: 'app-manage-open-idconnect',
@@ -48,7 +50,9 @@ import {SafeHtmlPipe} from "../../_pipes/safe-html.pipe";
     AgeRatingPipe,
     LibrarySelectorComponent,
     RoleSelectorComponent,
-    SafeHtmlPipe
+    SafeHtmlPipe,
+    DefaultValuePipe,
+    TagBadgeComponent
   ],
   templateUrl: './manage-open-idconnect.component.html',
   styleUrl: './manage-open-idconnect.component.scss',
@@ -94,6 +98,7 @@ export class ManageOpenIDConnectComponent implements OnInit {
         this.settingsForm.addControl('providerName', new FormControl(this.serverSettings.oidcConfig.providerName, []));
         this.settingsForm.addControl("defaultAgeRestriction", new FormControl(this.serverSettings.oidcConfig.defaultAgeRestriction, []));
         this.settingsForm.addControl('defaultIncludeUnknowns', new FormControl(this.serverSettings.oidcConfig.defaultIncludeUnknowns, []));
+        this.settingsForm.addControl('customScopes', new FormControl(this.serverSettings.oidcConfig.customScopes.join(","), []))
         this.cdRef.markForCheck();
 
         this.settingsForm.valueChanges.pipe(
@@ -130,6 +135,9 @@ export class ManageOpenIDConnectComponent implements OnInit {
     newSettings.oidcConfig.defaultAgeRestriction = parseInt(newSettings.oidcConfig.defaultAgeRestriction + '', 10) as AgeRating;
     newSettings.oidcConfig.defaultRoles = this.selectedRoles();
     newSettings.oidcConfig.defaultLibraries = this.selectedLibraries();
+    newSettings.oidcConfig.customScopes = (data.customScopes as string)
+      .split(',').map((item: string) => item.trim())
+      .filter((scope: string) => scope.length > 0);
 
     this.settingsService.updateServerSettings(newSettings).subscribe({
       next: data => {
@@ -146,6 +154,14 @@ export class ManageOpenIDConnectComponent implements OnInit {
         this.toastr.error(translate('errors.generic'))
       }
     })
+  }
+
+  breakString(s: string) {
+    if (s) {
+      return s.split(',');
+    }
+
+    return [];
   }
 
   authorityValidator(): AsyncValidatorFn {

--- a/UI/Web/src/app/admin/manage-open-idconnect/manage-open-idconnect.component.ts
+++ b/UI/Web/src/app/admin/manage-open-idconnect/manage-open-idconnect.component.ts
@@ -17,7 +17,7 @@ import {
   FormGroup,
   ReactiveFormsModule,
   ValidationErrors,
-  ValidatorFn, Validators
+  ValidatorFn
 } from "@angular/forms";
 import {SettingsService} from "../settings.service";
 import {OidcConfig} from "../_models/oidc-config";
@@ -83,8 +83,7 @@ export class ManageOpenIDConnectComponent implements OnInit {
         this.selectedLibraries.set(this.serverSettings.oidcConfig.defaultLibraries);
 
         this.settingsForm.addControl('authority', new FormControl(this.serverSettings.oidcConfig.authority, [], [this.authorityValidator()]));
-        this.settingsForm.addControl('clientId', new FormControl(this.serverSettings.oidcConfig.clientId,
-          [this.requiredIf('authority'), Validators.pattern("^(?!Kavita$).+$")])); // Not equal to Kavita
+        this.settingsForm.addControl('clientId', new FormControl(this.serverSettings.oidcConfig.clientId, [this.requiredIf('authority')]));
         this.settingsForm.addControl('provisionAccounts', new FormControl(this.serverSettings.oidcConfig.provisionAccounts, []));
         this.settingsForm.addControl('requireVerifiedEmail', new FormControl(this.serverSettings.oidcConfig.requireVerifiedEmail, []));
         this.settingsForm.addControl('syncUserSettings', new FormControl(this.serverSettings.oidcConfig.syncUserSettings, []));
@@ -101,7 +100,6 @@ export class ManageOpenIDConnectComponent implements OnInit {
           debounceTime(300),
           distinctUntilChanged(),
           takeUntilDestroyed(this.destroyRef),
-          filter(() => this.settingsForm.valid),
           filter(() => {
             // Do not auto save when provider settings have changed
             const settings: OidcConfig = this.settingsForm.getRawValue();

--- a/UI/Web/src/app/admin/manage-open-idconnect/manage-open-idconnect.component.ts
+++ b/UI/Web/src/app/admin/manage-open-idconnect/manage-open-idconnect.component.ts
@@ -8,7 +8,7 @@ import {
   OnInit,
   signal
 } from '@angular/core';
-import {TranslocoDirective} from "@jsverse/transloco";
+import {translate, TranslocoDirective} from "@jsverse/transloco";
 import {ServerSettings} from "../_models/server-settings";
 import {
   AbstractControl,
@@ -36,6 +36,7 @@ import {LibraryService} from "../../_services/library.service";
 import {LibrarySelectorComponent} from "../library-selector/library-selector.component";
 import {RoleSelectorComponent} from "../role-selector/role-selector.component";
 import {ToastrService} from "ngx-toastr";
+import {SafeHtmlPipe} from "../../_pipes/safe-html.pipe";
 
 @Component({
   selector: 'app-manage-open-idconnect',
@@ -46,7 +47,8 @@ import {ToastrService} from "ngx-toastr";
     SettingSwitchComponent,
     AgeRatingPipe,
     LibrarySelectorComponent,
-    RoleSelectorComponent
+    RoleSelectorComponent,
+    SafeHtmlPipe
   ],
   templateUrl: './manage-open-idconnect.component.html',
   styleUrl: './manage-open-idconnect.component.scss',
@@ -86,6 +88,8 @@ export class ManageOpenIDConnectComponent implements OnInit {
         this.settingsForm.addControl('provisionAccounts', new FormControl(this.serverSettings.oidcConfig.provisionAccounts, []));
         this.settingsForm.addControl('requireVerifiedEmail', new FormControl(this.serverSettings.oidcConfig.requireVerifiedEmail, []));
         this.settingsForm.addControl('syncUserSettings', new FormControl(this.serverSettings.oidcConfig.syncUserSettings, []));
+        this.settingsForm.addControl('rolesPrefix', new FormControl(this.serverSettings.oidcConfig.rolesPrefix, []));
+        this.settingsForm.addControl('rolesClaim', new FormControl(this.serverSettings.oidcConfig.rolesClaim, []));
         this.settingsForm.addControl('autoLogin', new FormControl(this.serverSettings.oidcConfig.autoLogin, []));
         this.settingsForm.addControl('disablePasswordAuthentication', new FormControl(this.serverSettings.oidcConfig.disablePasswordAuthentication, []));
         this.settingsForm.addControl('providerName', new FormControl(this.serverSettings.oidcConfig.providerName, []));
@@ -119,7 +123,7 @@ export class ManageOpenIDConnectComponent implements OnInit {
     this.save();
   }
 
-  save() {
+  save(showConfirmation: boolean = false) {
     if (!this.settingsForm.valid || !this.serverSettings || !this.oidcSettings) return;
 
     const data = this.settingsForm.getRawValue();
@@ -134,10 +138,14 @@ export class ManageOpenIDConnectComponent implements OnInit {
         this.serverSettings = data;
         this.oidcSettings.set(data.oidcConfig);
         this.cdRef.markForCheck();
+
+        if (showConfirmation) {
+          this.toastr.success(translate('manage-oidc-connect.save-success'))
+        }
       },
       error: error => {
         console.error(error);
-        this.toastr.error("errors.generic")
+        this.toastr.error(translate('errors.generic'))
       }
     })
   }

--- a/UI/Web/src/app/admin/manage-open-idconnect/manage-open-idconnect.component.ts
+++ b/UI/Web/src/app/admin/manage-open-idconnect/manage-open-idconnect.component.ts
@@ -17,7 +17,7 @@ import {
   FormGroup,
   ReactiveFormsModule,
   ValidationErrors,
-  ValidatorFn
+  ValidatorFn, Validators
 } from "@angular/forms";
 import {SettingsService} from "../settings.service";
 import {OidcConfig} from "../_models/oidc-config";
@@ -81,7 +81,8 @@ export class ManageOpenIDConnectComponent implements OnInit {
         this.selectedLibraries.set(this.serverSettings.oidcConfig.defaultLibraries);
 
         this.settingsForm.addControl('authority', new FormControl(this.serverSettings.oidcConfig.authority, [], [this.authorityValidator()]));
-        this.settingsForm.addControl('clientId', new FormControl(this.serverSettings.oidcConfig.clientId, [this.requiredIf('authority')]));
+        this.settingsForm.addControl('clientId', new FormControl(this.serverSettings.oidcConfig.clientId,
+          [this.requiredIf('authority'), Validators.pattern("^(?!Kavita$).+$")])); // Not equal to Kavita
         this.settingsForm.addControl('provisionAccounts', new FormControl(this.serverSettings.oidcConfig.provisionAccounts, []));
         this.settingsForm.addControl('requireVerifiedEmail', new FormControl(this.serverSettings.oidcConfig.requireVerifiedEmail, []));
         this.settingsForm.addControl('syncUserSettings', new FormControl(this.serverSettings.oidcConfig.syncUserSettings, []));
@@ -96,6 +97,7 @@ export class ManageOpenIDConnectComponent implements OnInit {
           debounceTime(300),
           distinctUntilChanged(),
           takeUntilDestroyed(this.destroyRef),
+          filter(() => this.settingsForm.valid),
           filter(() => {
             // Do not auto save when provider settings have changed
             const settings: OidcConfig = this.settingsForm.getRawValue();

--- a/UI/Web/src/app/admin/manage-settings/manage-settings.component.ts
+++ b/UI/Web/src/app/admin/manage-settings/manage-settings.component.ts
@@ -145,6 +145,7 @@ export class ManageSettingsComponent implements OnInit {
     modelSettings.smtpConfig = this.serverSettings.smtpConfig;
     modelSettings.installId = this.serverSettings.installId;
     modelSettings.installVersion = this.serverSettings.installVersion;
+    modelSettings.oidcConfig = this.serverSettings.oidcConfig;
 
     // Disabled FormControls are not added to the value
     if (this.isDocker) {

--- a/UI/Web/src/app/registration/user-login/user-login.component.ts
+++ b/UI/Web/src/app/registration/user-login/user-login.component.ts
@@ -82,7 +82,8 @@ export class UserLoginComponent implements OnInit {
     effect(() => {
       const skipAutoLogin = this.skipAutoLogin();
       const oidcConfig = this.oidcService.settings();
-      if (!oidcConfig || skipAutoLogin === undefined) return;
+      const isLoggingOut = this.oidcService.isLoggingOut();
+      if (!oidcConfig || skipAutoLogin === undefined || isLoggingOut) return;
 
       if (oidcConfig.autoLogin && !skipAutoLogin) {
         this.oidcService.login()

--- a/UI/Web/src/app/registration/user-login/user-login.component.ts
+++ b/UI/Web/src/app/registration/user-login/user-login.component.ts
@@ -83,6 +83,7 @@ export class UserLoginComponent implements OnInit {
       const skipAutoLogin = this.skipAutoLogin();
       const oidcConfig = this.oidcService.settings();
       const isLoggingOut = this.oidcService.isLoggingOut();
+
       if (!oidcConfig || skipAutoLogin === undefined || isLoggingOut) return;
 
       if (oidcConfig.autoLogin && !skipAutoLogin) {

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -58,7 +58,9 @@
         "roles-prefix-label": "Roles prefix",
         "roles-prefix-tooltip": "Kavita will filter out roles which do not have the prefix",
         "roles-claim-label": "Roles claim",
-        "roles-claim-tooltip": "The claim under which Kavita must look for your roles"
+        "roles-claim-tooltip": "The claim under which Kavita must look for your roles, leave empty to reset",
+        "custom-scopes-label": "Custom scopes",
+        "custom-scopes-tooltip": "Additional scopes Kavita will request from your OIDC when trying to login, separate by comma. If these are configured wrong, your OIDC may prevent you from login in."
     },
 
     "identity-provider-pipe": {

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -2496,7 +2496,8 @@
             "role-not-assigned": "You do not have the required roles assigned to access this application",
             "failed-to-update-email": "Failed to update email",
             "failed-to-update-username": "Failed to update username",
-            "email-in-use": "Email already in used by an other account"
+            "email-in-use": "Email already in used by an other account",
+            "syncing-user": "Failed to sync your account from OIDC,  please contact an administrator"
         }
     },
 

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -2493,7 +2493,10 @@
             "no-account": "No matching account found",
             "disabled-account": "This account is disabled, please contact an administrator",
             "creating-user": "Failed to create a new user, please contact an administrator",
-            "role-not-assigned": "You do not have the required roles assigned to access this application"
+            "role-not-assigned": "You do not have the required roles assigned to access this application",
+            "failed-to-update-email": "Failed to update email",
+            "failed-to-update-username": "Failed to update username",
+            "email-in-use": "Email already in used by an other account"
         }
     },
 

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -18,19 +18,20 @@
 
     "manage-oidc-connect": {
         "save": "{{common.save}}",
+        "save-success": "Successfully updated your OIDC settings",
         "notice": "Notice",
         "restart-required": "Changing Authority or Client ID requires a manual restart of Kavita to take effect.",
-        "provider": "Provider",
+        "provider-title": "Provider",
+        "provider-tooltip": "Kavita must be configured as a public client, and requires a redirect url to be set. Read the <a href='https://wiki.kavitareader.com/guides/admin-settings/open-id-connect/' target='_blank' rel='noreferrer noopener'>wiki</a> for more information.",
         "behavior-title": "Behavior",
         "other-field-required": "{{validation.other-field-required}}",
         "invalid-uri": "{{validation.invalid-uri}}",
-        "reserved-client-id": "Kavita cannot be used as client id for OIDC",
         "manual-save-label": "Changing provider settings requires a manual save",
 
         "authority-label": "Authority",
         "authority-tooltip": "The URL to your OIDC provider",
         "client-id-label": "Client ID",
-        "client-id-tooltip": "The ClientID set in your OIDC provider, can be anything",
+        "client-id-tooltip": "The ClientID set in your OIDC provider, can be anything except Kavita",
         "provision-accounts-label": "Provision accounts",
         "provision-accounts-tooltip": "Auto-create a new account when logging in via OIDC if it can't be matched to an existing one",
         "require-verified-email-label": "Require verified emails",
@@ -50,7 +51,14 @@
         "default-include-unknowns-tooltip": "Include unknown age ratings",
         "default-age-restriction-label": "Age rating",
         "default-age-restriction-tooltip": "Maximum age rating shown to new users",
-        "no-restriction": "{{restriction-selector.no-restriction}}"
+        "no-restriction": "{{restriction-selector.no-restriction}}",
+
+        "advanced-title": "Advanced settings",
+        "advanced-tooltip": "Only modify the following options if you know what you're doing",
+        "roles-prefix-label": "Roles prefix",
+        "roles-prefix-tooltip": "Kavita will filter out roles which do not have the prefix",
+        "roles-claim-label": "Roles claim",
+        "roles-claim-tooltip": "The claim under which Kavita must look for your roles"
     },
 
     "identity-provider-pipe": {

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -24,6 +24,7 @@
         "behavior-title": "Behavior",
         "other-field-required": "{{validation.other-field-required}}",
         "invalid-uri": "{{validation.invalid-uri}}",
+        "reserved-client-id": "Kavita cannot be used as client id for OIDC",
         "manual-save-label": "Changing provider settings requires a manual save",
 
         "authority-label": "Authority",

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -31,7 +31,7 @@
         "authority-label": "Authority",
         "authority-tooltip": "The URL to your OIDC provider",
         "client-id-label": "Client ID",
-        "client-id-tooltip": "The ClientID set in your OIDC provider, can be anything except Kavita",
+        "client-id-tooltip": "The ClientID set in your OIDC provider, can be anything",
         "provision-accounts-label": "Provision accounts",
         "provision-accounts-tooltip": "Auto-create a new account when logging in via OIDC if it can't be matched to an existing one",
         "require-verified-email-label": "Require verified emails",
@@ -2498,8 +2498,8 @@
             "role-not-assigned": "You do not have the required roles assigned to access this application",
             "failed-to-update-email": "Failed to update email",
             "failed-to-update-username": "Failed to update username",
-            "email-in-use": "Email already in used by an other account",
-            "syncing-user": "Failed to sync your account from OIDC,  please contact an administrator"
+            "email-in-use": "Email already in use by another account",
+            "syncing-user": "Failed to sync your account from OIDC, please contact an administrator"
         }
     },
 

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -22,7 +22,7 @@
         "notice": "Notice",
         "restart-required": "Changing Authority or Client ID requires a manual restart of Kavita to take effect.",
         "provider-title": "Provider",
-        "provider-tooltip": "Kavita must be configured as a public client, and requires a redirect url to be set. Read the <a href='https://wiki.kavitareader.com/guides/admin-settings/open-id-connect/' target='_blank' rel='noreferrer noopener'>wiki</a> for more information.",
+        "provider-tooltip": "Provider settings require you to manually click Save. Kavita must be configured as a public client and needs a redirect URL. See the <a href='https://wiki.kavitareader.com/guides/admin-settings/open-id-connect/' target='_blank' rel='noreferrer noopener'>wiki</a> for more details.",
         "behavior-title": "Behavior",
         "other-field-required": "{{validation.other-field-required}}",
         "invalid-uri": "{{validation.invalid-uri}}",
@@ -54,13 +54,13 @@
         "no-restriction": "{{restriction-selector.no-restriction}}",
 
         "advanced-title": "Advanced settings",
-        "advanced-tooltip": "Only modify the following options if you know what you're doing",
+        "advanced-tooltip": "Only modify these options if you understand their impact.",
         "roles-prefix-label": "Roles prefix",
-        "roles-prefix-tooltip": "Kavita will filter out roles which do not have the prefix",
+        "roles-prefix-tooltip": "Kavita will only consider roles that start with this prefix.",
         "roles-claim-label": "Roles claim",
-        "roles-claim-tooltip": "The claim under which Kavita must look for your roles, leave empty to reset",
+        "roles-claim-tooltip": "The claim Kavita will use to extract roles. Leave blank to use the default.",
         "custom-scopes-label": "Custom scopes",
-        "custom-scopes-tooltip": "Additional scopes Kavita will request from your OIDC when trying to login, separate by comma. If these are configured wrong, your OIDC may prevent you from login in."
+        "custom-scopes-tooltip": "Additional scopes to request from your OIDC provider during login. Separate multiple scopes with commas. Incorrect values may prevent login."
     },
 
     "identity-provider-pipe": {


### PR DESCRIPTION
### Added
- Added a setting to define a custom role prefix when syncing users via OIDC  
- Added a setting to specify a custom role claim when syncing users via OIDC  
- Added support for requesting custom scopes from your OIDC provider  

### Changed
- Users will now be logged out if they fail to sync via OIDC  
- Username and email are now also synced via OIDC  
- If no Age Restriction roles are configured, users will have unrestricted access to content when syncing via OIDC  

### Fixed
- Fixed an issue where users could get stuck in a login loop when failing to log in via OIDC with auto-redirect enabled (canary)  
- Fixed the authority validator incorrectly throwing errors when a trailing slash is present (canary)  
- Fixed logout not functioning correctly when auto-redirect is enabled (canary)  
- Fixed Age Restriction roles not recognizing NotApplicable, and now properly include Unknowns (canary)  
- Fixed an issue preventing settings from being saved in the General tab (canary)  