### PR TITLE
Update the PDF Metadata Parser to Accept Lengths By ObjectRef

### DIFF
--- a/API/Helpers/PdfMetadataExtractor.cs
+++ b/API/Helpers/PdfMetadataExtractor.cs
@@ -954,7 +954,7 @@ internal class PdfMetadataExtractor : IPdfMetadataExtractor
                 case "Length":
                     if (value.Type != PdfLexer.TokenType.Int)
                     {
-                        throw new PdfMetadataExtractorException("Expected integer after /Length");
+                        throw new PdfMetadataExtractorException($"Expected integer after /Length, but got {value.Type}");
                     }
 
                     length = (long)value.Value;
@@ -1361,7 +1361,7 @@ internal class PdfMetadataExtractor : IPdfMetadataExtractor
                 case "Metadata":
                     if (value.Type != PdfLexer.TokenType.ObjectRef)
                     {
-                        throw new PdfMetadataExtractorException("Expected object number after /Metadata");
+                        throw new PdfMetadataExtractorException($"Expected object number after /Metadata, but got {value.Type}");
                     }
 
                     meta = (long)value.Value;
@@ -1414,6 +1414,29 @@ internal class PdfMetadataExtractor : IPdfMetadataExtractor
         _metadata[key] = value;
     }
 
+    private PdfLexer.Token ResolveObjectRef(long position)
+    {
+        long originalPosition = _stream.Position;
+
+        try
+        {
+            _stream.Seek(position, SeekOrigin.Begin);
+            PdfLexer tmpLexer = new PdfLexer(_stream);
+
+            var token = tmpLexer.NextToken();
+            if (token.Type != PdfLexer.TokenType.ObjectStart) {
+                throw new PdfMetadataExtractorException($"[ResolveObjectRef] Expected object here but got {token.Type}");
+            }
+
+            return tmpLexer.NextToken();
+        }
+        finally
+        {
+            // Always restore the original position
+            _stream.Seek(originalPosition, SeekOrigin.Begin);
+        }
+    }
+
     private void ReadMetadataFromXml(long meta)
     {
         if (meta < 1 || meta >= _objectOffsets.Length || _objectOffsets[meta] == 0) return;
@@ -1453,19 +1476,28 @@ internal class PdfMetadataExtractor : IPdfMetadataExtractor
                     return true;
 
                 case "Length":
-                    if (value.Type != PdfLexer.TokenType.Int)
-                    {
-                        throw new PdfMetadataExtractorException("Expected integer after /Length");
+                    if (value.Type == PdfLexer.TokenType.ObjectRef) {
+                        value = ResolveObjectRef(_objectOffsets[(long)value.Value]);
                     }
-
-                    length = (long)value.Value;
+                    if (value.Type == PdfLexer.TokenType.Double)
+                    {
+                        length = Convert.ToInt64(value.Value);
+                    }
+                    else if (value.Type == PdfLexer.TokenType.Int)
+                    {
+                        length = (long)value.Value;
+                    }
+                    else
+                    {
+                        throw new PdfMetadataExtractorException($"Expected integer after /Length, but got {value.Type}");
+                    }
 
                     return true;
 
                 case "Filter":
                     if (value.Type != PdfLexer.TokenType.Name)
                     {
-                        throw new PdfMetadataExtractorException("Expected name after /Filter");
+                        throw new PdfMetadataExtractorException($"Expected name after /Filter, but got {value.Type}");
                     }
 
                     if ((string)value.Value != "FlateDecode")


### PR DESCRIPTION
# Changed
- Changed: Changed PDF parser exception messages to state what type was received in addition to what was expected

# Fixed
- Fixed: Fixed an issue with the PDF parser that prevented it from loading files that used a ObjectRef for the Length

Thanks!
