### PR TITLE
v0.8.8.3 - OIDC and OPDS Hotfix

### DIFF
--- a/Kavita.Common/Kavita.Common.csproj
+++ b/Kavita.Common/Kavita.Common.csproj
@@ -3,7 +3,7 @@
         <TargetFramework>net9.0</TargetFramework>
         <Company>kavitareader.com</Company>
         <Product>Kavita</Product>
-        <AssemblyVersion>0.8.8.2</AssemblyVersion>
+        <AssemblyVersion>0.8.8.3</AssemblyVersion>
         <NeutralLanguage>en</NeutralLanguage>
         <TieredPGO>true</TieredPGO>
     </PropertyGroup>


### PR DESCRIPTION
Looks like there were a few issues with OIDC and a bug in OPDS Pagination that didn't surface during testing. If you want to help us avoid hotfixes, join our nightly program and expand our testing capability. See you in v0.8.9. 

# Changed
- Changed: Kavita will now filter out unsupported scopes before requesting them from your OIDC provider 
- Changed: OIDC providers are now required to use tls (https)

# Fixed
- Fixed: Fixed a bug where announcements with images would scale weird
- Fixed: Fixed some OPDS feeds not including next markers (pagination) for certain total sizes. 
- Fixed: Fixed OIDC not working when a custom base URL is set 
- Fixed: Fixed admin users having age restrictions applied when created with default permissions via OIDC
- Fixed: Fixed not being able to set default age restriction to Not Applicable once changed
- Fixed: Fixed a race condition when changing both metadata and cover image of an entity, where one of the changes could be lost 
- Fixed: Fixed OPDS not working correctly when a base URL is set 
