### PR TITLE
Inherit web links for Series and bug fixes

### DIFF
--- a/API/Controllers/LibraryController.cs
+++ b/API/Controllers/LibraryController.cs
@@ -657,6 +657,7 @@ public class LibraryController : BaseApiController
         library.AllowMetadataMatching = dto.AllowMetadataMatching;
         library.EnableMetadata = dto.EnableMetadata;
         library.RemovePrefixForSortName = dto.RemovePrefixForSortName;
+        library.InheritWebLinksFromFirstChapter = dto.InheritWebLinksFromFirstChapter;
 
         library.LibraryFileTypes = dto.FileGroupTypes
             .Select(t => new LibraryFileTypeGroup() {FileTypeGroup = t, LibraryId = library.Id})

--- a/API/Controllers/PersonController.cs
+++ b/API/Controllers/PersonController.cs
@@ -17,6 +17,7 @@ using API.SignalR;
 using AutoMapper;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 using Nager.ArticleNumber;
 
 namespace API.Controllers;
@@ -112,12 +113,14 @@ public class PersonController : BaseApiController
             return BadRequest(await _localizationService.Translate(User.GetUserId(), "person-name-unique"));
         }
 
+        // Update name first, in case it got moved to aliases
+        person.Name = dto.Name.Trim();
+        person.NormalizedName = person.Name.ToNormalized();
+
         var success = await _personService.UpdatePersonAliasesAsync(person, dto.Aliases);
         if (!success) return BadRequest(await _localizationService.Translate(User.GetUserId(), "aliases-have-overlap"));
 
 
-        person.Name = dto.Name?.Trim();
-        person.NormalizedName = person.Name.ToNormalized();
         person.Description = dto.Description ?? string.Empty;
         person.CoverImageLocked = dto.CoverImageLocked;
 
@@ -236,17 +239,17 @@ public class PersonController : BaseApiController
     /// <summary>
     /// Ensure the alias is valid to be added. For example, the alias cannot be on another person or be the same as the current person name/alias.
     /// </summary>
-    /// <param name="personId"></param>
-    /// <param name="alias"></param>
+    /// <param name="dto">alias check request</param>
     /// <returns></returns>
-    [HttpGet("valid-alias")]
-    public async Task<ActionResult<bool>> IsValidAlias(int personId, string alias)
+    [HttpPost("valid-alias")]
+    public async Task<ActionResult<bool>> IsValidAlias(PersonAliasCheckDto dto)
     {
-        var person = await _unitOfWork.PersonRepository.GetPersonById(personId, PersonIncludes.Aliases);
+        var person = await _unitOfWork.PersonRepository.GetPersonById(dto.PersonId, PersonIncludes.Aliases);
         if (person == null) return NotFound();
 
-        var existingAlias = await _unitOfWork.PersonRepository.AnyAliasExist(alias);
-        return Ok(!existingAlias && person.NormalizedName != alias.ToNormalized());
+        var aliasIsName = dto.Name.ToNormalized() == dto.Alias.ToNormalized();
+        var existingAlias = await _unitOfWork.PersonRepository.AnyAliasExist(dto.Alias);
+        return Ok(!existingAlias && !aliasIsName);
     }
 
 

--- a/API/Controllers/PersonController.cs
+++ b/API/Controllers/PersonController.cs
@@ -12,6 +12,7 @@ using API.Entities.Enums;
 using API.Extensions;
 using API.Helpers;
 using API.Services;
+using API.Services.Plus;
 using API.Services.Tasks.Metadata;
 using API.SignalR;
 using AutoMapper;
@@ -49,7 +50,44 @@ public class PersonController : BaseApiController
     [HttpGet]
     public async Task<ActionResult<PersonDto>> GetPersonByName(string name)
     {
-        return Ok(await _unitOfWork.PersonRepository.GetPersonDtoByName(name, User.GetUserId()));
+        var person = await _unitOfWork.PersonRepository.GetPersonDtoByName(name, User.GetUserId());
+        if (person == null) return NotFound();
+
+        person.Roles = (await _unitOfWork.PersonRepository.GetRolesForPersonByName(person.Id, User.GetUserId())).ToList();
+
+        EnrichWithWebLinks(person);
+        return Ok(person);
+    }
+
+    /// <summary>
+    /// Populate <see cref="PersonDto.WebLinks"/> from set ids
+    /// </summary>
+    /// <param name="personDto"></param>
+    /// <remarks><see cref="PersonDto.Roles"/> must be set for this to work</remarks>
+    private static void EnrichWithWebLinks(PersonDto personDto)
+    {
+        if (personDto.Roles == null) return;
+
+        var isCharacter = personDto.Roles.Count == 1 && personDto.Roles.Contains(PersonRole.Character);
+        personDto.WebLinks = [];
+
+        if (personDto.AniListId != 0)
+        {
+            var urlPrefix = isCharacter ? ScrobblingService.AniListCharacterWebsite : ScrobblingService.AniListStaffWebsite;
+            personDto.WebLinks.Add($"{urlPrefix}{personDto.AniListId}");
+        }
+
+        if (personDto.MalId != 0)
+        {
+            var urlPrefix = isCharacter ? ScrobblingService.MalCharacterWebsite : ScrobblingService.MalStaffWebsite;
+            personDto.WebLinks.Add($"{urlPrefix}{personDto.MalId}");
+        }
+
+        // Hardcover currently does not seem to have characters
+        if (!string.IsNullOrEmpty(personDto.HardcoverId) && !isCharacter)
+        {
+            personDto.WebLinks.Add($"{ScrobblingService.HardcoverStaffWebsite}{personDto.HardcoverId}");
+        }
     }
 
     /// <summary>

--- a/API/Controllers/PersonController.cs
+++ b/API/Controllers/PersonController.cs
@@ -56,6 +56,7 @@ public class PersonController : BaseApiController
         person.Roles = (await _unitOfWork.PersonRepository.GetRolesForPersonByName(person.Id, User.GetUserId())).ToList();
 
         EnrichWithWebLinks(person);
+
         return Ok(person);
     }
 
@@ -287,6 +288,7 @@ public class PersonController : BaseApiController
 
         var aliasIsName = dto.Name.ToNormalized() == dto.Alias.ToNormalized();
         var existingAlias = await _unitOfWork.PersonRepository.AnyAliasExist(dto.Alias);
+
         return Ok(!existingAlias && !aliasIsName);
     }
 

--- a/API/DTOs/LibraryDto.cs
+++ b/API/DTOs/LibraryDto.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using API.Entities;
 using API.Entities.Enums;
 
 namespace API.DTOs;
@@ -74,4 +75,6 @@ public sealed record LibraryDto
     /// Should Kavita remove sort articles "The" for the sort name
     /// </summary>
     public bool RemovePrefixForSortName { get; set; } = false;
+    /// <inheritdoc cref="Library.InheritWebLinksFromFirstChapter"/>
+    public bool InheritWebLinksFromFirstChapter { get; init; }
 }

--- a/API/DTOs/Person/PersonAliasCheckDto.cs
+++ b/API/DTOs/Person/PersonAliasCheckDto.cs
@@ -1,17 +1,22 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace API.DTOs;
 
-public class PersonAliasCheckDto
+public sealed record PersonAliasCheckDto
 {
     /// <summary>
     /// The person to check against
     /// </summary>
+    [Required]
     public int PersonId { get; set; }
     /// <summary>
     /// The persons name in the form. In case it differs from the one in the database
     /// </summary>
+    [Required]
     public string Name { get; set; }
     /// <summary>
     /// The alias to check
     /// </summary>
+    [Required]
     public string Alias { get; set; }
 }

--- a/API/DTOs/Person/PersonAliasCheckDto.cs
+++ b/API/DTOs/Person/PersonAliasCheckDto.cs
@@ -1,0 +1,17 @@
+namespace API.DTOs;
+
+public class PersonAliasCheckDto
+{
+    /// <summary>
+    /// The person to check against
+    /// </summary>
+    public int PersonId { get; set; }
+    /// <summary>
+    /// The persons name in the form. In case it differs from the one in the database
+    /// </summary>
+    public string Name { get; set; }
+    /// <summary>
+    /// The alias to check
+    /// </summary>
+    public string Alias { get; set; }
+}

--- a/API/DTOs/Person/PersonDto.cs
+++ b/API/DTOs/Person/PersonDto.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using API.Entities.Enums;
 
 namespace API.DTOs.Person;
 #nullable enable
@@ -38,4 +39,16 @@ public class PersonDto
     /// </summary>
     /// <remarks>Kavita+ Only</remarks>
     public string? HardcoverId { get; set; }
+
+    /// <summary>
+    /// Web links derived from the various id of external websites
+    /// </summary>
+    /// <remarks>Only present when retrieving from person info endpoint</remarks>
+    public IList<string>? WebLinks { get; set; } = [];
+    /// <summary>
+    ///
+    /// </summary>
+    /// <remarks>Only present when retrieving from person info endpoint</remarks>
+    public IList<PersonRole>? Roles { get; set; } = [];
+
 }

--- a/API/DTOs/Person/PersonDto.cs
+++ b/API/DTOs/Person/PersonDto.cs
@@ -46,7 +46,7 @@ public class PersonDto
     /// <remarks>Only present when retrieving from person info endpoint</remarks>
     public IList<string>? WebLinks { get; set; } = [];
     /// <summary>
-    ///
+    /// All roles as if returned by the /api/person/roles endpoint
     /// </summary>
     /// <remarks>Only present when retrieving from person info endpoint</remarks>
     public IList<PersonRole>? Roles { get; set; } = [];

--- a/API/DTOs/UpdateLibraryDto.cs
+++ b/API/DTOs/UpdateLibraryDto.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using API.Entities;
 using API.Entities.Enums;
 
 namespace API.DTOs;
@@ -8,30 +9,45 @@ public sealed record UpdateLibraryDto
 {
     [Required]
     public int Id { get; init; }
+    /// <inheritdoc cref="Library.Name"/>
     [Required]
     public required string Name { get; init; }
+    /// <inheritdoc cref="Library.Type"/>
     [Required]
     public LibraryType Type { get; set; }
+    /// <inheritdoc cref="Library.Folders"/>
     [Required]
     public required IEnumerable<string> Folders { get; init; }
+    /// <inheritdoc cref="Library.FolderWatching"/>
     [Required]
     public bool FolderWatching { get; init; }
+    /// <inheritdoc cref="Library.IncludeInDashboard"/>
     [Required]
     public bool IncludeInDashboard { get; init; }
+    /// <inheritdoc cref="Library.IncludeInSearch"/>
     [Required]
     public bool IncludeInSearch { get; init; }
+    /// <inheritdoc cref="Library.ManageCollections"/>
     [Required]
     public bool ManageCollections { get; init; }
+    /// <inheritdoc cref="Library.ManageReadingLists"/>
     [Required]
     public bool ManageReadingLists { get; init; }
+    /// <inheritdoc cref="Library.AllowScrobbling"/>
     [Required]
     public bool AllowScrobbling { get; init; }
+    /// <inheritdoc cref="Library.AllowMetadataMatching"/>
     [Required]
     public bool AllowMetadataMatching { get; init; }
+    /// <inheritdoc cref="Library.EnableMetadata"/>
     [Required]
     public bool EnableMetadata { get; init; }
+    /// <inheritdoc cref="Library.RemovePrefixForSortName"/>
     [Required]
     public bool RemovePrefixForSortName { get; init; }
+    /// <inheritdoc cref="Library.InheritWebLinksFromFirstChapter"/>
+    [Required]
+    public bool InheritWebLinksFromFirstChapter { get; init; }
     /// <summary>
     /// What types of files to allow the scanner to pickup
     /// </summary>

--- a/API/Data/Migrations/20251023205956_SeriesInheritWebLinksFromFirstChapter.Designer.cs
+++ b/API/Data/Migrations/20251023205956_SeriesInheritWebLinksFromFirstChapter.Designer.cs
@@ -5,6 +5,7 @@ using API.Data;
 using API.Entities.MetadataMatching;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -12,9 +13,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace API.Data.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20251023205956_SeriesInheritWebLinksFromFirstChapter")]
+    partial class SeriesInheritWebLinksFromFirstChapter
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.10");

--- a/API/Data/Migrations/20251023205956_SeriesInheritWebLinksFromFirstChapter.cs
+++ b/API/Data/Migrations/20251023205956_SeriesInheritWebLinksFromFirstChapter.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace API.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class SeriesInheritWebLinksFromFirstChapter : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "InheritWebLinksFromFirstChapter",
+                table: "Library",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "InheritWebLinksFromFirstChapter",
+                table: "Library");
+        }
+    }
+}

--- a/API/Data/Repositories/PersonRepository.cs
+++ b/API/Data/Repositories/PersonRepository.cs
@@ -396,7 +396,8 @@ public class PersonRepository : IPersonRepository
 
     public async Task<bool> AnyAliasExist(string alias)
     {
-        return await _context.PersonAlias.AnyAsync(pa => pa.NormalizedAlias == alias.ToNormalized());
+        var normalizedAlias = alias.ToNormalized();
+        return await _context.PersonAlias.AnyAsync(pa => pa.NormalizedAlias == normalizedAlias);
     }
 
 

--- a/API/Entities/Library.cs
+++ b/API/Entities/Library.cs
@@ -56,6 +56,10 @@ public class Library : IEntityDate, IHasCoverImage
     /// Should Kavita remove sort articles "The" for the sort name
     /// </summary>
     public bool RemovePrefixForSortName { get; set; } = false;
+    /// <summary>
+    /// Should series inherit web links from the first chapter/volume
+    /// </summary>
+    public bool InheritWebLinksFromFirstChapter { get; set; } = false;
 
 
     public DateTime Created { get; set; }

--- a/API/Extensions/IdentityServiceExtensions.cs
+++ b/API/Extensions/IdentityServiceExtensions.cs
@@ -4,6 +4,7 @@ using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
 using System.Security.Claims;
 using System.Text;
+using System.Text.Json;
 using System.Threading.Tasks;
 using API.Constants;
 using API.Data;
@@ -161,6 +162,8 @@ public static class IdentityServiceExtensions
             new HttpDocumentRetriever { RequireHttps = !isDevelopment }
         );
 
+        services.AddSingleton(configurationManager);
+
         ICollection<string> supportedScopes;
         try
         {
@@ -242,11 +245,11 @@ public static class IdentityServiceExtensions
             options.GetClaimsFromUserInfoEndpoint = true;
 
             // Due to some (Authelia) OIDC providers, we need to map these claims explicitly. Such that no flow breaks in the
-            // OidcService
+            // OidcService. Claims from the UserInfoEndPoint are not added automatically, we map some to the claim we need.
+            // And copy all over down below
             options.MapInboundClaims = true;
             options.ClaimActions.MapJsonKey(ClaimTypes.Email, "email");
             options.ClaimActions.MapJsonKey(ClaimTypes.Name, "name");
-            options.ClaimActions.MapJsonKey(JwtRegisteredClaimNames.PreferredUsername, "preferred_username");
             options.ClaimActions.MapJsonKey(ClaimTypes.GivenName, "given_name");
 
             options.Scope.Clear();
@@ -259,6 +262,34 @@ public static class IdentityServiceExtensions
             options.Events = new OpenIdConnectEvents
             {
                 OnTicketReceived = OidcClaimsPrincipalConverter,
+                OnUserInformationReceived = ctx =>
+                {
+                    if (ctx.Principal?.Identity == null)
+                    {
+                        return Task.CompletedTask;
+                    }
+
+                    var identity = (ClaimsIdentity) ctx.Principal.Identity;
+
+                    // Copy all claims over as in, the ones we need mapped to something specific are above
+                    foreach (var property in ctx.User.RootElement.EnumerateObject())
+                    {
+                        var claimType = property.Name;
+                        if (property.Value.ValueKind == JsonValueKind.Array)
+                        {
+                            foreach (var element in property.Value.EnumerateArray())
+                            {
+                                identity.AddClaim(new Claim(claimType, element.ToString(), ClaimValueTypes.String, OpenIdConnect));
+                            }
+                        }
+                        else
+                        {
+                            identity.AddClaim(new Claim(claimType, property.Value.ToString(), ClaimValueTypes.String, OpenIdConnect));
+                        }
+                    }
+
+                    return  Task.CompletedTask;
+                },
                 OnAuthenticationFailed = ctx =>
                 {
                     ctx.Response.Redirect(baseUrl + "login?skipAutoLogin=true&error=" + Uri.EscapeDataString(ctx.Exception.Message));

--- a/API/Extensions/IdentityServiceExtensions.cs
+++ b/API/Extensions/IdentityServiceExtensions.cs
@@ -269,7 +269,7 @@ public static class IdentityServiceExtensions
                     }
                     catch (KavitaException ex)
                     {
-                        Log.Error(ex, "an exception occured during initial oidc flow");
+                        Log.Error(ex, "An exception occured during initial OIDC flow");
                         ctx.Response.Redirect(baseUrl + "login?skipAutoLogin=true&error=" + Uri.EscapeDataString(ex.Message));
                         ctx.HandleResponse();
                     }

--- a/API/Extensions/IdentityServiceExtensions.cs
+++ b/API/Extensions/IdentityServiceExtensions.cs
@@ -261,7 +261,19 @@ public static class IdentityServiceExtensions
 
             options.Events = new OpenIdConnectEvents
             {
-                OnTicketReceived = OidcClaimsPrincipalConverter,
+                OnTicketReceived = async ctx =>
+                {
+                    try
+                    {
+                        await OidcClaimsPrincipalConverter(ctx);
+                    }
+                    catch (KavitaException ex)
+                    {
+                        Log.Error(ex, "an exception occured during initial oidc flow");
+                        ctx.Response.Redirect(baseUrl + "login?skipAutoLogin=true&error=" + Uri.EscapeDataString(ex.Message));
+                        ctx.HandleResponse();
+                    }
+                },
                 OnUserInformationReceived = ctx =>
                 {
                     if (ctx.Principal?.Identity == null)

--- a/API/Services/Plus/ScrobblingService.cs
+++ b/API/Services/Plus/ScrobblingService.cs
@@ -168,10 +168,13 @@ public class ScrobblingService : IScrobblingService
 
     public const string AniListWeblinkWebsite = "https://anilist.co/manga/";
     public const string MalWeblinkWebsite = "https://myanimelist.net/manga/";
+    public const string MalStaffWebsite = "https://myanimelist.net/people/";
+    public const string MalCharacterWebsite = "https://myanimelist.net/character/";
     public const string GoogleBooksWeblinkWebsite = "https://books.google.com/books?id=";
     public const string MangaDexWeblinkWebsite = "https://mangadex.org/title/";
     public const string AniListStaffWebsite = "https://anilist.co/staff/";
     public const string AniListCharacterWebsite = "https://anilist.co/character/";
+    public const string HardcoverStaffWebsite = "https://hardcover.app/authors/";
 
 
     private static readonly Dictionary<string, int> WeblinkExtractionMap = new()

--- a/API/Services/Tasks/Scanner/ProcessSeries.cs
+++ b/API/Services/Tasks/Scanner/ProcessSeries.cs
@@ -336,6 +336,10 @@ public class ProcessSeries : IProcessSeries
             series.Metadata.Language = firstChapter.Language;
         }
 
+        if (!string.IsNullOrEmpty(firstChapter?.WebLinks) && library.InheritWebLinksFromFirstChapter)
+        {
+            series.Metadata.WebLinks = firstChapter.WebLinks;
+        }
 
         if (!string.IsNullOrEmpty(firstChapter?.SeriesGroup) && library.ManageCollections)
         {

--- a/UI/Web/src/app/_models/library/library.ts
+++ b/UI/Web/src/app/_models/library/library.ts
@@ -34,6 +34,7 @@ export interface Library {
     enableMetadata: boolean;
     removePrefixForSortName: boolean;
     collapseSeriesRelationships: boolean;
+    inheritWebLinksFromFirstChapter: boolean;
     libraryFileTypes: Array<FileTypeGroup>;
     excludePatterns: Array<string>;
 }

--- a/UI/Web/src/app/_models/metadata/person.ts
+++ b/UI/Web/src/app/_models/metadata/person.ts
@@ -30,6 +30,14 @@ export interface Person extends IHasCover {
   asin?: string;
   primaryColor: string;
   secondaryColor: string;
+  /**
+   * Only present when retrieving from person info endpoint
+   */
+  webLinks?: string[];
+  /**
+   * Only present when retrieving from person info endpoint
+   */
+  roles?: PersonRole[];
 }
 
 /**

--- a/UI/Web/src/app/_services/image.service.ts
+++ b/UI/Web/src/app/_services/image.service.ts
@@ -28,12 +28,12 @@ export class ImageService {
       if (this.themeService.isDarkTheme()) {
         this.placeholderImage = 'assets/images/image-placeholder.dark-min.png';
         this.errorImage = 'assets/images/error-placeholder2.dark-min.png';
-        this.errorWebLinkImage = 'assets/images/broken-black-32x32.png';
+        this.errorWebLinkImage = 'assets/images/broken-white-32x32.png';
         this.noPersonImage = 'assets/images/error-person-missing.dark.min.png';
       } else {
         this.placeholderImage = 'assets/images/image-placeholder-min.png';
         this.errorImage = 'assets/images/error-placeholder2-min.png';
-        this.errorWebLinkImage = 'assets/images/broken-white-32x32.png';
+        this.errorWebLinkImage = 'assets/images/broken-black-32x32.png';
         this.noPersonImage = 'assets/images/error-person-missing.min.png';
       }
     });

--- a/UI/Web/src/app/_services/person.service.ts
+++ b/UI/Web/src/app/_services/person.service.ts
@@ -73,8 +73,9 @@ export class PersonService {
     return this.httpClient.post<string>(this.baseUrl + 'person/fetch-cover?personId=' + personId, {}, TextResonse);
   }
 
-  isValidAlias(personId: number, alias: string) {
-    return this.httpClient.get<boolean>(this.baseUrl + `person/valid-alias?personId=${personId}&alias=${alias}`, TextResonse).pipe(
+  isValidAlias(personId: number, alias: string, name: string) {
+    const req = {personId, name, alias}
+    return this.httpClient.post<boolean>(this.baseUrl + `person/valid-alias`, req, TextResonse).pipe(
       map(valid => valid + '' === 'true')
     );
   }

--- a/UI/Web/src/app/_single-module/match-series-modal/match-series-modal.component.ts
+++ b/UI/Web/src/app/_single-module/match-series-modal/match-series-modal.component.ts
@@ -12,6 +12,7 @@ import {SettingItemComponent} from "../../settings/_components/setting-item/sett
 import {SettingSwitchComponent} from "../../settings/_components/setting-switch/setting-switch.component";
 import { ThemeService } from 'src/app/_services/theme.service';
 import { AsyncPipe } from '@angular/common';
+import {catchError, of, tap} from "rxjs";
 
 @Component({
     selector: 'app-match-series-modal',
@@ -55,13 +56,23 @@ export class MatchSeriesModalComponent implements OnInit {
     const model: any = this.formGroup.value;
     model.seriesId = this.series.id;
 
-    if (model.dontMatch) return;
-
-    this.seriesService.matchSeries(model).subscribe(results => {
+    if (model.dontMatch) {
       this.isLoading = false;
-      this.matches = results;
-      this.cdRef.markForCheck();
-    });
+      return;
+    }
+
+    this.seriesService.matchSeries(model).pipe(
+      tap(results => {
+        this.isLoading = false;
+        this.matches = results;
+        this.cdRef.markForCheck();
+      }),
+      catchError(() => {
+        this.isLoading = false;
+        this.cdRef.markForCheck();
+        return of([]);
+      })
+    ).subscribe();
   }
 
   close() {

--- a/UI/Web/src/app/cards/_modals/edit-series-modal/edit-series-modal.component.html
+++ b/UI/Web/src/app/cards/_modals/edit-series-modal/edit-series-modal.component.html
@@ -579,7 +579,11 @@
                       <div class="mb-3">
                         <app-setting-item [title]="t('max-items-title')" [subtitle]="t('highest-count-tooltip')" [toggleOnViewClick]="false" [showEdit]="false">
                           <ng-template #view>
-                            {{metadata.maxCount}}
+                            @if (metadata.maxCount === LooseLeafOrDefaultNumber) {
+                              {{t('no-data')}}
+                            } @else {
+                              {{metadata.maxCount}}
+                            }
                           </ng-template>
                         </app-setting-item>
                       </div>

--- a/UI/Web/src/app/cards/_modals/edit-series-modal/edit-series-modal.component.ts
+++ b/UI/Web/src/app/cards/_modals/edit-series-modal/edit-series-modal.component.ts
@@ -669,4 +669,6 @@ export class EditSeriesModalComponent implements OnInit {
         break;
     }
   }
+
+  protected readonly LooseLeafOrDefaultNumber = LooseLeafOrDefaultNumber;
 }

--- a/UI/Web/src/app/cards/bulk-selection.service.ts
+++ b/UI/Web/src/app/cards/bulk-selection.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, inject } from '@angular/core';
+import {inject, Injectable} from '@angular/core';
 import {NavigationStart, Router} from '@angular/router';
 import {ReplaySubject} from 'rxjs';
 import {filter} from 'rxjs/operators';
@@ -156,7 +156,7 @@ export class BulkSelectionService {
     }
 
     if (Object.keys(this.selectedCards).filter(item => item === 'bookmark').length > 0) {
-      return this.actionFactory.getBookmarkActions(callback);
+      return this.applyFilterToList(this.actionFactory.getBookmarkActions(callback), [Action.DownloadBookmark, Action.Delete]);
     }
 
     if (Object.keys(this.selectedCards).filter(item => item === 'sideNavStream').length > 0) {

--- a/UI/Web/src/app/chapter-detail/chapter-detail.component.ts
+++ b/UI/Web/src/app/chapter-detail/chapter-detail.component.ts
@@ -265,7 +265,7 @@ export class ChapterDetailComponent implements OnInit {
       this.series = results.series;
       this.chapter = results.chapter;
       this.size = this.chapter.files.reduce((sum, f) => sum + f.bytes, 0);
-      this.weblinks = this.chapter.webLinks.split(',');
+      this.weblinks = this.chapter.webLinks.length > 0 ? this.chapter.webLinks.split(',') : [];
       this.libraryType = results.libraryType;
       this.userReviews = results.chapterDetail.reviews.filter(r => !r.isExternal);
       this.plusReviews = results.chapterDetail.reviews.filter(r => r.isExternal);

--- a/UI/Web/src/app/person-detail/_modal/edit-person-modal/edit-person-modal.component.ts
+++ b/UI/Web/src/app/person-detail/_modal/edit-person-modal/edit-person-modal.component.ts
@@ -179,17 +179,18 @@ export class EditPersonModalComponent implements OnInit {
 
   aliasValidator(): AsyncValidatorFn {
     return (control: AbstractControl) => {
-      const name = control.value;
-      if (!name || name.trim().length === 0) {
+      const alias = control.value;
+      if (!alias || alias.trim().length === 0) {
         return of(null);
       }
 
-      return this.personService.isValidAlias(this.person.id, name).pipe(map(valid => {
+      const name = this.editForm.get('name')!.value;
+      return this.personService.isValidAlias(this.person.id, alias, name).pipe(map(valid => {
         if (valid) {
           return null;
         }
 
-        return { 'invalidAlias': {'alias': name} } as ValidationErrors;
+        return { 'invalidAlias': {'alias': alias} } as ValidationErrors;
       }));
     }
   }

--- a/UI/Web/src/app/person-detail/person-detail.component.html
+++ b/UI/Web/src/app/person-detail/person-detail.component.html
@@ -8,9 +8,9 @@
             <app-card-actionables [entity]="person" [inputActions]="personActions" [labelBy]="person.name" iconClass="fa-ellipsis-v" />
             <span>{{person.name}}</span>
 
-            @if (person.aniListId) {
-              <a class="ms-1" [href]="anilistUrl | safeUrl"  target="_blank" rel="noopener noreferrer">
-                <app-image height="24px" width="24px" aria-hidden="true" [imageUrl]="imageService.getWebLinkImage(anilistUrl)"
+            @for (webLink of (person.webLinks ?? []); track webLink) {
+              <a class="ms-1" [href]="webLink | safeUrl"  target="_blank" rel="noopener noreferrer">
+                <app-image height="24px" width="24px" aria-hidden="true" [imageUrl]="imageService.getWebLinkImage(webLink)"
                            [errorImage]="imageService.errorWebLinkImage" />
               </a>
             }
@@ -58,11 +58,11 @@
             }
 
 
-            @if (roles$ | async; as roles) {
-              @if (roles.length > 0) {
+            @if (person$ | async; as person) {
+              @if (person.roles && person.roles.length > 0) {
                 <span class="fw-bold mt-2">{{t('all-roles')}}</span>
                 <div>
-                  <app-badge-expander [items]="roles"
+                  <app-badge-expander [items]="person.roles"
                                       [itemsTillExpander]="6">
                     <ng-template #badgeExpanderItem let-item let-position="idx" let-last="last">
                       <a href="javascript:void(0)" class="dark-exempt btn-icon" (click)="loadFilterByRole(item)">{{item | personRole}}</a>
@@ -103,8 +103,8 @@
 
 
    <!-- Individual Works Carousel -->
-   @if (roles$ | async; as roles) {
-     @for(role of roles; track role) {
+   @if (person$ | async; as person) {
+     @for(role of (person.roles || []); track role) {
        <div class="row mt-2">
          <app-carousel-reel [items]="(chaptersByRole[role] | async)!" [title]="t('individual-role-title', {role: (role | personRole)})" (sectionClick)="loadFilterByRole(role)">
            <ng-template #carouselItem let-item>

--- a/UI/Web/src/app/sidenav/_modals/library-settings-modal/library-settings-modal.component.html
+++ b/UI/Web/src/app/sidenav/_modals/library-settings-modal/library-settings-modal.component.html
@@ -226,6 +226,16 @@
               </app-setting-switch>
             </div>
 
+            <div class="row g-0 mt-4 mb-4">
+              <app-setting-switch [title]="t('inherit-web-links-label')" [subtitle]="t('inherit-web-links-tooltip')">
+                <ng-template #switch>
+                  <div class="form-check form-switch float-end">
+                    <input type="checkbox" id="inherit-web-links" role="switch" formControlName="inheritWebLinksFromFirstChapter" class="form-check-input">
+                  </div>
+                </ng-template>
+              </app-setting-switch>
+            </div>
+
             <div class="setting-section-break"></div>
 
             <div class="row g-0 mt-4 pb-4">

--- a/UI/Web/src/app/sidenav/_modals/library-settings-modal/library-settings-modal.component.ts
+++ b/UI/Web/src/app/sidenav/_modals/library-settings-modal/library-settings-modal.component.ts
@@ -123,6 +123,7 @@ export class LibrarySettingsModalComponent implements OnInit {
     collapseSeriesRelationships: new FormControl<boolean>(false, { nonNullable: true, validators: [] }),
     enableMetadata: new FormControl<boolean>(true, { nonNullable: true, validators: [] }), // required validator doesn't check value, just if true
     removePrefixForSortName: new FormControl<boolean>(false, { nonNullable: true, validators: [] }),
+    inheritWebLinksFromFirstChapter: new FormControl<boolean>(false, { nonNullable: true, validators: []}),
     // TODO: Missing excludePatterns
   });
 
@@ -291,6 +292,7 @@ export class LibrarySettingsModalComponent implements OnInit {
       this.libraryForm.get('excludePatterns')?.setValue(this.excludePatterns ? this.library.excludePatterns : false);
       this.libraryForm.get('enableMetadata')?.setValue(this.library.enableMetadata);
       this.libraryForm.get('removePrefixForSortName')?.setValue(this.library.removePrefixForSortName);
+      this.libraryForm.get('inheritWebLinksFromFirstChapter')?.setValue(this.library.inheritWebLinksFromFirstChapter);
       this.selectedFolders = this.library.folders;
 
       this.madeChanges = false;

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -2463,7 +2463,8 @@
         "loose-leaf-volume": "Loose Leaf Chapters",
         "specials-volume": "Specials",
         "release-year-validation": "{{validation.year-validation}}",
-        "volumes-title": "{{tab.volumes-tab}}"
+        "volumes-title": "{{tab.volumes-tab}}",
+        "no-data": "{{common.no-data}}"
     },
 
     "edit-chapter-modal": {

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -1368,6 +1368,8 @@
         "enable-metadata-tooltip": "Allow Kavita to read metadata files which override filename parsing.",
         "remove-prefix-for-sortname-label": "Remove common prefixes for Sort Name",
         "remove-prefix-for-sortname-tooltip": "Kavita will remove common prefixes like 'The', 'A', 'An' from titles for sort name. Does not override set metadata.",
+        "inherit-web-links-label": "Inherit web links from first chapter",
+        "inherit-web-links-tooltip": "Should series inherit web links from their first chapter",
         "force-scan": "Force Scan",
         "force-scan-tooltip": "This will force a scan on the library, treating like a fresh scan",
         "reset": "{{common.reset}}",


### PR DESCRIPTION
# Added
- Added: Added a library setting to automatically copy weblinks from the first chapter in a series to the series. Defaults to false. (Closes FR #3857, 2 upvotes)

# Changed
- Changed: Highest count in series info will now show no data if it's an internal magic number. (Closes #4112)
- Changed: People pages will now also show external links to MyAnimeList and Hardcover if their respective IDs are configured

# Fixed
- Fixed: Fixed not being able to change a person's name and use it as an alias in the same action. (Fixes #4146)
- Fixed: Fixed bulk bookmark actions, showing view series. (Fixes #4138)
- Fixed: Fixed logging out with OIDC throwing an exception when using Authelia
- Fixed: Fixed some OIDC errors showing a json response rather than redirecting to the login screen
- Fixed: Fixed a potential edge case in the match modal code, allowing the spinner to stay indefinitely (Closes #4137)
- Fixed: Fixed broken link image being the wrong colour for light/dark themes
- Fixed: Fixed chapter detail, always showing a link to Kavita
- Fixed: Fixed character external AniList links being incorrect (Closes #4118)
