### PR TITLE
clear cache if extraction fails and retry

### DIFF
--- a/API/Services/CacheService.cs
+++ b/API/Services/CacheService.cs
@@ -210,7 +210,14 @@ public class CacheService : ICacheService
             }
 
             var files = chapter?.Files.ToList();
-            ExtractChapterFiles(extractPath, files, extractPdfToImages);
+            try {
+                ExtractChapterFiles(extractPath, files, extractPdfToImages);
+            }
+            catch (Exception ex) {
+                _logger.LogWarning(ex, "Extraction for {Path} failed. Cleaning up directory and retrying once.", extractPath);
+                _directoryService.ClearDirectory(_directoryService.CacheDirectory);
+                ExtractChapterFiles(extractPath, files, extractPdfToImages);
+            }
         } finally {
             extractLock.Release();
         }


### PR DESCRIPTION
this works well on my server but it feels hacky, lmk how i can improve it

# Added
- Added: Clear cache dir when extraction fails 

# Changed
- Changed: expections in extractfiles work (Closes #4096  number)

# Fixed
- Fixed: Fixed a bug (Fixes #4096 number)

