### PR TITLE
Added lazy-loading for PDFs in the PDF reader component

### DIFF
--- a/UI/Web/src/app/pdf-reader/_components/pdf-reader/pdf-reader.component.html
+++ b/UI/Web/src/app/pdf-reader/_components/pdf-reader/pdf-reader.component.html
@@ -2,23 +2,17 @@
   @if (accountService.currentUser$ | async; as user) {
     <div class="{{theme}}" #container>
 
-      @if (isLoading) {
-        <div class="loading mx-auto" style="min-width: 200px; width: 600px;">
-          <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
-          {{t('loading-message')}}
+      <div class="progress-container row g-0 align-items-center">
+        <div class="progress" style="height: 5px;">
+          <div class="progress-bar" role="progressbar" [ngStyle]="{'width': loadPercent + '%'}" [attr.aria-valuenow]="loadPercent" aria-valuemin="0" aria-valuemax="100"></div>
         </div>
-        <div class="progress-container row g-0 align-items-center">
-          <div class="progress" style="height: 5px;">
-            <div class="progress-bar" role="progressbar" [ngStyle]="{'width': loadPercent + '%'}" [attr.aria-valuenow]="loadPercent" aria-valuemin="0" aria-valuemax="100"></div>
-          </div>
-        </div>
-      }
+      </div>
 
       <ngx-extended-pdf-viewer
         #pdfViewer
         [src]="readerService.downloadPdf(this.chapterId)"
         [authorization]="'Bearer ' + user.token"
-        height="100vh"
+        height="calc(100vh - 5px)"
         [(page)]="currentPage"
         [textLayer]="true"
         [showHandToolButton]="true"

--- a/UI/Web/src/app/pdf-reader/_components/pdf-reader/pdf-reader.component.html
+++ b/UI/Web/src/app/pdf-reader/_components/pdf-reader/pdf-reader.component.html
@@ -2,17 +2,23 @@
   @if (accountService.currentUser$ | async; as user) {
     <div class="{{theme}}" #container>
 
-      <div class="progress-container row g-0 align-items-center">
-        <div class="progress" style="height: 5px;">
-          <div class="progress-bar" role="progressbar" [ngStyle]="{'width': loadPercent + '%'}" [attr.aria-valuenow]="loadPercent" aria-valuemin="0" aria-valuemax="100"></div>
+      @if (isLoading) {
+        <div class="loading-message-container">
+          <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+          {{t('loading-message')}}
         </div>
-      </div>
+        <div class="progress-container row g-0 align-items-center">
+          <div class="progress" style="height: 5px;">
+            <div class="progress-bar" role="progressbar" [ngStyle]="{'width': loadPercent + '%'}" [attr.aria-valuenow]="loadPercent" aria-valuemin="0" aria-valuemax="100"></div>
+          </div>
+        </div>
+      }
 
       <ngx-extended-pdf-viewer
         #pdfViewer
         [src]="readerService.downloadPdf(this.chapterId)"
         [authorization]="'Bearer ' + user.token"
-        height="calc(100vh - 5px)"
+        height="100vh"
         [(page)]="currentPage"
         [textLayer]="true"
         [showHandToolButton]="true"

--- a/UI/Web/src/app/pdf-reader/_components/pdf-reader/pdf-reader.component.scss
+++ b/UI/Web/src/app/pdf-reader/_components/pdf-reader/pdf-reader.component.scss
@@ -19,6 +19,10 @@
     color: lightblue !important;
 }
 
+.loading-message-container {
+  text-align: center;
+  min-width: 200px;
+}
 
 .progress-container {
     width: 100%;

--- a/UI/Web/src/app/pdf-reader/_components/pdf-reader/pdf-reader.component.ts
+++ b/UI/Web/src/app/pdf-reader/_components/pdf-reader/pdf-reader.component.ts
@@ -11,7 +11,7 @@ import {
   ViewChild
 } from '@angular/core';
 import {ActivatedRoute, Router} from '@angular/router';
-import {NgxExtendedPdfViewerModule, PageViewModeType, ProgressBarEvent, ScrollModeType} from 'ngx-extended-pdf-viewer';
+import {NgxExtendedPdfViewerModule, pdfDefaultOptions, PageViewModeType, ProgressBarEvent, ScrollModeType} from 'ngx-extended-pdf-viewer';
 import {ToastrService} from 'ngx-toastr';
 import {take} from 'rxjs';
 import {BookService} from 'src/app/book-reader/_services/book.service';
@@ -126,6 +126,7 @@ export class PdfReaderComponent implements OnInit, OnDestroy {
       this.navService.hideNavBar();
       this.themeService.clearThemes();
       this.navService.hideSideNav();
+      pdfDefaultOptions.disableAutoFetch = true;
   }
 
   @HostListener('window:keyup', ['$event'])

--- a/UI/Web/src/assets/langs/cs.json
+++ b/UI/Web/src/assets/langs/cs.json
@@ -2107,7 +2107,7 @@
     },
     "pdf-reader": {
         "incognito-mode": "Anonymní režim",
-        "loading-message": "Načítání......PDF může trvat déle, než se očekávalo",
+        "loading-message": "Načítání...",
         "light-theme-alt": "Světlý motiv",
         "dark-theme-alt": "Tmavý motiv",
         "close-reader-alt": "Zavřít čtečku",

--- a/UI/Web/src/assets/langs/de.json
+++ b/UI/Web/src/assets/langs/de.json
@@ -1557,7 +1557,7 @@
         "help-label": "{{common.help}}"
     },
     "pdf-reader": {
-        "loading-message": "Das Laden von……PDFs kann länger dauern als erwartet",
+        "loading-message": "Laden...",
         "incognito-mode": "Inkognito-Modus",
         "light-theme-alt": "Light Schema",
         "dark-theme-alt": "Dunkles Schema",

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -2150,7 +2150,7 @@
     },
 
     "pdf-reader": {
-        "loading-message": "Loading……PDFs may take longer than expected",
+        "loading-message": "Loading...",
         "incognito-mode": "Incognito Mode",
         "light-theme-alt": "Light Theme",
         "dark-theme-alt": "Dark Theme",

--- a/UI/Web/src/assets/langs/es.json
+++ b/UI/Web/src/assets/langs/es.json
@@ -1508,7 +1508,7 @@
         "help-label": "{{common.help}}"
     },
     "pdf-reader": {
-        "loading-message": "Cargando……los PDF pueden ser más lentos de lo esperado",
+        "loading-message": "Cargando...",
         "incognito-mode": "Modo incógnito",
         "light-theme-alt": "Tema claro",
         "dark-theme-alt": "Tema oscuro",

--- a/UI/Web/src/assets/langs/fr.json
+++ b/UI/Web/src/assets/langs/fr.json
@@ -1560,7 +1560,7 @@
         "help-label": "{{common.help}}"
     },
     "pdf-reader": {
-        "loading-message": "Chargement......de PDF peut prendre plus de temps que prévu",
+        "loading-message": "Chargement...",
         "incognito-mode": "Mode incognito",
         "light-theme-alt": "Thème clair",
         "dark-theme-alt": "Thème sombre",

--- a/UI/Web/src/assets/langs/ga.json
+++ b/UI/Web/src/assets/langs/ga.json
@@ -1560,7 +1560,7 @@
         "help-label": "{{common.help}}"
     },
     "pdf-reader": {
-        "loading-message": "Á Luchtú...... D'fhéadfadh sé go dtógfadh PDFanna níos faide ná mar a bhíothas ag súil leis",
+        "loading-message": "Á Luchtú...",
         "incognito-mode": "Mód Incognito",
         "light-theme-alt": "Téama Solais",
         "dark-theme-alt": "Téama Dorcha",

--- a/UI/Web/src/assets/langs/it.json
+++ b/UI/Web/src/assets/langs/it.json
@@ -1511,7 +1511,7 @@
         "cbl-repo": "Puoi trovare molti elenchi di lettura nella community <a href='https://github.com/DieselTech/CBL-ReadingLists' target='_blank' rel='noopener noreferrer'>repo</a>."
     },
     "pdf-reader": {
-        "loading-message": "Caricamento... I PDF potrebbero richiedere più tempo del previsto",
+        "loading-message": "Caricamento...",
         "incognito-mode": "Modalità Incognito",
         "light-theme-alt": "Tema Chiaro",
         "dark-theme-alt": "Tema Scuro",

--- a/UI/Web/src/assets/langs/ja.json
+++ b/UI/Web/src/assets/langs/ja.json
@@ -1381,7 +1381,7 @@
         "comicvine-parsing-label": "Comic Vine シリーズのマッチングを使用"
     },
     "pdf-reader": {
-        "loading-message": "ローディング...... PDF は期待以上の時間がかかる場合があります",
+        "loading-message": "ローディング...",
         "incognito-mode": "シークレットモード",
         "light-theme-alt": "ライトテーマ",
         "dark-theme-alt": "ダークテーマ",

--- a/UI/Web/src/assets/langs/ko.json
+++ b/UI/Web/src/assets/langs/ko.json
@@ -1550,7 +1550,7 @@
         "help-label": "{{common.help}}"
     },
     "pdf-reader": {
-        "loading-message": "로딩 중……PDF가 예상보다 오래 걸릴 수 있습니다",
+        "loading-message": "로딩 중...",
         "incognito-mode": "시크릿 모드",
         "light-theme-alt": "밝은 테마",
         "dark-theme-alt": "어두운 테마",

--- a/UI/Web/src/assets/langs/nl.json
+++ b/UI/Web/src/assets/langs/nl.json
@@ -1238,7 +1238,7 @@
         "final-import-step": "Laatste stap"
     },
     "pdf-reader": {
-        "loading-message": "Het laden van……PDF's kunnen langer duren dan verwacht",
+        "loading-message": "Laden...",
         "incognito-mode": "Incognito modus",
         "light-theme-alt": "Licht thema",
         "dark-theme-alt": "Donker thema",

--- a/UI/Web/src/assets/langs/pl.json
+++ b/UI/Web/src/assets/langs/pl.json
@@ -1560,7 +1560,7 @@
         "help-label": "{{common.help}}"
     },
     "pdf-reader": {
-        "loading-message": "Ładowanie… Pliki PDF mogą ładować się dłużej niż oczekiwano",
+        "loading-message": "Ładowanie...",
         "incognito-mode": "Tryb incognito",
         "light-theme-alt": "Jasny motyw",
         "dark-theme-alt": "Ciemny motyw",

--- a/UI/Web/src/assets/langs/pt.json
+++ b/UI/Web/src/assets/langs/pt.json
@@ -1560,7 +1560,7 @@
         "help-label": "{{common.help}}"
     },
     "pdf-reader": {
-        "loading-message": "A carregar....PDFs podem demorar mais que o esperado",
+        "loading-message": "A carregar...",
         "incognito-mode": "Modo Incógnito",
         "light-theme-alt": "Tema Claro",
         "dark-theme-alt": "Tema Escuro",

--- a/UI/Web/src/assets/langs/pt_BR.json
+++ b/UI/Web/src/assets/langs/pt_BR.json
@@ -1560,7 +1560,7 @@
         "help-label": "{{common.help}}"
     },
     "pdf-reader": {
-        "loading-message": "Carregando... PDFs podem demorar mais do que o esperado",
+        "loading-message": "Carregando...",
         "incognito-mode": "Modo Incógnito",
         "light-theme-alt": "Tema Claro",
         "dark-theme-alt": "Tema Escuro",

--- a/UI/Web/src/assets/langs/sk.json
+++ b/UI/Web/src/assets/langs/sk.json
@@ -1540,7 +1540,7 @@
         "comicvine-parsing-label": "Použite zhodu Comic Vine Serií"
     },
     "pdf-reader": {
-        "loading-message": "Načítavanie……súborov PDF môže trvať dlhšie, ako sa očakávalo",
+        "loading-message": "Načítavanie...",
         "incognito-mode": "Mód Inkognito",
         "light-theme-alt": "Svetlá téma",
         "dark-theme-alt": "Tmavá téma",

--- a/UI/Web/src/assets/langs/sv.json
+++ b/UI/Web/src/assets/langs/sv.json
@@ -2568,7 +2568,7 @@
         "light-theme-alt": "Ljust Tema",
         "dark-theme-alt": "Mörkt Tema",
         "toggle-incognito": "Stäng av Inkognitoläge",
-        "loading-message": "Laddar……PDFs kan ta längre än väntat",
+        "loading-message": "Laddar...",
         "incognito-mode": "Inkognitoläge"
     },
     "log-level-pipe": {

--- a/UI/Web/src/assets/langs/ta.json
+++ b/UI/Web/src/assets/langs/ta.json
@@ -2145,7 +2145,7 @@
         "cbl-repo": "சமூகத்தில் பல வாசிப்பு பட்டியல்களை நீங்கள் காணலாம் <a href = 'https: //github.com/dieseltech/cbl-readinglists' target = '_ வெற்று' rel = 'noopener norferrer'> களஞ்சி </a>."
     },
     "pdf-reader": {
-        "loading-message": "ஏற்றுதல் …… PDF கள் எதிர்பார்த்ததை விட அதிக நேரம் ஆகலாம்",
+        "loading-message": "ஏற்றுதல்...",
         "incognito-mode": "மறைநிலை பயன்முறை",
         "light-theme-alt": "ஒளி கருப்பொருள்",
         "dark-theme-alt": "இருண்ட கருப்பொருள்",

--- a/UI/Web/src/assets/langs/vi.json
+++ b/UI/Web/src/assets/langs/vi.json
@@ -1923,7 +1923,7 @@
         "light-theme-alt": "Chủ Đề Sáng",
         "dark-theme-alt": "Chủ Đề Tối",
         "close-reader-alt": "Đóng Trình Đọc",
-        "loading-message": "Đang tải……PDF có thể mất nhiều thời gian hơn dự kiến",
+        "loading-message": "Đang tải...",
         "toggle-incognito": "Tắt chế độ Ẩn Danh"
     },
     "pdf-layout-mode-pipe": {

--- a/UI/Web/src/assets/langs/zh_Hans.json
+++ b/UI/Web/src/assets/langs/zh_Hans.json
@@ -1560,7 +1560,7 @@
         "help-label": "{{common.help}}"
     },
     "pdf-reader": {
-        "loading-message": "加载中...PDF文件可能需要比预期更长的时间",
+        "loading-message": "加载中...",
         "incognito-mode": "隐身模式",
         "light-theme-alt": "明亮主题",
         "dark-theme-alt": "深色主题",

--- a/UI/Web/src/assets/langs/zh_Hant.json
+++ b/UI/Web/src/assets/langs/zh_Hant.json
@@ -2351,7 +2351,7 @@
     },
     "pdf-reader": {
         "close-reader-alt": "關閉閱讀器",
-        "loading-message": "載入中…PDF 可能需要比預期更長的時間",
+        "loading-message": "載入中...",
         "incognito-mode": "無痕模式",
         "light-theme-alt": "淺色主題",
         "dark-theme-alt": "深色主題",


### PR DESCRIPTION
# Changed
- Changed: PDFs are now downloaded on demand in the PDF reader, helping with initial load times for large PDFs (Fixes #3993)


# Example 
On a PDF with 227 pages (~140 MB), from page 207 to 227:
Before: 2136 requests, 54 MB transferred, 141 MB resources
After: 84 requests, 10 MB transferred, 13 MB resources

https://github.com/user-attachments/assets/004950fa-47b0-4429-b812-993ea27e4b7e  


https://github.com/user-attachments/assets/0104bc7c-a96e-46c2-89b5-a6cef2558334  



