### PR TITLE
Theme variable changes

### DIFF
--- a/UI/Web/src/_tag-card-common.scss
+++ b/UI/Web/src/_tag-card-common.scss
@@ -13,8 +13,11 @@
 }
 
 .tag-card:hover {
-  background-color: #3a3a3a;
+  background-color: var(--card-hover-bg-color);
   //transform: translateY(-3px); // Cool effect but has a weird background issue. ROBBIE: Fix this
+  & .tag-name, & .tag-meta {
+    color: var(--card-hover-text-color)
+  }
 }
 
 .tag-name {

--- a/UI/Web/src/app/_services/font.service.ts
+++ b/UI/Web/src/app/_services/font.service.ts
@@ -39,7 +39,7 @@ export class FontService {
   getFontFace(font: EpubFont): FontFace {
     // TODO: We need to refactor this so that we loadFonts with an array, fonts have an id to remove them, and we don't keep populating the document
     if (font.provider === FontProvider.System) {
-      return new FontFace(font.name, `url('/assets/fonts/${font.name}/${font.fileName}')`);
+      return new FontFace(font.name, `url('assets/fonts/${font.name}/${font.fileName}')`);
     }
 
     return new FontFace(font.name, `url(${this.baseUrl}font?fontId=${font.id}&apiKey=${this.encodedKey})`);

--- a/UI/Web/src/app/_single-module/card-actionables/card-actionables.component.scss
+++ b/UI/Web/src/app/_single-module/card-actionables/card-actionables.component.scss
@@ -28,12 +28,12 @@
     color: var(--dropdown-item-text-color);
     background-color: var(--dropdown-item-bg-color);
     &:hover {
-        color: var(--dropdown-item-text-color);
+        color: var(--dropdown-item-hover-text-color);
         background-color: var(--dropdown-item-hover-bg-color);
         cursor: pointer;
     }
     &:focus-visible {
-        color: var(--dropdown-item-text-color);
+        color: var(--dropdown-item-hover-text-color);
         background-color: var(--dropdown-item-hover-bg-color);
     }
 }

--- a/UI/Web/src/app/_single-module/cover-image/cover-image.component.scss
+++ b/UI/Web/src/app/_single-module/cover-image/cover-image.component.scss
@@ -58,6 +58,10 @@
         cursor: pointer;
     }
 
+    .card-title {
+        color: var(--card-overlay-text-color);
+    }
+
     .overlay-information--centered {
         position: absolute;
         border-radius: 15px;

--- a/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.scss
+++ b/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.scss
@@ -410,7 +410,7 @@ $pagination-opacity: 0;
 
   i {
     background-color: unset;
-    color: var(--br-actionbar-button-text-color);
+    color: var(--br-actionbar-button-text-color) !important;
   }
 
   &:active {

--- a/UI/Web/src/app/cards/_modals/bulk-add-to-collection/bulk-add-to-collection.component.scss
+++ b/UI/Web/src/app/cards/_modals/bulk-add-to-collection/bulk-add-to-collection.component.scss
@@ -1,5 +1,5 @@
 .clickable:hover, .clickable:focus {
-    background-color: var(--list-group-hover-bg-color, --primary-color);
+    background-color: var(--list-group-hover-bg-color, var(--primary-color));
 }
 
 .collection {

--- a/UI/Web/src/app/cards/_modals/bulk-set-reading-profile-modal/bulk-set-reading-profile-modal.component.scss
+++ b/UI/Web/src/app/cards/_modals/bulk-set-reading-profile-modal/bulk-set-reading-profile-modal.component.scss
@@ -1,5 +1,5 @@
 .clickable:hover, .clickable:focus {
-  background-color: var(--list-group-hover-bg-color, --primary-color);
+  background-color: var(--list-group-hover-bg-color, var(--primary-color));
 }
 
 .pill {

--- a/UI/Web/src/app/collections/_components/collection-owner/collection-owner.component.scss
+++ b/UI/Web/src/app/collections/_components/collection-owner/collection-owner.component.scss
@@ -1,4 +1,4 @@
 .text-accent {
   font-size: small;
-  color: var(---accent-text-color);
+  color: var(--accent-text-color);
 }

--- a/UI/Web/src/app/settings/_components/settings/settings.component.scss
+++ b/UI/Web/src/app/settings/_components/settings/settings.component.scss
@@ -1,7 +1,7 @@
 @use '../../../../theme/variables' as theme;
 
 h2 {
-  color: var(--side-nav-header-text-color, white);
+  color: var(--side-nav-header-text-color);
   font-weight: bold;
 }
 

--- a/UI/Web/src/app/settings/_components/settings/settings.component.scss
+++ b/UI/Web/src/app/settings/_components/settings/settings.component.scss
@@ -1,7 +1,7 @@
 @use '../../../../theme/variables' as theme;
 
 h2 {
-  color: white;
+  color: var(--side-nav-header-text-color, white);
   font-weight: bold;
 }
 

--- a/UI/Web/src/app/sidenav/preference-nav/preference-nav.component.scss
+++ b/UI/Web/src/app/sidenav/preference-nav/preference-nav.component.scss
@@ -68,7 +68,7 @@
 }
 
 .side-nav-header {
-  color: #d5d5d5;
+  color: var(--pref-side-nav-header-text-color);
   font-weight: bold;
   margin-left: 5px;
 }

--- a/UI/Web/src/theme/components/_buttons.scss
+++ b/UI/Web/src/theme/components/_buttons.scss
@@ -267,6 +267,12 @@ button:disabled, .form-control:disabled, .form-control[readonly], .disabled, :di
     }
 }
 
+button {
+  i.fa, i.fa-regular {
+    color: var(--btn-fa-icon-color);
+  }
+}
+
 .btn-check:focus + .btn, .btn:focus {
   box-shadow: 0 0 0 0.05rem var(--btn-focus-boxshadow-color);
 }

--- a/UI/Web/src/theme/components/_buttons.scss
+++ b/UI/Web/src/theme/components/_buttons.scss
@@ -14,10 +14,18 @@
   --bs-btn-active-bg: var(--primary-color-dark-shade);
   --bs-btn-active-border-color: var(--primary-color-dark-shade);
 
+  i {
+    color: var(--btn-primary-text-color);
+  }
+
   &:hover {
     color: var(--btn-primary-hover-text-color);
     background-color: var(--btn-primary-hover-bg-color);
     border-color: var(--btn-primary-hover-border-color);
+
+    i {
+      --btncolor: var(-primary-hover-text-color);
+    }
   }
 }
 
@@ -30,10 +38,18 @@
   background-color: var(--btn-outline-primary-bg-color);
   border-color: var(--btn-outline-primary-border-color);
 
+  i {
+    color: var(--btn-outline-primary-text-color);
+  }
+
   &:hover {
     color: var(--btn-outline-primary-hover-text-color) !important;
     background-color: var(--btn-outline-primary-hover-bg-color) !important;
     border-color: var(--btn-outline-primary-hover-border-color) !important;
+
+    i {
+      color: var(--btn-outline-primary-hover-text-color) !important;
+    }
   }
 }
 
@@ -82,6 +98,10 @@
   background-color: var(--btn-secondary-outline-bg-color);
   border-color: var(--btn-secondary-outline-border-color);
 
+  i {
+    color: var(--btn-secondary-outline-text-color);
+  }
+
   &:hover {
     --bs-btn-color: var(--btn-secondary-outline-hover-text-color);
     --bs-btn-hover-bg: var(-btn-secondary-outline-hover-bg-color);
@@ -94,6 +114,10 @@
     box-shadow: inset 0px -2px 0px 0px var(--btn-secondary-outline-text-color);
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
+
+    i {
+      color: var(--btn-secondary-outline-hover-text-color);
+    }
   }
 }
 
@@ -103,10 +127,18 @@
   background-color: var(--btn-danger-outline-bg-color);
   border-color: var(--btn-danger-outline-border-color);
 
+  i {
+    color: var(--btn-danger-outline-text-color);
+  }
+
   &:hover {
     color: var(--btn-danger-outline-hover-text-color);
     background-color: var(--btn-danger-outline-hover-bg-color);
     border-color: var(--btn-danger-outline-hover-border-color);
+
+    i {
+      color: var(--btn-danger-outline-hover-text-color);
+    }
   }
 }
 
@@ -132,6 +164,9 @@
   background-color: var(--btn-disabled-bg-color);
   color: var(--btn-disabled-text-color);
   border-color: var(--btn-disabled-border-color);
+  i {
+    color: var(--btn-disabled-text-color);
+  }
 }
 
 button:disabled, .form-control:disabled, .form-control[readonly], .disabled, :disabled {
@@ -160,6 +195,10 @@ button:disabled, .form-control:disabled, .form-control[readonly], .disabled, :di
   color: var(--body-text-color);
   border: none;
 
+  i {
+    color: var(--body-text-color);
+  }
+
   &:disabled {
     --bs-btn-disabled-bg: transparent;
   }
@@ -178,14 +217,26 @@ button:disabled, .form-control:disabled, .form-control[readonly], .disabled, :di
 
 .btn-primary-text {
   color: var(--btn-primary-text-text-color);
+
+  i {
+    color: var(--btn-primary-text-text-color);
+  }
 }
 
 .btn-secondary-text {
   color: var(--btn-secondary-text-text-color);
+
+  i {
+    color: var(--btn-secondary-text-text-color);
+  }
 }
 
 .btn-danger-text {
   color: var(--btn-danger-text-text-color);
+
+  i {
+    color: var(--btn-danger-text-text-color);
+  }
 }
 
 
@@ -194,6 +245,10 @@ button:disabled, .form-control:disabled, .form-control[readonly], .disabled, :di
   color: var(--btn-secondary-text-color);
   background-color: var(--btn-secondary-bg-color);
   border-color: var(--btn-secondary-border-color);
+
+  i {
+    color: var(--btn-secondary-text-color);
+  }
 }
 
 .btn.btn-secondary.alt {
@@ -210,35 +265,6 @@ button:disabled, .form-control:disabled, .form-control[readonly], .disabled, :di
       box-shadow: 0 0 0 0.05rem var(--btn-alt-focus-boxshadow-color);
       font-weight: var(--btn-secondary-font-weight);
     }
-}
-
-$button_types: '', -primary, -secondary, -outline-primary, -outline-secondary, -danger;
-$icon_classes: fa, fa-regular, fa-solid;
-
-// FA icon colors for all button types
-// the .nav exception is for the Activity button in the top nav bar
-@each $button_type in $button_types {
-  button.btn#{$button_type} {
-    @each $icon_class in $icon_classes {
-      i:not(.nav).#{$icon_class} {
-        color: var(--btn#{$button_type}-fa-icon-color);
-      }
-
-      &:hover {
-        i:not(.nav).#{$icon_class} {
-          color: var(--btn#{$button_type}-hover-fa-icon-color);
-        }
-      }
-    }
-  }
-}
-
-button.btn:disabled{
-  @each $icon_class in $icon_classes {
-    i:not(.nav).#{$icon_class} {
-      color: var(--btn-disabled-fa-icon-color);
-    }
-  }
 }
 
 .btn-check:focus + .btn, .btn:focus {

--- a/UI/Web/src/theme/components/_buttons.scss
+++ b/UI/Web/src/theme/components/_buttons.scss
@@ -24,7 +24,7 @@
     border-color: var(--btn-primary-hover-border-color);
 
     i {
-      --btncolor: var(-primary-hover-text-color);
+      color: var(--btn-primary-hover-text-color);
     }
   }
 }

--- a/UI/Web/src/theme/components/_buttons.scss
+++ b/UI/Web/src/theme/components/_buttons.scss
@@ -151,7 +151,7 @@ button:disabled, .form-control:disabled, .form-control[readonly], .disabled, :di
 
 
 .btn:focus, .btn:active, .btn:active:focus {
-  box-shadow: 0 0 0 0 var(---btn-focus-boxshadow-color) !important;
+  box-shadow: 0 0 0 0 var(--btn-focus-boxshadow-color) !important;
 }
 
 
@@ -224,21 +224,22 @@ $icon_classes: fa, fa-regular, fa-solid;
         color: var(--btn#{$button_type}-fa-icon-color);
       }
 
-      &:disabled {
-        i:not(.nav).#{$icon_class} {
-          color: var(--btn#{$button_type}-disabled-fa-icon-color, var(--btn#{$button_type}-disabled-text-color));
-        }
-      }
-
       &:hover {
         i:not(.nav).#{$icon_class} {
-          color: var(--btn#{$button_type}-hover-fa-icon-color, white);
+          color: var(--btn#{$button_type}-hover-fa-icon-color);
         }
       }
     }
   }
 }
 
+button.btn:disabled{
+  @each $icon_class in $icon_classes {
+    i:not(.nav).#{$icon_class} {
+      color: var(--btn-disabled-fa-icon-color);
+    }
+  }
+}
 
 .btn-check:focus + .btn, .btn:focus {
   box-shadow: 0 0 0 0.05rem var(--btn-focus-boxshadow-color);

--- a/UI/Web/src/theme/components/_buttons.scss
+++ b/UI/Web/src/theme/components/_buttons.scss
@@ -212,9 +212,33 @@ button:disabled, .form-control:disabled, .form-control[readonly], .disabled, :di
     }
 }
 
-button i.fa {
-  color: var(--btn-fa-icon-color);
+$button_types: '', -primary, -secondary, -outline-primary, -outline-secondary, -danger;
+$icon_classes: fa, fa-regular, fa-solid;
+
+// FA icon colors for all button types
+// the .nav exception is for the Activity button in the top nav bar
+@each $button_type in $button_types {
+  button.btn#{$button_type} {
+    @each $icon_class in $icon_classes {
+      i:not(.nav).#{$icon_class} {
+        color: var(--btn#{$button_type}-fa-icon-color);
+      }
+
+      &:disabled {
+        i:not(.nav).#{$icon_class} {
+          color: var(--btn#{$button_type}-disabled-fa-icon-color, var(--btn#{$button_type}-disabled-text-color));
+        }
+      }
+
+      &:hover {
+        i:not(.nav).#{$icon_class} {
+          color: var(--btn#{$button_type}-hover-fa-icon-color, white);
+        }
+      }
+    }
+  }
 }
+
 
 .btn-check:focus + .btn, .btn:focus {
   box-shadow: 0 0 0 0.05rem var(--btn-focus-boxshadow-color);

--- a/UI/Web/src/theme/components/_card.scss
+++ b/UI/Web/src/theme/components/_card.scss
@@ -38,6 +38,10 @@ $image-height: 232.91px;
 $image-filter-height: 160px;
 $image-width: 160px;
 
+.card-title {
+    --bs-card-title-color: var(--card-title-text-color);
+}
+
 .card-item-container {
     .card {
         max-width: $image-width;
@@ -76,12 +80,19 @@ $image-width: 160px;
                 height: $image-filter-height;
             }
         }
-    }
 
+        & .card-title {
+            color: var(--card-overlay-text-color);
+        }
+
+        & + .card-body {
+            color: var(--card-overlay-text-color);
+        }
+    }
 
     .card-body {
         padding: 0 5px !important;
-        background-color: rgba(0,0,0,0.7);
+        background-color: var(--card-background-color, rgba(0,0,0,0.7));
         border-width: var(--card-border-width);
         border-style: var(--card-border-style);
         border-color: var(--card-border-color);

--- a/UI/Web/src/theme/components/_card.scss
+++ b/UI/Web/src/theme/components/_card.scss
@@ -92,7 +92,7 @@ $image-width: 160px;
 
     .card-body {
         padding: 0 5px !important;
-        background-color: var(--card-body-bg-color, rgba(0,0,0,0.7));
+        background-color: var(--card-body-bg-color);
         border-width: var(--card-border-width);
         border-style: var(--card-border-style);
         border-color: var(--card-border-color);

--- a/UI/Web/src/theme/components/_card.scss
+++ b/UI/Web/src/theme/components/_card.scss
@@ -92,7 +92,7 @@ $image-width: 160px;
 
     .card-body {
         padding: 0 5px !important;
-        background-color: var(--card-background-color, rgba(0,0,0,0.7));
+        background-color: var(--card-body-bg-color, rgba(0,0,0,0.7));
         border-width: var(--card-border-width);
         border-style: var(--card-border-style);
         border-color: var(--card-border-color);

--- a/UI/Web/src/theme/components/_input.scss
+++ b/UI/Web/src/theme/components/_input.scss
@@ -3,14 +3,16 @@ input:not([type="range"]), .form-control {
     color: var(--input-text-color);
     border-color: var(--input-border-color);
 
-    &:focus {
+    &:focus:not([type="checkbox"]) {
         border-color: var(--input-focused-border-color);
         background-color: var(--input-bg-color);
         color: var(--input-text-color);
         box-shadow: 0 0 0 .25rem var(--input-focus-boxshadow-color);
     }
 
-    &:read-only {
+    // Checkboxes are selected by the :read-only pseudo-class, even when they're editable
+    // See https://developer.mozilla.org/en-US/docs/Web/CSS/:read-only
+    &:read-only:not([type="checkbox"]) {
         background-color: var(--input-bg-readonly-color);
         cursor: initial;
     }

--- a/UI/Web/src/theme/components/_input.scss
+++ b/UI/Web/src/theme/components/_input.scss
@@ -3,7 +3,7 @@ input:not([type="range"]), .form-control {
     color: var(--input-text-color);
     border-color: var(--input-border-color);
 
-    &:focus:not([type="checkbox"]) {
+    &:focus:not(:checked) {
         border-color: var(--input-focused-border-color);
         background-color: var(--input-bg-color);
         color: var(--input-text-color);

--- a/UI/Web/src/theme/components/_selects.scss
+++ b/UI/Web/src/theme/components/_selects.scss
@@ -14,11 +14,6 @@
         box-shadow: 0 0 0 0.25rem var(--input-focus-boxshadow-color);
     }
 
-    &:read-only {
-        background-color: var(--input-bg-readonly-color);
-        cursor: initial;
-    }
-
     &:disabled {
         cursor: not-allowed;
         pointer-events: none;

--- a/UI/Web/src/theme/components/_sidenav.scss
+++ b/UI/Web/src/theme/components/_sidenav.scss
@@ -114,7 +114,6 @@
       }
 
       .active-highlight {
-        background-color: #2f2f2f;
         background-color: var(--side-nav-item-color);
         width: 0.25rem;
         height: 100%;
@@ -227,7 +226,7 @@
           text-align: unset;
           margin-left: 0.75rem;
           font-size: 0.9rem;
-          color: var(--side-nav-text-color, #999999);
+          color: var(--side-nav-text-color);
           
           div {
             display: flex;

--- a/UI/Web/src/theme/components/_sidenav.scss
+++ b/UI/Web/src/theme/components/_sidenav.scss
@@ -115,7 +115,7 @@
 
       .active-highlight {
         background-color: #2f2f2f;
-        background-color: rgb(255 255 255 / 9%);
+        background-color: var(--side-nav-item-color, rgb(255 255 255 / 9%));
         width: 0.25rem;
         height: 100%;
         position: absolute;
@@ -203,7 +203,7 @@
       padding-left: 1.125rem;
 
       .side-nav-header {
-        color: #ffffff;
+        color: var(--side-nav-header-text-color, #ffffff);
         font-size: 1rem;
         margin-left: unset;
 
@@ -227,7 +227,7 @@
           text-align: unset;
           margin-left: 0.75rem;
           font-size: 0.9rem;
-          color: #999999;
+          color: var(--side-nav-text-color, #999999);
           
           div {
             display: flex;
@@ -238,6 +238,11 @@
           }
         }
 
+        &:hover {
+          .side-nav-text {
+            color: var(--side-nav-hover-text-color);
+          }
+        }
         .card-actions {
           display: none;
         }

--- a/UI/Web/src/theme/components/_sidenav.scss
+++ b/UI/Web/src/theme/components/_sidenav.scss
@@ -115,7 +115,7 @@
 
       .active-highlight {
         background-color: #2f2f2f;
-        background-color: var(--side-nav-item-color, rgb(255 255 255 / 9%));
+        background-color: var(--side-nav-item-color);
         width: 0.25rem;
         height: 100%;
         position: absolute;
@@ -203,7 +203,7 @@
       padding-left: 1.125rem;
 
       .side-nav-header {
-        color: var(--side-nav-header-text-color, #ffffff);
+        color: var(--side-nav-header-text-color);
         font-size: 1rem;
         margin-left: unset;
 

--- a/UI/Web/src/theme/themes/dark.scss
+++ b/UI/Web/src/theme/themes/dark.scss
@@ -256,7 +256,7 @@
     --side-nav-mobile-box-shadow: 3px 0em 5px 10em rgb(0 0 0 / 50%);
     --side-nav-hover-text-color: white;
     --side-nav-hover-bg-color: black;
-    --side-nav-text-color: hsla(0,0%,100%,.85);
+    --side-nav-text-color: #999999;
     --side-nav-header-text-color: white;
     --side-nav-border-radius: 3px;
     --side-nav-border: none;
@@ -272,6 +272,7 @@
     --side-nav-item-color: rgb(255 255 255 / 9%);
     --side-nav-item-closed-color: var(--elevation-layer10);
     --side-nav-item-closed-hover-color: white;
+    --pref-side-nav-header-text-color: #d5d5d5;
 
     /* List items */
     --list-group-item-text-color: var(--body-text-color);

--- a/UI/Web/src/theme/themes/dark.scss
+++ b/UI/Web/src/theme/themes/dark.scss
@@ -169,25 +169,13 @@
     --btn-alt-hover-bg-color: #3b4466;
     --btn-alt-focus-bg-color: #343c59;
     --btn-alt-focus-boxshadow-color: rgb(255 255 255 / 50%);
+    --btn-fa-icon-color: white;
     --btn-disabled-bg-color: #343a40;
     --btn-disabled-text-color: white;
     --btn-disabled-border-color: #6c757d;
     --bs-btn-disabled-border-color: transparent;
     --btn-actions-border-radius: 0.375rem;
     --btn-actions-hover-bg: rgb(255 255 255 / 18%);
-    --btn-fa-icon-color: white;
-    --btn-disabled-fa-icon-color: white;
-    --btn-hover-fa-icon-color: white;
-    --btn-primary-fa-icon-color: white;
-    --btn-primary-hover-fa-icon-color: white;
-    --btn-secondary-fa-icon-color: white;
-    --btn-secondary-hover-fa-icon-color: white;
-    --btn-outline-primary-fa-icon-color: white;
-    --btn-outline-primary-hover-fa-icon-color: white;
-    --btn-outline-secondary-fa-icon-color: white;
-    --btn-outline-secondary-hover-fa-icon-color: white;
-    --btn-danger-fa-icon-color: white;
-    --btn-danger-hover-fa-icon-color: white;
 
 
     /* Nav (Tabs) */

--- a/UI/Web/src/theme/themes/dark.scss
+++ b/UI/Web/src/theme/themes/dark.scss
@@ -169,13 +169,30 @@
     --btn-alt-hover-bg-color: #3b4466;
     --btn-alt-focus-bg-color: #343c59;
     --btn-alt-focus-boxshadow-color: rgb(255 255 255 / 50%);
-    --btn-fa-icon-color: white;
     --btn-disabled-bg-color: #343a40;
     --btn-disabled-text-color: white;
     --btn-disabled-border-color: #6c757d;
     --bs-btn-disabled-border-color: transparent;
     --btn-actions-border-radius: 0.375rem;
     --btn-actions-hover-bg: rgb(255 255 255 / 18%);
+    --btn-fa-icon-color: white;
+    --btn-disabled-fa-icon-color: white;
+    --btn-hover-fa-icon-color: white;
+    --btn-primary-fa-icon-color: white;
+    --btn-primary-disabled-fa-icon-color: white;
+    --btn-primary-hover-fa-icon-color: white;
+    --btn-secondary-fa-icon-color: white;
+    --btn-secondary-disabled-fa-icon-color: white;
+    --btn-secondary-hover-fa-icon-color: white;
+    --btn-outline-primary-fa-icon-color: white;
+    --btn-outline-primary-disabled-fa-icon-color: white;
+    --btn-outline-primary-hover-fa-icon-color: white;
+    --btn-outline-secondary-fa-icon-color: white;
+    --btn-outline-secondary-disabled-fa-icon-color: white;
+    --btn-outline-secondary-hover-fa-icon-color: white;
+    --btn-danger-fa-icon-color: white;
+    --btn-danger-disabled-fa-icon-color: white;
+    --btn-danger-hover-fa-icon-color: white;
 
 
     /* Nav (Tabs) */
@@ -245,6 +262,7 @@
     --side-nav-hover-text-color: white;
     --side-nav-hover-bg-color: black;
     --side-nav-text-color: hsla(0,0%,100%,.85);
+    --side-nav-header-text-color: white;
     --side-nav-border-radius: 3px;
     --side-nav-border: none;
     --side-nav-border-closed: none;
@@ -256,6 +274,7 @@
     --side-nav-item-active-text-color: #fff;
     --side-nav-active-bg-color: transparent;
     --side-nav-overlay-color: var(--elevation-layer11-dark);
+    --side-nav-item-color: rgb(255 255 255 / 9%);
     --side-nav-item-closed-color: var(--elevation-layer10);
     --side-nav-item-closed-hover-color: white;
 
@@ -353,6 +372,9 @@
     --card-overlay-bg-color: rgba(0, 0, 0, 0);
     --card-overlay-hover-bg-color: rgba(30,30,30,.6);
     --card-progress-triangle-size: 28px;
+    --card-body-bg-color: rgba(0,0,0,0.7);
+    --card-title-text-color: var(--card-text-color);
+    --card-overlay-text-color: var(--card-text-color);
 
     /* Slider */
     --slider-text-color: white;

--- a/UI/Web/src/theme/themes/dark.scss
+++ b/UI/Web/src/theme/themes/dark.scss
@@ -370,6 +370,8 @@
     --card-body-bg-color: rgba(0,0,0,0.7);
     --card-title-text-color: var(--card-text-color);
     --card-overlay-text-color: var(--card-text-color);
+    --card-hover-text-color: var(--card-text-color);
+    --card-hover-bg-color: #3a3a3a;
 
     /* Slider */
     --slider-text-color: white;

--- a/UI/Web/src/theme/themes/dark.scss
+++ b/UI/Web/src/theme/themes/dark.scss
@@ -179,19 +179,14 @@
     --btn-disabled-fa-icon-color: white;
     --btn-hover-fa-icon-color: white;
     --btn-primary-fa-icon-color: white;
-    --btn-primary-disabled-fa-icon-color: white;
     --btn-primary-hover-fa-icon-color: white;
     --btn-secondary-fa-icon-color: white;
-    --btn-secondary-disabled-fa-icon-color: white;
     --btn-secondary-hover-fa-icon-color: white;
     --btn-outline-primary-fa-icon-color: white;
-    --btn-outline-primary-disabled-fa-icon-color: white;
     --btn-outline-primary-hover-fa-icon-color: white;
     --btn-outline-secondary-fa-icon-color: white;
-    --btn-outline-secondary-disabled-fa-icon-color: white;
     --btn-outline-secondary-hover-fa-icon-color: white;
     --btn-danger-fa-icon-color: white;
-    --btn-danger-disabled-fa-icon-color: white;
     --btn-danger-hover-fa-icon-color: white;
 
 


### PR DESCRIPTION
In the course of trying to improve the Light Theme, I had to make some changes to the styles and CSS variables. I've tried to keep things backwards compatible

# Changed
- Changed: Refactored some styles to use CSS variables. In all cases, the previous style values were used as the default values for backwards compatibility.
- Changed: FA icons in buttons now use the same color as the containing button's text color

# Fixed
- Fixed: Fixed a bug in the font service that expected System-provided fonts to be located at the root of the web server, which would break in installations using a base URL (develop)

# Theme
- Added: new CSS variables for better theming
  + `--card-title-text-color`: Text color for card titles.
  + `--card-body-bg-color`: Background color for card bodies (`.card-body`).
  + `--card-overlay-text-color`: Text color in card overlays (e.g. the overlay when hovering over library entries).
  + `--side-nav-header-text-color`: Text color of side navigation headers.
  + `--pref-side-nav-header-text-color`: Text color of side navigation headers in the preferences page.
  + `--side-nav-item-color`:  The non-active counterpart to `--side-nav-item-active-color`, i.e. the color of the vertical bar to the left of side navigation items not currently active.