### PR TITLE
Manga Reader Double Page Offset

### DIFF
--- a/API/Entities/Enums/UserPreferences/KeyBindTarget.cs
+++ b/API/Entities/Enums/UserPreferences/KeyBindTarget.cs
@@ -42,4 +42,7 @@ public enum KeyBindTarget
 
     [Description(nameof(PageDown))]
     PageDown = 12,
+
+    [Description(nameof(OffsetDoublePage))]
+    OffsetDoublePage = 13,
 }

--- a/UI/Web/package-lock.json
+++ b/UI/Web/package-lock.json
@@ -1316,6 +1316,7 @@
       "version": "21.0.6",
       "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-21.0.6.tgz",
       "integrity": "sha512-UcIUx+fbn0VLlCBCIYxntAzWG3zPRUo0K7wvuK0MC6ZFCWawgewx9SdLLZTqcaWe1g5FRQlQeVQcFgHAO5R2Mw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "7.28.4",
@@ -1348,6 +1349,7 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
       "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -1360,6 +1362,7 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
       "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^7.2.0",
@@ -1374,6 +1377,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
       "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^10.3.0",
@@ -1391,6 +1395,7 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
       "integrity": "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.2.1",
@@ -1408,6 +1413,7 @@
       "version": "18.0.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
       "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^9.0.1",
@@ -1425,6 +1431,7 @@
       "version": "22.0.0",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
       "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=23"
@@ -6375,6 +6382,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "readdirp": "^4.0.1"
@@ -6497,7 +6505,8 @@
     "node_modules/convert-source-map": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "dev": true
     },
     "node_modules/cookie": {
       "version": "0.7.2",
@@ -6798,6 +6807,31 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
+    "node_modules/encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/entities": {
@@ -9971,6 +10005,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.18.0"
@@ -9983,7 +10018,8 @@
     "node_modules/reflect-metadata": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
-      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "dev": true
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
@@ -10195,6 +10231,7 @@
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
       "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -10881,7 +10918,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/UI/Web/src/app/_models/preferences/preferences.ts
+++ b/UI/Web/src/app/_models/preferences/preferences.ts
@@ -69,6 +69,7 @@ export enum KeyBindTarget {
   Escape = 'Escape',
   PageUp = 'PageUp',
   PageDown = 'PageDown',
+  OffsetDoublePage = 'OffsetDoublePage',
 }
 
 export interface OpdsPreferences {

--- a/UI/Web/src/app/_models/preferences/reading-profiles.ts
+++ b/UI/Web/src/app/_models/preferences/reading-profiles.ts
@@ -39,6 +39,7 @@ export interface ReadingProfile {
   allowAutomaticWebtoonReaderDetection: boolean;
   widthOverride?: number;
   disableWidthOverride: UserBreakpoint;
+  pageOffset: boolean;
 
   // Book Reader
   bookReaderMargin: number;

--- a/UI/Web/src/app/_pipes/keybind-setting-description.pipe.ts
+++ b/UI/Web/src/app/_pipes/keybind-setting-description.pipe.ts
@@ -36,6 +36,8 @@ export class KeybindSettingDescriptionPipe implements PipeTransform {
         return this.create('key-bind-title-page-up', 'key-bind-tooltip-page-up');
       case KeyBindTarget.PageDown:
         return this.create('key-bind-title-page-down', 'key-bind-tooltip-page-up');
+      case KeyBindTarget.OffsetDoublePage:
+        return this.create('key-bind-title-offset-double-page', 'key-bind-tooltip-offset-double-page');
     }
   }
 

--- a/UI/Web/src/app/_services/key-bind.service.ts
+++ b/UI/Web/src/app/_services/key-bind.service.ts
@@ -127,6 +127,7 @@ export const DefaultKeyBinds: Readonly<Record<KeyBindTarget, KeyBind[]>> = {
   [KeyBindTarget.Escape]: [{key: KeyCode.Escape}],
   [KeyBindTarget.PageUp]: [{key: KeyCode.ArrowUp}],
   [KeyBindTarget.PageDown]: [{key: KeyCode.ArrowDown}],
+  [KeyBindTarget.OffsetDoublePage]: [{key: KeyCode.KeyO}],
 } as const;
 
 type KeyBindGroup = {
@@ -161,6 +162,7 @@ export const KeyBindGroups: KeyBindGroup[] = [
       {target: KeyBindTarget.PageLeft},
       {target: KeyBindTarget.PageUp},
       {target: KeyBindTarget.PageDown},
+      {target: KeyBindTarget.OffsetDoublePage},
     ],
   }
 ];

--- a/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.html
+++ b/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.html
@@ -281,6 +281,15 @@
                       </div>
                     </div>
                   </div>
+
+                  <div class="mb-3">
+                    <div class="mb-3">
+                      <div class="form-check form-switch" [title]="generalSettingsForm.get('pageOffset')?.disabled ? t('offset-only-double') : ''">
+                        <input type="checkbox" id="page-offset" formControlName="pageOffset" class="form-check-input" switch>
+                        <label class="form-check-label" for="page-offset">{{t('page-offset-label')}}</label>
+                      </div>
+                    </div>
+                  </div>
                 </div>
               </div>
               <div class="row mb-2">

--- a/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.html
+++ b/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.html
@@ -255,39 +255,31 @@
                 </div>
                 <div class="col-md-3 col-sm-12">
                   <div class="mb-3">
-                    <div class="mb-3">
-                      <div class="form-check form-switch">
-                        <input type="checkbox" id="auto-close" formControlName="autoCloseMenu" class="form-check-input" switch>
-                        <label class="form-check-label" for="auto-close">{{t('auto-close-menu-label')}}</label>
-                      </div>
+                    <div class="form-check form-switch">
+                      <input type="checkbox" id="auto-close" formControlName="autoCloseMenu" class="form-check-input" switch>
+                      <label class="form-check-label" for="auto-close">{{t('auto-close-menu-label')}}</label>
                     </div>
                   </div>
 
                   <div class="mb-3">
-                    <div class="mb-3">
-                      <div class="form-check form-switch">
-                        <input type="checkbox" id="swipe-to-paginate" formControlName="swipeToPaginate" class="form-check-input" switch>
-                        <label class="form-check-label" for="swipe-to-paginate">{{t('swipe-enabled-label')}}</label>
-                      </div>
+                    <div class="form-check form-switch">
+                      <input type="checkbox" id="swipe-to-paginate" formControlName="swipeToPaginate" class="form-check-input" switch>
+                      <label class="form-check-label" for="swipe-to-paginate">{{t('swipe-enabled-label')}}</label>
                     </div>
                   </div>
                 </div>
                 <div class="col-md-3 col-sm-12">
                   <div class="mb-3">
-                    <div class="mb-3">
-                      <div class="form-check form-switch">
-                        <input type="checkbox" id="emulate-book" formControlName="emulateBook" class="form-check-input" switch>
-                        <label class="form-check-label" for="emulate-book">{{t('emulate-comic-book-label')}}</label>
-                      </div>
+                    <div class="form-check form-switch">
+                      <input type="checkbox" id="emulate-book" formControlName="emulateBook" class="form-check-input" switch>
+                      <label class="form-check-label" for="emulate-book">{{t('emulate-comic-book-label')}}</label>
                     </div>
                   </div>
 
                   <div class="mb-3">
-                    <div class="mb-3">
-                      <div class="form-check form-switch" [title]="generalSettingsForm.get('pageOffset')?.disabled ? t('offset-only-double') : ''">
-                        <input type="checkbox" id="page-offset" formControlName="pageOffset" class="form-check-input" switch>
-                        <label class="form-check-label" for="page-offset">{{t('page-offset-label')}}</label>
-                      </div>
+                    <div class="form-check form-switch" [title]="generalSettingsForm.get('pageOffset')?.disabled ? t('offset-only-double') : ''">
+                      <input type="checkbox" id="page-offset" formControlName="pageOffset" class="form-check-input" switch>
+                      <label class="form-check-label" for="page-offset">{{t('page-offset-label')}}</label>
                     </div>
                   </div>
                 </div>

--- a/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.ts
+++ b/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.ts
@@ -542,6 +542,9 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
           case KeyBindTarget.BookmarkPage:
             this.bookmarkPage();
             break;
+          case KeyBindTarget.OffsetDoublePage:
+            this.togglePageOffset();
+            break;
           case KeyBindTarget.GoTo:
             const goToPageNum = await this.promptForPage();
             if (goToPageNum === null) { return; }
@@ -558,7 +561,7 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       [
         KeyBindTarget.ToggleFullScreen, KeyBindTarget.BookmarkPage, KeyBindTarget.OpenHelp, KeyBindTarget.GoTo,
         KeyBindTarget.ToggleMenu, KeyBindTarget.PageRight, KeyBindTarget.PageLeft, KeyBindTarget.Escape,
-        KeyBindTarget.PageUp, KeyBindTarget.PageDown,
+        KeyBindTarget.PageUp, KeyBindTarget.PageDown, KeyBindTarget.OffsetDoublePage,
       ],
     );
 
@@ -747,7 +750,8 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       layoutMode: new FormControl(this.layoutMode),
       darkness: new FormControl(100),
       emulateBook: new FormControl(this.readingProfile.emulateBook),
-      swipeToPaginate: new FormControl(this.readingProfile.swipeToPaginate)
+      swipeToPaginate: new FormControl(this.readingProfile.swipeToPaginate),
+      pageOffset: new FormControl(this.mangaReaderService.getPageOffset()),
     });
 
     this.readerModeSubject.next(this.readerMode);
@@ -793,6 +797,7 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
         this.generalSettingsForm.get('widthSlider')?.enable();
         this.generalSettingsForm.get('fittingOption')?.enable();
         this.generalSettingsForm.get('emulateBook')?.enable();
+        this.generalSettingsForm.get('pageOffset')?.disable();
       } else {
         this.generalSettingsForm.get('pageSplitOption')?.setValue(PageSplitOption.NoSplit);
         this.generalSettingsForm.get('pageSplitOption')?.disable();
@@ -800,6 +805,7 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
         this.generalSettingsForm.get('fittingOption')?.setValue(this.mangaReaderService.translateScalingOption(ScalingOption.FitToHeight));
         this.generalSettingsForm.get('fittingOption')?.disable();
         this.generalSettingsForm.get('emulateBook')?.enable();
+        this.generalSettingsForm.get('pageOffset')?.enable();
       }
       this.cdRef.markForCheck();
 
@@ -813,6 +819,14 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
     this.generalSettingsForm.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
       this.autoCloseMenu = this.generalSettingsForm.get('autoCloseMenu')?.value;
       this.pageSplitOption = parseInt(this.generalSettingsForm.get('pageSplitOption')?.value, 10);
+      const pageOffset = this.generalSettingsForm.get('pageOffset')?.value;
+      if (pageOffset !== undefined) {
+        this.mangaReaderService.setPageOffset(pageOffset ? 1 : 0);
+        const adjustedPage = this.mangaReaderService.adjustForDoubleReader(this.pageNum);
+        this.pageNumSubject.next({pageNum: adjustedPage, maxPages: this.maxPages});
+        this.pageNum = adjustedPage;
+        this.goToPage(this.pageNum);
+      }
 
       const needsSplitting = this.mangaReaderService.isWidePage(this.readerService.imageUrlToPageNum(this.canvasImage.src));
       // If we need to split on a menu change, then we need to re-render.
@@ -1770,6 +1784,22 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       });
   }
 
+  togglePageOffset() {
+    if (this.layoutMode === LayoutMode.Single || this.readerMode === ReaderMode.Webtoon) {
+      this.toastr.info(translate('manga-reader.offset-only-double'));
+      return;
+    }
+
+    const currentValue = this.generalSettingsForm.get('pageOffset')?.value;
+    this.generalSettingsForm.patchValue({pageOffset: !currentValue});
+    
+    if (!currentValue) {
+      this.toastr.info(translate('manga-reader.offset-enabled'));
+    } else {
+      this.toastr.info(translate('manga-reader.offset-disabled'));
+    }
+  }
+
   // This is menu only code
   toggleReaderMode() {
     switch(this.readerMode) {
@@ -1805,6 +1835,7 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       this.generalSettingsForm.get('pageSplitOption')?.disable()
       this.generalSettingsForm.get('fittingOption')?.disable()
       this.generalSettingsForm.get('layoutMode')?.disable();
+      this.generalSettingsForm.get('pageOffset')?.disable();
     } else {
       this.generalSettingsForm.get('fittingOption')?.enable()
       this.generalSettingsForm.get('pageSplitOption')?.enable();
@@ -1813,6 +1844,9 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       if (this.layoutMode !== LayoutMode.Single) {
         this.generalSettingsForm.get('pageSplitOption')?.disable();
         this.generalSettingsForm.get('fittingOption')?.disable();
+        this.generalSettingsForm.get('pageOffset')?.enable();
+      } else {
+        this.generalSettingsForm.get('pageOffset')?.disable();
       }
     }
     this.cdRef.markForCheck();
@@ -1898,6 +1932,7 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       {keyBindTarget: KeyBindTarget.ToggleMenu},
       {keyBindTarget: KeyBindTarget.OpenHelp},
       {keyBindTarget: KeyBindTarget.BookmarkPage, description: 'bookmark'},
+      {keyBindTarget: KeyBindTarget.OffsetDoublePage, description: 'offset-double-page'},
       {key: translate('shortcuts-modal.double-click'), description: 'bookmark'},
     ];
 

--- a/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.ts
+++ b/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.ts
@@ -751,7 +751,7 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       darkness: new FormControl(100),
       emulateBook: new FormControl(this.readingProfile.emulateBook),
       swipeToPaginate: new FormControl(this.readingProfile.swipeToPaginate),
-      pageOffset: new FormControl(this.mangaReaderService.getPageOffset()),
+      pageOffset: new FormControl(this.readingProfile.pageOffset),
     });
 
     this.readerModeSubject.next(this.readerMode);
@@ -821,7 +821,7 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       this.pageSplitOption = parseInt(this.generalSettingsForm.get('pageSplitOption')?.value, 10);
       const pageOffset = this.generalSettingsForm.get('pageOffset')?.value;
       if (pageOffset !== undefined) {
-        this.mangaReaderService.setPageOffset(pageOffset ? 1 : 0);
+        this.mangaReaderService.setPageOffset(pageOffset);
         const adjustedPage = this.mangaReaderService.adjustForDoubleReader(this.pageNum);
         this.pageNumSubject.next({pageNum: adjustedPage, maxPages: this.maxPages});
         this.pageNum = adjustedPage;
@@ -1786,18 +1786,11 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
 
   togglePageOffset() {
     if (this.layoutMode === LayoutMode.Single || this.readerMode === ReaderMode.Webtoon) {
-      this.toastr.info(translate('manga-reader.offset-only-double'));
       return;
     }
 
     const currentValue = this.generalSettingsForm.get('pageOffset')?.value;
     this.generalSettingsForm.patchValue({pageOffset: !currentValue});
-    
-    if (!currentValue) {
-      this.toastr.info(translate('manga-reader.offset-enabled'));
-    } else {
-      this.toastr.info(translate('manga-reader.offset-disabled'));
-    }
   }
 
   // This is menu only code

--- a/UI/Web/src/app/manga-reader/_service/manga-reader.service.ts
+++ b/UI/Web/src/app/manga-reader/_service/manga-reader.service.ts
@@ -17,6 +17,7 @@ export class MangaReaderService {
   private pageDimensions: DimensionMap = {};
   private pairs: {[key: number]: number} = {};
   private renderer: Renderer2;
+  private pageOffset: number = 0;
 
   constructor() {
     const rendererFactory = inject(RendererFactory2);
@@ -33,9 +34,13 @@ export class MangaReaderService {
       };
     });
     this.pairs = chapterInfo.doublePairs!;
+    this.pageOffset = 0;
   }
 
   adjustForDoubleReader(page: number) {
+    if (this.pageOffset === 1) {
+      return Math.floor(page / 2) * 2;
+    }
     if (!this.pairs.hasOwnProperty(page)) return page;
     return this.pairs[page];
   }
@@ -71,7 +76,20 @@ export class MangaReaderService {
    * @returns
    */
   isCoverImage(pageNumber: number) {
+    if (this.pageOffset === 1) return false;
     return pageNumber === 0;
+  }
+
+  togglePageOffset() {
+    this.pageOffset = this.pageOffset === 0 ? 1 : 0;
+  }
+
+  getPageOffset() {
+    return this.pageOffset;
+  }
+
+  setPageOffset(offset: number) {
+    this.pageOffset = offset;
   }
 
   /**

--- a/UI/Web/src/app/manga-reader/_service/manga-reader.service.ts
+++ b/UI/Web/src/app/manga-reader/_service/manga-reader.service.ts
@@ -17,7 +17,7 @@ export class MangaReaderService {
   private pageDimensions: DimensionMap = {};
   private pairs: {[key: number]: number} = {};
   private renderer: Renderer2;
-  private pageOffset: number = 0;
+  private hasPageOffset: boolean = false;
 
   constructor() {
     const rendererFactory = inject(RendererFactory2);
@@ -34,11 +34,11 @@ export class MangaReaderService {
       };
     });
     this.pairs = chapterInfo.doublePairs!;
-    this.pageOffset = 0;
+    this.hasPageOffset = false;
   }
 
   adjustForDoubleReader(page: number) {
-    if (this.pageOffset === 1) {
+    if (this.hasPageOffset === true) {
       return Math.floor(page / 2) * 2;
     }
     if (!this.pairs.hasOwnProperty(page)) return page;
@@ -76,20 +76,20 @@ export class MangaReaderService {
    * @returns
    */
   isCoverImage(pageNumber: number) {
-    if (this.pageOffset === 1) return false;
+    if (this.hasPageOffset) return false;
     return pageNumber === 0;
   }
 
   togglePageOffset() {
-    this.pageOffset = this.pageOffset === 0 ? 1 : 0;
+    this.hasPageOffset = !this.hasPageOffset;
   }
 
   getPageOffset() {
-    return this.pageOffset;
+    return this.hasPageOffset;
   }
 
-  setPageOffset(offset: number) {
-    this.pageOffset = offset;
+  setPageOffset(toggle: boolean) {
+    this.hasPageOffset = toggle;
   }
 
   /**

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -2098,7 +2098,9 @@
         "key-bind-title-page-up": "Page up",
         "key-bind-tooltip-page-up": "Move one page upwards",
         "key-bind-title-page-down": "Page down",
-        "key-bind-tooltip-page-down": "Move one page downwards"
+        "key-bind-tooltip-page-down": "Move one page downwards",
+        "key-bind-title-offset-double-page": "Offset double page",
+        "key-bind-tooltip-offset-double-page": "Manually offset pages for double page spread alignment"
     },
 
     "collection-detail": {
@@ -2204,7 +2206,8 @@
         "bookmark": "Bookmark current page",
         "double-click": "double click",
         "close-reader": "Close reader",
-        "toggle-menu": "Toggle Menu"
+        "toggle-menu": "Toggle Menu",
+        "offset-double-page": "Manually offset pages for spread alignment"
 
     },
 
@@ -2461,7 +2464,11 @@
         "reading-profile-updated": "Reading profile updated",
         "reading-profile-promoted": "Reading profile promoted",
         "emulate-comic-book-label": "{{manage-reading-profiles.emulate-comic-book-label}}",
-        "series-progress": "Series Progress: {{percentage}}"
+        "series-progress": "Series Progress: {{percentage}}",
+        "page-offset-label": "Page Offset",
+        "offset-enabled": "Page offset enabled",
+        "offset-disabled": "Page offset disabled",
+        "offset-only-double": "Page offset only works in double page layout"
     },
 
     "metadata-filter": {

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -2465,10 +2465,7 @@
         "reading-profile-promoted": "Reading profile promoted",
         "emulate-comic-book-label": "{{manage-reading-profiles.emulate-comic-book-label}}",
         "series-progress": "Series Progress: {{percentage}}",
-        "page-offset-label": "Page Offset",
-        "offset-enabled": "Page offset enabled",
-        "offset-disabled": "Page offset disabled",
-        "offset-only-double": "Page offset only works in double page layout"
+        "page-offset-label": "Page Offset"
     },
 
     "metadata-filter": {


### PR DESCRIPTION
# Added
- Added: Page offset toggle for double page manga reader mode to manually adjust page alignment for proper double-page spreads (Closes FR #2660, 37 upvotes)
- Added: New keybind (default: 'O' key) to toggle page offset during reading
- Added: Page offset toggle switch in reader settings menu that is only enabled when in double page layout mode
- ~~Added: Toast notifications to provide feedback when toggling page offset via keyboard shortcut~~
- Added: Help modal entry and keybind settings for the offset double page feature

# Changed
- Changed: Double page reader now respects page offset setting when calculating which pages to display, allowing users to shift alignment for better spread matching
- Changed: Cover page detection now considers page offset state, preventing offset from applying to cover images when disabled
- Changed: Form controls in reader settings now dynamically enable/disable page offset option based on current layout mode (disabled in single page and webtoon modes)