### PR TITLE
Theme changes for Light Theme renewal and typo fixes

### DIFF
--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -260,7 +260,7 @@
 
     "theme-manager": {
         "title": "Theme Manager",
-        "description": "Kavita comes in my colors, find a color scheme that meets your needs or build one yourself and share it. Themes may be applied for your account or applied to all accounts.",
+        "description": "Kavita comes in many colors, find a color scheme that meets your needs or build one yourself and share it. Themes may be applied for your account or applied to all accounts.",
         "site-themes": "Site Themes",
         "set-default": "Set Default",
         "default-theme": "Default",
@@ -1346,7 +1346,7 @@
         "help-us-part-3": "to naming and organizing your media.",
         "naming-conventions-part-1": "Kavita has ",
         "naming-conventions-part-2": "folder requirements.",
-        "naming-conventions-part-3": "Check this link to ensure you are following, else files my not show up in scan.",
+        "naming-conventions-part-3": "Check this link to ensure you are following, else files may not show up in scan.",
         "cover-description": "Custom library image icons are optional",
         "cover-description-extra": "Library image should not be large. Aim for a small file, 32x32 pixels in size. Kavita does not perform validation on size.",
         "manage-collection-label": "Manage Collections",

--- a/UI/Web/src/theme/components/_buttons.scss
+++ b/UI/Web/src/theme/components/_buttons.scss
@@ -268,7 +268,7 @@ button:disabled, .form-control:disabled, .form-control[readonly], .disabled, :di
 }
 
 button {
-  i.fa, i.fa-regular {
+  i {
     color: var(--btn-fa-icon-color);
   }
 }

--- a/UI/Web/src/theme/components/_buttons.scss
+++ b/UI/Web/src/theme/components/_buttons.scss
@@ -278,8 +278,16 @@ button {
 }
 
 /* Button with dropdown */
-.btn-group.dropdown > button {
+.btn-group.dropdown button {
+  &.dropdown-item {
+    i {
+      color: var(--dropdown-item-text-color)
+    }
 
+    &:hover i {
+      color: var(--dropdown-item-hover-text-color)
+    }
+  }
 }
 
 .btn-unstyled {


### PR DESCRIPTION
Follow-up to #4070


# Changed
- Changed: Changed the color of FA icons in dropdown menus to match the text color (so far, only the 👓 Read Incognito dropdown option under the series detail page's Read button) 

# Fixed
- Fixed: FA button icon generic styling will no longer override styles defined by more specific button icon styles (develop)
- Fixed: A couple of typos in localization
