### PR TITLE
Styles quill editor and some bug fixes

### DIFF
--- a/UI/Web/src/app/_services/epub-reader-menu.service.ts
+++ b/UI/Web/src/app/_services/epub-reader-menu.service.ts
@@ -67,12 +67,13 @@ export class EpubReaderMenuService {
     this.isDrawerOpen.set(true);
   }
 
-  openViewTocDrawer(chapterId: number, callbackFn: (evt: LoadPageEvent | null) => void) {
+  openViewTocDrawer(chapterId: number, pageNum: number, callbackFn: (evt: LoadPageEvent | null) => void) {
     if (this.offcanvasService.hasOpenOffcanvas()) {
       this.offcanvasService.dismiss();
     }
     const ref = this.offcanvasService.open(ViewTocDrawerComponent, {position: 'end'});
     ref.componentInstance.chapterId.set(chapterId);
+    ref.componentInstance.pageNum.set(pageNum)
     ref.componentInstance.loadPage.subscribe((res: LoadPageEvent | null) => {
       // Check if we are on mobile to collapse the menu
       if (this.utilityService.activeUserBreakpoint() <= UserBreakpoint.Mobile) {

--- a/UI/Web/src/app/_services/epub-reader-menu.service.ts
+++ b/UI/Web/src/app/_services/epub-reader-menu.service.ts
@@ -73,7 +73,7 @@ export class EpubReaderMenuService {
     }
     const ref = this.offcanvasService.open(ViewTocDrawerComponent, {position: 'end'});
     ref.componentInstance.chapterId.set(chapterId);
-    ref.componentInstance.pageNum.set(pageNum)
+    ref.componentInstance.pageNum.set(pageNum);
     ref.componentInstance.loadPage.subscribe((res: LoadPageEvent | null) => {
       // Check if we are on mobile to collapse the menu
       if (this.utilityService.activeUserBreakpoint() <= UserBreakpoint.Mobile) {

--- a/UI/Web/src/app/_services/epub-reader-settings.service.ts
+++ b/UI/Web/src/app/_services/epub-reader-settings.service.ts
@@ -18,7 +18,7 @@ import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {UserBreakpoint, UtilityService} from "../shared/_services/utility.service";
 
 export interface ReaderSettingUpdate {
-  setting: 'pageStyle' | 'clickToPaginate' | 'fullscreen' | 'writingStyle' | 'bookReaderLayoutMode' | 'readingDirection' | 'immersiveMode' | 'theme';
+  setting: 'pageStyle' | 'clickToPaginate' | 'fullscreen' | 'writingStyle' | 'layoutMode' | 'readingDirection' | 'immersiveMode' | 'theme';
   object: any;
 }
 
@@ -153,7 +153,7 @@ export class EpubReaderSettingsService {
       if (!this.isInitialized) return;
 
       this.settingUpdateSubject.next({
-        setting: 'bookReaderLayoutMode',
+        setting: 'layoutMode',
         object: mode,
       });
     });
@@ -605,7 +605,6 @@ export class EpubReaderSettingsService {
   private updateImplicitProfile(): void {
     if (!this._currentReadingProfile() || !this._currentSeriesId()) return;
 
-    console.log("Updating implicit reading profile")
     this.readingProfileService.updateImplicit(this.packReadingProfile(), this._currentSeriesId()!)
       .subscribe({
         next: newProfile => {
@@ -634,11 +633,11 @@ export class EpubReaderSettingsService {
     data.bookReaderFontSize = modelSettings.bookReaderFontSize;
     data.bookReaderLineSpacing = modelSettings.bookReaderLineSpacing;
     data.bookReaderMargin = modelSettings.bookReaderMargin;
+
+    // Update from signals
     data.bookReaderTapToPaginate = this._clickToPaginate();
     data.bookReaderLayoutMode = this._layoutMode();
     data.bookReaderImmersiveMode = this._immersiveMode();
-
-    // Update from signals
     data.bookReaderReadingDirection = this._readingDirection();
     data.bookReaderWritingStyle = this._writingStyle();
 

--- a/UI/Web/src/app/_services/epub-reader-settings.service.ts
+++ b/UI/Web/src/app/_services/epub-reader-settings.service.ts
@@ -69,6 +69,7 @@ export class EpubReaderSettingsService {
   private settingsForm!: BookReadingProfileFormGroup;
   private fontFamilies: FontFamily[] = this.bookService.getFontFamilies();
   private isUpdatingFromForm = false; // Flag to prevent infinite loops
+  private isInitialized = this._isInitialized(); // Non signal, updates in effect
 
   // Event subject for component communication (keep this for now, can be converted to effect later)
   private settingUpdateSubject = new Subject<ReaderSettingUpdate>();
@@ -76,7 +77,6 @@ export class EpubReaderSettingsService {
   // Public readonly signals
   public readonly currentReadingProfile = this._currentReadingProfile.asReadonly();
   public readonly parentReadingProfile = this._parentReadingProfile.asReadonly();
-  public readonly isInitialized = this._isInitialized.asReadonly();
 
   // Settings as readonly signals
   public readonly pageStyles = this._pageStyles.asReadonly();
@@ -123,65 +123,75 @@ export class EpubReaderSettingsService {
       }
     });
 
+    effect(() => {
+      this.isInitialized = this._isInitialized();
+    });
+
     // Effect to emit setting updates when signals change
     effect(() => {
-      if (!this._isInitialized()) return;
+      const styles = this._pageStyles();
+      if (!this.isInitialized) return;
 
       this.settingUpdateSubject.next({
         setting: 'pageStyle',
-        object: this._pageStyles()
+        object: styles,
       });
     });
 
     effect(() => {
-      if (!this._isInitialized()) return;
+      const clickToPaginate = this._clickToPaginate();
+      if (!this.isInitialized) return;
 
       this.settingUpdateSubject.next({
         setting: 'clickToPaginate',
-        object: this._clickToPaginate()
+        object: clickToPaginate,
       });
     });
 
     effect(() => {
-      if (!this._isInitialized()) return;
+      const mode = this._layoutMode();
+      if (!this.isInitialized) return;
 
       this.settingUpdateSubject.next({
         setting: 'bookReaderLayoutMode',
-        object: this._layoutMode()
+        object: mode,
       });
     });
 
     effect(() => {
-      if (!this._isInitialized()) return;
+      const direction = this._readingDirection();
+      if (!this.isInitialized) return;
 
       this.settingUpdateSubject.next({
         setting: 'readingDirection',
-        object: this._readingDirection()
+        object: direction,
       });
     });
 
     effect(() => {
-      if (!this._isInitialized()) return;
+      const style = this._writingStyle();
+      if (!this.isInitialized) return;
 
       this.settingUpdateSubject.next({
         setting: 'writingStyle',
-        object: this._writingStyle()
+        object: style,
       });
     });
 
     effect(() => {
-      if (!this._isInitialized()) return;
+      const mode = this._immersiveMode();
+      if (!this.isInitialized) return;
 
       this.settingUpdateSubject.next({
         setting: 'immersiveMode',
-        object: this._immersiveMode()
+        object: mode,
       });
     });
 
     effect(() => {
-      if (!this._isInitialized()) return;
-
       const theme = this._activeTheme();
+      if (!this.isInitialized) return;
+
       if (theme) {
         this.settingUpdateSubject.next({
           setting: 'theme',

--- a/UI/Web/src/app/_services/epub-reader-settings.service.ts
+++ b/UI/Web/src/app/_services/epub-reader-settings.service.ts
@@ -1,15 +1,15 @@
 import {computed, DestroyRef, effect, inject, Injectable, signal} from '@angular/core';
-import {Observable, Subject} from 'rxjs';
+import {firstValueFrom, Observable, Subject} from 'rxjs';
 import {bookColorThemes, PageStyle} from "../book-reader/_components/reader-settings/reader-settings.component";
 import {ReadingDirection} from '../_models/preferences/reading-direction';
 import {WritingStyle} from '../_models/preferences/writing-style';
 import {BookPageLayoutMode} from "../_models/readers/book-page-layout-mode";
-import {FormControl, FormGroup} from "@angular/forms";
+import {FormControl, FormGroup, NonNullableFormBuilder} from "@angular/forms";
 import {ReadingProfile, ReadingProfileKind} from "../_models/preferences/reading-profiles";
 import {BookService, FontFamily} from "../book-reader/_services/book.service";
 import {ThemeService} from './theme.service';
 import {ReadingProfileService} from "./reading-profile.service";
-import {debounceTime, filter, skip, tap} from "rxjs/operators";
+import {debounceTime, distinctUntilChanged, filter, skip, tap} from "rxjs/operators";
 import {BookTheme} from "../_models/preferences/book-theme";
 import {DOCUMENT} from "@angular/common";
 import {translate} from "@jsverse/transloco";
@@ -18,9 +18,22 @@ import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {UserBreakpoint, UtilityService} from "../shared/_services/utility.service";
 
 export interface ReaderSettingUpdate {
-  setting: 'pageStyle' | 'clickToPaginate' | 'fullscreen' | 'writingStyle' | 'layoutMode' | 'readingDirection' | 'immersiveMode' | 'theme';
+  setting: 'pageStyle' | 'clickToPaginate' | 'fullscreen' | 'writingStyle' | 'bookReaderLayoutMode' | 'readingDirection' | 'immersiveMode' | 'theme';
   object: any;
 }
+
+export type BookReadingProfileFormGroup = FormGroup<{
+  bookReaderMargin: FormControl<number>;
+  bookReaderLineSpacing: FormControl<number>;
+  bookReaderFontSize: FormControl<number>;
+  bookReaderFontFamily: FormControl<string>;
+  bookReaderTapToPaginate: FormControl<boolean>;
+  bookReaderReadingDirection: FormControl<ReadingDirection>;
+  bookReaderWritingStyle: FormControl<WritingStyle>;
+  bookReaderThemeName: FormControl<string>;
+  bookReaderLayoutMode: FormControl<BookPageLayoutMode>;
+  bookReaderImmersiveMode:FormControl <boolean>;
+}>
 
 
 @Injectable({
@@ -34,6 +47,7 @@ export class EpubReaderSettingsService {
   private readonly utilityService = inject(UtilityService);
   private readonly toastr = inject(ToastrService);
   private readonly document = inject(DOCUMENT);
+  private readonly fb = inject(NonNullableFormBuilder);
 
   // Core signals - these will be the single source of truth
   private readonly _currentReadingProfile = signal<ReadingProfile | null>(null);
@@ -52,7 +66,7 @@ export class EpubReaderSettingsService {
   private readonly _isFullscreen = signal<boolean>(false);
 
   // Form will be managed separately but updated from signals
-  private settingsForm: FormGroup = new FormGroup({});
+  private settingsForm!: BookReadingProfileFormGroup;
   private fontFamilies: FontFamily[] = this.bookService.getFontFamilies();
   private isUpdatingFromForm = false; // Flag to prevent infinite loops
 
@@ -132,7 +146,7 @@ export class EpubReaderSettingsService {
       if (!this._isInitialized()) return;
 
       this.settingUpdateSubject.next({
-        setting: 'layoutMode',
+        setting: 'bookReaderLayoutMode',
         object: this._layoutMode()
       });
     });
@@ -188,7 +202,7 @@ export class EpubReaderSettingsService {
     // Load parent profile if needed
     if (readingProfile.kind === ReadingProfileKind.Implicit) {
       try {
-        const parent = await this.readingProfileService.getForSeries(seriesId, true).toPromise();
+        const parent = await firstValueFrom(this.readingProfileService.getForSeries(seriesId, true));
         this._parentReadingProfile.set(parent || null);
       } catch (error) {
         console.error('Failed to load parent reading profile:', error);
@@ -253,7 +267,7 @@ export class EpubReaderSettingsService {
   /**
    * Get the current settings form (for components that need direct form access)
    */
-  getSettingsForm(): FormGroup {
+  getSettingsForm(): BookReadingProfileFormGroup {
     return this.settingsForm;
   }
 
@@ -288,7 +302,7 @@ export class EpubReaderSettingsService {
       : ReadingDirection.LeftToRight;
 
     this._readingDirection.set(newDirection);
-    this.debouncedUpdateProfile();
+    this.settingsForm.get('bookReaderReadingDirection')!.setValue(newDirection);
   }
 
   /**
@@ -301,7 +315,7 @@ export class EpubReaderSettingsService {
       : WritingStyle.Horizontal;
 
     this._writingStyle.set(newStyle);
-    this.debouncedUpdateProfile();
+    this.settingsForm.get('bookReaderWritingStyle')!.setValue(newStyle);
   }
 
   /**
@@ -312,7 +326,7 @@ export class EpubReaderSettingsService {
     if (theme) {
       this._activeTheme.set(theme);
       if (update) {
-        this.debouncedUpdateProfile();
+        this.settingsForm.get('bookReaderThemeName')!.setValue(themeName);
       }
     }
   }
@@ -320,24 +334,22 @@ export class EpubReaderSettingsService {
   updateLayoutMode(mode: BookPageLayoutMode): void {
     this._layoutMode.set(mode);
     // Update form control to keep in sync
-    this.settingsForm.get('layoutMode')?.setValue(mode, { emitEvent: false });
-    this.debouncedUpdateProfile();
+    this.settingsForm.get('bookReaderLayoutMode')?.setValue(mode, { emitEvent: false });
   }
 
   updateClickToPaginate(value: boolean): void {
     this._clickToPaginate.set(value);
-    this.settingsForm.get('bookReaderTapToPaginate')?.setValue(value, { emitEvent: false });
-    this.debouncedUpdateProfile();
+    this.settingsForm.get('bookReaderTapToPaginate')?.setValue(value);
   }
 
   updateReadingDirection(value: ReadingDirection): void {
     this._readingDirection.set(value);
-    this.debouncedUpdateProfile();
+    this.settingsForm.get('bookReaderReadingDirection')?.setValue(value);
   }
 
   updateWritingStyle(value: WritingStyle) {
     this._writingStyle.set(value);
-    this.debouncedUpdateProfile();
+    this.settingsForm.get('bookReaderWritingStyle')?.setValue(value);
   }
 
   updateFullscreen(value: boolean) {
@@ -352,17 +364,6 @@ export class EpubReaderSettingsService {
     if (value) {
       this._clickToPaginate.set(true);
     }
-  }
-
-  // Debounced update method to prevent too many API calls
-  private updateTimeout: any;
-  private debouncedUpdateProfile(): void {
-    if (this.updateTimeout) {
-      clearTimeout(this.updateTimeout);
-    }
-    this.updateTimeout = setTimeout(() => {
-      this.updateImplicitProfile();
-    }, 500);
   }
 
   /**
@@ -421,7 +422,7 @@ export class EpubReaderSettingsService {
       bookReaderTapToPaginate: this._clickToPaginate(),
       bookReaderLineSpacing: profile.bookReaderLineSpacing,
       bookReaderMargin: profile.bookReaderMargin,
-      layoutMode: this._layoutMode(),
+      bookReaderLayoutMode: this._layoutMode(),
       bookReaderImmersiveMode: this._immersiveMode()
     }, { emitEvent: false });
   }
@@ -433,17 +434,19 @@ export class EpubReaderSettingsService {
     const profile = this._currentReadingProfile();
     if (!profile) return;
 
-    // Clear existing form
-    this.settingsForm = new FormGroup({});
-
-    // Add controls with current values
-    this.settingsForm.addControl('bookReaderFontFamily', new FormControl(profile.bookReaderFontFamily));
-    this.settingsForm.addControl('bookReaderFontSize', new FormControl(profile.bookReaderFontSize));
-    this.settingsForm.addControl('bookReaderTapToPaginate', new FormControl(this._clickToPaginate()));
-    this.settingsForm.addControl('bookReaderLineSpacing', new FormControl(profile.bookReaderLineSpacing));
-    this.settingsForm.addControl('bookReaderMargin', new FormControl(profile.bookReaderMargin));
-    this.settingsForm.addControl('layoutMode', new FormControl(this._layoutMode()));
-    this.settingsForm.addControl('bookReaderImmersiveMode', new FormControl(this._immersiveMode()));
+    // Recreate the form
+    this.settingsForm = new FormGroup({
+      bookReaderMargin: this.fb.control(profile.bookReaderMargin),
+      bookReaderLineSpacing: this.fb.control(profile.bookReaderLineSpacing),
+      bookReaderFontSize: this.fb.control(profile.bookReaderFontSize),
+      bookReaderFontFamily: this.fb.control(profile.bookReaderFontFamily),
+      bookReaderTapToPaginate: this.fb.control(this._clickToPaginate()),
+      bookReaderReadingDirection: this.fb.control(this._readingDirection()),
+      bookReaderWritingStyle: this.fb.control(profile.bookReaderWritingStyle),
+      bookReaderThemeName: this.fb.control(profile.bookReaderThemeName),
+      bookReaderLayoutMode: this.fb.control(this._layoutMode()),
+      bookReaderImmersiveMode: this.fb.control(this._immersiveMode()),
+    });
 
     // Set up value change subscriptions
     this.setupFormSubscriptions();
@@ -527,7 +530,7 @@ export class EpubReaderSettingsService {
     });
 
     // Layout mode changes
-    this.settingsForm.get('layoutMode')?.valueChanges.pipe(
+    this.settingsForm.get('bookReaderLayoutMode')?.valueChanges.pipe(
       takeUntilDestroyed(this.destroyRef)
     ).subscribe((layoutMode: BookPageLayoutMode) => {
       this.isUpdatingFromForm = true;
@@ -552,15 +555,13 @@ export class EpubReaderSettingsService {
 
     // Update implicit profile on form changes (debounced) - ONLY source of profile updates
     this.settingsForm.valueChanges.pipe(
-      debounceTime(500), // Increased debounce time
+      debounceTime(500),
+      distinctUntilChanged(),
       skip(1), // Skip initial form creation
-      takeUntilDestroyed(this.destroyRef)
-    ).subscribe(() => {
-      // Only update if we're not currently updating from form changes
-      if (!this.isUpdatingFromForm) {
-        this.updateImplicitProfile();
-      }
-    });
+      takeUntilDestroyed(this.destroyRef),
+      filter(() => !this.isUpdatingFromForm),
+      tap(() => this.updateImplicitProfile()),
+    ).subscribe();
   }
 
   /**
@@ -594,6 +595,7 @@ export class EpubReaderSettingsService {
   private updateImplicitProfile(): void {
     if (!this._currentReadingProfile() || !this._currentSeriesId()) return;
 
+    console.log("Updating implicit reading profile")
     this.readingProfileService.updateImplicit(this.packReadingProfile(), this._currentSeriesId()!)
       .subscribe({
         next: newProfile => {

--- a/UI/Web/src/app/book-reader/_components/_annotations/annotation-card/annotation-card.component.scss
+++ b/UI/Web/src/app/book-reader/_components/_annotations/annotation-card/annotation-card.component.scss
@@ -18,3 +18,7 @@ $green-color: rgba(34, 197, 94);
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
 }
+
+:host ::ng-deep quill-view {
+  color: var(--drawer-text-color);
+}

--- a/UI/Web/src/app/book-reader/_components/_drawers/view-edit-annotation-drawer/view-edit-annotation-drawer.component.html
+++ b/UI/Web/src/app/book-reader/_components/_drawers/view-edit-annotation-drawer/view-edit-annotation-drawer.component.html
@@ -72,10 +72,15 @@
 
           <div class="setting-section-break" aria-hidden="true"></div>
 
-
           <div class="row g-0 mt-2 mb-2 mx-auto">
             @if (isEditOrCreateMode()) {
-              <quill-editor theme="snow" formControlName="note" format="object" (onContentChanged)="updateContent($event)"/>
+              <app-quill-wrapper
+                controlName="note"
+                [formGroup]="formGroup"
+                [theme]="QuillTheme.Snow"
+                (contentChanged)="updateContent($event)"
+              >
+              </app-quill-wrapper>
             } @else {
               <quill-view [content]="annotation()!.comment" format="json" theme="snow"></quill-view>
             }

--- a/UI/Web/src/app/book-reader/_components/_drawers/view-edit-annotation-drawer/view-edit-annotation-drawer.component.ts
+++ b/UI/Web/src/app/book-reader/_components/_drawers/view-edit-annotation-drawer/view-edit-annotation-drawer.component.ts
@@ -207,21 +207,23 @@ export class ViewEditAnnotationDrawerComponent implements OnInit {
   }
 
   ngOnInit(){
-    if (this.isEditMode()) {
-      this.formGroup.valueChanges.pipe(
-        debounceTime(350),
-        switchMap(_ => {
-          const updatedAnnotation = this.annotation();
-          if (!updatedAnnotation) return of();
-
-          updatedAnnotation.containsSpoiler = this.formGroup.get('hasSpoiler')!.value;
-          updatedAnnotation.comment = JSON.stringify(this.annotationNote);
-
-          return this.annotationService.updateAnnotation(updatedAnnotation);
-        }),
-        takeUntilDestroyed(this.destroyRef)
-      ).subscribe();
+    if (!this.isEditMode()) {
+      return;
     }
+
+    this.formGroup.valueChanges.pipe(
+      debounceTime(350),
+      switchMap(_ => {
+        const updatedAnnotation = this.annotation();
+        if (!updatedAnnotation) return of();
+
+        updatedAnnotation.containsSpoiler = this.formGroup.get('hasSpoiler')!.value;
+        updatedAnnotation.comment = JSON.stringify(this.annotationNote);
+
+        return this.annotationService.updateAnnotation(updatedAnnotation);
+      }),
+      takeUntilDestroyed(this.destroyRef)
+    ).subscribe();
   }
 
   createAnnotation() {

--- a/UI/Web/src/app/book-reader/_components/_drawers/view-edit-annotation-drawer/view-edit-annotation-drawer.component.ts
+++ b/UI/Web/src/app/book-reader/_components/_drawers/view-edit-annotation-drawer/view-edit-annotation-drawer.component.ts
@@ -14,7 +14,6 @@ import {NgbActiveOffcanvas} from "@ng-bootstrap/ng-bootstrap";
 import {AnnotationService} from "../../../../_services/annotation.service";
 import {FormControl, FormGroup, ReactiveFormsModule} from "@angular/forms";
 import {Annotation} from "../../../_models/annotations/annotation";
-import {QuillEditorComponent, QuillViewComponent} from "ngx-quill";
 import {TranslocoDirective} from "@jsverse/transloco";
 import {takeUntilDestroyed} from "@angular/core/rxjs-interop";
 import {debounceTime, switchMap} from "rxjs/operators";
@@ -28,6 +27,8 @@ import {SafeHtmlPipe} from "../../../../_pipes/safe-html.pipe";
 import {EpubHighlightService} from "../../../../_services/epub-highlight.service";
 import {PageChapterLabelPipe} from "../../../../_pipes/page-chapter-label.pipe";
 import {UserBreakpoint, UtilityService} from "../../../../shared/_services/utility.service";
+import {QuillWrapperComponent, QuillTheme} from "../../quill-wrapper/quill-wrapper.component";
+import {ContentChange, QuillViewComponent} from "ngx-quill";
 
 export enum AnnotationMode {
   View = 0,
@@ -40,13 +41,14 @@ const INIT_HIGHLIGHT_DELAY = 200;
 @Component({
   selector: 'app-view-edit-annotation-drawer',
   imports: [
-    QuillEditorComponent,
+    QuillWrapperComponent,
     ReactiveFormsModule,
-    QuillViewComponent,
     TranslocoDirective,
     HighlightBarComponent,
     NgStyle,
-    PageChapterLabelPipe
+    PageChapterLabelPipe,
+    QuillWrapperComponent,
+    QuillViewComponent
   ],
   templateUrl: './view-edit-annotation-drawer.component.html',
   styleUrl: './view-edit-annotation-drawer.component.scss',
@@ -225,7 +227,7 @@ export class ViewEditAnnotationDrawerComponent {
     // For create annotation, we have to have this hack
     highlightAnnotation.createdUtc = '0001-01-01T00:00:00Z';
     highlightAnnotation.lastModifiedUtc = '0001-01-01T00:00:00Z'
-    
+
     this.annotationService.createAnnotation(highlightAnnotation).subscribe(_ => {
       this.close();
     });
@@ -245,7 +247,7 @@ export class ViewEditAnnotationDrawerComponent {
     this.activeOffcanvas.close();
   }
 
-  updateContent(event: any) {
+  updateContent(event: ContentChange) {
     this.annotationNote = event.content;
   }
 
@@ -315,4 +317,5 @@ export class ViewEditAnnotationDrawerComponent {
 
   protected readonly AnnotationMode = AnnotationMode;
   protected readonly UserBreakpoint = UserBreakpoint;
+  protected readonly QuillTheme = QuillTheme;
 }

--- a/UI/Web/src/app/book-reader/_components/_drawers/view-edit-annotation-drawer/view-edit-annotation-drawer.component.ts
+++ b/UI/Web/src/app/book-reader/_components/_drawers/view-edit-annotation-drawer/view-edit-annotation-drawer.component.ts
@@ -5,14 +5,14 @@ import {
   DestroyRef,
   effect,
   inject,
-  model,
+  model, OnInit,
   Signal,
   ViewChild,
   ViewContainerRef
 } from '@angular/core';
 import {NgbActiveOffcanvas} from "@ng-bootstrap/ng-bootstrap";
 import {AnnotationService} from "../../../../_services/annotation.service";
-import {FormControl, FormGroup, ReactiveFormsModule} from "@angular/forms";
+import {FormControl, FormGroup, NonNullableFormBuilder, ReactiveFormsModule} from "@angular/forms";
 import {Annotation} from "../../../_models/annotations/annotation";
 import {TranslocoDirective} from "@jsverse/transloco";
 import {takeUntilDestroyed} from "@angular/core/rxjs-interop";
@@ -54,7 +54,7 @@ const INIT_HIGHLIGHT_DELAY = 200;
   styleUrl: './view-edit-annotation-drawer.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class ViewEditAnnotationDrawerComponent {
+export class ViewEditAnnotationDrawerComponent implements OnInit {
   private readonly activeOffcanvas = inject(NgbActiveOffcanvas);
   private readonly annotationService = inject(AnnotationService);
   private readonly destroyRef = inject(DestroyRef);
@@ -63,6 +63,7 @@ export class ViewEditAnnotationDrawerComponent {
   private readonly safeHtml = new SafeHtmlPipe();
   private readonly sanitizer = inject(DomSanitizer);
   private readonly epubHighlightService = inject(EpubHighlightService);
+  private readonly fb = inject(NonNullableFormBuilder);
   protected readonly utilityService = inject(UtilityService);
 
   @ViewChild('renderTarget', {read: ViewContainerRef}) renderTarget!: ViewContainerRef;
@@ -76,9 +77,12 @@ export class ViewEditAnnotationDrawerComponent {
   totalText!: Signal<SafeHtml>;
 
 
-  formGroup!: FormGroup;
+  formGroup!: FormGroup<{
+    note: FormControl<object>,
+    hasSpoiler: FormControl<boolean>,
+    selectedSlotIndex: FormControl<number>,
+  }>;
   annotationNote: object = {};
-  isSetup = false;
 
   constructor() {
     this.titleColor = computed(() => {
@@ -183,39 +187,41 @@ export class ViewEditAnnotationDrawerComponent {
       return this.sanitizer.bypassSecurityTrustHtml(`${this.safeHtml.transform(beforeText)}<app-epub-highlight id="epub-highlight-${annotationId}">${this.safeHtml.transform(selectedText)}</app-epub-highlight>${this.safeHtml.transform(trimmedAfterText)}`);
     });
 
+    this.formGroup = this.fb.group({
+      note: this.fb.control<object>({}, []),
+      hasSpoiler: this.fb.control<boolean>(false, []),
+      selectedSlotIndex: this.fb.control<number>(0, []),
+    });
 
     effect(() => {
-      const isEditMode = this.isEditMode();
       const annotation = this.annotation();
+      if (!annotation) return;
 
       // Side effect - patch in the current note
       // Parse the stored JSON string back to Delta object
-      this.annotationNote = annotation?.comment ? JSON.parse(annotation.comment) : {}
-      this.formGroup =  new FormGroup({
-        'note': new FormControl(this.annotationNote, []),
-        'hasSpoiler': new FormControl(annotation?.containsSpoiler, []),
-        'selectedSlotIndex': new FormControl(annotation?.selectedSlotIndex ?? 0, [])
-      });
-
-      if (isEditMode && !this.isSetup) {
-        console.log('Setting up auto-save');
-        this.formGroup.valueChanges.pipe(
-          debounceTime(350),
-          switchMap(_ => {
-            const updatedAnnotation = this.annotation();
-            if (!updatedAnnotation) return of();
-
-            updatedAnnotation.containsSpoiler = this.formGroup.get('hasSpoiler')!.value;
-            updatedAnnotation.comment = JSON.stringify(this.annotationNote);
-
-            return this.annotationService.updateAnnotation(updatedAnnotation);
-          }),
-          takeUntilDestroyed(this.destroyRef)
-        ).subscribe();
-
-        this.isSetup = true;
-      }
+      this.annotationNote = annotation?.comment ? JSON.parse(annotation.comment) : {};
+      this.formGroup.get('note')!.setValue(this.annotationNote);
+      this.formGroup.get('hasSpoiler')!.setValue(annotation.containsSpoiler);
+      this.formGroup.get('selectedSlotIndex')!.setValue(annotation.selectedSlotIndex);
     });
+  }
+
+  ngOnInit(){
+    if (this.isEditMode()) {
+      this.formGroup.valueChanges.pipe(
+        debounceTime(350),
+        switchMap(_ => {
+          const updatedAnnotation = this.annotation();
+          if (!updatedAnnotation) return of();
+
+          updatedAnnotation.containsSpoiler = this.formGroup.get('hasSpoiler')!.value;
+          updatedAnnotation.comment = JSON.stringify(this.annotationNote);
+
+          return this.annotationService.updateAnnotation(updatedAnnotation);
+        }),
+        takeUntilDestroyed(this.destroyRef)
+      ).subscribe();
+    }
   }
 
   createAnnotation() {

--- a/UI/Web/src/app/book-reader/_components/_drawers/view-toc-drawer/view-toc-drawer.component.html
+++ b/UI/Web/src/app/book-reader/_components/_drawers/view-toc-drawer/view-toc-drawer.component.html
@@ -12,14 +12,14 @@
       <li [ngbNavItem]="TabID.TableOfContents">
         <a ngbNavLink>{{t('toc-header')}}</a>
         <ng-template ngbNavContent>
-          <app-table-of-contents [chapters]="chapters()" [chapterId]="chapterId()!" [pageNum]="pageNum"
+          <app-table-of-contents [chapters]="chapters()" [chapterId]="chapterId()!" [pageNum]="pageNum()"
                                  [currentPageAnchor]="currentPageAnchor" (loadChapter)="loadChapterPage($event)"></app-table-of-contents>
         </ng-template>
       </li>
       <li [ngbNavItem]="TabID.PersonalTableOfContents">
         <a ngbNavLink>{{t('personal-header')}}</a>
         <ng-template ngbNavContent>
-          <app-personal-table-of-contents [chapterId]="chapterId()!" [pageNum]="pageNum" (loadChapter)="loadChapterPart($event)"
+          <app-personal-table-of-contents [chapterId]="chapterId()!" [pageNum]="pageNum()" (loadChapter)="loadChapterPart($event)"
                                           [tocRefresh]="refreshPToC"></app-personal-table-of-contents>
         </ng-template>
       </li>

--- a/UI/Web/src/app/book-reader/_components/_drawers/view-toc-drawer/view-toc-drawer.component.ts
+++ b/UI/Web/src/app/book-reader/_components/_drawers/view-toc-drawer/view-toc-drawer.component.ts
@@ -59,6 +59,10 @@ export class ViewTocDrawerComponent {
   private readonly bookService = inject(BookService);
 
   chapterId = model<number>();
+  /**
+   * Current Page
+   */
+  pageNum = model.required<number>();
 
   /**
    * Sub Nav tab id
@@ -68,10 +72,6 @@ export class ViewTocDrawerComponent {
    * The actual pages from the epub, used for showing on table of contents. This must be here as we need access to it for scroll anchors
    */
   chapters = model<Array<BookChapterItem>>([]);
-  /**
-   * Current Page
-   */
-  pageNum = 0;
 
   /**
    * A anchors that map to the page number. When you click on one of these, we will load a given page up for the user.

--- a/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.ts
+++ b/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.ts
@@ -921,7 +921,6 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
     this.readerService.closeReader(this.readingListMode, this.readingListId);
   }
 
-
   sortElements(a: Element, b: Element) {
     const aTop = a.getBoundingClientRect().top;
       const bTop = b.getBoundingClientRect().top;
@@ -1011,7 +1010,6 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
     }
   }
 
-
   /**
    * Adds a click handler for any anchors that have 'kavita-page'. If 'kavita-page' present, changes page to kavita-page and optionally passes a part value
    * from 'kavita-part', which will cause the reader to scroll to the marker.
@@ -1051,7 +1049,6 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
     }
   }
 
-
   async promptForPage() {
     const promptConfig = {...this.confirmService.defaultPrompt};
     promptConfig.header = translate('book-reader.go-to-page');
@@ -1083,9 +1080,6 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
     this.pageNum.set(page);
     this.loadPage();
   }
-
-
-
 
   loadPage(part?: string | undefined, scrollTop?: number | undefined) {
     this.isLoading.set(true);
@@ -1121,7 +1115,6 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       }, 10);
     });
   }
-
 
   /**
    * Injects the new DOM needed to provide the bookmark functionality.
@@ -1267,7 +1260,6 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
 
   }
 
-
   setupPage(part?: string | undefined, scrollTop?: number | undefined) {
     this.isLoading.set(false);
     this.cdRef.markForCheck();
@@ -1350,7 +1342,6 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
     this.renderer.setStyle(emptyPage, 'width', this.columnHeight());
     this.renderer.appendChild(this.bookContentElemRef.nativeElement, emptyPage);
   }
-
 
   goBack() {
     if (!this.adhocPageHistory.isEmpty()) {
@@ -1558,7 +1549,6 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
         : this.getPageWidth();
   }
 
-
   getFirstVisibleElementXPath() {
     let resumeElement: string | null = null;
     if (!this.bookContentElemRef || !this.bookContentElemRef.nativeElement) return null;
@@ -1674,7 +1664,7 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       case "writingStyle":
         this.applyWritingStyle();
         break;
-      case "layoutMode":
+      case "bookReaderLayoutMode":
         this.applyLayoutMode(res.object as BookPageLayoutMode);
         break;
       case "readingDirection":
@@ -1811,7 +1801,6 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
     //   setTimeout(() => this.scrollTo(lastSelector));
     // }
   }
-
 
   applyImmersiveMode(immersiveMode: boolean) {
     if (immersiveMode && !this.epubMenuService.isDrawerOpen()) {
@@ -1992,7 +1981,6 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       }
     });
   }
-
 
   viewToCDrawer() {
     this.epubMenuService.openViewTocDrawer(this.chapterId, this.pageNum(), (res: LoadPageEvent | null) => {

--- a/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.ts
+++ b/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.ts
@@ -66,6 +66,7 @@ import {AnnotationService} from "../../../_services/annotation.service";
 import {Annotation} from "../../_models/annotations/annotation";
 import getBoundingClientRect from "@popperjs/core/lib/dom-utils/getBoundingClientRect";
 import {LabelType, NgxSliderModule, Options} from "@angular-slider/ngx-slider";
+import {ProgressBookmark} from "../../../_models/readers/progress-bookmark";
 
 
 interface HistoryPoint {
@@ -779,7 +780,6 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
         return;
       }
 
-
       this.bookTitle = info.bookTitle;
       this.titleService.setTitle('Kavita - ' + this.bookTitle);
       this.cdRef.markForCheck();
@@ -792,78 +792,85 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
         tap((update) => this.handleReaderSettingsUpdate(update))
       ).subscribe();
 
-
+      // Load all required data from the API
       forkJoin({
         chapter: this.seriesService.getChapter(this.chapterId),
         progress: this.readerService.getProgress(this.chapterId),
         chapters: this.bookService.getBookChapters(this.chapterId),
-      }).subscribe(results => {
-        this.chapter = results.chapter;
-        this.volumeId = results.chapter.volumeId;
-        this.maxPages.set(results.chapter.pages);
-        this.chapters = results.chapters;
-        this.pageNum.set(results.progress.pageNum);
-        this.cdRef.markForCheck();
-
-        if (results.progress.bookScrollId) {
-          // Don't descope here as document hasn't loaded
-          this.lastSeenScrollPartPath = results.progress.bookScrollId;
+      }).subscribe({
+        next: ({chapter, progress, chapters}) => {
+          this.setupBookReader(chapter, progress, chapters);
+        },
+        error: () => {
+          setTimeout(() => {
+            this.closeReader();
+          }, 200);
         }
-
-        this.continuousChaptersStack.push(this.chapterId);
-
-        this.libraryService.getLibraryType(this.libraryId).pipe(take(1)).subscribe(type => {
-          this.libraryType = type;
-        });
-
-        this.updateImageSizes();
-
-        if (this.pageNum() >= this.maxPages()) {
-          this.pageNum.set(this.maxPages() - 1);
-          this.cdRef.markForCheck();
-          this.saveProgress();
-        }
-
-        this.readerService.getNextChapter(this.seriesId, this.volumeId, this.chapterId, this.readingListId).pipe(take(1)).subscribe(chapterId => {
-          this.nextChapterId = chapterId;
-          if (chapterId === CHAPTER_ID_DOESNT_EXIST || chapterId === this.chapterId) {
-            this.nextChapterDisabled = true;
-            this.nextChapterPrefetched = true;
-            this.cdRef.markForCheck();
-            return;
-          }
-          this.setPageNum(this.pageNum());
-        });
-        this.readerService.getPrevChapter(this.seriesId, this.volumeId, this.chapterId, this.readingListId).pipe(take(1)).subscribe(chapterId => {
-          this.prevChapterId = chapterId;
-          if (chapterId === CHAPTER_ID_DOESNT_EXIST || chapterId === this.chapterId) {
-            this.prevChapterDisabled = true;
-            this.prevChapterPrefetched = true; // If there is no prev chapter, then mark it as prefetched
-            this.cdRef.markForCheck();
-            return;
-          }
-          this.setPageNum(this.pageNum());
-        });
-
-        // If there is an annotation to load, prioritize it
-        if (this.annotationToLoad() > 0) {
-          this.annotationService.getAnnotation(this.annotationToLoad()).subscribe((data) => {
-            this.annotationToLoad.set(-1);
-            this.setPageNum(data.pageNumber);
-            this.loadPage(data.xPath || undefined);
-            this.readerService.enableWakeLock(this.reader.nativeElement);
-          });
-        } else {
-          // Check if user progress has part, if so load it so we scroll to it
-          this.loadPage(results.progress.bookScrollId || undefined);
-          this.readerService.enableWakeLock(this.reader.nativeElement);
-        }
-      }, () => {
-        setTimeout(() => {
-          this.closeReader();
-        }, 200);
       });
     });
+  }
+
+  private setupBookReader(chapter: Chapter, progress: ProgressBookmark, chapters: BookChapterItem[]) {
+    this.chapter = chapter;
+    this.volumeId = chapter.volumeId;
+    this.maxPages.set(chapter.pages);
+    this.chapters = chapters;
+    this.pageNum.set(progress.pageNum);
+    this.cdRef.markForCheck();
+
+    if (progress.bookScrollId) {
+      // Don't descope here as document hasn't loaded
+      this.lastSeenScrollPartPath = progress.bookScrollId;
+    }
+
+    this.continuousChaptersStack.push(this.chapterId);
+
+    this.libraryService.getLibraryType(this.libraryId).pipe(take(1)).subscribe(type => {
+      this.libraryType = type;
+    });
+
+    this.updateImageSizes();
+
+    if (this.pageNum() >= this.maxPages()) {
+      this.pageNum.set(this.maxPages() - 1);
+      this.cdRef.markForCheck();
+      this.saveProgress();
+    }
+
+    this.readerService.getNextChapter(this.seriesId, this.volumeId, this.chapterId, this.readingListId).pipe(take(1)).subscribe(chapterId => {
+      this.nextChapterId = chapterId;
+      if (chapterId === CHAPTER_ID_DOESNT_EXIST || chapterId === this.chapterId) {
+        this.nextChapterDisabled = true;
+        this.nextChapterPrefetched = true;
+        this.cdRef.markForCheck();
+        return;
+      }
+      this.setPageNum(this.pageNum());
+    });
+    this.readerService.getPrevChapter(this.seriesId, this.volumeId, this.chapterId, this.readingListId).pipe(take(1)).subscribe(chapterId => {
+      this.prevChapterId = chapterId;
+      if (chapterId === CHAPTER_ID_DOESNT_EXIST || chapterId === this.chapterId) {
+        this.prevChapterDisabled = true;
+        this.prevChapterPrefetched = true; // If there is no prev chapter, then mark it as prefetched
+        this.cdRef.markForCheck();
+        return;
+      }
+      this.setPageNum(this.pageNum());
+    });
+
+    // If there is an annotation to load, prioritize it
+    if (this.annotationToLoad() > 0) {
+      this.annotationService.getAnnotation(this.annotationToLoad()).subscribe((data) => {
+        this.annotationToLoad.set(-1);
+        this.setPageNum(data.pageNumber);
+        this.loadPage(data.xPath || undefined);
+        this.readerService.enableWakeLock(this.reader.nativeElement);
+      });
+    } else {
+      // Check if user progress has part, if so load it so we scroll to it
+      this.loadPage(progress.bookScrollId || undefined);
+      this.readerService.enableWakeLock(this.reader.nativeElement);
+    }
   }
 
   // TODO: BUG: When I resize on 1 column, there is page shift that breaks the clean columns

--- a/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.ts
+++ b/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.ts
@@ -792,7 +792,6 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
         tap((update) => this.handleReaderSettingsUpdate(update))
       ).subscribe();
 
-      // Load all required data from the API
       forkJoin({
         chapter: this.seriesService.getChapter(this.chapterId),
         progress: this.readerService.getProgress(this.chapterId),
@@ -1671,7 +1670,7 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       case "writingStyle":
         this.applyWritingStyle();
         break;
-      case "bookReaderLayoutMode":
+      case "layoutMode":
         this.applyLayoutMode(res.object as BookPageLayoutMode);
         break;
       case "readingDirection":

--- a/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.ts
+++ b/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.ts
@@ -1995,7 +1995,7 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
 
 
   viewToCDrawer() {
-    this.epubMenuService.openViewTocDrawer(this.chapterId, (res: LoadPageEvent | null) => {
+    this.epubMenuService.openViewTocDrawer(this.chapterId, this.pageNum(), (res: LoadPageEvent | null) => {
       if (res === null) return;
 
       this.setPageNum(res.pageNumber);

--- a/UI/Web/src/app/book-reader/_components/quill-wrapper/quill-wrapper.component.html
+++ b/UI/Web/src/app/book-reader/_components/quill-wrapper/quill-wrapper.component.html
@@ -1,0 +1,28 @@
+<div [formGroup]="formGroup()!">
+  <quill-editor class="w-100"
+                [format]="format()"
+                [theme]="theme()"
+                [formControlName]="controlName()"
+                (onContentChanged)="contentChanged.emit($event)">
+
+    <div quill-editor-toolbar>
+
+      @for (toolbarItem of toolbar(); track $index) {
+        <span>
+          @if (toolbarItem.value !== undefined) {
+            <button type="button" [class]="toolbarItem.key" [value]="toolbarItem.value"></button>
+          } @else if (toolbarItem.values !== undefined) {
+            <select [class]="toolbarItem.key">
+              @for (value of toolbarItem.values; track value) {
+                <option [value]="value">{{value}}</option>
+              }
+            </select>
+          }
+
+        </span>
+      }
+
+    </div>
+
+  </quill-editor>
+</div>

--- a/UI/Web/src/app/book-reader/_components/quill-wrapper/quill-wrapper.component.html
+++ b/UI/Web/src/app/book-reader/_components/quill-wrapper/quill-wrapper.component.html
@@ -7,22 +7,28 @@
 
     <div quill-editor-toolbar>
 
-      @for (toolbarItem of toolbar(); track $index) {
-        <span>
+      @for (toolbarGroup of toolbar(); track $index) {
 
-          @if (toolbarItem.value !== undefined) {
-            <button type="button" [class]="toolbarItem.key + ' quil-wrapper-btn'" [value]="toolbarItem.value"></button>
-          } @else if (toolbarItem.values !== undefined) {
-            <select [class]="toolbarItem.key + ' quil-wrapper-select'">
-              @for (value of toolbarItem.values; track value) {
-                <option [value]="value">{{value}}</option>
+        <div class="ql-formats">
+          @for (toolbarItem of toolbarGroup; track $index) {
+            <span>
+
+              @if (toolbarItem.value !== undefined) {
+                <button type="button" [class]="toolbarItem.key + ' quil-wrapper-btn'" [value]="toolbarItem.value"></button>
+              } @else if (toolbarItem.values !== undefined) {
+                <select [class]="toolbarItem.key + ' quil-wrapper-select'">
+                  @for (value of toolbarItem.values; track value) {
+                    <option [value]="value">{{ value }}</option>
+                  }
+                </select>
+              } @else {
+                <button type="button" [class]="toolbarItem.key + ' quil-wrapper-btn'"></button>
               }
-            </select>
-          } @else {
-            <button type="button" [class]="toolbarItem.key + ' quil-wrapper-btn'"></button>
-          }
 
-        </span>
+          </span>
+          }
+        </div>
+
       }
     </div>
 

--- a/UI/Web/src/app/book-reader/_components/quill-wrapper/quill-wrapper.component.html
+++ b/UI/Web/src/app/book-reader/_components/quill-wrapper/quill-wrapper.component.html
@@ -9,19 +9,21 @@
 
       @for (toolbarItem of toolbar(); track $index) {
         <span>
+
           @if (toolbarItem.value !== undefined) {
-            <button type="button" [class]="toolbarItem.key" [value]="toolbarItem.value"></button>
+            <button type="button" [class]="toolbarItem.key + ' quil-wrapper-btn'" [value]="toolbarItem.value"></button>
           } @else if (toolbarItem.values !== undefined) {
-            <select [class]="toolbarItem.key">
+            <select [class]="toolbarItem.key + ' quil-wrapper-select'">
               @for (value of toolbarItem.values; track value) {
                 <option [value]="value">{{value}}</option>
               }
             </select>
+          } @else {
+            <button type="button" [class]="toolbarItem.key + ' quil-wrapper-btn'"></button>
           }
 
         </span>
       }
-
     </div>
 
   </quill-editor>

--- a/UI/Web/src/app/book-reader/_components/quill-wrapper/quill-wrapper.component.scss
+++ b/UI/Web/src/app/book-reader/_components/quill-wrapper/quill-wrapper.component.scss
@@ -1,24 +1,23 @@
 :host ::ng-deep quill-editor {
-
   .ql-toolbar,
   .ql-container {
-    border: 1px solid var(--primary-color);
+    border: 0.0625rem solid var(--primary-color);
     background-color: var(--drawer-bg-color);
   }
 
- .ql-toolbar {
-   border-bottom: 1px solid var(--primary-color);
-   padding: 8px;
-   border-radius: 5px 5px 0 0 !important;
+  .ql-toolbar {
+    border-bottom: 0.0625rem solid var(--primary-color);
+    padding: 0.5rem;
+    border-radius: 0.3125rem 0.3125rem 0 0 !important;
 
-   .ql-formats {
-      margin-right: 15px;
+    .ql-formats {
+      margin-right: 0.9375rem;
     }
   }
 
   .ql-container {
     border-top: none;
-    border-radius: 0 0 5px 5px !important;
+    border-radius: 0 0 0.3125rem 0.3125rem !important;
 
     .ql-editor {
       background-color: var(--theme-bg-color);
@@ -28,8 +27,13 @@
         color: var(--input-placeholder-color);
       }
 
-      p {
-        min-height: 75px;
+      &.ql-blank::before {
+        font-style: italic;
+        color: var(--input-placeholder-color);
+      }
+
+      &:focus {
+        outline: none;
       }
     }
   }
@@ -38,10 +42,10 @@
   button[class*="ql-"] {
     color: var(--drawer-text-color) !important;
     background-color: transparent;
-    border: 1px solid transparent;
-    border-radius: 3px;
-    padding: 5px;
-    margin: 2px;
+    border: 0.0625rem solid transparent;
+    border-radius: 0.1875rem;
+    padding: 0.3125rem;
+    margin: 0.125rem;
     cursor: pointer;
 
     &:hover {
@@ -79,20 +83,18 @@
   .ql-picker {
     color: var(--drawer-text-color) !important;
     background-color: var(--drawer-bg-color) !important;
-    margin: 2px;
-    min-width: 30px;
+    margin: 0.125rem;
+    min-width: 1.875rem;
 
     .ql-picker-label {
       color: var(--drawer-text-color) !important;
-      border: 1px solid var(--input-border-color);
-      border-radius: 3px;
+      border: 0.0625rem solid var(--input-border-color);
+      border-radius: 0.1875rem;
       background-color: var(--input-bg-color) !important;
-
       text-align: center !important;
       display: flex !important;
       align-items: flex-start !important;
-      justify-content: start !important;
-
+      justify-content: flex-start !important;
 
       &:hover {
         .ql-stroke {
@@ -107,18 +109,16 @@
 
     .ql-picker-options {
       background-color: var(--drawer-bg-color);
-      border: 1px solid var(--input-border-color);
-      border-radius: 3px;
-      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-
-      // Ensure the dropdown is not wider than the select
+      border: 0.0625rem solid var(--input-border-color);
+      border-radius: 0.1875rem;
+      box-shadow: 0 0.125rem 0.5rem rgba(0, 0, 0, 0.1);
       min-width: auto !important;
       width: 100% !important;
 
       .ql-picker-item {
         color: var(--drawer-text-color) !important;
-        border-radius: 5px;
-        padding-left: 2px;
+        border-radius: 0.3125rem;
+        padding-left: 0.125rem;
 
         &:hover {
           background-color: var(--btn-primary-hover-bg-color);
@@ -152,8 +152,8 @@
   select.quil-wrapper-select {
     background-color: var(--input-bg-color);
     color: var(--input-text-color);
-    border: 1px solid var(--input-border-color);
-    border-radius: 3px;
+    border: 0.0625rem solid var(--input-border-color);
+    border-radius: 0.1875rem;
 
     option {
       background-color: var(--drawer-bg-color);
@@ -161,18 +161,9 @@
     }
   }
 
-  .ql-editor.ql-blank::before {
-    font-style: italic;
-    color: var(--input-placeholder-color);
-  }
-
-  .ql-editor:focus {
-    outline: none;
-  }
-
   .ql-formats:not(:last-child) {
-    margin-right: 15px;
-    padding-right: 15px;
-    border-right: 1px solid var(--input-border-color);
+    margin-right: 0.9375rem;
+    padding-right: 0.9375rem;
+    border-right: 0.0625rem solid var(--input-border-color);
   }
 }

--- a/UI/Web/src/app/book-reader/_components/quill-wrapper/quill-wrapper.component.scss
+++ b/UI/Web/src/app/book-reader/_components/quill-wrapper/quill-wrapper.component.scss
@@ -1,0 +1,178 @@
+:host ::ng-deep quill-editor {
+
+  .ql-toolbar,
+  .ql-container {
+    border: 1px solid var(--primary-color);
+    background-color: var(--drawer-bg-color);
+  }
+
+ .ql-toolbar {
+   border-bottom: 1px solid var(--primary-color);
+   padding: 8px;
+   border-radius: 5px 5px 0 0 !important;
+
+   .ql-formats {
+      margin-right: 15px;
+    }
+  }
+
+  .ql-container {
+    border-top: none;
+    border-radius: 0 0 5px 5px !important;
+
+    .ql-editor {
+      background-color: var(--theme-bg-color);
+      color: var(--body-text-color);
+
+      &::before {
+        color: var(--input-placeholder-color);
+      }
+
+      p {
+        min-height: 75px;
+      }
+    }
+  }
+
+  .quil-wrapper-btn,
+  button[class*="ql-"] {
+    color: var(--drawer-text-color) !important;
+    background-color: transparent;
+    border: 1px solid transparent;
+    border-radius: 3px;
+    padding: 5px;
+    margin: 2px;
+    cursor: pointer;
+
+    &:hover {
+      background-color: var(--btn-primary-hover-bg-color);
+      color: var(--btn-primary-hover-text-color) !important;
+    }
+
+    svg {
+      transform: scale(1.5);
+    }
+
+    &.ql-active {
+      background-color: var(--btn-primary-bg-color);
+      color: var(--drawer-text-color) !important;
+
+      .ql-stroke {
+        stroke: var(--drawer-text-color) !important;
+      }
+
+      .ql-fill {
+        fill: var(--drawer-text-color) !important;
+      }
+    }
+  }
+
+  .ql-stroke {
+    stroke: var(--drawer-text-color) !important;
+  }
+
+  .ql-fill {
+    fill: var(--drawer-text-color) !important;
+  }
+
+  .quil-wrapper-select,
+  .ql-picker {
+    color: var(--drawer-text-color) !important;
+    background-color: var(--drawer-bg-color) !important;
+    margin: 2px;
+    min-width: 30px;
+
+    .ql-picker-label {
+      color: var(--drawer-text-color) !important;
+      border: 1px solid var(--input-border-color);
+      border-radius: 3px;
+      background-color: var(--input-bg-color) !important;
+
+      text-align: center !important;
+      display: flex !important;
+      align-items: flex-start !important;
+      justify-content: start !important;
+
+
+      &:hover {
+        .ql-stroke {
+          stroke: var(--btn-primary-hover-text-color) !important;
+        }
+      }
+
+      svg {
+        display: none !important;
+      }
+    }
+
+    .ql-picker-options {
+      background-color: var(--drawer-bg-color);
+      border: 1px solid var(--input-border-color);
+      border-radius: 3px;
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+
+      // Ensure the dropdown is not wider than the select
+      min-width: auto !important;
+      width: 100% !important;
+
+      .ql-picker-item {
+        color: var(--drawer-text-color) !important;
+        border-radius: 5px;
+        padding-left: 2px;
+
+        &:hover {
+          background-color: var(--btn-primary-hover-bg-color);
+          color: var(--btn-primary-hover-text-color) !important;
+        }
+
+        &.ql-selected {
+          background-color: var(--btn-primary-bg-color);
+          color: var(--drawer-text-color) !important;
+        }
+      }
+    }
+
+    &.ql-expanded {
+      .ql-picker-label {
+        border-color: var(--primary-color);
+        background-color: var(--btn-primary-bg-color);
+        color: var(--drawer-text-color) !important;
+
+        .ql-stroke {
+          stroke: var(--drawer-text-color) !important;
+        }
+
+        svg {
+          display: none !important;
+        }
+      }
+    }
+  }
+
+  select.quil-wrapper-select {
+    background-color: var(--input-bg-color);
+    color: var(--input-text-color);
+    border: 1px solid var(--input-border-color);
+    border-radius: 3px;
+
+    option {
+      background-color: var(--drawer-bg-color);
+      color: var(--drawer-text-color);
+    }
+  }
+
+  .ql-editor.ql-blank::before {
+    font-style: italic;
+    color: var(--input-placeholder-color);
+  }
+
+  .ql-editor:focus {
+    outline: none;
+  }
+
+  .ql-formats:not(:last-child) {
+    margin-right: 15px;
+    padding-right: 15px;
+    border-right: 1px solid var(--input-border-color);
+  }
+}

--- a/UI/Web/src/app/book-reader/_components/quill-wrapper/quill-wrapper.component.ts
+++ b/UI/Web/src/app/book-reader/_components/quill-wrapper/quill-wrapper.component.ts
@@ -16,7 +16,7 @@ export enum QuillToolbarKey {
   Underline = 'ql-underline',
   Strikethrough = 'ql-strike',
   Blockquote = 'ql-blockquote',
-  CodeBlock = 'ql-blockquote',
+  CodeBlock = 'ql-code-block',
   Header = 'ql-header',
   List = 'ql-list',
   Script = 'ql-script',
@@ -52,7 +52,7 @@ export interface ToolbarItem {
 
 // There is very little documentation to what values are possible.
 // https://quilljs.com/docs/modules/toolbar + inspect the editor on that page to figure it out
-const DefaultToolbarItems: ToolbarItem[][] = [
+const defaultToolbarItems: ToolbarItem[][] = [
   [
     {
       key: QuillToolbarKey.FontSize,
@@ -119,9 +119,9 @@ export class QuillWrapperComponent {
 
   /**
    * Items to show in the toolbar
-   * @default DefaultToolbarItems
+   * @default defaultToolbarItems
    */
-  toolBarItems = input(DefaultToolbarItems);
+  toolBarItems = input(defaultToolbarItems);
 
   /**
    * If not an empty list, only items with their keys present will be shown

--- a/UI/Web/src/app/book-reader/_components/quill-wrapper/quill-wrapper.component.ts
+++ b/UI/Web/src/app/book-reader/_components/quill-wrapper/quill-wrapper.component.ts
@@ -49,29 +49,17 @@ export interface ToolbarItem {
 }
 
 const DefaultToolbarItems: ToolbarItem[] = [
-  {
-    key: QuillToolbarKey.Bold,
-    value: '',
-  },
-  {
-    key: QuillToolbarKey.Italic,
-    value: '',
-  },
-  {
-    key: QuillToolbarKey.Underline,
-    value: '',
-  },
-  {
-    key: QuillToolbarKey.Strikethrough,
-    value: '',
-  },
+  {key: QuillToolbarKey.Bold},
+  {key: QuillToolbarKey.Italic},
+  {key: QuillToolbarKey.Underline},
+  {key: QuillToolbarKey.Strikethrough},
   {
     key: QuillToolbarKey.FontSize,
-    values: ['small', '', 'large', 'huge']
+    values: ['small', '', 'large', 'huge'],
   },
   {
     key: QuillToolbarKey.Font,
-    values: ['', 'sans', 'monospace'],
+    values: ['', 'serif', 'monospace'],
   }
 ];
 

--- a/UI/Web/src/app/book-reader/_components/quill-wrapper/quill-wrapper.component.ts
+++ b/UI/Web/src/app/book-reader/_components/quill-wrapper/quill-wrapper.component.ts
@@ -1,0 +1,151 @@
+import {ChangeDetectionStrategy, Component, computed, EventEmitter, input, OnInit, Output} from '@angular/core';
+import {ContentChange, QuillEditorComponent, QuillFormat} from "ngx-quill";
+import {FormGroup, ReactiveFormsModule} from "@angular/forms";
+
+export enum QuillTheme {
+  Snow = 'snow',
+  Bubble = 'bubble',
+}
+
+/**
+ * Keys for the different options to display in the toolbar
+ */
+export enum QuillToolbarKey {
+  Bold = 'ql-bold',
+  Italic = 'ql-italic',
+  Underline = 'ql-underline',
+  Strikethrough = 'ql-strike',
+  Blockquote = 'ql-blockquote',
+  CodeBlock = 'ql-blockquote',
+  Header = 'ql-header',
+  List = 'ql-list',
+  Script = 'ql-script',
+  Indent = 'ql-indent',
+  Direction = 'ql-direction',
+  FontSize = 'ql-size',
+  Color = 'ql-color',
+  BackgroundColor = 'ql-background',
+  Font = 'ql-font',
+  Alignment = 'ql-align',
+  EmbedLink = 'ql-link',
+  EmbedImage = 'ql-image',
+  EmbedVideo = 'ql-video',
+  Table = 'ql-table',
+}
+
+export interface ToolbarItem {
+  /**
+   * This key is not always unique
+   */
+  key: QuillToolbarKey;
+  /**
+   * Value passed to the button itself
+   */
+  value?: string;
+  /**
+   * Values used for the select component
+   */
+  values?: string[];
+}
+
+const DefaultToolbarItems: ToolbarItem[] = [
+  {
+    key: QuillToolbarKey.Bold,
+    value: '',
+  },
+  {
+    key: QuillToolbarKey.Italic,
+    value: '',
+  },
+  {
+    key: QuillToolbarKey.Underline,
+    value: '',
+  },
+  {
+    key: QuillToolbarKey.Strikethrough,
+    value: '',
+  },
+  {
+    key: QuillToolbarKey.FontSize,
+    values: ['small', '', 'large', 'huge']
+  },
+  {
+    key: QuillToolbarKey.Font,
+    values: ['', 'sans', 'monospace'],
+  }
+];
+
+/**
+ * This component is a wrapper around the quill editor for a nicer to use API, and styling that integrates into the
+ * Kavita style
+ */
+@Component({
+  selector: 'app-quill-wrapper',
+  imports: [
+    QuillEditorComponent,
+    ReactiveFormsModule,
+  ],
+  templateUrl: './quill-wrapper.component.html',
+  styleUrl: './quill-wrapper.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class QuillWrapperComponent implements OnInit {
+
+  /**
+   * The data format used to pass through quill.
+   * @default Object
+   */
+  format = input<QuillFormat>('object');
+
+  /**
+   * The quill theme to use
+   * @default Snow
+   */
+  theme = input(QuillTheme.Snow);
+
+  formGroup = input.required<FormGroup>();
+  controlName = input.required<string>();
+
+  /**
+   * Deligation of the quill onContentChange event
+   */
+  @Output() contentChanged = new EventEmitter<ContentChange>();
+
+  /**
+   * Items to show in the toolbar
+   * @default DefaultToolbarItems
+   */
+  toolBarItems = input(DefaultToolbarItems);
+
+  /**
+   * If not an empty list, only items with their keys present will be shown
+   */
+  whiteList = input<QuillToolbarKey[]>([]);
+  /**
+   * Keys in this list will not be shown, unless in the whiteList
+   */
+  blackList = input<QuillToolbarKey[]>([]);
+
+
+  toolbar = computed(() => {
+    const items = this.toolBarItems();
+    const whiteList = this.whiteList();
+    const blackList = this.blackList();
+
+    if (whiteList.length === 0 && blackList.length === 0) {
+      return items;
+    }
+
+    if (whiteList.length > 0) {
+      return items.filter(item => whiteList.includes(item.key));
+    }
+
+    return items.filter(item => !blackList.includes(item.key));
+  });
+
+  ngOnInit() {
+    console.log("Init Quil Wrapper")
+  }
+
+
+}

--- a/UI/Web/src/app/book-reader/_components/quill-wrapper/quill-wrapper.component.ts
+++ b/UI/Web/src/app/book-reader/_components/quill-wrapper/quill-wrapper.component.ts
@@ -31,6 +31,7 @@ export enum QuillToolbarKey {
   EmbedImage = 'ql-image',
   EmbedVideo = 'ql-video',
   Table = 'ql-table',
+  Clean = 'ql-clean',
 }
 
 export interface ToolbarItem {
@@ -44,23 +45,40 @@ export interface ToolbarItem {
   value?: string;
   /**
    * Values used for the select component
+   * Pass an **empty** array to use the quill defaults
    */
   values?: string[];
 }
 
-const DefaultToolbarItems: ToolbarItem[] = [
-  {key: QuillToolbarKey.Bold},
-  {key: QuillToolbarKey.Italic},
-  {key: QuillToolbarKey.Underline},
-  {key: QuillToolbarKey.Strikethrough},
-  {
-    key: QuillToolbarKey.FontSize,
-    values: ['small', '', 'large', 'huge'],
-  },
-  {
-    key: QuillToolbarKey.Font,
-    values: ['', 'serif', 'monospace'],
-  }
+// There is very little documentation to what values are possible.
+// https://quilljs.com/docs/modules/toolbar + inspect the editor on that page to figure it out
+const DefaultToolbarItems: ToolbarItem[][] = [
+  [
+    {
+      key: QuillToolbarKey.FontSize,
+      values: [],
+    },
+    {
+      key: QuillToolbarKey.Font,
+      values: [],
+    },
+  ],
+  [
+    {key: QuillToolbarKey.Bold},
+    {key: QuillToolbarKey.Italic},
+    {key: QuillToolbarKey.Underline},
+    {key: QuillToolbarKey.Strikethrough},
+    {key: QuillToolbarKey.List, value: 'bullet'},
+    {key: QuillToolbarKey.List, value: 'ordered'},
+  ],
+  [
+    {key: QuillToolbarKey.EmbedLink},
+    {key: QuillToolbarKey.EmbedImage},
+  ],
+
+  [
+    {key: QuillToolbarKey.Clean},
+  ]
 ];
 
 /**
@@ -77,7 +95,7 @@ const DefaultToolbarItems: ToolbarItem[] = [
   styleUrl: './quill-wrapper.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class QuillWrapperComponent implements OnInit {
+export class QuillWrapperComponent {
 
   /**
    * The data format used to pass through quill.
@@ -125,15 +143,14 @@ export class QuillWrapperComponent implements OnInit {
     }
 
     if (whiteList.length > 0) {
-      return items.filter(item => whiteList.includes(item.key));
+      return items
+        .map(group => group.filter(item => whiteList.includes(item.key)))
+        .filter(group => group.length > 0);
     }
 
-    return items.filter(item => !blackList.includes(item.key));
+    return items
+      .map(group => group.filter(item => !blackList.includes(item.key)))
+      .filter(group => group.length > 0);
   });
-
-  ngOnInit() {
-    console.log("Init Quil Wrapper")
-  }
-
 
 }

--- a/UI/Web/src/app/book-reader/_components/reader-settings/reader-settings.component.html
+++ b/UI/Web/src/app/book-reader/_components/reader-settings/reader-settings.component.html
@@ -136,13 +136,13 @@
                 </span>
                   <br>
                   <div class="btn-group d-flex justify-content-center" role="group" [attr.aria-label]="t('layout-mode-label')">
-                    <input type="radio" formControlName="layoutMode" [value]="BookPageLayoutMode.Default" class="btn-check" id="layout-mode-default" autocomplete="off">
+                    <input type="radio" formControlName="bookReaderLayoutMode" [value]="BookPageLayoutMode.Default" class="btn-check" id="layout-mode-default" autocomplete="off">
                     <label class="btn btn-outline-primary" for="layout-mode-default">{{t('layout-mode-option-scroll')}}</label>
 
-                    <input type="radio" formControlName="layoutMode" [value]="BookPageLayoutMode.Column1" class="btn-check" id="layout-mode-col1" autocomplete="off">
+                    <input type="radio" formControlName="bookReaderLayoutMode" [value]="BookPageLayoutMode.Column1" class="btn-check" id="layout-mode-col1" autocomplete="off">
                     <label class="btn btn-outline-primary" for="layout-mode-col1">{{t('layout-mode-option-1col')}}</label>
 
-                    <input type="radio" formControlName="layoutMode" [value]="BookPageLayoutMode.Column2" class="btn-check" id="layout-mode-col2" autocomplete="off">
+                    <input type="radio" formControlName="bookReaderLayoutMode" [value]="BookPageLayoutMode.Column2" class="btn-check" id="layout-mode-col2" autocomplete="off">
                     <label class="btn btn-outline-primary" for="layout-mode-col2">{{t('layout-mode-option-2col')}}</label>
                   </div>
                 </div>

--- a/UI/Web/src/app/book-reader/_components/reader-settings/reader-settings.component.ts
+++ b/UI/Web/src/app/book-reader/_components/reader-settings/reader-settings.component.ts
@@ -23,7 +23,7 @@ import {
 import {TranslocoDirective} from "@jsverse/transloco";
 import {ReadingProfileService} from "../../../_services/reading-profile.service";
 import {ReadingProfile, ReadingProfileKind} from "../../../_models/preferences/reading-profiles";
-import {EpubReaderSettingsService} from "../../../_services/epub-reader-settings.service";
+import {BookReadingProfileFormGroup, EpubReaderSettingsService} from "../../../_services/epub-reader-settings.service";
 
 /**
  * Used for book reader. Do not use for other components
@@ -103,7 +103,7 @@ export class ReaderSettingsComponent implements OnInit {
    */
   fontOptions: Array<string> = [];
   fontFamilies: Array<FontFamily> = [];
-  settingsForm: FormGroup = new FormGroup({});
+  settingsForm!: BookReadingProfileFormGroup;
   /**
    * System provided themes
    */

--- a/UI/Web/src/app/book-reader/_components/table-of-contents/table-of-contents.component.html
+++ b/UI/Web/src/app/book-reader/_components/table-of-contents/table-of-contents.component.html
@@ -1,13 +1,15 @@
 <ng-container *transloco="let t; prefix: 'table-of-contents'">
   <div class="table-of-contents">
-    @if (chapters().length === 0) {
+    @let bookChapters = chapters();
+
+    @if (bookChapters.length === 0) {
       <div>
         <em>{{t('no-data')}}</em>
       </div>
-    } @else if (chapters().length === 1) {
+    } @else if (bookChapters.length === 1) {
       <div>
         <ul>
-          @for(chapter of chapters()[0].children; track chapter.title) {
+          @for(chapter of bookChapters[0].children; track chapter.title) {
             <li class="{{chapter.page === pageNum() ? 'active': ''}}">
               <a href="javascript:void(0);" (click)="loadChapterPage(chapter.page, chapter.part)">{{chapter.title}}</a>
             </li>
@@ -15,7 +17,7 @@
         </ul>
       </div>
     } @else {
-      @for (chapterGroup of chapters(); track chapterGroup.title + chapterGroup.children.length) {
+      @for (chapterGroup of bookChapters; track chapterGroup.title + chapterGroup.children.length) {
         <ul class="chapter-title">
           <li class="{{isChapterSelected(chapterGroup) ? 'active': ''}}" (click)="loadChapterPage(chapterGroup.page, '')">
             {{chapterGroup.title}}

--- a/UI/Web/src/app/book-reader/_components/table-of-contents/table-of-contents.component.html
+++ b/UI/Web/src/app/book-reader/_components/table-of-contents/table-of-contents.component.html
@@ -1,21 +1,21 @@
 <ng-container *transloco="let t; prefix: 'table-of-contents'">
   <div class="table-of-contents">
-    @if (chapters.length === 0) {
+    @if (chapters().length === 0) {
       <div>
         <em>{{t('no-data')}}</em>
       </div>
-    } @else if (chapters.length === 1) {
+    } @else if (chapters().length === 1) {
       <div>
         <ul>
-          @for(chapter of chapters[0].children; track chapter.title) {
-            <li class="{{chapter.page === pageNum ? 'active': ''}}">
+          @for(chapter of chapters()[0].children; track chapter.title) {
+            <li class="{{chapter.page === pageNum() ? 'active': ''}}">
               <a href="javascript:void(0);" (click)="loadChapterPage(chapter.page, chapter.part)">{{chapter.title}}</a>
             </li>
           }
         </ul>
       </div>
     } @else {
-      @for (chapterGroup of chapters; track chapterGroup.title + chapterGroup.children.length) {
+      @for (chapterGroup of chapters(); track chapterGroup.title + chapterGroup.children.length) {
         <ul class="chapter-title">
           <li class="{{isChapterSelected(chapterGroup) ? 'active': ''}}" (click)="loadChapterPage(chapterGroup.page, '')">
             {{chapterGroup.title}}

--- a/UI/Web/src/app/book-reader/_components/table-of-contents/table-of-contents.component.ts
+++ b/UI/Web/src/app/book-reader/_components/table-of-contents/table-of-contents.component.ts
@@ -38,7 +38,7 @@ export class TableOfContentsComponent {
   }
 
   loadChapterPage(pageNum: number, part: string) {
-    this.pageNum.set(pageNum)
+    this.pageNum.set(pageNum);
     this.currentPageAnchor.set(part);
 
     this.loadChapter.emit({pageNum, part});
@@ -69,7 +69,7 @@ export class TableOfContentsComponent {
   }
 
   isAnchorSelected(chapter: BookChapterItem) {
-    return this.cleanIdSelector(chapter.part) === this.currentPageAnchor()
+    return this.cleanIdSelector(chapter.part) === this.currentPageAnchor();
   }
 
 }

--- a/UI/Web/src/app/book-reader/_components/table-of-contents/table-of-contents.component.ts
+++ b/UI/Web/src/app/book-reader/_components/table-of-contents/table-of-contents.component.ts
@@ -3,8 +3,8 @@ import {
   ChangeDetectorRef,
   Component,
   EventEmitter,
-  inject,
-  Input,
+  inject, input,
+  Input, model,
   Output
 } from '@angular/core';
 import {BookChapterItem} from '../../_models/book-chapter-item';
@@ -21,10 +21,10 @@ export class TableOfContentsComponent {
 
   private readonly cdRef = inject(ChangeDetectorRef);
 
-  @Input({required: true}) chapterId!: number;
-  @Input({required: true}) pageNum!: number;
-  @Input({required: true}) currentPageAnchor!: string;
-  @Input() chapters:Array<BookChapterItem> = [];
+  chapterId = model.required<number>();
+  pageNum = model.required<number>();
+  currentPageAnchor = model.required<string>();
+  chapters = model.required<Array<BookChapterItem>>();
 
   @Output() loadChapter: EventEmitter<{pageNum: number, part: string}> = new EventEmitter();
 
@@ -38,32 +38,38 @@ export class TableOfContentsComponent {
   }
 
   loadChapterPage(pageNum: number, part: string) {
+    this.pageNum.set(pageNum)
+    this.currentPageAnchor.set(part);
+
     this.loadChapter.emit({pageNum, part});
   }
 
   isChapterSelected(chapterGroup: BookChapterItem) {
-    if (chapterGroup.page === this.pageNum) {
+    const currentPageNum = this.pageNum();
+    const chapters = this.chapters();
+
+    if (chapterGroup.page === currentPageNum) {
       return true;
     }
 
-    const idx = this.chapters.indexOf(chapterGroup);
+    const idx = chapters.indexOf(chapterGroup);
     if (idx < 0) {
       return false; // should never happen
     }
 
     const nextIdx = idx + 1;
     // Last chapter
-    if (nextIdx >= this.chapters.length) {
-      return chapterGroup.page < this.pageNum;
+    if (nextIdx >= chapters.length) {
+      return chapterGroup.page < currentPageNum;
     }
 
     // Passed chapter, and next chapter has not been reached
-    const next = this.chapters[nextIdx];
-    return chapterGroup.page < this.pageNum && next.page > this.pageNum;
+    const next = chapters[nextIdx];
+    return chapterGroup.page < currentPageNum && next.page > currentPageNum;
   }
 
   isAnchorSelected(chapter: BookChapterItem) {
-    return this.cleanIdSelector(chapter.part) === this.currentPageAnchor
+    return this.cleanIdSelector(chapter.part) === this.currentPageAnchor()
   }
 
 }


### PR DESCRIPTION
# Added
- Added: API around the Quill editor toolbar

# Changed
- Changed: Styled the Quill editor to align with the rest of the book reader

# Fixed
- Fixed: Fixed text not being readable on different epub reader themes in a lot of places
- Fixed: Fixed ToC active chapter highlighting
- Fixed: Fixed annotation only saving the first change
- Fixed: Fixed an exception occurring when opening the epub reader



For this commit, https://github.com/Kareadita/Kavita/commit/f69c424e479a1b2f69e1c5ab596b0e0b6f9efe63, I think my reasoning is correct. But will need double-checking. I didn't notice any changes in behaviour with it as opposed to without it. 
