### PR TITLE
Series/Volume/Chapter detail pages can now have title be customizable via Themes

### DIFF
--- a/UI/Web/src/_series-detail-common.scss
+++ b/UI/Web/src/_series-detail-common.scss
@@ -1,7 +1,7 @@
 @use './theme/variables' as theme;
 
 .title {
-  color: white;
+  color: var(--detail-title-color, white);
   font-weight: bold;
   font-size: 1.75rem;
 }

--- a/UI/Web/src/theme/themes/dark.scss
+++ b/UI/Web/src/theme/themes/dark.scss
@@ -437,6 +437,7 @@
     --login-input-placeholder-color: #fff;
 
     /** Series Detail **/
+    --detail-title-color: white;
     --detail-subtitle-color: lightgrey;
 
     /** Search **/


### PR DESCRIPTION
# Theme
- Added CSS var for series detail title color, allowing themes to configure the color. Falls back to the default of white if color not supplied in theme.