### PR TITLE
Fix container process ignoring signals, preventing clean stop

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,7 +30,7 @@ fi
 echo "Starting Kavita"
 echo ls -l "/kavita/config/appsettings.json"
 
-./Kavita
+exec ./Kavita
 
 #if [[ "$PUID" -eq 0 ]]; then
 #    # Run as root


### PR DESCRIPTION
# Fixed
- Fixed: Fixed container process ignoring signals, notably preventing cleanly stopping the container with `docker stop` or `podman stop`