### PR TITLE
Fix text bleeding in EPUB reader column layouts (#4040)

### DIFF
--- a/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.scss
+++ b/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.scss
@@ -242,7 +242,7 @@ $action-bar-height: 38px;
 .column-layout-1 {
   .book-content {
     column-count: 1;
-    column-gap: 20px;
+    column-gap: 0px;
     overflow: hidden;
     word-break: break-word;
     overflow-wrap: break-word;
@@ -252,7 +252,7 @@ $action-bar-height: 38px;
 .column-layout-2 {
   .book-content {
     column-count: 2;
-    column-gap: 20px;
+    column-gap: 0px;
     overflow: hidden;
     word-break: break-word;
     overflow-wrap: break-word;

--- a/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.ts
+++ b/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.ts
@@ -548,9 +548,9 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
         case BookPageLayoutMode.Default:
           return 'unset';
         case BookPageLayoutMode.Column1:
-          return (base - COLUMN_GAP) + 'px';
+          return base + 'px';
         case BookPageLayoutMode.Column2:
-          return ((base - COLUMN_GAP) / 2) + 'px';
+          return (base / 2) + 'px';
         default:
           return 'unset';
       }

--- a/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.ts
+++ b/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.ts
@@ -548,9 +548,9 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
         case BookPageLayoutMode.Default:
           return 'unset';
         case BookPageLayoutMode.Column1:
-          return (base / 2) + 'px';
+          return (base - COLUMN_GAP) + 'px';
         case BookPageLayoutMode.Column2:
-          return (base / 4) + 'px';
+          return ((base - COLUMN_GAP) / 2) + 'px';
         default:
           return 'unset';
       }

--- a/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.ts
+++ b/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.ts
@@ -1724,8 +1724,9 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
     if (!(this.pageStyles() || {}).hasOwnProperty('margin-left')) return 0; // TODO: Test this, added for safety during refactor
 
     const margin = (window.innerWidth * (parseInt(this.pageStyles()['margin-left'], 10) / 100)) * 2;
+    const columnGapModifier = this.columnGapModifier();
     const windowWidth = window.innerWidth || document.documentElement.clientWidth;
-    return windowWidth - margin;
+    return windowWidth - margin - (COLUMN_GAP * columnGapModifier);
   }
 
   convertVwToPx(vwValue: number) {

--- a/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.ts
+++ b/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.ts
@@ -548,11 +548,9 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
         case BookPageLayoutMode.Default:
           return 'unset';
         case BookPageLayoutMode.Column1:
-          return ((base / 2) - 4) + 'px';
+          return (base / 2) + 'px';
         case BookPageLayoutMode.Column2:
-          //return (this.readingSectionElemRef?.nativeElement?.clientWidth - this.getMargin() + 1) / 2 + 'px';
-          return (((this.readingSectionElemRef?.nativeElement?.clientWidth ?? base)) / 4) + 1 + 'px'
-          //return ((base) / 4) + 6 + 'px'
+          return (base / 4) + 'px';
         default:
           return 'unset';
       }
@@ -1692,17 +1690,18 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
     if (this.readingSectionElemRef == null) return 0;
 
     const margin = (this.convertVwToPx(parseInt(marginLeft, 10)) * 2);
+    const baseWidth = this.readingSectionElemRef.nativeElement.clientWidth - margin;
 
     // console.log('page size calc, client width: ', this.readingSectionElemRef.nativeElement.clientWidth)
     // console.log('page size calc, margin: ', margin)
-    // console.log('page size calc, col gap: ', ((COLUMN_GAP / 2) * columnGapModifier));
+    // console.log('page size calc, col gap: ', ((COLUMN_GAP) * columnGapModifier));
     // console.log("clientWidth", this.readingSectionElemRef.nativeElement.clientWidth, "window", window.innerWidth, "margin", margin, "left", marginLeft)
     // console.log('clientWidth: ', this.readingSectionElemRef.nativeElement.clientWidth, 'offsetWidth:', this.readingSectionElemRef.nativeElement.offsetWidth, 'bbox:', this.readingSectionElemRef.nativeElement.getBoundingClientRect().width);
 
     if (calculationMethod === EpubPageCalculationMethod.Default) {
-      return this.readingSectionElemRef.nativeElement.clientWidth - margin + (((COLUMN_GAP) * columnGapModifier));
+      return baseWidth - (COLUMN_GAP * columnGapModifier);
     } else {
-      return this.readingSectionElemRef.nativeElement.clientWidth - margin + (((COLUMN_GAP) * columnGapModifier) + 10);
+      return baseWidth - (COLUMN_GAP * columnGapModifier);
     }
   });
 
@@ -1714,7 +1713,7 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       case BookPageLayoutMode.Column1:
         return 1;
       case BookPageLayoutMode.Column2:
-        return calculationMethod === EpubPageCalculationMethod.Default ? 1 : 1.25;
+        return calculationMethod === EpubPageCalculationMethod.Default ? 2 : 2.5;
     }
   });
 

--- a/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.ts
+++ b/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.ts
@@ -1681,10 +1681,8 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
    */
   pageWidth = computed(() => {
     this.windowWidth(); // Ensure re-compute when windows size changes (element clientWidth isn't a signal)
-    this.pageCalcMode();
 
     console.log('page width recalulated')
-    const calculationMethod = this.pageCalcMode();
     const marginLeft = this.pageStyles()['margin-left'];
     const columnGapModifier = this.columnGapModifier();
     if (this.readingSectionElemRef == null) return 0;
@@ -1698,22 +1696,17 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
     // console.log("clientWidth", this.readingSectionElemRef.nativeElement.clientWidth, "window", window.innerWidth, "margin", margin, "left", marginLeft)
     // console.log('clientWidth: ', this.readingSectionElemRef.nativeElement.clientWidth, 'offsetWidth:', this.readingSectionElemRef.nativeElement.offsetWidth, 'bbox:', this.readingSectionElemRef.nativeElement.getBoundingClientRect().width);
 
-    if (calculationMethod === EpubPageCalculationMethod.Default) {
-      return baseWidth - (COLUMN_GAP * columnGapModifier);
-    } else {
-      return baseWidth - (COLUMN_GAP * columnGapModifier);
-    }
+    return baseWidth - (COLUMN_GAP * columnGapModifier);
   });
 
   columnGapModifier = computed(() => {
-    const calculationMethod = this.pageCalcMode();
     switch(this.layoutMode()) {
       case BookPageLayoutMode.Default:
         return 0;
       case BookPageLayoutMode.Column1:
         return 1;
       case BookPageLayoutMode.Column2:
-        return calculationMethod === EpubPageCalculationMethod.Default ? 2 : 2.5;
+        return 2;
     }
   });
 


### PR DESCRIPTION
This pull request updates the page size and layout calculations in the `BookReaderComponent` to improve accuracy and consistency for different page layout modes and calculation methods. The changes focus on simplifying the logic and correcting the computed values for column layouts.

**Layout Calculation Updates:**

* The logic for calculating the page width in `BookPageLayoutMode.Column1` and `BookPageLayoutMode.Column2` has been simplified to use direct division of the `base` value, removing extra offsets and unnecessary client width checks.

**Page Size Calculation Improvements:**

* The page size calculation now consistently uses a new `baseWidth` variable and subtracts the column gap instead of adding it, which corrects the computed page size for both calculation methods.

**Column Modifier Adjustment:**

* The column modifier for `BookPageLayoutMode.Column2` has been updated to return `2` or `2.5` (instead of `1` or `1.25`), ensuring the correct number of columns is used in the layout calculation logic.


Fixes #4040 
/claim #4040

