### PR TITLE
feat(ui): Add alphabetical library sorting option to SideNav

### DIFF
--- a/UI/Web/src/app/sidenav/_components/side-nav/side-nav.component.html
+++ b/UI/Web/src/app/sidenav/_components/side-nav/side-nav.component.html
@@ -7,10 +7,28 @@
 
 
         <app-side-nav-item cdkDrag cdkDragDisabled icon="fa-home" [title]="t('home')" link="/home/">
-          <ng-container actions>
-            <app-card-actionables [inputActions]="homeActions" labelBy="home" iconClass="fa-ellipsis-v" (actionHandler)="performHomeAction($event)" />
-          </ng-container>
-        </app-side-nav-item>
+  <ng-container actions>
+          @if (!editMode) {
+            <button type="button" 
+                    class="btn btn-icon btn-sm me-1" 
+                    (mousedown)="$event.stopPropagation()"
+                    (click)="$event.preventDefault(); $event.stopPropagation(); toggleLibrarySort()" 
+                    [title]="'Sort Libraries'">
+              <i class="fa text-muted"
+                style="font-size: 1rem;" 
+                [ngClass]="{
+                  'fa-sort': (sortOrder$ | async) === 'default',
+                  'fa-sort-alpha-down': (sortOrder$ | async) === 'asc',
+                  'fa-sort-alpha-up': (sortOrder$ | async) === 'desc'
+                }">
+              </i>
+            </button>
+          }
+    <app-card-actionables [inputActions]="homeActions" labelBy="home" iconClass="fa-ellipsis-v" (actionHandler)="performHomeAction($event)" />
+  </ng-container>
+</app-side-nav-item>
+
+               
 
         @if (navStreams$ | async; as streams) {
           @if (showAll) {

--- a/UI/Web/src/app/sidenav/_components/side-nav/side-nav.component.ts
+++ b/UI/Web/src/app/sidenav/_components/side-nav/side-nav.component.ts
@@ -11,7 +11,7 @@ import {Action, ActionFactoryService, ActionItem} from '../../../_services/actio
 import {ActionService} from '../../../_services/action.service';
 import {NavService} from '../../../_services/nav.service';
 import {takeUntilDestroyed} from "@angular/core/rxjs-interop";
-import {BehaviorSubject, merge, Observable, of, ReplaySubject, startWith, switchMap} from "rxjs";
+import {BehaviorSubject, merge, Observable, of, ReplaySubject, startWith, switchMap, combineLatest} from "rxjs";
 import {AsyncPipe, NgClass} from "@angular/common";
 import {SideNavItemComponent} from "../side-nav-item/side-nav-item.component";
 import {FilterPipe} from "../../../_pipes/filter.pipe";
@@ -94,38 +94,83 @@ export class SideNavComponent implements OnInit {
       );
     })
   );
+  // New: Tracks sorting mode
+  sortOrderSubject = new BehaviorSubject<'default' | 'asc' | 'desc'>('default');
+  sortOrder$ = this.sortOrderSubject.asObservable();
 
-  navStreams$: Observable<SideNavStream[]> = merge(
+  navStreams$: Observable<SideNavStream[]> = combineLatest([
+    // Input 1: The Data Stream (Initial Load + Reloads on Events)
+    merge(
+      this.loadDataOnInit$,
+      this.messageHub.messages$.pipe(
+        filter(event => event.event === EVENTS.LibraryModified || event.event === EVENTS.SideNavUpdate),
+        tap(() => this.cachedData = null), // Clear cache so we get fresh data
+        switchMap(() => this.loadDataOnInit$)
+      )
+    ),
+    // Input 2: Show All / Show Less Toggle
     this.showAll$.pipe(
       startWith(false),
       distinctUntilChanged(),
-      tap(showAll => this.showAll = showAll),
-      switchMap(showAll =>
-        showAll
-          ? this.loadDataOnInit$.pipe(
-            tap(d => this.totalSize = d.length),
-          )
-          : this.loadDataOnInit$.pipe(
-            tap(d => this.totalSize = d.length),
-            map(d => d.slice(0, this.ItemLimit))
-          )
-      ),
-      takeUntilDestroyed(this.destroyRef),
-    ), this.messageHub.messages$.pipe(
-      filter(event => event.event === EVENTS.LibraryModified || event.event === EVENTS.SideNavUpdate),
-      tap(() => {
-          this.cachedData = null; // Reset cached data to null to get latest
-      }),
-      switchMap(() => {
-        if (this.showAll) return this.loadDataOnInit$;
-        else return this.loadDataOnInit$.pipe(map(d => d.slice(0, this.ItemLimit)))
-      }), // Reload data when events occur
-      takeUntilDestroyed(this.destroyRef),
-    )
-  ).pipe(
-      startWith(null),
-      filter(data => data !== null),
-      takeUntilDestroyed(this.destroyRef),
+      tap(showAll => this.showAll = showAll)
+    ),
+    // Input 3: The Sort Order
+    this.sortOrder$
+  ]).pipe(
+    map(([data, showAll, sortOrder]) => {
+      this.totalSize = data.length;
+      
+      // If Default, just return the server order (User's custom drag-and-drop order)
+      if (sortOrder === 'default') {
+        const result = [...data];
+        return showAll ? result : result.slice(0, this.ItemLimit);
+      }
+
+      // --- SMART SORT LOGIC ---
+      
+      // 1. Separate "System" items (Provided) from "Sortable" itemss (Libraries/SmartFilters)
+      const systemStreams: SideNavStream[] = [];
+      const libraryStreams: SideNavStream[] = [];
+
+      data.forEach(stream => {
+        // List of types to IGNORE during sort to Keep them pinned at the top
+        const isSystem = [
+          SideNavStreamType.AllSeries,
+          SideNavStreamType.Bookmarks,
+          SideNavStreamType.ReadingLists,
+          SideNavStreamType.Collections,
+          SideNavStreamType.WantToRead,
+          SideNavStreamType.BrowseAuthors,
+          SideNavStreamType.ExternalSource
+        ].includes(stream.streamType);
+
+        if (isSystem) {
+          systemStreams.push(stream);
+        } else {
+          libraryStreams.push(stream);
+        }
+      });
+
+      // 2. Sort ONLY the libraries
+      if (sortOrder === 'asc') {
+        libraryStreams.sort((a, b) => a.name.localeCompare(b.name));
+      } else if (sortOrder === 'desc') {
+        libraryStreams.sort((a, b) => b.name.localeCompare(a.name));
+      }
+
+      // 3. Combine: System Items (Top) + Sorted Libraries (Bottom)
+      const finalResult = [...systemStreams, ...libraryStreams];
+
+      // 4. Apply Limit
+      if (!showAll) {
+        return finalResult.slice(0, this.ItemLimit);
+      }
+
+      return finalResult;
+    }),
+    startWith(null),
+    filter(d => d !== null),
+    takeUntilDestroyed(this.destroyRef)
   );
 
   collapseSideNavOnMobileNav$ = this.router.events.pipe(
@@ -174,6 +219,21 @@ export class SideNavComponent implements OnInit {
       this.loadDataSubject.next();
     });
   }
+
+  toggleLibrarySort() {
+  const current = this.sortOrderSubject.value;
+  
+  // Cycle the logic
+  if (current === 'default') {
+    this.sortOrderSubject.next('asc');
+  } else if (current === 'asc') {
+    this.sortOrderSubject.next('desc');
+  } else {
+    this.sortOrderSubject.next('default');
+  }
+
+  this.cdRef.markForCheck();
+}
 
   async handleAction(action: ActionItem<Library>, library: Library) {
     const lib = library;
@@ -254,6 +314,11 @@ export class SideNavComponent implements OnInit {
   }
 
   showMore(edit: boolean = false) {
+    // If entering Edit Mode (Reorder), force sort to Default so dragging makes sense
+    if (edit) {
+      this.sortOrderSubject.next('default'); 
+    }
+
     this.showAllSubject.next(true);
     this.editMode = edit;
     this.cdRef.markForCheck();


### PR DESCRIPTION
# Added
- Added: Option to sort the Side Nav libraries alphabetically (Ascending and Descending) via a new toggle button on the Home item
- Added: 'Smart Sort' logic that keeps system items (like 'Want to Read' or 'Collections') pinned to the top while sorting user libraries

# Changed
- Changed: Entering 'Edit Mode' (Manual Reorder) on the Side Nav now automatically resets the sort order to Default to prevent conflict with manual dragging

# Fixed
![scanner_animation](https://github.com/user-attachments/assets/42c85bad-f363-4222-9bbf-496d072afdbc)
