### PR TITLE
More scanner improvements, up to 50% off

### DIFF
--- a/API.Tests/Helpers/ScannerHelper.cs
+++ b/API.Tests/Helpers/ScannerHelper.cs
@@ -80,8 +80,6 @@ public class ScannerHelper
         var processSeries = new ProcessSeries(_unitOfWork, Substitute.For<ILogger<ProcessSeries>>(),
             Substitute.For<IEventHub>(),
             ds, Substitute.For<ICacheHelper>(), readingItemService, new FileService(fs),
-            Substitute.For<IMetadataService>(),
-            Substitute.For<IWordCountAnalyzerService>(),
             Substitute.For<IReadingListService>(),
             Substitute.For<IExternalMetadataService>());
 

--- a/API.Tests/Helpers/ScannerHelper.cs
+++ b/API.Tests/Helpers/ScannerHelper.cs
@@ -88,6 +88,9 @@ public class ScannerHelper
         var serviceProvider = Substitute.For<IServiceProvider>();
         serviceProvider.GetService(typeof(IUnitOfWork)).Returns(_unitOfWork);
         serviceProvider.GetService(typeof(IProcessSeries)).Returns(processSeries);
+        serviceProvider.GetService(typeof(IMetadataService)).Returns(Substitute.For<IMetadataService>());
+        serviceProvider.GetService(typeof(IWordCountAnalyzerService))
+            .Returns(Substitute.For<IWordCountAnalyzerService>());
 
         var scope = Substitute.For<IServiceScope>();
         scope.ServiceProvider.Returns(serviceProvider);

--- a/API/Controllers/LibraryController.cs
+++ b/API/Controllers/LibraryController.cs
@@ -96,6 +96,8 @@ public class LibraryController : BaseApiController
             .Select(t => new LibraryExcludePattern() {Pattern = t, LibraryId = library.Id})
             .Distinct()
             .ToList();
+        library.RemovePrefixForSortName = dto.RemovePrefixForSortName;
+        library.DefaultLanguage = dto.DefaultLanguage;
 
         // Override Scrobbling for Comic libraries since there are no providers to scrobble to
         if (library.Type == LibraryType.Comic)

--- a/API/Controllers/SeriesController.cs
+++ b/API/Controllers/SeriesController.cs
@@ -245,7 +245,7 @@ public class SeriesController : BaseApiController
 
         if (needsRefreshMetadata)
         {
-            _taskScheduler.RefreshSeriesMetadata(series.LibraryId, series.Id);
+            await _taskScheduler.RefreshSeriesMetadata(series.LibraryId, series.Id);
         }
 
         return Ok();
@@ -402,9 +402,9 @@ public class SeriesController : BaseApiController
     /// <returns></returns>
     [Authorize(Policy = "RequireAdminRole")]
     [HttpPost("refresh-metadata")]
-    public ActionResult RefreshSeriesMetadata(RefreshSeriesDto refreshSeriesDto)
+    public async Task<ActionResult> RefreshSeriesMetadata(RefreshSeriesDto refreshSeriesDto)
     {
-        _taskScheduler.RefreshSeriesMetadata(refreshSeriesDto.LibraryId, refreshSeriesDto.SeriesId, refreshSeriesDto.ForceUpdate, refreshSeriesDto.ForceColorscape);
+        await _taskScheduler.RefreshSeriesMetadata(refreshSeriesDto.LibraryId, refreshSeriesDto.SeriesId, refreshSeriesDto.ForceUpdate, refreshSeriesDto.ForceColorscape);
         return Ok();
     }
 

--- a/API/Controllers/UploadController.cs
+++ b/API/Controllers/UploadController.cs
@@ -130,7 +130,7 @@ public class UploadController : BaseApiController
                 // Refresh covers
                 if (string.IsNullOrEmpty(uploadFileDto.Url))
                 {
-                    _taskScheduler.RefreshSeriesMetadata(series.LibraryId, series.Id, true);
+                    await _taskScheduler.RefreshSeriesMetadata(series.LibraryId, series.Id, true);
                 }
 
                 await _eventHub.SendMessageAsync(MessageFactory.CoverUpdate,
@@ -305,7 +305,7 @@ public class UploadController : BaseApiController
                 if (string.IsNullOrEmpty(uploadFileDto.Url))
                 {
                     var series = (await _unitOfWork.SeriesRepository.GetSeriesByIdAsync(volume!.SeriesId))!;
-                    _taskScheduler.RefreshSeriesMetadata(series.LibraryId, series.Id, true);
+                    await _taskScheduler.RefreshSeriesMetadata(series.LibraryId, series.Id, true);
                 }
 
 
@@ -365,7 +365,7 @@ public class UploadController : BaseApiController
                 if (string.IsNullOrEmpty(uploadFileDto.Url))
                 {
                     var series = (await _unitOfWork.SeriesRepository.GetSeriesByIdAsync(volume.SeriesId))!;
-                    _taskScheduler.RefreshSeriesMetadata(series.LibraryId, series.Id, true);
+                    await _taskScheduler.RefreshSeriesMetadata(series.LibraryId, series.Id, true);
                 }
 
 
@@ -477,7 +477,7 @@ public class UploadController : BaseApiController
             {
                 await _unitOfWork.CommitAsync();
                 if (originalFile != null) System.IO.File.Delete(originalFile);
-                _taskScheduler.RefreshSeriesMetadata(series.LibraryId, series.Id, true);
+                await _taskScheduler.RefreshSeriesMetadata(series.LibraryId, series.Id, true);
                 return Ok();
             }
 

--- a/API/DTOs/OPDS/Internal/Feed.cs
+++ b/API/DTOs/OPDS/Internal/Feed.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Xml.Serialization;
+using Newtonsoft.Json;
 
 namespace API.DTOs.OPDS;
 

--- a/API/Data/Metadata/ComicInfo.cs
+++ b/API/Data/Metadata/ComicInfo.cs
@@ -1,9 +1,11 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
 using API.Entities;
 using API.Entities.Enums;
+using API.Helpers;
 using API.Services;
 using Kavita.Common.Extensions;
 using Nager.ArticleNumber;
@@ -132,6 +134,24 @@ public class ComicInfo
     public string Teams { get; set; } = string.Empty;
     public string Locations { get; set; } = string.Empty;
 
+    public IList<string> GetPeopleForRole(PersonRole role) => role switch
+    {
+        PersonRole.Other => [],
+        PersonRole.Writer => TagHelper.GetTagValues(Writer),
+        PersonRole.Penciller => TagHelper.GetTagValues(Penciller),
+        PersonRole.Inker => TagHelper.GetTagValues(Inker),
+        PersonRole.Colorist => TagHelper.GetTagValues(Colorist),
+        PersonRole.Letterer => TagHelper.GetTagValues(Letterer),
+        PersonRole.CoverArtist => TagHelper.GetTagValues(CoverArtist),
+        PersonRole.Editor => TagHelper.GetTagValues(Editor),
+        PersonRole.Publisher => TagHelper.GetTagValues(Publisher),
+        PersonRole.Character => TagHelper.GetTagValues(Characters),
+        PersonRole.Translator => [],
+        PersonRole.Imprint => TagHelper.GetTagValues(Imprint),
+        PersonRole.Team => TagHelper.GetTagValues(Teams),
+        PersonRole.Location => TagHelper.GetTagValues(Locations),
+        _ => throw new ArgumentOutOfRangeException(nameof(role), role, null)
+    };
 
     public static AgeRating ConvertAgeRatingToEnum(string value)
     {

--- a/API/Data/Metadata/ComicInfo.cs
+++ b/API/Data/Metadata/ComicInfo.cs
@@ -146,7 +146,7 @@ public class ComicInfo
         PersonRole.Editor => TagHelper.GetTagValues(Editor),
         PersonRole.Publisher => TagHelper.GetTagValues(Publisher),
         PersonRole.Character => TagHelper.GetTagValues(Characters),
-        PersonRole.Translator => [],
+        PersonRole.Translator => TagHelper.GetTagValues(Translator),
         PersonRole.Imprint => TagHelper.GetTagValues(Imprint),
         PersonRole.Team => TagHelper.GetTagValues(Teams),
         PersonRole.Location => TagHelper.GetTagValues(Locations),

--- a/API/Extensions/EnumerableExtensions.cs
+++ b/API/Extensions/EnumerableExtensions.cs
@@ -69,4 +69,10 @@ public static class EnumerableExtensions
 
         return q;
     }
+
+    public static IEnumerable<TSource> WhereNotNull<TSource>(this IEnumerable<TSource?> source)
+    where TSource : class
+    {
+        return source.Where(item => item != null)!;
+    }
 }

--- a/API/Helpers/Builders/PersonBuilder.cs
+++ b/API/Helpers/Builders/PersonBuilder.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#nullable enable
+using System.Collections.Generic;
 using System.Linq;
 using API.Entities.Person;
 using API.Extensions;
@@ -10,12 +11,12 @@ public class PersonBuilder : IEntityBuilder<Person>
     private readonly Person _person;
     public Person Build() => _person;
 
-    public PersonBuilder(string name)
+    public PersonBuilder(string name, string? normalizedName = null)
     {
         _person = new Person()
         {
             Name = name.Trim(),
-            NormalizedName = name.ToNormalized(),
+            NormalizedName = string.IsNullOrEmpty(normalizedName) ? name.ToNormalized() : normalizedName,
             SeriesMetadataPeople = new List<SeriesMetadataPeople>(),
             ChapterPeople = new List<ChapterPeople>()
         };

--- a/API/Helpers/PersonHelper.cs
+++ b/API/Helpers/PersonHelper.cs
@@ -31,6 +31,14 @@ public static class PersonHelper
         }
         return dict;
     }
+
+    /// <summary>
+    /// Update people of a specific role for this series. Removes removed people, and adds missing ones.
+    /// </summary>
+    /// <param name="databasePeople">All people references in the series chapters as build by <see cref="ConstructNameAndAliasDictionary"/></param>
+    /// <param name="metadata">Series metadata</param>
+    /// <param name="chapterPeople">All chapter people with</param>
+    /// <param name="role">The role to link with</param>
     public static void UpdateSeriesMetadataPeople(
         Dictionary<string, Person> databasePeople,
         SeriesMetadata metadata,
@@ -65,7 +73,7 @@ public static class PersonHelper
 
         foreach (var person in newPeople)
         {
-            if (metadata.People.Any(mp => mp.PersonId == person.Id && mp.Role == role)) continue;
+            if (metadata.People.Any(mp => mp.Person.NormalizedName == person.NormalizedName && mp.Role == role)) continue;
 
             metadata.People.Add(new SeriesMetadataPeople
             {
@@ -73,11 +81,18 @@ public static class PersonHelper
                 Person = person,
                 SeriesMetadataId = metadata.Id,
                 SeriesMetadata = metadata,
-                Role = role
+                Role = role,
             });
         }
     }
 
+    /// <summary>
+    /// Update people of a specific role for this chapter. Removes removed people, and adds missing ones.
+    /// </summary>
+    /// <param name="databasePeople">All people references in the series chapters as build by <see cref="ConstructNameAndAliasDictionary"/></param>
+    /// <param name="chapter">The chapter</param>
+    /// <param name="comicInfoPeople">The people as defined in the chapters ComicInfo</param>
+    /// <param name="role">The role to link them with</param>
     public static void UpdateChapterPeople(
         Dictionary<string, Person> databasePeople,
         Chapter chapter,
@@ -106,14 +121,14 @@ public static class PersonHelper
 
         foreach (var person in newPeople)
         {
-            if (chapter.People.Any(cp => cp.PersonId == person.Id && cp.Role == role)) continue;
+            if (chapter.People.Any(cp => cp.Person.NormalizedName == person.NormalizedName && cp.Role == role)) continue;
 
             chapter.People.Add(new ChapterPeople
             {
                 PersonId = person.Id,
                 Person = person,
                 ChapterId = chapter.Id,
-                Role = role
+                Role = role,
             });
         }
     }

--- a/API/Helpers/PersonHelper.cs
+++ b/API/Helpers/PersonHelper.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using API.Data;
+using API.Data.Metadata;
 using API.DTOs;
 using API.Entities;
 using API.Entities.Enums;
@@ -29,6 +30,92 @@ public static class PersonHelper
             }
         }
         return dict;
+    }
+    public static void UpdateSeriesMetadataPeople(
+        Dictionary<string, Person> databasePeople,
+        SeriesMetadata metadata,
+        IEnumerable<ChapterPeople> chapterPeople,
+        PersonRole role)
+    {
+        var normalizedPeople = chapterPeople
+            .Where(cp => cp.Role == role)
+            .Select(cp => cp.Person.NormalizedName)
+            .Distinct()
+            .ToList();
+
+        var existingMetadataPeople = metadata.People
+            .Where(mp => mp.Role == role)
+            .ToList();
+
+        var existingPeopleNames = new HashSet<string>(
+            existingMetadataPeople.Select(mp => mp.Person.NormalizedName));
+
+        var toRemove = existingMetadataPeople
+            .Where(mp => !normalizedPeople.Contains(mp.Person.NormalizedName));
+
+        foreach (var existingMetadataPerson in toRemove)
+        {
+            metadata.People.Remove(existingMetadataPerson);
+        }
+
+        var newPeople = normalizedPeople
+            .Where(p => !existingPeopleNames.Contains(p))
+            .Select(p => databasePeople[p])
+            .ToList();
+
+        foreach (var person in newPeople)
+        {
+            if (metadata.People.Any(mp => mp.PersonId == person.Id && mp.Role == role)) continue;
+
+            metadata.People.Add(new SeriesMetadataPeople
+            {
+                PersonId = person.Id,
+                Person = person,
+                SeriesMetadataId = metadata.Id,
+                SeriesMetadata = metadata,
+                Role = role
+            });
+        }
+    }
+
+    public static void UpdateChapterPeople(
+        Dictionary<string, Person> databasePeople,
+        Chapter chapter,
+        IList<string> comicInfoPeople,
+        PersonRole role)
+    {
+        var normalizedPeople = comicInfoPeople.Select(p => p.ToNormalized()).Distinct().ToList();
+
+        var existingChapterPeople = chapter.People
+            .Where(cp => cp.Role == role)
+            .ToList();
+
+        var existingPeopleNames = new HashSet<string>(existingChapterPeople.Select(cp => cp.Person.NormalizedName));
+
+        var toRemove = existingChapterPeople
+            .Where(p => !normalizedPeople.Contains(p.Person.NormalizedName));
+        foreach (var existingChapterPerson in toRemove)
+        {
+            chapter.People.Remove(existingChapterPerson);
+        }
+
+        var newPeople = normalizedPeople
+            .Where(p => !existingPeopleNames.Contains(p))
+            .Select(p => databasePeople[p])
+            .ToList();
+
+        foreach (var person in newPeople)
+        {
+            if (chapter.People.Any(cp => cp.PersonId == person.Id && cp.Role == role)) continue;
+
+            chapter.People.Add(new ChapterPeople
+            {
+                PersonId = person.Id,
+                Person = person,
+                ChapterId = chapter.Id,
+                Role = role
+            });
+        }
     }
 
     public static async Task UpdateSeriesMetadataPeopleAsync(SeriesMetadata metadata, ICollection<SeriesMetadataPeople> metadataPeople,
@@ -119,7 +206,6 @@ public static class PersonHelper
             await unitOfWork.CommitAsync();
         }
     }
-
 
 
     public static async Task UpdateChapterPeopleAsync(Chapter chapter, IList<string> people, PersonRole role, IUnitOfWork unitOfWork)

--- a/API/Services/MetadataService.cs
+++ b/API/Services/MetadataService.cs
@@ -217,11 +217,12 @@ public class MetadataService : IMetadataService
     /// <param name="series"></param>
     /// <param name="forceUpdate"></param>
     /// <param name="encodeFormat"></param>
-    private void ProcessSeriesCoverGen(Series series, bool forceUpdate, EncodeFormat encodeFormat, CoverImageSize coverImageSize, bool forceColorScape = false)
+    private async Task ProcessSeriesCoverGen(Series series, bool forceUpdate, EncodeFormat encodeFormat, CoverImageSize coverImageSize, bool forceColorScape = false)
     {
         _logger.LogDebug("[MetadataService] Processing cover image generation for series: {SeriesName}", series.OriginalName);
         try
         {
+            var totalVolumes = series.Volumes.Count;
             var volumeIndex = 0;
             var firstVolumeUpdated = false;
             foreach (var volume in series.Volumes)
@@ -246,6 +247,10 @@ public class MetadataService : IMetadataService
                 {
                     firstVolumeUpdated = true;
                 }
+
+                await _eventHub.SendMessageAsync(MessageFactory.NotificationProgress,
+                    MessageFactory.CoverUpdateProgressEvent(series.LibraryId, volumeIndex / (float) totalVolumes, ProgressEventType.Started, series.Name));
+
                 volumeIndex++;
             }
 
@@ -315,7 +320,7 @@ public class MetadataService : IMetadataService
 
                 try
                 {
-                    ProcessSeriesCoverGen(series, forceUpdate, encodeFormat, coverImageSize, forceColorScape);
+                    await ProcessSeriesCoverGen(series, forceUpdate, encodeFormat, coverImageSize, forceColorScape);
                 }
                 catch (Exception ex)
                 {
@@ -385,7 +390,7 @@ public class MetadataService : IMetadataService
         await _eventHub.SendMessageAsync(MessageFactory.NotificationProgress,
             MessageFactory.CoverUpdateProgressEvent(series.LibraryId, 0F, ProgressEventType.Started, series.Name));
 
-        ProcessSeriesCoverGen(series, forceUpdate, encodeFormat, coverImageSize, forceColorScape);
+        await ProcessSeriesCoverGen(series, forceUpdate, encodeFormat, coverImageSize, forceColorScape);
 
 
         if (_unitOfWork.HasChanges())

--- a/API/Services/MetadataService.cs
+++ b/API/Services/MetadataService.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using API.Comparators;
 using API.Data;
+using API.DTOs.Settings;
 using API.Entities;
 using API.Entities.Enums;
 using API.Entities.Interfaces;
@@ -34,7 +35,7 @@ public interface IMetadataService
     /// <param name="seriesId"></param>
     /// <param name="forceUpdate">Overrides any cache logic and forces execution</param>
 
-    Task GenerateCoversForSeries(int libraryId, int seriesId, bool forceUpdate = true, bool forceColorScape = true);
+    Task GenerateCoversForSeries(ServerSettingDto serverSetting, int libraryId, int seriesId, bool forceUpdate = true, bool forceColorScape = true);
     Task GenerateCoversForSeries(Series series, EncodeFormat encodeFormat, CoverImageSize coverImageSize, bool forceUpdate = false, bool forceColorScape = true);
     Task RemoveAbandonedMetadataKeys();
 }
@@ -356,7 +357,7 @@ public class MetadataService : IMetadataService
     /// <param name="seriesId"></param>
     /// <param name="forceUpdate">Overrides any cache logic and forces execution</param>
     /// <param name="forceColorScape">Will ensure that the colorscape is regenerated</param>
-    public async Task GenerateCoversForSeries(int libraryId, int seriesId, bool forceUpdate = true, bool forceColorScape = true)
+    public async Task GenerateCoversForSeries(ServerSettingDto serverSetting, int libraryId, int seriesId, bool forceUpdate = true, bool forceColorScape = true)
     {
         var series = await _unitOfWork.SeriesRepository.GetFullSeriesForSeriesIdAsync(seriesId);
         if (series == null)
@@ -365,10 +366,8 @@ public class MetadataService : IMetadataService
             return;
         }
 
-        // TODO: Cache this because it's called a lot during scans
-        var settings = await _unitOfWork.SettingsRepository.GetSettingsDtoAsync();
-        var encodeFormat = settings.EncodeMediaAs;
-        var coverImageSize = settings.CoverImageSize;
+        var encodeFormat = serverSetting.EncodeMediaAs;
+        var coverImageSize = serverSetting.CoverImageSize;
 
         await GenerateCoversForSeries(series, encodeFormat, coverImageSize, forceUpdate, forceColorScape);
     }

--- a/API/Services/ReadingListService.cs
+++ b/API/Services/ReadingListService.cs
@@ -579,7 +579,7 @@ public class ReadingListService : IReadingListService
             CblName = cblReading.Name,
             Success = CblImportResult.Success,
             Results = [],
-            SuccessfulInserts = new List<CblBookResult>()
+            SuccessfulInserts = []
         };
 
         if (IsCblEmpty(cblReading, importSummary, out var readingListFromCbl)) return readingListFromCbl;

--- a/API/Services/Tasks/Scanner/ProcessSeries.cs
+++ b/API/Services/Tasks/Scanner/ProcessSeries.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Threading.Channels;
 using System.Threading.Tasks;
 using API.Data;
 using API.Data.Metadata;
@@ -30,7 +31,7 @@ namespace API.Services.Tasks.Scanner;
 
 public interface IProcessSeries
 {
-    Task ProcessSeriesAsync(MetadataSettingsDto settings, IList<ParserInfo> parsedInfos, Library library, int totalToProcess, bool forceUpdate = false);
+    Task ProcessSeriesAsync(MetadataSettingsDto settings, Channel<int> channel, IList<ParserInfo> parsedInfos, Library library, int totalToProcess, bool forceUpdate = false);
 }
 
 /// <summary>
@@ -71,7 +72,7 @@ public class ProcessSeries : IProcessSeries
     }
 
 
-    public async Task ProcessSeriesAsync(MetadataSettingsDto settings, IList<ParserInfo> parsedInfos, Library library, int totalToProcess, bool forceUpdate = false)
+    public async Task ProcessSeriesAsync(MetadataSettingsDto settings, Channel<int> channel, IList<ParserInfo> parsedInfos, Library library, int totalToProcess, bool forceUpdate = false)
     {
         if (!parsedInfos.Any()) return;
 
@@ -223,8 +224,8 @@ public class ProcessSeries : IProcessSeries
         {
             await _externalMetadataService.FetchSeriesMetadata(series.Id, series.Library.Type);
         }
-        await _metadataService.GenerateCoversForSeries(series.LibraryId, series.Id, false, false);
-        await _wordCountAnalyzerService.ScanSeries(series.LibraryId, series.Id, forceUpdate);
+
+        await channel.Writer.WriteAsync(series.Id);
     }
 
     private async Task ReportDuplicateSeriesLookup(Library library, ParserInfo firstInfo, Exception ex)

--- a/API/Services/Tasks/Scanner/ProcessSeries.cs
+++ b/API/Services/Tasks/Scanner/ProcessSeries.cs
@@ -31,7 +31,7 @@ namespace API.Services.Tasks.Scanner;
 
 public interface IProcessSeries
 {
-    Task ProcessSeriesAsync(MetadataSettingsDto settings, Channel<int> channel, IList<ParserInfo> parsedInfos, Library library, int totalToProcess, bool forceUpdate = false);
+    Task<int?> ProcessSeriesAsync(MetadataSettingsDto settings, IList<ParserInfo> parsedInfos, Library library, int totalToProcess, bool forceUpdate = false);
 }
 
 /// <summary>
@@ -72,9 +72,9 @@ public class ProcessSeries : IProcessSeries
     }
 
 
-    public async Task ProcessSeriesAsync(MetadataSettingsDto settings, Channel<int> channel, IList<ParserInfo> parsedInfos, Library library, int totalToProcess, bool forceUpdate = false)
+    public async Task<int?> ProcessSeriesAsync(MetadataSettingsDto settings, IList<ParserInfo> parsedInfos, Library library, int totalToProcess, bool forceUpdate = false)
     {
-        if (!parsedInfos.Any()) return;
+        if (!parsedInfos.Any()) return null;
 
         var seriesAdded = false;
         var scanWatch = Stopwatch.StartNew();
@@ -97,7 +97,7 @@ public class ProcessSeries : IProcessSeries
         catch (Exception ex)
         {
             await ReportDuplicateSeriesLookup(library, firstInfo, ex);
-            return;
+            return null;
         }
 
         if (series == null)
@@ -174,7 +174,7 @@ public class ProcessSeries : IProcessSeries
                     await _eventHub.SendMessageAsync(MessageFactory.Error,
                         MessageFactory.ErrorEvent($"There was an issue writing to the DB for Series {series.OriginalName}",
                             ex.Message));
-                    return;
+                    return null;
                 }
                 catch (Exception ex)
                 {
@@ -186,7 +186,7 @@ public class ProcessSeries : IProcessSeries
                     await _eventHub.SendMessageAsync(MessageFactory.Error,
                         MessageFactory.ErrorEvent($"There was an issue writing to the DB for Series {series.OriginalName}",
                             ex.Message));
-                    return;
+                    return null;
                 }
 
 
@@ -217,7 +217,7 @@ public class ProcessSeries : IProcessSeries
         catch (Exception ex)
         {
             _logger.LogError(ex, "[ScannerService] There was an exception updating series for {SeriesName}", series.Name);
-            return;
+            return null;
         }
 
         if (seriesAdded)
@@ -225,7 +225,7 @@ public class ProcessSeries : IProcessSeries
             await _externalMetadataService.FetchSeriesMetadata(series.Id, series.Library.Type);
         }
 
-        await channel.Writer.WriteAsync(series.Id);
+        return series.Id;
     }
 
     private async Task ReportDuplicateSeriesLookup(Library library, ParserInfo firstInfo, Exception ex)

--- a/API/Services/Tasks/Scanner/ProcessSeries.cs
+++ b/API/Services/Tasks/Scanner/ProcessSeries.cs
@@ -42,43 +42,40 @@ public class ProcessSeriesArgs
     public required bool ForceUpdate { get; init; }
 }
 
+internal class UpdateChapterArgs
+{
+    public required MetadataSettingsDto Settings { get; set; }
+    public required Series Series { get; set; }
+    public required Volume Volume { get; set; }
+    public required IList<ParserInfo> ParsedInfos { get; set; }
+    public required Dictionary<string, Person> DatabasePeople { get; set; }
+    public required bool ForceUpdate { get; set; }
+}
+
+internal class UpdateChapterComicInfoArgs
+{
+    public required MetadataSettingsDto Settings { get; set; }
+    public required Chapter Chapter { get; set; }
+    public required ComicInfo? ComicInfo { get; set; }
+    public required Dictionary<string, Person> DatabasePeople { get; set; }
+    public required bool ForceUpdate { get; set; }
+}
+
 /// <summary>
 /// All code needed to Update a Series from a Scan action
 /// </summary>
-public class ProcessSeries : IProcessSeries
+public class ProcessSeries(
+    IUnitOfWork unitOfWork,
+    ILogger<ProcessSeries> logger,
+    IEventHub eventHub,
+    IDirectoryService directoryService,
+    ICacheHelper cacheHelper,
+    IReadingItemService readingItemService,
+    IFileService fileService,
+    IReadingListService readingListService,
+    IExternalMetadataService externalMetadataService)
+    : IProcessSeries
 {
-    private readonly IUnitOfWork _unitOfWork;
-    private readonly ILogger<ProcessSeries> _logger;
-    private readonly IEventHub _eventHub;
-    private readonly IDirectoryService _directoryService;
-    private readonly ICacheHelper _cacheHelper;
-    private readonly IReadingItemService _readingItemService;
-    private readonly IFileService _fileService;
-    private readonly IMetadataService _metadataService;
-    private readonly IWordCountAnalyzerService _wordCountAnalyzerService;
-    private readonly IReadingListService _readingListService;
-    private readonly IExternalMetadataService _externalMetadataService;
-
-
-    public ProcessSeries(IUnitOfWork unitOfWork, ILogger<ProcessSeries> logger, IEventHub eventHub,
-        IDirectoryService directoryService, ICacheHelper cacheHelper, IReadingItemService readingItemService,
-        IFileService fileService, IMetadataService metadataService, IWordCountAnalyzerService wordCountAnalyzerService,
-        IReadingListService readingListService,
-        IExternalMetadataService externalMetadataService)
-    {
-        _unitOfWork = unitOfWork;
-        _logger = logger;
-        _eventHub = eventHub;
-        _directoryService = directoryService;
-        _cacheHelper = cacheHelper;
-        _readingItemService = readingItemService;
-        _fileService = fileService;
-        _metadataService = metadataService;
-        _wordCountAnalyzerService = wordCountAnalyzerService;
-        _readingListService = readingListService;
-        _externalMetadataService = externalMetadataService;
-    }
-
 
     public async Task<int?> ProcessSeriesAsync(MetadataSettingsDto settings, IList<ParserInfo> parsedInfos, ProcessSeriesArgs args)
     {
@@ -89,9 +86,9 @@ public class ProcessSeries : IProcessSeries
         var seriesAdded = false;
         var scanWatch = Stopwatch.StartNew();
         var seriesName = parsedInfos[0].Series;
-        await _eventHub.SendMessageAsync(MessageFactory.NotificationProgress,
+        await eventHub.SendMessageAsync(MessageFactory.NotificationProgress,
             MessageFactory.LibraryScanProgressEvent(library.Name, ProgressEventType.Updated, seriesName, args.LeftToProcess, args.TotalToProcess));
-        _logger.LogInformation("[ScannerService] Beginning series update on {SeriesName}, Forced: {ForceUpdate}", seriesName, args.ForceUpdate);
+        logger.LogInformation("[ScannerService] Beginning series update on {SeriesName}, Forced: {ForceUpdate}", seriesName, args.ForceUpdate);
 
         // Check if there is a Series
         var firstInfo = parsedInfos[0];
@@ -101,7 +98,7 @@ public class ProcessSeries : IProcessSeries
             // There is an opportunity to allow duplicate series here. Like if One is in root/marvel/batman and another is root/dc/batman
             // by changing to a ToList() and if multiple, doing a firstInfo.FirstFolder/RootFolder type check
             series =
-                await _unitOfWork.SeriesRepository.GetFullSeriesByAnyName(firstInfo.Series, firstInfo.LocalizedSeries,
+                await unitOfWork.SeriesRepository.GetFullSeriesByAnyName(firstInfo.Series, firstInfo.LocalizedSeries,
                     library.Id, firstInfo.Format);
         }
         catch (Exception ex)
@@ -116,19 +113,20 @@ public class ProcessSeries : IProcessSeries
             series = new SeriesBuilder(firstInfo.Series)
                 .WithLocalizedName(firstInfo.LocalizedSeries)
                 .Build();
-            _unitOfWork.SeriesRepository.Add(series);
+            unitOfWork.SeriesRepository.Add(series);
         }
 
         if (series.LibraryId == 0) series.LibraryId = library.Id;
 
         try
         {
-            _logger.LogInformation("[ScannerService] Processing series {SeriesName} with {Count} files", series.OriginalName, parsedInfos.Count);
+            logger.LogInformation("[ScannerService] Processing series {SeriesName} with {Count} files", series.OriginalName, parsedInfos.Count);
 
             // parsedInfos[0] is not the first volume or chapter. We need to find it using a ComicInfo check (as it uses firstParsedInfo for series sort)
             var firstParsedInfo = parsedInfos.FirstOrDefault(p => p.ComicInfo != null, firstInfo);
+            var databasePeople = await LoadAndCreateMissingChapterPeople(parsedInfos);
 
-            await UpdateVolumes(settings, series, parsedInfos, args.ForceUpdate);
+            await UpdateVolumes(databasePeople, settings, series, parsedInfos, args.ForceUpdate);
             series.Pages = series.Volumes.Sum(v => v.Pages);
 
             series.NormalizedName = series.Name.ToNormalized();
@@ -163,37 +161,37 @@ public class ProcessSeries : IProcessSeries
                 series.NormalizedLocalizedName = series.LocalizedName.ToNormalized();
             }
 
-            await UpdateSeriesMetadata(settings, series, library);
+            await UpdateSeriesMetadata(databasePeople, settings, series, library);
 
             // Update series FolderPath here
             await UpdateSeriesFolderPath(parsedInfos, library, series);
 
             series.UpdateLastFolderScanned();
 
-            if (_unitOfWork.HasChanges())
+            if (unitOfWork.HasChanges())
             {
                 try
                 {
-                    await _unitOfWork.CommitAsync();
+                    await unitOfWork.CommitAsync();
                 }
                 catch (DbUpdateConcurrencyException ex)
                 {
-                    _logger.LogCritical(ex,
+                    logger.LogCritical(ex,
                         "[ScannerService] There was an issue writing to the database for series {SeriesName}",
                         series.Name);
-                    await _eventHub.SendMessageAsync(MessageFactory.Error,
+                    await eventHub.SendMessageAsync(MessageFactory.Error,
                         MessageFactory.ErrorEvent($"There was an issue writing to the DB for Series {series.OriginalName}",
                             ex.Message));
                     return null;
                 }
                 catch (Exception ex)
                 {
-                    await _unitOfWork.RollbackAsync();
-                    _logger.LogCritical(ex,
+                    await unitOfWork.RollbackAsync();
+                    logger.LogCritical(ex,
                         "[ScannerService] There was an issue writing to the database for series {SeriesName}",
                         series.Name);
 
-                    await _eventHub.SendMessageAsync(MessageFactory.Error,
+                    await eventHub.SendMessageAsync(MessageFactory.Error,
                         MessageFactory.ErrorEvent($"There was an issue writing to the DB for Series {series.OriginalName}",
                             ex.Message));
                     return null;
@@ -203,7 +201,7 @@ public class ProcessSeries : IProcessSeries
                 // Process reading list after commit as we need to commit per list
                 if (library.ManageReadingLists)
                 {
-                    await _readingListService.CreateReadingListsFromSeries(series, library);
+                    await readingListService.CreateReadingListsFromSeries(series, library);
                 }
 
 
@@ -213,26 +211,26 @@ public class ProcessSeries : IProcessSeries
                     // BackgroundJob.Enqueue(() =>
                     //     _externalMetadataService.FetchSeriesMetadata(series.Id, series.Library.Type));
 
-                    await _eventHub.SendMessageAsync(MessageFactory.SeriesAdded,
+                    await eventHub.SendMessageAsync(MessageFactory.SeriesAdded,
                         MessageFactory.SeriesAddedEvent(series.Id, series.Name, series.LibraryId), false);
                 }
                 else
                 {
-                    await _unitOfWork.ExternalSeriesMetadataRepository.LinkRecommendationsToSeries(series);
+                    await unitOfWork.ExternalSeriesMetadataRepository.LinkRecommendationsToSeries(series);
                 }
 
-                _logger.LogInformation("[ScannerService] Finished series update on {SeriesName} in {Milliseconds} ms", seriesName, scanWatch.ElapsedMilliseconds);
+                logger.LogInformation("[ScannerService] Finished series update on {SeriesName} in {Milliseconds} ms", seriesName, scanWatch.ElapsedMilliseconds);
             }
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "[ScannerService] There was an exception updating series for {SeriesName}", series.Name);
+            logger.LogError(ex, "[ScannerService] There was an exception updating series for {SeriesName}", series.Name);
             return null;
         }
 
         if (seriesAdded)
         {
-            await _externalMetadataService.FetchSeriesMetadata(series.Id, series.Library.Type);
+            await externalMetadataService.FetchSeriesMetadata(series.Id, series.Library.Type);
         }
 
         return series.Id;
@@ -240,7 +238,7 @@ public class ProcessSeries : IProcessSeries
 
     private async Task ReportDuplicateSeriesLookup(Library library, ParserInfo firstInfo, Exception ex)
     {
-        var seriesCollisions = await _unitOfWork.SeriesRepository.GetAllSeriesByAnyName(firstInfo.LocalizedSeries, string.Empty, library.Id, firstInfo.Format);
+        var seriesCollisions = await unitOfWork.SeriesRepository.GetAllSeriesByAnyName(firstInfo.LocalizedSeries, string.Empty, library.Id, firstInfo.Format);
 
         seriesCollisions = seriesCollisions.Where(collision =>
             collision.Name != firstInfo.Series || collision.LocalizedName != firstInfo.LocalizedSeries).ToList();
@@ -256,10 +254,10 @@ public class ProcessSeries : IProcessSeries
 
             var htmlTable = $"<table class='table table-striped'><thead><tr><th>Series 1</th><th>Series 2</th></tr></thead><tbody>{string.Join(string.Empty, tableRows)}</tbody></table>";
 
-            _logger.LogError(ex, "[ScannerService] Scanner found a Series {SeriesName} which matched another Series {LocalizedName} in a different folder parallel to Library {LibraryName} root folder. This is not allowed. Please correct, scan will abort",
+            logger.LogError(ex, "[ScannerService] Scanner found a Series {SeriesName} which matched another Series {LocalizedName} in a different folder parallel to Library {LibraryName} root folder. This is not allowed. Please correct, scan will abort",
                 firstInfo.Series, firstInfo.LocalizedSeries, library.Name);
 
-            await _eventHub.SendMessageAsync(MessageFactory.Error,
+            await eventHub.SendMessageAsync(MessageFactory.Error,
                 MessageFactory.ErrorEvent($"Library {library.Name} Series collision on {firstInfo.Series}",
                     htmlTable));
         }
@@ -270,12 +268,12 @@ public class ProcessSeries : IProcessSeries
     {
         var libraryFolders = library.Folders.Select(l => Parser.Parser.NormalizePath(l.Path)).ToList();
         var seriesFiles = parsedInfos.Select(f => Parser.Parser.NormalizePath(f.FullFilePath)).ToList();
-        var seriesDirs = _directoryService.FindHighestDirectoriesFromFiles(libraryFolders, seriesFiles);
+        var seriesDirs = directoryService.FindHighestDirectoriesFromFiles(libraryFolders, seriesFiles);
         if (seriesDirs.Keys.Count == 0)
         {
-            _logger.LogCritical(
+            logger.LogCritical(
                 "Scan Series has files spread outside a main series folder. This has negative performance effects. Please ensure all series are under a single folder from library");
-            await _eventHub.SendMessageAsync(MessageFactory.Info,
+            await eventHub.SendMessageAsync(MessageFactory.Info,
                 MessageFactory.InfoEvent($"{series.Name} has files spread outside a single series folder",
                     "This has negative performance effects. Please ensure all series are under a single folder from library"));
         }
@@ -287,20 +285,20 @@ public class ProcessSeries : IProcessSeries
                 // BUG: FolderPath can be a level higher than it needs to be. I'm not sure why it's like this, but I thought it should be one level lower.
                 // I think it's like this because higher level is checked or not checked. But i think we can do both
                 series.FolderPath = Parser.Parser.NormalizePath(seriesDirs.Keys.First());
-                _logger.LogDebug("Updating {Series} FolderPath to {FolderPath}", series.Name, series.FolderPath);
+                logger.LogDebug("Updating {Series} FolderPath to {FolderPath}", series.Name, series.FolderPath);
             }
         }
 
-        var lowestFolder = _directoryService.FindLowestDirectoriesFromFiles(libraryFolders, seriesFiles);
+        var lowestFolder = directoryService.FindLowestDirectoriesFromFiles(libraryFolders, seriesFiles);
         if (!string.IsNullOrEmpty(lowestFolder))
         {
             series.LowestFolderPath = lowestFolder;
-            _logger.LogDebug("Updating {Series} LowestFolderPath to {FolderPath}", series.Name, series.LowestFolderPath);
+            logger.LogDebug("Updating {Series} LowestFolderPath to {FolderPath}", series.Name, series.LowestFolderPath);
         }
     }
 
 
-    private async Task UpdateSeriesMetadata(MetadataSettingsDto settings, Series series, Library library)
+    private async Task UpdateSeriesMetadata(Dictionary<string, Person> databasePeople, MetadataSettingsDto settings, Series series, Library library)
     {
         series.Metadata ??= new SeriesMetadataBuilder().Build();
         var firstChapter = SeriesService.GetFirstChapterForMetadata(series);
@@ -365,125 +363,16 @@ public class ProcessSeries : IProcessSeries
         }
 
         #region PeopleAndTagsAndGenres
-        if (!series.Metadata.WriterLocked)
-        {
-            var personSw = Stopwatch.StartNew();
-            var chapterPeople = chapters.SelectMany(c => c.People.Where(p => p.Role == PersonRole.Writer)).ToList();
-            if (ShouldUpdatePeopleForRole(series, chapterPeople, PersonRole.Writer))
-            {
-                await UpdateSeriesMetadataPeople(series.Metadata, series.Metadata.People, chapterPeople, PersonRole.Writer);
-            }
-            _logger.LogTrace("[TIME] Kavita took {Time} ms to process writer on Series: {File} for {Count} people", personSw.ElapsedMilliseconds, series.Name, chapterPeople.Count);
-        }
 
-        if (!series.Metadata.ColoristLocked)
+        foreach (var personRole in Enum.GetValues<PersonRole>().Where(r => r != PersonRole.Other))
         {
-            var chapterPeople = chapters.SelectMany(c => c.People.Where(p => p.Role == PersonRole.Colorist)).ToList();
-            if (ShouldUpdatePeopleForRole(series, chapterPeople, PersonRole.Colorist))
-            {
-                await UpdateSeriesMetadataPeople(series.Metadata, series.Metadata.People, chapterPeople, PersonRole.Colorist);
-            }
-        }
+            var chapterPeople = chapters
+                .SelectMany(c => c.People.Where(p => p.Role == personRole)).ToList();
 
-        if (!series.Metadata.PublisherLocked)
-        {
-            var chapterPeople = chapters.SelectMany(c => c.People.Where(p => p.Role == PersonRole.Publisher)).ToList();
-            if (ShouldUpdatePeopleForRole(series, chapterPeople, PersonRole.Publisher))
-            {
-                await UpdateSeriesMetadataPeople(series.Metadata, series.Metadata.People, chapterPeople, PersonRole.Publisher);
-            }
-        }
+            if (!ShouldUpdatePeopleForRole(series, chapterPeople, personRole)) continue;
 
-        if (!series.Metadata.CoverArtistLocked)
-        {
-            var chapterPeople = chapters.SelectMany(c => c.People.Where(p => p.Role == PersonRole.CoverArtist)).ToList();
-            if (ShouldUpdatePeopleForRole(series, chapterPeople, PersonRole.CoverArtist))
-            {
-                await UpdateSeriesMetadataPeople(series.Metadata, series.Metadata.People, chapterPeople, PersonRole.CoverArtist);
-            }
+            PersonHelper.UpdateSeriesMetadataPeople(databasePeople, series.Metadata, chapterPeople, personRole);
         }
-
-        if (!series.Metadata.CharacterLocked)
-        {
-            var chapterPeople = chapters.SelectMany(c => c.People.Where(p => p.Role == PersonRole.Character)).ToList();
-            if (ShouldUpdatePeopleForRole(series, chapterPeople, PersonRole.Character))
-            {
-                await UpdateSeriesMetadataPeople(series.Metadata, series.Metadata.People, chapterPeople, PersonRole.Character);
-            }
-        }
-
-        if (!series.Metadata.EditorLocked)
-        {
-            var chapterPeople = chapters.SelectMany(c => c.People.Where(p => p.Role == PersonRole.Editor)).ToList();
-            if (ShouldUpdatePeopleForRole(series, chapterPeople, PersonRole.Editor))
-            {
-                await UpdateSeriesMetadataPeople(series.Metadata, series.Metadata.People, chapterPeople, PersonRole.Editor);
-            }
-        }
-
-        if (!series.Metadata.InkerLocked)
-        {
-            var chapterPeople = chapters.SelectMany(c => c.People.Where(p => p.Role == PersonRole.Inker)).ToList();
-            if (ShouldUpdatePeopleForRole(series, chapterPeople, PersonRole.Inker))
-            {
-                await UpdateSeriesMetadataPeople(series.Metadata, series.Metadata.People, chapterPeople, PersonRole.Inker);
-            }
-        }
-
-        if (!series.Metadata.ImprintLocked)
-        {
-            var chapterPeople = chapters.SelectMany(c => c.People.Where(p => p.Role == PersonRole.Imprint)).ToList();
-            if (ShouldUpdatePeopleForRole(series, chapterPeople, PersonRole.Imprint))
-            {
-                await UpdateSeriesMetadataPeople(series.Metadata, series.Metadata.People, chapterPeople, PersonRole.Imprint);
-            }
-        }
-
-        if (!series.Metadata.TeamLocked)
-        {
-            var chapterPeople = chapters.SelectMany(c => c.People.Where(p => p.Role == PersonRole.Team)).ToList();
-            if (ShouldUpdatePeopleForRole(series, chapterPeople, PersonRole.Team))
-            {
-                await UpdateSeriesMetadataPeople(series.Metadata, series.Metadata.People, chapterPeople, PersonRole.Team);
-            }
-        }
-
-        if (!series.Metadata.LocationLocked && !series.Metadata.AllKavitaPlus(PersonRole.Location))
-        {
-            var chapterPeople = chapters.SelectMany(c => c.People.Where(p => p.Role == PersonRole.Location)).ToList();
-            if (ShouldUpdatePeopleForRole(series, chapterPeople, PersonRole.Location))
-            {
-                await UpdateSeriesMetadataPeople(series.Metadata, series.Metadata.People, chapterPeople, PersonRole.Location);
-            }
-        }
-
-        if (!series.Metadata.LettererLocked && !series.Metadata.AllKavitaPlus(PersonRole.Letterer))
-        {
-            var chapterPeople = chapters.SelectMany(c => c.People.Where(p => p.Role == PersonRole.Letterer)).ToList();
-            if (ShouldUpdatePeopleForRole(series, chapterPeople, PersonRole.Location))
-            {
-                await UpdateSeriesMetadataPeople(series.Metadata, series.Metadata.People, chapterPeople, PersonRole.Letterer);
-            }
-        }
-
-        if (!series.Metadata.PencillerLocked && !series.Metadata.AllKavitaPlus(PersonRole.Penciller))
-        {
-            var chapterPeople = chapters.SelectMany(c => c.People.Where(p => p.Role == PersonRole.Penciller)).ToList();
-            if (ShouldUpdatePeopleForRole(series, chapterPeople, PersonRole.Penciller))
-            {
-                await UpdateSeriesMetadataPeople(series.Metadata, series.Metadata.People, chapterPeople, PersonRole.Penciller);
-            }
-        }
-
-        if (!series.Metadata.TranslatorLocked && !series.Metadata.AllKavitaPlus(PersonRole.Translator))
-        {
-            var chapterPeople = chapters.SelectMany(c => c.People.Where(p => p.Role == PersonRole.Translator)).ToList();
-            if (ShouldUpdatePeopleForRole(series, chapterPeople, PersonRole.Translator))
-            {
-                await UpdateSeriesMetadataPeople(series.Metadata, series.Metadata.People, chapterPeople, PersonRole.Translator);
-            }
-        }
-
 
         if (!series.Metadata.TagsLocked)
         {
@@ -532,10 +421,10 @@ public class ProcessSeries : IProcessSeries
     private async Task UpdateCollectionTags(Series series, Chapter firstChapter)
     {
         // Get the default admin to associate these tags to
-        var defaultAdmin = await _unitOfWork.UserRepository.GetDefaultAdminUser(AppUserIncludes.Collections);
+        var defaultAdmin = await unitOfWork.UserRepository.GetDefaultAdminUser(AppUserIncludes.Collections);
         if (defaultAdmin == null) return;
 
-        _logger.LogInformation("Collection tag(s) found for {SeriesName}, updating collections", series.Name);
+        logger.LogInformation("Collection tag(s) found for {SeriesName}, updating collections", series.Name);
         var sw = Stopwatch.StartNew();
 
         foreach (var collection in firstChapter.SeriesGroup.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
@@ -547,14 +436,14 @@ public class ProcessSeries : IProcessSeries
             // If the collection tag does not exist, create a new one
             if (collectionTag == null)
             {
-                _logger.LogDebug("Creating new collection tag for {Tag}", collection);
+                logger.LogDebug("Creating new collection tag for {Tag}", collection);
 
                 collectionTag = new AppUserCollectionBuilder(collection).Build();
                 defaultAdmin.Collections.Add(collectionTag);
 
-                _unitOfWork.UserRepository.Update(defaultAdmin);
+                unitOfWork.UserRepository.Update(defaultAdmin);
 
-                await _unitOfWork.CommitAsync();
+                await unitOfWork.CommitAsync();
             }
 
             // Check if the Series is already associated with this collection
@@ -567,10 +456,10 @@ public class ProcessSeries : IProcessSeries
             collectionTag.Items.Add(series);
 
             // Update the collection age rating
-            await _unitOfWork.CollectionTagRepository.UpdateCollectionAgeRating(collectionTag);
+            await unitOfWork.CollectionTagRepository.UpdateCollectionAgeRating(collectionTag);
         }
 
-        _logger.LogTrace("[TIME] Kavita took {Time} ms to process collections on Series: {Name}", sw.ElapsedMilliseconds, series.Name);
+        logger.LogTrace("[TIME] Kavita took {Time} ms to process collections on Series: {Name}", sw.ElapsedMilliseconds, series.Name);
     }
 
 
@@ -638,7 +527,7 @@ public class ProcessSeries : IProcessSeries
     private async Task UpdateSeriesMetadataPeople(SeriesMetadata metadata, ICollection<SeriesMetadataPeople> metadataPeople,
         IEnumerable<ChapterPeople> chapterPeople, PersonRole role)
     {
-        await PersonHelper.UpdateSeriesMetadataPeopleAsync(metadata, metadataPeople, chapterPeople, role, _unitOfWork);
+        await PersonHelper.UpdateSeriesMetadataPeopleAsync(metadata, metadataPeople, chapterPeople, role, unitOfWork);
     }
 
     private void DeterminePublicationStatus(Series series, List<Chapter> chapters)
@@ -696,12 +585,12 @@ public class ProcessSeries : IProcessSeries
         }
         catch (Exception ex)
         {
-            _logger.LogCritical(ex, "There was an issue determining Publication Status");
+            logger.LogCritical(ex, "There was an issue determining Publication Status");
             series.Metadata.PublicationStatus = PublicationStatus.OnGoing;
         }
     }
 
-    private async Task UpdateVolumes(MetadataSettingsDto settings, Series series, IList<ParserInfo> parsedInfos, bool forceUpdate = false)
+    private async Task UpdateVolumes(Dictionary<string, Person> databasePeople, MetadataSettingsDto settings, Series series, IList<ParserInfo> parsedInfos, bool forceUpdate = false)
     {
         // Add new volumes and update chapters per volume
         var distinctVolumes = parsedInfos.DistinctVolumes();
@@ -717,7 +606,7 @@ public class ProcessSeries : IProcessSeries
             {
                 // TODO: Push this to UI in some way
                 if (!ex.Message.Equals("Sequence contains more than one matching element")) throw;
-                _logger.LogCritical(ex, "[ScannerService] Kavita found corrupted volume entries on {SeriesName}. Please delete the series from Kavita via UI and rescan", series.Name);
+                logger.LogCritical(ex, "[ScannerService] Kavita found corrupted volume entries on {SeriesName}. Please delete the series from Kavita via UI and rescan", series.Name);
                 throw new KavitaException(
                     $"Kavita found corrupted volume entries on {series.Name}. Please delete the series from Kavita via UI and rescan");
             }
@@ -734,7 +623,15 @@ public class ProcessSeries : IProcessSeries
 
             var infos = parsedInfos.Where(p => p.Volumes == volumeNumber).ToArray();
 
-            await UpdateChapters(settings, series, volume, infos, forceUpdate);
+            await UpdateChapters(new UpdateChapterArgs
+            {
+                Settings = settings,
+                Series = series,
+                Volume = volume,
+                ParsedInfos = infos,
+                DatabasePeople = databasePeople,
+                ForceUpdate = forceUpdate
+            });
             volume.Pages = volume.Chapters.Sum(c => c.Pages);
         }
 
@@ -751,51 +648,51 @@ public class ProcessSeries : IProcessSeries
         if (series.Volumes.Count == nonDeletedVolumes.Count) return;
 
 
-        _logger.LogDebug("[ScannerService] Removed {Count} volumes from {SeriesName} where parsed infos were not mapping with volume name",
+        logger.LogDebug("[ScannerService] Removed {Count} volumes from {SeriesName} where parsed infos were not mapping with volume name",
             (series.Volumes.Count - nonDeletedVolumes.Count), series.Name);
         var deletedVolumes = series.Volumes.Except(nonDeletedVolumes);
         foreach (var volume in deletedVolumes)
         {
             var file = volume.Chapters.FirstOrDefault()?.Files?.FirstOrDefault()?.FilePath ?? string.Empty;
-            if (!string.IsNullOrEmpty(file) && _directoryService.FileSystem.File.Exists(file))
+            if (!string.IsNullOrEmpty(file) && directoryService.FileSystem.File.Exists(file))
             {
                 // This can happen when file is renamed and volume is removed
-                _logger.LogInformation(
+                logger.LogInformation(
                     "[ScannerService] Volume cleanup code was trying to remove a volume with a file still existing on disk (usually volume marker removed) File: {File}",
                     file);
             }
 
-            _logger.LogDebug("[ScannerService] Removed {SeriesName} - Volume {Volume}: {File}", series.Name, volume.Name, file);
+            logger.LogDebug("[ScannerService] Removed {SeriesName} - Volume {Volume}: {File}", series.Name, volume.Name, file);
         }
 
         series.Volumes = nonDeletedVolumes;
     }
 
-    private async Task UpdateChapters(MetadataSettingsDto settings, Series series, Volume volume, IList<ParserInfo> parsedInfos, bool forceUpdate = false)
+    private async Task UpdateChapters(UpdateChapterArgs args)
     {
         // Add new chapters
-        foreach (var info in parsedInfos)
+        foreach (var info in args.ParsedInfos)
         {
             // Specials go into their own chapters with Range being their filename and IsSpecial = True. Non-Specials with Vol and Chap as 0
             // also are treated like specials for UI grouping.
             Chapter? chapter;
             try
             {
-                chapter = volume.Chapters.GetChapterByRange(info);
+                chapter = args.Volume.Chapters.GetChapterByRange(info);
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "{FileName} mapped as '{Series} - Vol {Volume} Ch {Chapter}' is a duplicate, skipping", info.FullFilePath, info.Series, info.Volumes, info.Chapters);
+                logger.LogError(ex, "{FileName} mapped as '{Series} - Vol {Volume} Ch {Chapter}' is a duplicate, skipping", info.FullFilePath, info.Series, info.Volumes, info.Chapters);
                 continue;
             }
 
             if (chapter == null)
             {
-                _logger.LogDebug(
+                logger.LogDebug(
                     "[ScannerService] Adding new chapter, {Series} - Vol {Volume} Ch {Chapter}", info.Series, info.Volumes, info.Chapters);
                 chapter = ChapterBuilder.FromParserInfo(info).Build();
-                volume.Chapters.Add(chapter);
-                series.UpdateLastChapterAdded();
+                args.Volume.Chapters.Add(chapter);
+                args.Series.UpdateLastChapterAdded();
             }
             else
             {
@@ -804,7 +701,7 @@ public class ProcessSeries : IProcessSeries
 
 
             // Add files
-            AddOrUpdateFileForChapter(chapter, info, forceUpdate);
+            AddOrUpdateFileForChapter(chapter, info, args.ForceUpdate);
 
             chapter.Number = Parser.Parser.MinNumberFromRange(info.Chapters).ToString(CultureInfo.InvariantCulture);
             chapter.MinNumber = Parser.Parser.MinNumberFromRange(info.Chapters);
@@ -824,16 +721,23 @@ public class ProcessSeries : IProcessSeries
 
             try
             {
-                await UpdateChapterFromComicInfo(settings, chapter, info.ComicInfo, forceUpdate);
+                await UpdateChapterFromComicInfo(new UpdateChapterComicInfoArgs
+                {
+                    Settings = args.Settings,
+                    Chapter = chapter,
+                    ComicInfo = info.ComicInfo,
+                    DatabasePeople = args.DatabasePeople,
+                    ForceUpdate = args.ForceUpdate,
+                });
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "There was some issue when updating chapter's metadata");
+                logger.LogError(ex, "There was some issue when updating chapter's metadata");
             }
 
         }
 
-        RemoveChapters(volume, parsedInfos);
+        RemoveChapters(args.Volume, args.ParsedInfos);
     }
 
     private void RemoveChapters(Volume volume, IList<ParserInfo> parsedInfos)
@@ -869,7 +773,7 @@ public class ProcessSeries : IProcessSeries
 
                 if (existingChapter.Files.Count != 0) continue;
 
-                _logger.LogDebug("[ScannerService] Removed chapter {Chapter} for Volume {VolumeNumber} on {SeriesName}",
+                logger.LogDebug("[ScannerService] Removed chapter {Chapter} for Volume {VolumeNumber} on {SeriesName}",
                     existingChapter.Range, volume.Name, parsedInfos[0].Series);
                 chaptersToRemove.Add(existingChapter); // Mark chapter for removal
             }
@@ -878,7 +782,7 @@ public class ProcessSeries : IProcessSeries
                 var filesExist = existingChapter.Files.Any(f => File.Exists(f.FilePath));
                 if (filesExist) continue;
 
-                _logger.LogDebug("[ScannerService] Removed chapter {Chapter} for Volume {VolumeNumber} on {SeriesName} as no files exist",
+                logger.LogDebug("[ScannerService] Removed chapter {Chapter} for Volume {VolumeNumber} on {SeriesName} as no files exist",
                     existingChapter.Range, volume.Name, parsedInfos[0].Series);
                 chaptersToRemove.Add(existingChapter); // Mark chapter for removal
             }
@@ -891,20 +795,19 @@ public class ProcessSeries : IProcessSeries
         }
     }
 
-
     private void AddOrUpdateFileForChapter(Chapter chapter, ParserInfo info, bool forceUpdate = false)
     {
         chapter.Files ??= [];
         var existingFile = chapter.Files.SingleOrDefault(f => f.FilePath == info.FullFilePath);
-        var fileInfo = _directoryService.FileSystem.FileInfo.New(info.FullFilePath);
+        var fileInfo = directoryService.FileSystem.FileInfo.New(info.FullFilePath);
         if (existingFile != null)
         {
             // TODO: I wonder if we can simplify this force check.
             existingFile.Format = info.Format;
 
-            if (!forceUpdate && !_fileService.HasFileBeenModifiedSince(existingFile.FilePath, existingFile.LastModified) && existingFile.Pages != 0) return;
+            if (!forceUpdate && !fileService.HasFileBeenModifiedSince(existingFile.FilePath, existingFile.LastModified) && existingFile.Pages != 0) return;
 
-            existingFile.Pages = _readingItemService.GetNumberOfPages(info.FullFilePath, info.Format);
+            existingFile.Pages = readingItemService.GetNumberOfPages(info.FullFilePath, info.Format);
             existingFile.Extension = fileInfo.Extension.ToLowerInvariant();
             existingFile.FileName = Parser.Parser.RemoveExtensionIfSupported(existingFile.FilePath);
             existingFile.FilePath = Parser.Parser.NormalizePath(existingFile.FilePath);
@@ -916,7 +819,7 @@ public class ProcessSeries : IProcessSeries
         else
         {
 
-            var file = new MangaFileBuilder(info.FullFilePath, info.Format, _readingItemService.GetNumberOfPages(info.FullFilePath, info.Format))
+            var file = new MangaFileBuilder(info.FullFilePath, info.Format, readingItemService.GetNumberOfPages(info.FullFilePath, info.Format))
                 .WithExtension(fileInfo.Extension)
                 .WithBytes(fileInfo.Length)
                 .WithHash()
@@ -925,12 +828,15 @@ public class ProcessSeries : IProcessSeries
         }
     }
 
-    private async Task UpdateChapterFromComicInfo(MetadataSettingsDto settings, Chapter chapter, ComicInfo? comicInfo, bool forceUpdate = false)
+    private async Task UpdateChapterFromComicInfo(UpdateChapterComicInfoArgs args)
     {
+        var comicInfo = args.ComicInfo;
+        var chapter = args.Chapter;
+
         if (comicInfo == null) return;
         var firstFile = chapter.Files.MinBy(x => x.Chapter);
         if (firstFile == null ||
-            _cacheHelper.IsFileUnmodifiedSinceCreationOrLastScan(chapter, forceUpdate, firstFile)) return;
+            cacheHelper.IsFileUnmodifiedSinceCreationOrLastScan(chapter, args.ForceUpdate, firstFile)) return;
 
         var sw = Stopwatch.StartNew();
         if (!chapter.AgeRatingLocked)
@@ -1013,85 +919,12 @@ public class ProcessSeries : IProcessSeries
             chapter.ReleaseDate = new DateTime(comicInfo.Year, month, day);
         }
 
-        if (!chapter.IsPersonRoleLocked(PersonRole.Colorist))
+        foreach (var personRole in Enum.GetValues<PersonRole>().Where(r => r != PersonRole.Other))
         {
-            var people = TagHelper.GetTagValues(comicInfo.Colorist);
-            await UpdateChapterPeopleAsync(chapter, people, PersonRole.Colorist);
-        }
+            if (chapter.IsPersonRoleLocked(personRole)) continue;
 
-        if (!chapter.IsPersonRoleLocked(PersonRole.Character))
-        {
-            var people = TagHelper.GetTagValues(comicInfo.Characters);
-            await UpdateChapterPeopleAsync(chapter, people, PersonRole.Character);
-        }
-
-
-        if (!chapter.IsPersonRoleLocked(PersonRole.Translator))
-        {
-            var people = TagHelper.GetTagValues(comicInfo.Translator);
-            await UpdateChapterPeopleAsync(chapter, people, PersonRole.Translator);
-        }
-
-        if (!chapter.IsPersonRoleLocked(PersonRole.Writer))
-        {
-            var personSw = Stopwatch.StartNew();
-            var people = TagHelper.GetTagValues(comicInfo.Writer);
-            await UpdateChapterPeopleAsync(chapter, people, PersonRole.Writer);
-            _logger.LogTrace("[TIME] Kavita took {Time} ms to process writer on Chapter: {File} for {Count} people", personSw.ElapsedMilliseconds, chapter.Files.First().FileName, people.Count);
-        }
-
-        if (!chapter.IsPersonRoleLocked(PersonRole.Editor))
-        {
-            var people = TagHelper.GetTagValues(comicInfo.Editor);
-            await UpdateChapterPeopleAsync(chapter, people, PersonRole.Editor);
-        }
-
-        if (!chapter.IsPersonRoleLocked(PersonRole.Inker))
-        {
-            var people = TagHelper.GetTagValues(comicInfo.Inker);
-            await UpdateChapterPeopleAsync(chapter, people, PersonRole.Inker);
-        }
-
-        if (!chapter.IsPersonRoleLocked(PersonRole.Letterer))
-        {
-            var people = TagHelper.GetTagValues(comicInfo.Letterer);
-            await UpdateChapterPeopleAsync(chapter, people, PersonRole.Letterer);
-        }
-
-        if (!chapter.IsPersonRoleLocked(PersonRole.Penciller))
-        {
-            var people = TagHelper.GetTagValues(comicInfo.Penciller);
-            await UpdateChapterPeopleAsync(chapter, people, PersonRole.Penciller);
-        }
-
-        if (!chapter.IsPersonRoleLocked(PersonRole.CoverArtist))
-        {
-            var people = TagHelper.GetTagValues(comicInfo.CoverArtist);
-            await UpdateChapterPeopleAsync(chapter, people, PersonRole.CoverArtist);
-        }
-
-        if (!chapter.IsPersonRoleLocked(PersonRole.Publisher))
-        {
-            var people = TagHelper.GetTagValues(comicInfo.Publisher);
-            await UpdateChapterPeopleAsync(chapter, people, PersonRole.Publisher);
-        }
-
-        if (!chapter.IsPersonRoleLocked(PersonRole.Imprint))
-        {
-            var people = TagHelper.GetTagValues(comicInfo.Imprint);
-            await UpdateChapterPeopleAsync(chapter, people, PersonRole.Imprint);
-        }
-
-        if (!chapter.IsPersonRoleLocked(PersonRole.Team))
-        {
-            var people = TagHelper.GetTagValues(comicInfo.Teams);
-            await UpdateChapterPeopleAsync(chapter, people, PersonRole.Team);
-        }
-
-        if (!chapter.IsPersonRoleLocked(PersonRole.Location))
-        {
-            var people = TagHelper.GetTagValues(comicInfo.Locations);
-            await UpdateChapterPeopleAsync(chapter, people, PersonRole.Location);
+            var comicInfoPeople = comicInfo.GetPeopleForRole(personRole);
+            PersonHelper.UpdateChapterPeople(args.DatabasePeople, chapter, comicInfoPeople, personRole);
         }
 
         if (!chapter.GenresLocked || !chapter.TagsLocked)
@@ -1099,7 +932,7 @@ public class ProcessSeries : IProcessSeries
             var genres = TagHelper.GetTagValues(comicInfo.Genre);
             var tags = TagHelper.GetTagValues(comicInfo.Tags);
 
-            ExternalMetadataService.GenerateExternalGenreAndTagsList(genres, tags, settings,
+            ExternalMetadataService.GenerateExternalGenreAndTagsList(genres, tags, args.Settings,
                 out var finalTags, out var finalGenres);
 
             if (!chapter.GenresLocked)
@@ -1115,43 +948,57 @@ public class ProcessSeries : IProcessSeries
 
         }
 
-        _logger.LogTrace("[TIME] Kavita took {Time} ms to create/update Chapter: {File}", sw.ElapsedMilliseconds, chapter.Files.First().FileName);
+        logger.LogTrace("[TIME] Kavita took {Time} ms to create/update Chapter: {File}", sw.ElapsedMilliseconds, chapter.Files.First().FileName);
     }
 
     private async Task UpdateChapterGenres(Chapter chapter, IEnumerable<string> genreNames)
     {
         try
         {
-            await GenreHelper.UpdateChapterGenres(chapter, genreNames, _unitOfWork);
+            await GenreHelper.UpdateChapterGenres(chapter, genreNames, unitOfWork);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "There was an error updating the chapter genres");
+            logger.LogError(ex, "There was an error updating the chapter genres");
         }
     }
-
 
     private async Task UpdateChapterTags(Chapter chapter, IEnumerable<string> tagNames)
     {
         try
         {
-            await TagHelper.UpdateChapterTags(chapter, tagNames, _unitOfWork);
+            await TagHelper.UpdateChapterTags(chapter, tagNames, unitOfWork);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "There was an error updating the chapter tags");
+            logger.LogError(ex, "There was an error updating the chapter tags");
         }
     }
 
-    private async Task UpdateChapterPeopleAsync(Chapter chapter, IList<string> people, PersonRole role)
+    private async Task<Dictionary<string, Person>> LoadAndCreateMissingChapterPeople(IList<ParserInfo> parserInfos)
     {
-        try
-        {
-            await PersonHelper.UpdateChapterPeopleAsync(chapter, people, role, _unitOfWork);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "[ScannerService] There was an issue adding/updating a person");
-        }
+        var comicInfos = parserInfos.Select(pi => pi.ComicInfo).WhereNotNull().ToList();
+
+        var allPeople = Enum.GetValues<PersonRole>()
+            .SelectMany(role => comicInfos.SelectMany(ci => ci.GetPeopleForRole(role)))
+            .Select(person => new {Name = person, NormalizaedName = person.ToNormalized()})
+            .DistinctBy(person => person.NormalizaedName)
+            .ToList();
+
+        var normalizedNames = allPeople.Select(p => p.NormalizaedName).ToList();
+
+        var peopleInDatabase = await unitOfWork.PersonRepository.GetPeopleByNames(normalizedNames);
+        var existingPeopleDict = PersonHelper.ConstructNameAndAliasDictionary(peopleInDatabase);
+
+        var peopleToAdd = allPeople
+            .Where(p => !existingPeopleDict.ContainsKey(p.NormalizaedName))
+            .Select(p => new PersonBuilder(p.Name).Build())
+            .ToList();
+
+        await unitOfWork.DataContext.Person.AddRangeAsync(peopleToAdd);
+
+        peopleToAdd.ForEach(p => existingPeopleDict[p.NormalizedName] = p);
+
+        return existingPeopleDict;
     }
 }

--- a/API/Services/Tasks/Scanner/ProcessSeries.cs
+++ b/API/Services/Tasks/Scanner/ProcessSeries.cs
@@ -31,7 +31,15 @@ namespace API.Services.Tasks.Scanner;
 
 public interface IProcessSeries
 {
-    Task<int?> ProcessSeriesAsync(MetadataSettingsDto settings, IList<ParserInfo> parsedInfos, Library library, int totalToProcess, bool forceUpdate = false);
+    Task<int?> ProcessSeriesAsync(MetadataSettingsDto settings, IList<ParserInfo> parsedInfos, ProcessSeriesArgs args);
+}
+
+public class ProcessSeriesArgs
+{
+    public required Library Library { get; init; }
+    public required int TotalToProcess { get; init; }
+    public required int LeftToProcess { get; init; }
+    public required bool ForceUpdate { get; init; }
 }
 
 /// <summary>
@@ -72,16 +80,18 @@ public class ProcessSeries : IProcessSeries
     }
 
 
-    public async Task<int?> ProcessSeriesAsync(MetadataSettingsDto settings, IList<ParserInfo> parsedInfos, Library library, int totalToProcess, bool forceUpdate = false)
+    public async Task<int?> ProcessSeriesAsync(MetadataSettingsDto settings, IList<ParserInfo> parsedInfos, ProcessSeriesArgs args)
     {
         if (!parsedInfos.Any()) return null;
+
+        var library = args.Library;
 
         var seriesAdded = false;
         var scanWatch = Stopwatch.StartNew();
         var seriesName = parsedInfos[0].Series;
         await _eventHub.SendMessageAsync(MessageFactory.NotificationProgress,
-            MessageFactory.LibraryScanProgressEvent(library.Name, ProgressEventType.Updated, seriesName, totalToProcess));
-        _logger.LogInformation("[ScannerService] Beginning series update on {SeriesName}, Forced: {ForceUpdate}", seriesName, forceUpdate);
+            MessageFactory.LibraryScanProgressEvent(library.Name, ProgressEventType.Updated, seriesName, args.LeftToProcess, args.TotalToProcess));
+        _logger.LogInformation("[ScannerService] Beginning series update on {SeriesName}, Forced: {ForceUpdate}", seriesName, args.ForceUpdate);
 
         // Check if there is a Series
         var firstInfo = parsedInfos[0];
@@ -118,7 +128,7 @@ public class ProcessSeries : IProcessSeries
             // parsedInfos[0] is not the first volume or chapter. We need to find it using a ComicInfo check (as it uses firstParsedInfo for series sort)
             var firstParsedInfo = parsedInfos.FirstOrDefault(p => p.ComicInfo != null, firstInfo);
 
-            await UpdateVolumes(settings, series, parsedInfos, forceUpdate);
+            await UpdateVolumes(settings, series, parsedInfos, args.ForceUpdate);
             series.Pages = series.Volumes.Sum(v => v.Pages);
 
             series.NormalizedName = series.Name.ToNormalized();

--- a/API/Services/Tasks/Scanner/ProcessSeries.cs
+++ b/API/Services/Tasks/Scanner/ProcessSeries.cs
@@ -34,31 +34,31 @@ public interface IProcessSeries
     Task<int?> ProcessSeriesAsync(MetadataSettingsDto settings, IList<ParserInfo> parsedInfos, ProcessSeriesArgs args);
 }
 
-public class ProcessSeriesArgs
+public sealed record ProcessSeriesArgs
 {
     public required Library Library { get; init; }
     public required int TotalToProcess { get; init; }
     public required int LeftToProcess { get; init; }
-    public required bool ForceUpdate { get; init; }
+    public bool ForceUpdate { get; init; } = false;
 }
 
-internal class UpdateChapterArgs
+internal sealed record UpdateChapterArgs
 {
-    public required MetadataSettingsDto Settings { get; set; }
-    public required Series Series { get; set; }
-    public required Volume Volume { get; set; }
-    public required IList<ParserInfo> ParsedInfos { get; set; }
-    public required Dictionary<string, Person> DatabasePeople { get; set; }
-    public required bool ForceUpdate { get; set; }
+    public required MetadataSettingsDto Settings { get; init; }
+    public required Series Series { get; init; }
+    public required Volume Volume { get; init; }
+    public required IList<ParserInfo> ParsedInfos { get; init; }
+    public required Dictionary<string, Person> DatabasePeople { get; init; }
+    public bool ForceUpdate { get; init; } = false;
 }
 
-internal class UpdateChapterComicInfoArgs
+internal sealed record UpdateChapterComicInfoArgs
 {
-    public required MetadataSettingsDto Settings { get; set; }
-    public required Chapter Chapter { get; set; }
-    public required ComicInfo? ComicInfo { get; set; }
-    public required Dictionary<string, Person> DatabasePeople { get; set; }
-    public required bool ForceUpdate { get; set; }
+    public required MetadataSettingsDto Settings { get; init; }
+    public required Chapter Chapter { get; init; }
+    public required ComicInfo? ComicInfo { get; init; }
+    public required Dictionary<string, Person> DatabasePeople { get; init; }
+    public bool ForceUpdate { get; init; } = false;
 }
 
 /// <summary>

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -321,10 +321,7 @@ public class ScannerService : IScannerService
         var settings = await _unitOfWork.SettingsRepository.GetMetadataSettingDto();
 
         var toProcessList = toProcess.Select(k => parsedSeries[k]).ToList();
-        await ProcessParserInfo(settings, toProcessList, library.Id, bypassFolderOptimizationChecks);
-
-        await _eventHub.SendMessageAsync(MessageFactory.NotificationProgress,
-            MessageFactory.LibraryScanProgressEvent(library.Name, ProgressEventType.Ended, series.Name, 0));
+        await ProcessParserInfo(settings, toProcessList, library, bypassFolderOptimizationChecks);
 
         // Tell UI that this series is done
         await _eventHub.SendMessageAsync(MessageFactory.ScanSeries,
@@ -665,23 +662,28 @@ public class ScannerService : IScannerService
 
         _logger.LogInformation("[ScannerService] Found {SeriesCount} Series that need processing in {Time} ms", toProcess.Count, scanSw.ElapsedMilliseconds + scanElapsedTime);
 
-        var totalFiles = await ProcessParserInfo(settings, toProcess.Values.ToList(), library.Id, forceUpdate);
-
-        await _eventHub.SendMessageAsync(MessageFactory.NotificationProgress,
-            MessageFactory.FileScanProgressEvent(string.Empty, library.Name, ProgressEventType.Ended));
+        var totalFiles = await ProcessParserInfo(settings, toProcess.Values.ToList(), library, forceUpdate);
 
         _logger.LogInformation("[ScannerService] Finished scan in {ScanAndUpdateTime} milliseconds.", scanSw.ElapsedMilliseconds + scanElapsedTime);
 
         return totalFiles;
     }
 
-    private async Task<int> ProcessParserInfo(MetadataSettingsDto settings, IList<IList<ParserInfo>> toProcess, int libraryId, bool forceUpdate)
+    /// <summary>
+    /// Runs metadata updates (database heavy) and extra tasks (I/O heavy) in parallel
+    /// </summary>
+    /// <param name="settings"></param>
+    /// <param name="toProcess"></param>
+    /// <param name="library"></param>
+    /// <param name="forceUpdate"></param>
+    /// <returns>Total amount of processed files</returns>
+    private async Task<int> ProcessParserInfo(MetadataSettingsDto settings, IList<IList<ParserInfo>> toProcess, Library library, bool forceUpdate)
     {
         var channel = Channel.CreateUnbounded<int>();
 
         var serverSettings = await _unitOfWork.SettingsRepository.GetSettingsDtoAsync();
 
-        var dbTask = Task.Run(async () => await DbTasks(channel, settings, toProcess, libraryId, forceUpdate));
+        var dbTask = Task.Run(async () => await DbMetadataTask(channel, settings, toProcess, library.Id, library.Name, forceUpdate));
 
         var amountOfProcessors = Environment.ProcessorCount;
         var usingCount = Math.Max(1, amountOfProcessors / 2);
@@ -691,14 +693,14 @@ public class ScannerService : IScannerService
         IList<Task<long>> tasks = [];
         for (var i = 0; i < usingCount; i++)
         {
-            tasks.Add(Task.Run(async () => await IoTasks(channel, serverSettings, libraryId, forceUpdate)));
+            tasks.Add(Task.Run(async () => await ExtraWorkTask(channel, serverSettings, library.Id, forceUpdate)));
         }
 
         tasks.Add(dbTask);
 
         await Task.WhenAll(tasks);
 
-        var totalIoTime = tasks.Select(t => t.Result).Sum() - dbTask.Result;
+        var totalIoTime = tasks.Select(t => t.Result).Sum();
         var avgTimePerThread = totalIoTime / usingCount;
         _logger.LogDebug("[ScannerService] Spend {Elapsed}ms processing covers & word count, {Average}ms per thread",
             totalIoTime, avgTimePerThread);
@@ -706,7 +708,15 @@ public class ScannerService : IScannerService
         return (int) dbTask.Result;
     }
 
-    private async Task<long> IoTasks(Channel<int> channel, ServerSettingDto serverSettings, int libraryId, bool forceUpdate)
+    /// <summary>
+    /// A thread handling cover generation and word count. Completes when the channel completes
+    /// </summary>
+    /// <param name="channel"></param>
+    /// <param name="serverSettings"></param>
+    /// <param name="libraryId"></param>
+    /// <param name="forceUpdate"></param>
+    /// <returns></returns>
+    private async Task<long> ExtraWorkTask(Channel<int> channel, ServerSettingDto serverSettings, int libraryId, bool forceUpdate)
     {
         var sw = Stopwatch.StartNew();
 
@@ -723,7 +733,17 @@ public class ScannerService : IScannerService
         return sw.ElapsedMilliseconds;
     }
 
-    private async Task<long> DbTasks(Channel<int> channel, MetadataSettingsDto settings, IList<IList<ParserInfo>> toProcess, int libraryId, bool forceUpdate)
+    /// <summary>
+    /// Processes all founds series sequentially, and writes the seriesIds to the channel afterwards
+    /// </summary>
+    /// <param name="channel"></param>
+    /// <param name="settings"></param>
+    /// <param name="toProcess"></param>
+    /// <param name="libraryId"></param>
+    /// <param name="libraryName"></param>
+    /// <param name="forceUpdate"></param>
+    /// <returns>The total amount of processed files</returns>
+    private async Task<long> DbMetadataTask(Channel<int> channel, MetadataSettingsDto settings, IList<IList<ParserInfo>> toProcess, int libraryId, string libraryName, bool forceUpdate)
     {
         var totalFiles = 0;
         var seriesLeftToProcess = toProcess.Count;
@@ -764,11 +784,13 @@ public class ScannerService : IScannerService
             channel.Writer.Complete();
         }
 
-        _logger.LogDebug("[ScannerService] Finished writing metadata for {Count} series in {Elasped}ms", toProcess.Count, sw.ElapsedMilliseconds);
+        await _eventHub.SendMessageAsync(MessageFactory.NotificationProgress,
+            MessageFactory.FileScanProgressEvent(string.Empty, libraryName, ProgressEventType.Ended));
+
+        _logger.LogDebug("[ScannerService] Finished writing metadata for {Count} series in {Elapsed}ms", toProcess.Count, sw.ElapsedMilliseconds);
 
         return totalFiles;
     }
-
 
     private static void UpdateLastScanned(Library library)
     {

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -226,7 +226,9 @@ public class ScannerService : IScannerService
         var libraryPaths = library.Folders.Select(f => f.Path).ToList();
         if (await ShouldScanSeries(seriesId, library, libraryPaths, series, true) != ScanCancelReason.NoCancel)
         {
-            BackgroundJob.Enqueue(() => _metadataService.GenerateCoversForSeries(series.LibraryId, seriesId, false, false));
+            var serverSettings = await _unitOfWork.SettingsRepository.GetSettingsDtoAsync();
+
+            BackgroundJob.Enqueue(() => _metadataService.GenerateCoversForSeries(serverSettings, series.LibraryId, seriesId, false, false));
             BackgroundJob.Enqueue(() => _wordCountAnalyzerService.ScanSeries(library.Id, seriesId, bypassFolderOptimizationChecks));
             return;
         }
@@ -686,13 +688,15 @@ public class ScannerService : IScannerService
 
     private async Task IoTasks(Channel<int> channel, int libraryId, bool forceUpdate)
     {
+        var serverSettings = await _unitOfWork.SettingsRepository.GetSettingsDtoAsync();
+
         await foreach (var seriesId in channel.Reader.ReadAllAsync())
         {
             using var scope = _scopeFactory.CreateScope();
             var metadataService = scope.ServiceProvider.GetRequiredService<IMetadataService>();
             var wordCountAnalyzerService = scope.ServiceProvider.GetRequiredService<IWordCountAnalyzerService>();
 
-            await metadataService.GenerateCoversForSeries(libraryId, seriesId, false, false);
+            await metadataService.GenerateCoversForSeries(serverSettings, libraryId, seriesId, false, false);
             await wordCountAnalyzerService.ScanSeries(libraryId, seriesId, forceUpdate);
         }
     }

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -708,6 +708,7 @@ public class ScannerService : IScannerService
     {
         var totalFiles = 0;
         var seriesLeftToProcess = toProcess.Count;
+        var totalSeriesToProcess = toProcess.Count;
 
         foreach (var pSeries in toProcess)
         {
@@ -720,7 +721,14 @@ public class ScannerService : IScannerService
             // Library needs to be returned from the used UnitOfWork
             var library = (await unitOfWork.LibraryRepository.GetLibraryForIdAsync(libraryId, LibraryIncludes.Folders | LibraryIncludes.FileTypes | LibraryIncludes.ExcludePatterns))!;
 
-            var seriesId = await processSeries.ProcessSeriesAsync(settings, pSeries, library, seriesLeftToProcess, forceUpdate);
+            var seriesId = await processSeries.ProcessSeriesAsync(settings, pSeries, new ProcessSeriesArgs
+            {
+                Library = library,
+                LeftToProcess =  seriesLeftToProcess,
+                TotalToProcess = totalSeriesToProcess,
+                ForceUpdate = forceUpdate,
+            });
+
             if (seriesId != null)
             {
                 await channel.Writer.WriteAsync(seriesId.Value);

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -672,7 +672,7 @@ public class ScannerService : IScannerService
         await _eventHub.SendMessageAsync(MessageFactory.NotificationProgress,
             MessageFactory.FileScanProgressEvent(string.Empty, library.Name, ProgressEventType.Ended));
 
-        _logger.LogInformation("[ScannerService] Finished file scan in {ScanAndUpdateTime} milliseconds. Updating database", scanSw.ElapsedMilliseconds + scanElapsedTime);
+        _logger.LogInformation("[ScannerService] Finished scan in {ScanAndUpdateTime} milliseconds.", scanSw.ElapsedMilliseconds + scanElapsedTime);
 
         return totalFiles;
     }
@@ -684,15 +684,34 @@ public class ScannerService : IScannerService
         var serverSettings = await _unitOfWork.SettingsRepository.GetSettingsDtoAsync();
 
         var dbTask = Task.Run(async () => await DbTasks(channel, settings, toProcess, libraryId, forceUpdate));
-        var ioTask = Task.Run(async () => await IoTasks(channel, serverSettings, libraryId, forceUpdate));
 
-        await Task.WhenAll(dbTask, ioTask);
+        var amountOfProcessors = Environment.ProcessorCount;
+        var usingCount = Math.Max(1, amountOfProcessors / 2);
+        _logger.LogDebug("[ScannerService] Going to use {Cores} / {TotalCores} threads for I/O tasks this scan",
+            usingCount, amountOfProcessors);
 
-        return dbTask.Result;
+        IList<Task<long>> tasks = [];
+        for (var i = 0; i < usingCount; i++)
+        {
+            tasks.Add(Task.Run(async () => await IoTasks(channel, serverSettings, libraryId, forceUpdate)));
+        }
+
+        tasks.Add(dbTask);
+
+        await Task.WhenAll(tasks);
+
+        var totalIoTime = tasks.Select(t => t.Result).Sum() - dbTask.Result;
+        var avgTimePerThread = totalIoTime / usingCount;
+        _logger.LogDebug("[ScannerService] Spend {Elapsed}ms processing covers & word count, {Average}ms per thread",
+            totalIoTime, avgTimePerThread);
+
+        return (int) dbTask.Result;
     }
 
-    private async Task IoTasks(Channel<int> channel, ServerSettingDto serverSettings, int libraryId, bool forceUpdate)
+    private async Task<long> IoTasks(Channel<int> channel, ServerSettingDto serverSettings, int libraryId, bool forceUpdate)
     {
+        var sw = Stopwatch.StartNew();
+
         await foreach (var seriesId in channel.Reader.ReadAllAsync())
         {
             using var scope = _scopeFactory.CreateScope();
@@ -702,13 +721,16 @@ public class ScannerService : IScannerService
             await metadataService.GenerateCoversForSeries(serverSettings, libraryId, seriesId, false, false);
             await wordCountAnalyzerService.ScanSeries(libraryId, seriesId, forceUpdate);
         }
+
+        return sw.ElapsedMilliseconds;
     }
 
-    private async Task<int> DbTasks(Channel<int> channel, MetadataSettingsDto settings, IList<IList<ParserInfo>> toProcess, int libraryId, bool forceUpdate)
+    private async Task<long> DbTasks(Channel<int> channel, MetadataSettingsDto settings, IList<IList<ParserInfo>> toProcess, int libraryId, bool forceUpdate)
     {
         var totalFiles = 0;
         var seriesLeftToProcess = toProcess.Count;
         var totalSeriesToProcess = toProcess.Count;
+        var sw = Stopwatch.StartNew();
 
         try
         {
@@ -743,6 +765,8 @@ public class ScannerService : IScannerService
         {
             channel.Writer.Complete();
         }
+
+        _logger.LogDebug("[ScannerService] Finished writing metadata for {Count} series in {Elasped}ms", toProcess.Count, sw.ElapsedMilliseconds);
 
         return totalFiles;
     }

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -5,9 +5,11 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading;
+using System.Threading.Channels;
 using System.Threading.Tasks;
 using API.Data;
 using API.Data.Repositories;
+using API.DTOs.KavitaPlus.Metadata;
 using API.Entities;
 using API.Entities.Enums;
 using API.Extensions;
@@ -313,25 +315,16 @@ public class ScannerService : IScannerService
             key.NormalizedName.Equals(series.OriginalName?.ToNormalized()))
             .ToList();
 
-        var seriesLeftToProcess = toProcess.Count;
-        foreach (var pSeries in toProcess)
-        {
-            // Process Series
-            var seriesProcessStopWatch = Stopwatch.StartNew();
-            var settings = await _unitOfWork.SettingsRepository.GetMetadataSettingDto();
+        var settings = await _unitOfWork.SettingsRepository.GetMetadataSettingDto();
 
-            using var scope = _scopeFactory.CreateScope();
-            var unitOfWork =  scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
-            var processSeries = scope.ServiceProvider.GetRequiredService<IProcessSeries>();
+        var channel = Channel.CreateUnbounded<int>();
 
-            // Library needs to be returned from the used UnitOfWork
-            library = (await unitOfWork.LibraryRepository.GetLibraryForIdAsync(library.Id, LibraryIncludes.Folders | LibraryIncludes.FileTypes | LibraryIncludes.ExcludePatterns))!;
+        var toProcessList = toProcess.Select(k => parsedSeries[k]).ToList();
+        var dbWriter = ProcessParserInfo(settings, toProcessList, library.Id, bypassFolderOptimizationChecks, channel);
 
-            await processSeries.ProcessSeriesAsync(settings, parsedSeries[pSeries], library, seriesLeftToProcess, bypassFolderOptimizationChecks);
+        var ioWriter = IoTasks(channel, library.Id, bypassFolderOptimizationChecks);
 
-            _logger.LogTrace("[TIME] Kavita took {Time} ms to process {SeriesName}", seriesProcessStopWatch.ElapsedMilliseconds, parsedSeries[pSeries][0].Series);
-            seriesLeftToProcess--;
-        }
+        await Task.WhenAll(dbWriter, ioWriter);
 
         await _eventHub.SendMessageAsync(MessageFactory.NotificationProgress,
             MessageFactory.LibraryScanProgressEvent(library.Name, ProgressEventType.Ended, series.Name, 0));
@@ -674,13 +667,44 @@ public class ScannerService : IScannerService
             await CreateAllTagsAsync(processedTags);
         }
 
+        _logger.LogInformation("[ScannerService] Found {SeriesCount} Series that need processing in {Time} ms", toProcess.Count, scanSw.ElapsedMilliseconds + scanElapsedTime);
+
+        var channel = Channel.CreateUnbounded<int>();
+
+        var dbWriter = ProcessParserInfo(settings, toProcess.Values.ToList(), library.Id, forceUpdate, channel);
+        var ioWriter = IoTasks(channel, library.Id, forceUpdate);
+
+        await Task.WhenAll(dbWriter, ioWriter);
+
+        await _eventHub.SendMessageAsync(MessageFactory.NotificationProgress,
+            MessageFactory.FileScanProgressEvent(string.Empty, library.Name, ProgressEventType.Ended));
+
+        _logger.LogInformation("[ScannerService] Finished file scan in {ScanAndUpdateTime} milliseconds. Updating database", scanElapsedTime);
+
+        return dbWriter.Result;
+    }
+
+    private async Task IoTasks(Channel<int> channel, int libraryId, bool forceUpdate)
+    {
+        await foreach (var seriesId in channel.Reader.ReadAllAsync())
+        {
+            using var scope = _scopeFactory.CreateScope();
+            var metadataService = scope.ServiceProvider.GetRequiredService<IMetadataService>();
+            var wordCountAnalyzerService = scope.ServiceProvider.GetRequiredService<IWordCountAnalyzerService>();
+
+            await metadataService.GenerateCoversForSeries(libraryId, seriesId, false, false);
+            await wordCountAnalyzerService.ScanSeries(libraryId, seriesId, forceUpdate);
+        }
+    }
+
+    private async Task<int> ProcessParserInfo(MetadataSettingsDto settings, IList<IList<ParserInfo>> toProcess, int libraryId, bool forceUpdate, Channel<int> channel)
+    {
         var totalFiles = 0;
         var seriesLeftToProcess = toProcess.Count;
-        _logger.LogInformation("[ScannerService] Found {SeriesCount} Series that need processing in {Time} ms", toProcess.Count, scanSw.ElapsedMilliseconds + scanElapsedTime);
 
         foreach (var pSeries in toProcess)
         {
-            totalFiles += pSeries.Value.Count;
+            totalFiles += pSeries.Count;
             var seriesProcessStopWatch = Stopwatch.StartNew();
 
             using var scope = _scopeFactory.CreateScope();
@@ -688,19 +712,15 @@ public class ScannerService : IScannerService
             var processSeries = scope.ServiceProvider.GetRequiredService<IProcessSeries>();
 
             // Library needs to be returned from the used UnitOfWork
-            library = (await unitOfWork.LibraryRepository.GetLibraryForIdAsync(library.Id, LibraryIncludes.Folders | LibraryIncludes.FileTypes | LibraryIncludes.ExcludePatterns))!;
+            var library = (await unitOfWork.LibraryRepository.GetLibraryForIdAsync(libraryId, LibraryIncludes.Folders | LibraryIncludes.FileTypes | LibraryIncludes.ExcludePatterns))!;
 
-            await processSeries.ProcessSeriesAsync(settings, pSeries.Value, library, seriesLeftToProcess, forceUpdate);
+            await processSeries.ProcessSeriesAsync(settings, channel, pSeries, library, seriesLeftToProcess, forceUpdate);
 
-            _logger.LogTrace("[TIME] Kavita took {Time} ms to process {SeriesName}", seriesProcessStopWatch.ElapsedMilliseconds, pSeries.Value[0].Series);
+            _logger.LogTrace("[TIME] Kavita took {Time} ms to process {SeriesName}", seriesProcessStopWatch.ElapsedMilliseconds, pSeries[0].Series);
             seriesLeftToProcess--;
         }
 
-
-        await _eventHub.SendMessageAsync(MessageFactory.NotificationProgress,
-            MessageFactory.FileScanProgressEvent(string.Empty, library.Name, ProgressEventType.Ended));
-
-        _logger.LogInformation("[ScannerService] Finished file scan in {ScanAndUpdateTime} milliseconds. Updating database", scanElapsedTime);
+        channel.Writer.Complete();
 
         return totalFiles;
     }

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -683,8 +683,8 @@ public class ScannerService : IScannerService
 
         var serverSettings = await _unitOfWork.SettingsRepository.GetSettingsDtoAsync();
 
-        var dbTask = DbTasks(settings, toProcess, libraryId, forceUpdate, channel);
-        var ioTask = IoTasks(channel, serverSettings, libraryId, forceUpdate);
+        var dbTask = Task.Run(async () => await DbTasks(settings, toProcess, libraryId, forceUpdate, channel));
+        var ioTask = Task.Run(async () => await IoTasks(channel, serverSettings, libraryId, forceUpdate));
 
         await Task.WhenAll(dbTask, ioTask);
 

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -683,7 +683,7 @@ public class ScannerService : IScannerService
 
         var serverSettings = await _unitOfWork.SettingsRepository.GetSettingsDtoAsync();
 
-        var dbTask = Task.Run(async () => await DbTasks(settings, toProcess, libraryId, forceUpdate, channel));
+        var dbTask = Task.Run(async () => await DbTasks(channel, settings, toProcess, libraryId, forceUpdate));
         var ioTask = Task.Run(async () => await IoTasks(channel, serverSettings, libraryId, forceUpdate));
 
         await Task.WhenAll(dbTask, ioTask);
@@ -704,7 +704,7 @@ public class ScannerService : IScannerService
         }
     }
 
-    private async Task<int> DbTasks(MetadataSettingsDto settings, IList<IList<ParserInfo>> toProcess, int libraryId, bool forceUpdate, Channel<int> channel)
+    private async Task<int> DbTasks(Channel<int> channel, MetadataSettingsDto settings, IList<IList<ParserInfo>> toProcess, int libraryId, bool forceUpdate)
     {
         var totalFiles = 0;
         var seriesLeftToProcess = toProcess.Count;

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using API.Data;
 using API.Data.Repositories;
 using API.DTOs.KavitaPlus.Metadata;
+using API.DTOs.Settings;
 using API.Entities;
 using API.Entities.Enums;
 using API.Extensions;
@@ -319,17 +320,12 @@ public class ScannerService : IScannerService
 
         var settings = await _unitOfWork.SettingsRepository.GetMetadataSettingDto();
 
-        var channel = Channel.CreateUnbounded<int>();
-
         var toProcessList = toProcess.Select(k => parsedSeries[k]).ToList();
-        var dbWriter = ProcessParserInfo(settings, toProcessList, library.Id, bypassFolderOptimizationChecks, channel);
-
-        var ioWriter = IoTasks(channel, library.Id, bypassFolderOptimizationChecks);
-
-        await Task.WhenAll(dbWriter, ioWriter);
+        await ProcessParserInfo(settings, toProcessList, library.Id, bypassFolderOptimizationChecks);
 
         await _eventHub.SendMessageAsync(MessageFactory.NotificationProgress,
             MessageFactory.LibraryScanProgressEvent(library.Name, ProgressEventType.Ended, series.Name, 0));
+
         // Tell UI that this series is done
         await _eventHub.SendMessageAsync(MessageFactory.ScanSeries,
             MessageFactory.ScanSeriesEvent(library.Id, seriesId, series.Name));
@@ -671,25 +667,32 @@ public class ScannerService : IScannerService
 
         _logger.LogInformation("[ScannerService] Found {SeriesCount} Series that need processing in {Time} ms", toProcess.Count, scanSw.ElapsedMilliseconds + scanElapsedTime);
 
-        var channel = Channel.CreateUnbounded<int>();
-
-        var dbWriter = ProcessParserInfo(settings, toProcess.Values.ToList(), library.Id, forceUpdate, channel);
-        var ioWriter = IoTasks(channel, library.Id, forceUpdate);
-
-        await Task.WhenAll(dbWriter, ioWriter);
+        var totalFiles = await ProcessParserInfo(settings, toProcess.Values.ToList(), library.Id, forceUpdate);
 
         await _eventHub.SendMessageAsync(MessageFactory.NotificationProgress,
             MessageFactory.FileScanProgressEvent(string.Empty, library.Name, ProgressEventType.Ended));
 
-        _logger.LogInformation("[ScannerService] Finished file scan in {ScanAndUpdateTime} milliseconds. Updating database", scanElapsedTime);
+        _logger.LogInformation("[ScannerService] Finished file scan in {ScanAndUpdateTime} milliseconds. Updating database", scanSw.ElapsedMilliseconds + scanElapsedTime);
 
-        return dbWriter.Result;
+        return totalFiles;
     }
 
-    private async Task IoTasks(Channel<int> channel, int libraryId, bool forceUpdate)
+    private async Task<int> ProcessParserInfo(MetadataSettingsDto settings, IList<IList<ParserInfo>> toProcess, int libraryId, bool forceUpdate)
     {
+        var channel = Channel.CreateUnbounded<int>();
+
         var serverSettings = await _unitOfWork.SettingsRepository.GetSettingsDtoAsync();
 
+        var dbTask = DbTasks(settings, toProcess, libraryId, forceUpdate, channel);
+        var ioTask = IoTasks(channel, serverSettings, libraryId, forceUpdate);
+
+        await Task.WhenAll(dbTask, ioTask);
+
+        return dbTask.Result;
+    }
+
+    private async Task IoTasks(Channel<int> channel, ServerSettingDto serverSettings, int libraryId, bool forceUpdate)
+    {
         await foreach (var seriesId in channel.Reader.ReadAllAsync())
         {
             using var scope = _scopeFactory.CreateScope();
@@ -701,7 +704,7 @@ public class ScannerService : IScannerService
         }
     }
 
-    private async Task<int> ProcessParserInfo(MetadataSettingsDto settings, IList<IList<ParserInfo>> toProcess, int libraryId, bool forceUpdate, Channel<int> channel)
+    private async Task<int> DbTasks(MetadataSettingsDto settings, IList<IList<ParserInfo>> toProcess, int libraryId, bool forceUpdate, Channel<int> channel)
     {
         var totalFiles = 0;
         var seriesLeftToProcess = toProcess.Count;
@@ -709,7 +712,6 @@ public class ScannerService : IScannerService
         foreach (var pSeries in toProcess)
         {
             totalFiles += pSeries.Count;
-            var seriesProcessStopWatch = Stopwatch.StartNew();
 
             using var scope = _scopeFactory.CreateScope();
             var unitOfWork =  scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
@@ -718,9 +720,12 @@ public class ScannerService : IScannerService
             // Library needs to be returned from the used UnitOfWork
             var library = (await unitOfWork.LibraryRepository.GetLibraryForIdAsync(libraryId, LibraryIncludes.Folders | LibraryIncludes.FileTypes | LibraryIncludes.ExcludePatterns))!;
 
-            await processSeries.ProcessSeriesAsync(settings, channel, pSeries, library, seriesLeftToProcess, forceUpdate);
+            var seriesId = await processSeries.ProcessSeriesAsync(settings, pSeries, library, seriesLeftToProcess, forceUpdate);
+            if (seriesId != null)
+            {
+                await channel.Writer.WriteAsync(seriesId.Value);
+            }
 
-            _logger.LogTrace("[TIME] Kavita took {Time} ms to process {SeriesName}", seriesProcessStopWatch.ElapsedMilliseconds, pSeries[0].Series);
             seriesLeftToProcess--;
         }
 

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -710,34 +710,39 @@ public class ScannerService : IScannerService
         var seriesLeftToProcess = toProcess.Count;
         var totalSeriesToProcess = toProcess.Count;
 
-        foreach (var pSeries in toProcess)
+        try
         {
-            totalFiles += pSeries.Count;
-
-            using var scope = _scopeFactory.CreateScope();
-            var unitOfWork =  scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
-            var processSeries = scope.ServiceProvider.GetRequiredService<IProcessSeries>();
-
-            // Library needs to be returned from the used UnitOfWork
-            var library = (await unitOfWork.LibraryRepository.GetLibraryForIdAsync(libraryId, LibraryIncludes.Folders | LibraryIncludes.FileTypes | LibraryIncludes.ExcludePatterns))!;
-
-            var seriesId = await processSeries.ProcessSeriesAsync(settings, pSeries, new ProcessSeriesArgs
+            foreach (var pSeries in toProcess)
             {
-                Library = library,
-                LeftToProcess =  seriesLeftToProcess,
-                TotalToProcess = totalSeriesToProcess,
-                ForceUpdate = forceUpdate,
-            });
+                totalFiles += pSeries.Count;
 
-            if (seriesId != null)
-            {
-                await channel.Writer.WriteAsync(seriesId.Value);
+                using var scope = _scopeFactory.CreateScope();
+                var unitOfWork = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+                var processSeries = scope.ServiceProvider.GetRequiredService<IProcessSeries>();
+
+                // Library needs to be returned from the used UnitOfWork
+                var library = (await unitOfWork.LibraryRepository.GetLibraryForIdAsync(libraryId, LibraryIncludes.Folders | LibraryIncludes.FileTypes | LibraryIncludes.ExcludePatterns))!;
+
+                var seriesId = await processSeries.ProcessSeriesAsync(settings, pSeries, new ProcessSeriesArgs
+                {
+                    Library = library,
+                    LeftToProcess = seriesLeftToProcess,
+                    TotalToProcess = totalSeriesToProcess,
+                    ForceUpdate = forceUpdate,
+                });
+
+                if (seriesId != null)
+                {
+                    await channel.Writer.WriteAsync(seriesId.Value);
+                }
+
+                seriesLeftToProcess--;
             }
-
-            seriesLeftToProcess--;
         }
-
-        channel.Writer.Complete();
+        finally // Ensure the channel is closed in case of an exception that we didn't expect
+        {
+            channel.Writer.Complete();
+        }
 
         return totalFiles;
     }

--- a/API/Services/Tasks/ScannerService.cs
+++ b/API/Services/Tasks/ScannerService.cs
@@ -643,20 +643,18 @@ public class ScannerService : IScannerService
             var allGenres = toProcess
                 .SelectMany(s => s.Value
                     .SelectMany(p => p.ComicInfo?.Genre?
-                                         .Split(",", StringSplitOptions.RemoveEmptyEntries)
-                                         .Select(g => g.Trim())
-                                         .Where(g => !string.IsNullOrWhiteSpace(g))
+                                         .Split(",", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
                                      ?? []))
-                .Distinct().ToList();
+                .Distinct()
+                .ToList();
 
             var allTags = toProcess
                 .SelectMany(s => s.Value
                     .SelectMany(p => p.ComicInfo?.Tags?
-                                         .Split(",", StringSplitOptions.RemoveEmptyEntries)
-                                         .Select(g => g.Trim())
-                                         .Where(g => !string.IsNullOrWhiteSpace(g))
+                                         .Split(",", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
                                      ?? []))
-                .Distinct().ToList();
+                .Distinct()
+                .ToList();
 
             ExternalMetadataService.GenerateExternalGenreAndTagsList(allGenres, allTags, settings,
                 out var processedTags, out var processedGenres);

--- a/API/SignalR/MessageFactory.cs
+++ b/API/SignalR/MessageFactory.cs
@@ -513,21 +513,27 @@ public static class MessageFactory
     /// <param name="libraryName"></param>
     /// <param name="eventType"></param>
     /// <param name="seriesName"></param>
+    /// <param name="leftToProcess"></param>
+    /// <param name="totalToProcess"></param>
     /// <returns></returns>
-    public static SignalRMessage LibraryScanProgressEvent(string libraryName, string eventType, string seriesName = "", int? totalToProcess = null)
+    public static SignalRMessage LibraryScanProgressEvent(string libraryName, string eventType, string seriesName = "", int? leftToProcess = null, int? totalToProcess = null)
     {
+        var hasProgress = totalToProcess.HasValue && leftToProcess.HasValue;
+
         return new SignalRMessage()
         {
             Name = ScanProgress,
             Title = $"Processing {seriesName}",
             SubTitle = seriesName,
             EventType = eventType,
-            Progress = ProgressType.Indeterminate,
+            Progress = hasProgress ?  ProgressType.Determinate : ProgressType.Indeterminate,
             Body = new
             {
                 SeriesName = seriesName,
                 LibraryName = libraryName,
-                LeftToProcess = totalToProcess
+                LeftToProcess = leftToProcess,
+                TotalToProcess = totalToProcess,
+                Progress = hasProgress ? (totalToProcess - leftToProcess) / (float) totalToProcess.Value : null,
             }
         };
     }

--- a/UI/Web/src/app/_services/series.service.ts
+++ b/UI/Web/src/app/_services/series.service.ts
@@ -106,8 +106,11 @@ export class SeriesService {
     );
   }
 
-  getRecentlyUpdatedSeries() {
-    return this.httpClient.post<SeriesGroup[]>(this.baseUrl + 'series/recently-updated-series', {});
+  getRecentlyUpdatedSeries(pageNum?: number, itemsPerPage?: number) {
+    let params = new HttpParams();
+    params = this.utilityService.addPaginationIfExists(params, pageNum, itemsPerPage);
+
+    return this.httpClient.post<SeriesGroup[]>(this.baseUrl + 'series/recently-updated-series', {}, {params});
   }
 
   getWantToRead(pageNum?: number, itemsPerPage?: number, filter?: FilterV2<FilterField>): Observable<PaginatedResult<Series[]>> {

--- a/UI/Web/src/app/dashboard/_components/dashboard.component.ts
+++ b/UI/Web/src/app/dashboard/_components/dashboard.component.ts
@@ -158,7 +158,8 @@ export class DashboardComponent implements OnInit {
                 .pipe(map(d => d.result), tap(() => this.increment()), takeUntilDestroyed(this.destroyRef), shareReplay({bufferSize: 1, refCount: true}));
             break;
           case StreamType.RecentlyUpdated:
-            s.api = this.seriesService.getRecentlyUpdatedSeries().pipe(tap(() => this.increment()), takeUntilDestroyed(this.destroyRef), shareReplay({bufferSize: 1, refCount: true}));
+            s.api = this.seriesService.getRecentlyUpdatedSeries(1, 20)
+              .pipe(tap(() => this.increment()), takeUntilDestroyed(this.destroyRef), shareReplay({bufferSize: 1, refCount: true}));
             break;
           case StreamType.SmartFilter:
             s.api = this.filterUtilityService.decodeFilter(s.smartFilterEncoded!).pipe(

--- a/UI/Web/src/app/nav/_components/events-widget/events-widget.component.html
+++ b/UI/Web/src/app/nav/_components/events-widget/events-widget.component.html
@@ -55,7 +55,7 @@
                 }
                 @if (message.name === EVENTS.ScanProgress && message.body.leftToProcess > 0) {
                   <div class="accent-text mb-1" [title]="t('left-to-process', {leftToProcess: message.body.leftToProcess})">
-                    {{t('left-to-process', {leftToProcess: message.body.leftToProcess})}}
+                    {{t('left-to-process', {leftToProcess: message.body.leftToProcess, totalToProcess: message.body.totalToProcess})}}
                   </div>
                 }
                 <div class="progress-container row g-0 align-items-center">
@@ -81,6 +81,11 @@
                          aria-valuemin="0" aria-valuemax="100"></div>
                   </div>
                 </div>
+                @if (message.name === EVENTS.ScanProgress && message.body.leftToProcess > 0) {
+                  <div class="accent-text mb-1" [title]="t('left-to-process', {leftToProcess: message.body.leftToProcess})">
+                    {{t('left-to-process', {leftToProcess: message.body.leftToProcess, totalToProcess: message.body.totalToProcess})}}
+                  </div>
+                }
               </li>
             }
           }

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -2113,7 +2113,7 @@
         "users-online-count": "{{num}} Users online",
         "active-events-title": "Active Events:",
         "no-data": "Not much going on here",
-        "left-to-process": "Left to Process: {{leftToProcess}}",
+        "left-to-process": "Left to Process: {{leftToProcess}} / {{totalToProcess}}",
         "download-in-queue": "{{num}} downloads in Queue"
     },
 


### PR DESCRIPTION
# Changed
- Changed: Run metadata saving, and extra work on separate threads during the scan loop
- Changed: Show a progress bar in the UI for the scan
- Changed: Cover UI updates will now have a progress bar with information in it
- Changed: Massively improve the performance of updating a series during the scan loop

# Fixed
- Fixed: Fixed recently updated not using pagination, causing the dashboard to become unresponsive when a large amount of series were recently added (#4177)
- Fixed: Fixed some library settings not saving on creation. (Closes #4198 & #4186)

Closes #2391 (from early testing of the last PR)
