### PR TITLE
Feature/pdf render changeable resolution

### DIFF
--- a/API.Tests/Services/BookServiceTests.cs
+++ b/API.Tests/Services/BookServiceTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO;
 using System.IO.Abstractions;
 using System.Threading.Tasks;
+using API.Data;
 using API.Entities.Enums;
 using API.Services;
 using API.Services.Tasks.Scanner.Parser;
@@ -20,7 +21,7 @@ public class BookServiceTests
         var directoryService = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), new FileSystem());
         _bookService = new BookService(_logger, directoryService,
             new ImageService(Substitute.For<ILogger<ImageService>>(), directoryService)
-            , Substitute.For<IMediaErrorService>());
+            , Substitute.For<IMediaErrorService>(), Substitute.For<IUnitOfWork>());
     }
 
     [Theory]

--- a/API/DTOs/Settings/ServerSettingDTO.cs
+++ b/API/DTOs/Settings/ServerSettingDTO.cs
@@ -88,6 +88,10 @@ public sealed record ServerSettingDto
     /// </summary>
     public CoverImageSize CoverImageSize { get; set; }
     /// <summary>
+    /// How large rendered PDF images should be
+    /// </summary>
+    public PdfRenderResolution PdfRenderResolution { get; set; }
+    /// <summary>
     /// SMTP Configuration
     /// </summary>
     public SmtpConfigDto SmtpConfig { get; set; }

--- a/API/Data/Seed.cs
+++ b/API/Data/Seed.cs
@@ -405,6 +405,7 @@ public static class Seed
                 new() {Key = ServerSettingKey.OnDeckProgressDays, Value = "30"},
                 new() {Key = ServerSettingKey.OnDeckUpdateDays, Value = "7"},
                 new() {Key = ServerSettingKey.CoverImageSize, Value = nameof(CoverImageSize.Default)},
+                new() {Key = ServerSettingKey.PdfRenderResolution, Value = nameof(PdfRenderResolution.Default)},
                 new() {
                     Key = ServerSettingKey.CacheSize, Value = Configuration.DefaultCacheMemory + string.Empty
                 }, // Not used from DB, but DB is sync with appSettings.json

--- a/API/Entities/Enums/PdfRenderResolution.cs
+++ b/API/Entities/Enums/PdfRenderResolution.cs
@@ -15,16 +15,3 @@ public enum PdfRenderResolution
     /// </summary>
     Ultra = 3,
 }
-public static class PdfRenderResolutionExtensions
-{
-    public static (int dim1, int dim2) GetDimensions(this PdfRenderResolution size)
-    {
-        return size switch
-        {
-            PdfRenderResolution.Default => (1080, 1920),
-            PdfRenderResolution.High => (1920, 2560),
-            PdfRenderResolution.Ultra => (2160, 3840),
-            _ => (1080, 1920)
-        };
-    }
-}

--- a/API/Entities/Enums/PdfRenderResolution.cs
+++ b/API/Entities/Enums/PdfRenderResolution.cs
@@ -1,0 +1,30 @@
+﻿namespace API.Entities.Enums;
+
+public enum PdfRenderResolution
+{
+    /// <summary>
+    /// Default Size: 1080x1920 (wxh)
+    /// </summary>
+    Default = 1,
+    /// <summary>
+    /// 1920x2560
+    /// </summary>
+    High = 2,
+    /// <summary>
+    /// 2160x3840
+    /// </summary>
+    Ultra = 3,
+}
+public static class PdfRenderResolutionExtensions
+{
+    public static (int dim1, int dim2) GetDimensions(this PdfRenderResolution size)
+    {
+        return size switch
+        {
+            PdfRenderResolution.Default => (1080, 1920),
+            PdfRenderResolution.High => (1920, 2560),
+            PdfRenderResolution.Ultra => (2160, 3840),
+            _ => (1080, 1920)
+        };
+    }
+}

--- a/API/Entities/Enums/PdfRenderResolutionExtensions.cs
+++ b/API/Entities/Enums/PdfRenderResolutionExtensions.cs
@@ -1,0 +1,15 @@
+﻿namespace API.Entities.Enums;
+
+public static class PdfRenderResolutionExtensions
+{
+    public static (int dim1, int dim2) GetDimensions(this PdfRenderResolution size)
+    {
+        return size switch
+        {
+            PdfRenderResolution.Default => (1080, 1920),
+            PdfRenderResolution.High => (1920, 2560),
+            PdfRenderResolution.Ultra => (2160, 3840),
+            _ => (1080, 1920)
+        };
+    }
+}

--- a/API/Entities/Enums/ServerSettingKey.cs
+++ b/API/Entities/Enums/ServerSettingKey.cs
@@ -202,5 +202,9 @@ public enum ServerSettingKey
     /// </summary>
     [Description("OidcConfiguration")]
     OidcConfiguration = 40,
-
+    /// <summary>
+    /// The resolution to render PDFs as when delivering them as images.
+    /// </summary>
+    [Description("pdfRenderResolution")]
+    PdfRenderResolution = 41,
 }

--- a/API/Helpers/Converters/ServerSettingConverter.cs
+++ b/API/Helpers/Converters/ServerSettingConverter.cs
@@ -82,6 +82,9 @@ public class ServerSettingConverter : ITypeConverter<IEnumerable<ServerSetting>,
                 case ServerSettingKey.CoverImageSize:
                     destination.CoverImageSize = Enum.Parse<CoverImageSize>(row.Value);
                     break;
+                case ServerSettingKey.PdfRenderResolution:
+                    destination.PdfRenderResolution = Enum.Parse<PdfRenderResolution>(row.Value);
+                    break;
                 case ServerSettingKey.EncodeMediaAs:
                     destination.EncodeMediaAs = Enum.Parse<EncodeFormat>(row.Value);
                     break;

--- a/API/Services/BookService.cs
+++ b/API/Services/BookService.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using API.Data;
 using API.Data.Metadata;
 using API.DTOs.Reader;
 using API.Entities;
@@ -78,6 +79,7 @@ public partial class BookService : IBookService
     private const string BookApiUrl = "book-resources?file=";
     public const string BookReaderBodyScope = "//BODY/APP-ROOT[1]/DIV[1]/DIV[1]/DIV[1]/APP-BOOK-READER[1]/DIV[1]/DIV[2]/DIV[1]/DIV[1]/DIV[1]";
     private readonly PdfComicInfoExtractor _pdfComicInfoExtractor;
+    private readonly IUnitOfWork _unitOfWork;
 
     /// <summary>
     /// Setup the most lenient book parsing options possible as people have some really bad epubs
@@ -124,9 +126,10 @@ public partial class BookService : IBookService
         }
     };
 
-    public BookService(ILogger<BookService> logger, IDirectoryService directoryService, IImageService imageService, IMediaErrorService mediaErrorService)
+    public BookService(ILogger<BookService> logger, IDirectoryService directoryService, IImageService imageService, IMediaErrorService mediaErrorService, IUnitOfWork unitOfWork)
     {
         _logger = logger;
+        _unitOfWork = unitOfWork;
         _directoryService = directoryService;
         _imageService = imageService;
         _mediaErrorService = mediaErrorService;
@@ -1415,7 +1418,10 @@ public partial class BookService : IBookService
     {
         _directoryService.ExistOrCreate(targetDirectory);
 
-        using var docReader = DocLib.Instance.GetDocReader(fileFilePath, new PageDimensions(1080, 1920));
+        var settings = _unitOfWork.SettingsRepository.GetSettingsDtoAsync().Result;
+        var dims = settings.PdfRenderResolution.GetDimensions();
+
+        using var docReader = DocLib.Instance.GetDocReader(fileFilePath, new PageDimensions(dims.dim1, dims.dim2));
         var pages = docReader.GetPageCount();
         Parallel.For(0, pages, pageNumber =>
         {

--- a/API/Services/SettingsService.cs
+++ b/API/Services/SettingsService.cs
@@ -405,6 +405,12 @@ public class SettingsService : ISettingsService
                 setting.Value = ((int)updateSettingsDto.CoverImageSize).ToString();
                 _unitOfWork.SettingsRepository.Update(setting);
             }
+            if (setting.Key == ServerSettingKey.PdfRenderResolution &&
+                ((int)updateSettingsDto.PdfRenderResolution).ToString() != setting.Value)
+            {
+                setting.Value = ((int)updateSettingsDto.PdfRenderResolution).ToString();
+                _unitOfWork.SettingsRepository.Update(setting);
+            }
 
             if (setting.Key == ServerSettingKey.HostName && updateSettingsDto.HostName + string.Empty != setting.Value)
             {

--- a/UI/Web/src/app/_pipes/pdf-render-resolution.pipe.ts
+++ b/UI/Web/src/app/_pipes/pdf-render-resolution.pipe.ts
@@ -1,0 +1,23 @@
+﻿import {Pipe, PipeTransform} from '@angular/core';
+import {PdfRenderResolution} from "../admin/_models/pdf-render-resolution";
+import {translate} from "@jsverse/transloco";
+
+@Pipe({
+  name: 'pdfRenderResolution',
+  standalone: true
+})
+export class PdfRenderResolutionPipe implements PipeTransform {
+
+  transform(value: PdfRenderResolution): string {
+    switch (value) {
+      case PdfRenderResolution.Default:
+        return translate('pdf-render-resolution.default');
+      case PdfRenderResolution.High:
+        return translate('pdf-render-resolution.high');
+      case PdfRenderResolution.Ultra:
+        return translate('pdf-render-resolution.ultra');
+
+    }
+  }
+
+}

--- a/UI/Web/src/app/_pipes/pdf-render-resolution.pipe.ts
+++ b/UI/Web/src/app/_pipes/pdf-render-resolution.pipe.ts
@@ -7,7 +7,6 @@ import {translate} from "@jsverse/transloco";
   standalone: true
 })
 export class PdfRenderResolutionPipe implements PipeTransform {
-
   transform(value: PdfRenderResolution): string {
     switch (value) {
       case PdfRenderResolution.Default:
@@ -16,8 +15,6 @@ export class PdfRenderResolutionPipe implements PipeTransform {
         return translate('pdf-render-resolution.high');
       case PdfRenderResolution.Ultra:
         return translate('pdf-render-resolution.ultra');
-
     }
   }
-
 }

--- a/UI/Web/src/app/admin/_models/pdf-render-resolution.ts
+++ b/UI/Web/src/app/admin/_models/pdf-render-resolution.ts
@@ -1,0 +1,9 @@
+﻿export enum PdfRenderResolution {
+  Default = 1,
+  High = 2,
+  Ultra = 3,
+}
+
+export const allPdfRenderResolutions = Object.keys(PdfRenderResolution)
+  .filter(key => !isNaN(Number(key)) && parseInt(key, 10) >= 0)
+  .map(key => parseInt(key, 10)) as PdfRenderResolution[];

--- a/UI/Web/src/app/admin/_models/server-settings.ts
+++ b/UI/Web/src/app/admin/_models/server-settings.ts
@@ -1,6 +1,7 @@
 import {EncodeFormat} from "./encode-format";
 import {CoverImageSize} from "./cover-image-size";
 import {SmtpConfig} from "./smtp-config";
+import {PdfRenderResolution} from "./pdf-render-resolution";
 import {OidcConfig} from "./oidc-config";
 
 export interface ServerSettings {
@@ -25,6 +26,7 @@ export interface ServerSettings {
     onDeckProgressDays: number;
     onDeckUpdateDays: number;
     coverImageSize: CoverImageSize;
+    pdfRenderResolution: PdfRenderResolution;
     smtpConfig: SmtpConfig;
     oidcConfig: OidcConfig;
     installId: string;

--- a/UI/Web/src/app/admin/manage-media-settings/manage-media-settings.component.html
+++ b/UI/Web/src/app/admin/manage-media-settings/manage-media-settings.component.html
@@ -36,7 +36,7 @@
               <ng-template #edit>
                 <select class="form-select" formControlName="pdfRenderResolution">
                   @for (opt of allPdfRenderResolutions; track opt) {
-                    <option [value]="opt">{{opt | pdfRenderResolution}}</option>
+                    <option [ngValue]="opt">{{opt | pdfRenderResolution}}</option>
                   }
                 </select>
               </ng-template>

--- a/UI/Web/src/app/admin/manage-media-settings/manage-media-settings.component.html
+++ b/UI/Web/src/app/admin/manage-media-settings/manage-media-settings.component.html
@@ -28,6 +28,23 @@
         </div>
 
         <div class="row g-0 mt-2">
+          @if(settingsForm.get('pdfRenderResolution'); as formControl) {
+            <app-setting-item [title]="t('pdf-render-resolution')" [subtitle]="t('pdf-render-resolution')">
+              <ng-template #view>
+                {{formControl!.value | pdfRenderResolution}}
+              </ng-template>
+              <ng-template #edit>
+                <select class="form-select" formControlName="pdfRenderResolution">
+                  @for (opt of allPdfRenderResolutions; track opt) {
+                    <option [value]="opt">{{opt | pdfRenderResolution}}</option>
+                  }
+                </select>
+              </ng-template>
+            </app-setting-item>
+          }
+        </div>
+
+        <div class="row g-0 mt-2">
           @if(settingsForm.get('coverImageSize'); as formControl) {
             <app-setting-item [title]="t('cover-image-size-label')" [subtitle]="t('cover-image-size-tooltip')">
               <ng-template #view>

--- a/UI/Web/src/app/admin/manage-media-settings/manage-media-settings.component.html
+++ b/UI/Web/src/app/admin/manage-media-settings/manage-media-settings.component.html
@@ -29,7 +29,7 @@
 
         <div class="row g-0 mt-2">
           @if(settingsForm.get('pdfRenderResolution'); as formControl) {
-            <app-setting-item [title]="t('pdf-render-resolution')" [subtitle]="t('pdf-render-resolution')">
+            <app-setting-item [title]="t('pdf-render-resolution-label')" [subtitle]="t('pdf-render-resolution-tooltip')">
               <ng-template #view>
                 {{formControl!.value | pdfRenderResolution}}
               </ng-template>

--- a/UI/Web/src/app/admin/manage-media-settings/manage-media-settings.component.ts
+++ b/UI/Web/src/app/admin/manage-media-settings/manage-media-settings.component.ts
@@ -9,9 +9,11 @@ import {NgbModal} from '@ng-bootstrap/ng-bootstrap';
 import {allEncodeFormats} from '../_models/encode-format';
 import {translate, TranslocoDirective, TranslocoService} from "@jsverse/transloco";
 import {allCoverImageSizes, CoverImageSize} from '../_models/cover-image-size';
+import {PdfRenderResolution, allPdfRenderResolutions} from '../_models/pdf-render-resolution';
 import {SettingItemComponent} from "../../settings/_components/setting-item/setting-item.component";
 import {EncodeFormatPipe} from "../../_pipes/encode-format.pipe";
 import {CoverImageSizePipe} from "../../_pipes/cover-image-size.pipe";
+import {PdfRenderResolutionPipe} from "../../_pipes/pdf-render-resolution.pipe"
 import {ConfirmService} from "../../shared/confirm.service";
 import {takeUntilDestroyed} from "@angular/core/rxjs-interop";
 import {pageLayoutModes} from "../../_models/preferences/reading-profiles";
@@ -21,7 +23,7 @@ import {pageLayoutModes} from "../../_models/preferences/reading-profiles";
   templateUrl: './manage-media-settings.component.html',
   styleUrls: ['./manage-media-settings.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [ReactiveFormsModule, TranslocoDirective, SettingItemComponent, EncodeFormatPipe, CoverImageSizePipe]
+  imports: [ReactiveFormsModule, TranslocoDirective, SettingItemComponent, EncodeFormatPipe, CoverImageSizePipe, PdfRenderResolutionPipe]
 })
 export class ManageMediaSettingsComponent implements OnInit {
 
@@ -35,6 +37,7 @@ export class ManageMediaSettingsComponent implements OnInit {
 
   protected readonly allEncodeFormats = allEncodeFormats;
   protected readonly allCoverImageSizes = allCoverImageSizes;
+  protected readonly allPdfRenderResolutions = allPdfRenderResolutions;
 
   serverSettings!: ServerSettings;
   settingsForm: FormGroup = new FormGroup({});
@@ -46,6 +49,8 @@ export class ManageMediaSettingsComponent implements OnInit {
       this.settingsForm.addControl('encodeMediaAs', new FormControl(this.serverSettings.encodeMediaAs, [Validators.required]));
       this.settingsForm.addControl('bookmarksDirectory', new FormControl(this.serverSettings.bookmarksDirectory, [Validators.required]));
       this.settingsForm.addControl('coverImageSize', new FormControl(this.serverSettings.coverImageSize || CoverImageSize.Default, [Validators.required]));
+      this.settingsForm.addControl('pdfRenderResolution', new FormControl(this.serverSettings.pdfRenderResolution || PdfRenderResolution.Default, [Validators.required]));
+
 
       // Automatically save settings as we edit them
       this.settingsForm.valueChanges.pipe(
@@ -89,6 +94,7 @@ export class ManageMediaSettingsComponent implements OnInit {
     this.settingsForm.get('encodeMediaAs')?.setValue(this.serverSettings.encodeMediaAs, {onlySelf: true, emitEvent: false});
     this.settingsForm.get('bookmarksDirectory')?.setValue(this.serverSettings.bookmarksDirectory, {onlySelf: true, emitEvent: false});
     this.settingsForm.get('coverImageSize')?.setValue(this.serverSettings.coverImageSize, {onlySelf: true, emitEvent: false});
+    this.settingsForm.get('pdfRenderResolution')?.setValue(this.serverSettings.pdfRenderResolution, {onlySelf: true, emitEvent: false});
     this.settingsForm.markAsPristine();
     this.cdRef.markForCheck();
   }
@@ -98,6 +104,7 @@ export class ManageMediaSettingsComponent implements OnInit {
     modelSettings.encodeMediaAs = parseInt(this.settingsForm.get('encodeMediaAs')?.value, 10);
     modelSettings.bookmarksDirectory = this.settingsForm.get('bookmarksDirectory')?.value;
     modelSettings.coverImageSize = parseInt(this.settingsForm.get('coverImageSize')?.value, 10);
+    modelSettings.pdfRenderResolution = parseInt(this.settingsForm.get('pdfRenderResolution')?.value, 10);
 
     return modelSettings;
   }

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -1782,6 +1782,8 @@
 
         "media-issue-title": "Media Issues",
         "scrobble-issue-title": "Scrobble Issues",
+        "pdf-render-resolution-label": "PDF Render Resolution",
+        "pdf-render-resolution-tooltip": "Resolution at which PDFs will be rendered. Higher resolutions will take longer to render and consume more memory. If you experience issues with PDF rendering, try lowering this.",
         "cover-image-size-label": "Cover Image Size",
         "cover-image-size-tooltip": "How large should cover images generate as. Note: Anything larger than the default will incur longer page load times."
     },

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -1788,6 +1788,12 @@
         "cover-image-size-tooltip": "How large should cover images generate as. Note: Anything larger than the default will incur longer page load times."
     },
 
+    "pdf-render-resolution": {
+        "default": "Default (1080x1920)",
+        "high": "High (1920x2560)",
+        "ultra": "Ultra (2160x3840)"
+    },
+
     "cover-image-size": {
         "default": "Default (320x455)",
         "medium": "Medium (640x909)",


### PR DESCRIPTION
# Added
- Added: Added the ability to change the PDF renderer resolution (Mihon-apps) via a Server Setting. The admin can choose Default (1080x1920), High (1920x2560) or Ultra (2160x3840) (Thanks @StereotypicalCat)

# Changed
- Changed:  (Performance) Slight memory improvement in creating images from PDFs
