### PR TITLE
Improve required restart hint for OIDC

### DIFF
--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -20,7 +20,7 @@
         "save": "{{common.save}}",
         "save-success": "Successfully updated your OIDC settings",
         "notice": "Notice",
-        "restart-required": "Changing Authority or Client ID requires a manual restart of Kavita to take effect.",
+        "restart-required": "Changing Provider or Advanced settings requires a manual restart of Kavita to take effect.",
         "provider-title": "Provider",
         "provider-tooltip": "Provider settings require you to manually click Save. Kavita must be configured as a confidential client and needs a redirect URL. See the <a href='https://wiki.kavitareader.com/guides/admin-settings/open-id-connect/' target='_blank' rel='noreferrer noopener'>wiki</a> for more details.",
         "behavior-title": "Behavior",


### PR DESCRIPTION
# Fixed
- Fixed: Improve the required restart hint for OIDC config to include all changes that require a manual restart. 

I know this might be a bit too broad now but IMO reads better than adding another one e.g. "If a, b or c was changed, then". At least changes to `Custom scopes` requires a manual restart to get properly applied. 