### PR TITLE
sorting series by user rating

### DIFF
--- a/API/DTOs/Filtering/SortField.cs
+++ b/API/DTOs/Filtering/SortField.cs
@@ -1,4 +1,4 @@
-﻿namespace API.DTOs.Filtering;
+namespace API.DTOs.Filtering;
 
 public enum SortField
 {
@@ -38,6 +38,11 @@ public enum SortField
     /// Randomise the order
     /// </summary>
     Random = 9,
+    /// <summary>
+    /// By user rating
+    /// </summary>
+    UserRating = 10,
+
 }
 
 public enum AnnotationSortField

--- a/API/Extensions/QueryExtensions/Filtering/SeriesSort.cs
+++ b/API/Extensions/QueryExtensions/Filtering/SeriesSort.cs
@@ -36,12 +36,8 @@ public static class SeriesSort
                 .Max(), sortOptions),
             SortField.AverageRating => query.DoOrderBy(s => s.ExternalSeriesMetadata.ExternalRatings
                 .Where(p => p.SeriesId == s.Id).Average(p => p.AverageScore), sortOptions),
-
-            SortField.UserRating => query.
-                DoOrderBy(s => s.Ratings.Where(r => r.SeriesId == s.Id && r.AppUserId == userId).Max(r => r.Rating), sortOptions)
-                .ThenBy(s => s.SortName.ToLower())
-                ,
-
+            SortField.UserRating => query.DoOrderBy(s => s.Ratings.Where(r => r.SeriesId == s.Id && r.AppUserId == userId).Max(r => r.Rating), sortOptions)
+                .ThenBy(s => s.SortName.ToLower()),
             SortField.Random => query.DoOrderBy(s => EF.Functions.Random(), sortOptions),
             _ => query
         };

--- a/API/Extensions/QueryExtensions/Filtering/SeriesSort.cs
+++ b/API/Extensions/QueryExtensions/Filtering/SeriesSort.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using API.DTOs.Filtering;
 using API.Entities;
 using Microsoft.EntityFrameworkCore;
@@ -36,6 +36,12 @@ public static class SeriesSort
                 .Max(), sortOptions),
             SortField.AverageRating => query.DoOrderBy(s => s.ExternalSeriesMetadata.ExternalRatings
                 .Where(p => p.SeriesId == s.Id).Average(p => p.AverageScore), sortOptions),
+
+            SortField.UserRating => query.
+                DoOrderBy(s => s.Ratings.Where(r => r.SeriesId == s.Id && r.AppUserId == userId).Max(r => r.Rating), sortOptions)
+                .ThenBy(s => s.SortName.ToLower())
+                ,
+
             SortField.Random => query.DoOrderBy(s => EF.Functions.Random(), sortOptions),
             _ => query
         };

--- a/API/Extensions/QueryExtensions/QueryableExtensions.cs
+++ b/API/Extensions/QueryExtensions/QueryableExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
@@ -353,7 +353,7 @@ public static class QueryableExtensions
     /// <param name="keySelector"></param>
     /// <param name="sortOptions"></param>
     /// <returns></returns>
-    public static IQueryable<T> DoOrderBy<T, TKey>(this IQueryable<T> query, Expression<Func<T, TKey>> keySelector, SortOptions sortOptions)
+    public static IOrderedQueryable<T> DoOrderBy<T, TKey>(this IQueryable<T> query, Expression<Func<T, TKey>> keySelector, SortOptions sortOptions)
     {
         return sortOptions.IsAscending ? query.OrderBy(keySelector) : query.OrderByDescending(keySelector);
     }

--- a/UI/Web/src/app/_models/metadata/series-filter.ts
+++ b/UI/Web/src/app/_models/metadata/series-filter.ts
@@ -20,7 +20,8 @@ export enum SortField {
    * Kavita+ only
    */
   AverageRating = 8,
-  Random = 9
+  Random = 9,
+  UserRating = 10,
 }
 
 export const allSeriesSortFields = Object.keys(SortField)

--- a/UI/Web/src/app/_pipes/sort-field.pipe.ts
+++ b/UI/Web/src/app/_pipes/sort-field.pipe.ts
@@ -71,7 +71,9 @@ export class SortFieldPipe implements PipeTransform {
         return this.translocoService.translate('sort-field-pipe.average-rating');
       case SortField.Random:
         return this.translocoService.translate('sort-field-pipe.random');
-    }
+      case SortField.UserRating:
+          return this.translocoService.translate('sort-field-pipe.user-rating');
+      }
   }
 
 }

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -2434,7 +2434,7 @@
         "read-progress": "Last Read",
         "average-rating": "Average Rating",
         "random": "Random",
-        "user-rating": "User rating",
+        "user-rating": "Own rating",
         "person-name": "Name",
         "person-series-count": "Series Count",
         "person-chapter-count": "Chapter Count",

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -2434,6 +2434,7 @@
         "read-progress": "Last Read",
         "average-rating": "Average Rating",
         "random": "Random",
+        "user-rating": "User rating",
         "person-name": "Name",
         "person-series-count": "Series Count",
         "person-chapter-count": "Chapter Count",


### PR DESCRIPTION
# Added
- Added: sorting series by user rating (Closes FR #4210, 1 upvote)

I made it so that series is firstly ordered by the rating, and secondly by the series sort name, so that it's less chaotic and more consistent.

Would've liked to add the rating actually visible in the UI only when this specific filter is in use, but that would be a larger change
and more of a question to the UX design. Someone who is doing UX could consider it later.

I only added english translation for the text, not sure what's the process on this.