### PR TITLE
Increase OIDC timeout

### DIFF
--- a/UI/Web/src/app/_services/oidc.service.ts
+++ b/UI/Web/src/app/_services/oidc.service.ts
@@ -7,7 +7,7 @@ import {OidcPublicConfig} from "../admin/_models/oidc-config";
 import {takeUntilDestroyed, toObservable} from "@angular/core/rxjs-interop";
 import {ToastrService} from "ngx-toastr";
 import {translate} from "@jsverse/transloco";
-import {APP_BASE_HREF} from "@angular/common";
+import {APP_BASE_HREF, DOCUMENT} from "@angular/common";
 
 /**
  * Enum mirror of angular-oauth2-oidc events which are used in Kavita
@@ -24,10 +24,13 @@ export enum OidcEvents {
 })
 export class OidcService {
 
+  public static OidcTimeOutKey = 'kavita-oidc-timeout';
+  public static DefaultOidcTimeOut = 6000;
+
   private readonly oauth2 = inject(OAuthService);
   private readonly httpClient = inject(HttpClient);
   private readonly destroyRef = inject(DestroyRef);
-  private readonly toastR = inject(ToastrService);
+  private readonly document = inject(DOCUMENT);
 
   protected readonly baseUrl = inject(APP_BASE_HREF);
   private readonly apiBaseUrl = environment.apiUrl;
@@ -57,7 +60,14 @@ export class OidcService {
   constructor() {
     this.oauth2.setStorage(localStorage);
 
-    window.addEventListener('online', () => {
+    if (!localStorage.getItem(OidcService.OidcTimeOutKey)) {
+      localStorage.setItem(OidcService.OidcTimeOutKey, OidcService.DefaultOidcTimeOut+'');
+    }
+
+    // Refresh tokens when user returns to the page
+    this.document.addEventListener('visibilitychange', () => {
+      if (this.document.visibilityState === 'hidden') return;
+
       if (!this.hasValidAccessToken() && this.oauth2.getRefreshToken()) {
         this.oauth2.refreshToken().catch(err => console.error("failed to refresh token when coming online", err));
       }

--- a/UI/Web/src/main.ts
+++ b/UI/Web/src/main.ts
@@ -88,7 +88,18 @@ const translocoOptions = {
   } as TranslocoConfig
 };
 
-const OIDC_TIMEOUT_MS = 2000;
+function getOidcTimeOut(): number {
+  const timeOut = localStorage.getItem(OidcService.OidcTimeOutKey);
+  if (!timeOut) {
+    return OidcService.DefaultOidcTimeOut;
+  }
+
+  try {
+    return parseInt(timeOut)
+  } catch (e) {
+    return OidcService.DefaultOidcTimeOut;
+  }
+}
 
 function getBaseHref(platformLocation: PlatformLocation): string {
   return platformLocation.getBaseHrefFromDOM();
@@ -153,7 +164,7 @@ function bootstrapUser() {
         })
       );
     }),
-    timeout(OIDC_TIMEOUT_MS), // Give the browser 2s to load the discovery document and login
+    timeout(getOidcTimeOut()),
     catchError(err => {
       console.error("OIDC setup failed:", err);
       if (err.name === 'TimeoutError') {


### PR DESCRIPTION
# Changed
- Changed: Store OIDC time in localStore until we can find a time that works for everyone (kavita-oidc-timeout)
- Changed: Actually check if we need to refresh tokens when returning to the browser tab