### PR TITLE
Last of the Year - Page Offset, Device-bound Reading Profiles, and more!

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -27,3 +27,5 @@ indent_size = 2
 [*.cs]
 # Disable SonarLint warning S1075 (Don't use hardcoded url)
 dotnet_diagnostic.S1075.severity = none
+# Logging is never disabled in this project
+dotnet_diagnostic.CA1873.severity = none

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -15,5 +15,4 @@ _imageService.Resize(...);
 return;
 ```
 - Operation (+,-,*, etc) should always have spaces around it; I.e. `a + b` not `a+b`.
-- Comma's `,` should always be followed by a space
 - When setting href directectly (not using Angulars routing) it should always be prefixed with baseURL

--- a/.gitignore
+++ b/.gitignore
@@ -538,6 +538,7 @@ UI/Web/.angular/
 BenchmarkDotNet.Artifacts
 .claude/
 API/config/*backup.zip
+API/config/DataProtection-Keys/*
 
 
 API.Tests/Services/Test Data/ImageService/**/*_output*

--- a/.gitignore
+++ b/.gitignore
@@ -538,7 +538,6 @@ UI/Web/.angular/
 BenchmarkDotNet.Artifacts
 .claude/
 API/config/*backup.zip
-API/config/DataProtection-Keys/*
 
 
 API.Tests/Services/Test Data/ImageService/**/*_output*

--- a/API.Tests/Services/BookServiceTests.cs
+++ b/API.Tests/Services/BookServiceTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO;
 using System.IO.Abstractions;
 using System.Threading.Tasks;
+using API.Data;
 using API.Entities.Enums;
 using API.Services;
 using API.Services.Tasks.Scanner.Parser;
@@ -20,7 +21,7 @@ public class BookServiceTests
         var directoryService = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), new FileSystem());
         _bookService = new BookService(_logger, directoryService,
             new ImageService(Substitute.For<ILogger<ImageService>>(), directoryService)
-            , Substitute.For<IMediaErrorService>());
+            , Substitute.For<IMediaErrorService>(), Substitute.For<IUnitOfWork>());
     }
 
     [Theory]

--- a/API.Tests/Services/ClientDeviceServiceTests.cs
+++ b/API.Tests/Services/ClientDeviceServiceTests.cs
@@ -112,6 +112,8 @@ public class ClientDeviceServiceTests : AbstractDbTest
         var firstDevice = await service.IdentifyOrRegisterDeviceAsync(user.Id, clientInfo, null);
         var fingerprint = firstDevice.DeviceFingerprint;
 
+        context.ChangeTracker.Clear();
+
         // Act - Same device, still no client device ID (e.g., OPDS reader without device ID support)
         var secondDevice = await service.IdentifyOrRegisterDeviceAsync(user.Id, clientInfo, null);
 

--- a/API.Tests/Services/DeviceServiceTests.cs
+++ b/API.Tests/Services/DeviceServiceTests.cs
@@ -19,7 +19,8 @@ public class DeviceServiceDbTests(ITestOutputHelper outputHelper): AbstractDbTes
 
     private Task<IDeviceService> Setup(IUnitOfWork unitOfWork)
     {
-        return Task.FromResult<IDeviceService>(new DeviceService(unitOfWork, _logger, Substitute.For<IEmailService>()));
+        return Task.FromResult<IDeviceService>(new DeviceService(unitOfWork, _logger,
+            Substitute.For<IEmailService>(), Substitute.For<IReadingProfileService>()));
     }
 
     [Fact]

--- a/API.Tests/Services/ReaderServiceTests.cs
+++ b/API.Tests/Services/ReaderServiceTests.cs
@@ -30,9 +30,9 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
 
     private ReaderService Setup(IUnitOfWork unitOfWork)
     {
-     return new ReaderService(unitOfWork, Substitute.For<ILogger<ReaderService>>(),
+        return new ReaderService(unitOfWork, Substitute.For<ILogger<ReaderService>>(),
          Substitute.For<IEventHub>(), Substitute.For<IImageService>(),
-         new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), new MockFileSystem()),
+             new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), new MockFileSystem()),
          Substitute.For<IScrobblingService>(), Substitute.For<IReadingSessionService>(),
          Substitute.For<IClientInfoAccessor>(), Substitute.For<ISeriesService>(), Substitute.For<IEntityDisplayService>());
     }
@@ -55,16 +55,21 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
     public async Task CapPageToChapterTest()
     {
         var (unitOfWork, context, _) = await CreateDatabase();
-        var readerService = Setup(unitOfWork);
+                var readerService = Setup(unitOfWork);
+
+       var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
 
         var series = new SeriesBuilder("Test")
+           .WithLibraryId(library.Id)
             .WithVolume(new VolumeBuilder(API.Services.Tasks.Scanner.Parser.Parser.LooseLeafVolume)
                 .WithChapter(new ChapterBuilder(API.Services.Tasks.Scanner.Parser.Parser.DefaultChapter)
                     .WithPages(1)
                     .Build())
                 .Build())
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
+
 
 
         context.Series.Add(series);
@@ -87,16 +92,21 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
     public async Task SaveReadingProgress_ShouldCreateNewEntity()
     {
         var (unitOfWork, context, _) = await CreateDatabase();
-        var readerService = Setup(unitOfWork);
+                var readerService = Setup(unitOfWork);
+
+       var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
 
         var series = new SeriesBuilder("Test")
+           .WithLibraryId(library.Id)
             .WithVolume(new VolumeBuilder(API.Services.Tasks.Scanner.Parser.Parser.LooseLeafVolume)
                 .WithChapter(new ChapterBuilder(API.Services.Tasks.Scanner.Parser.Parser.DefaultChapter)
                     .WithPages(1)
                     .Build())
                 .Build())
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
+
 
         context.Series.Add(series);
 
@@ -126,16 +136,21 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
     public async Task SaveReadingProgress_ShouldUpdateExisting()
     {
         var (unitOfWork, context, _) = await CreateDatabase();
-        var readerService = Setup(unitOfWork);
+                var readerService = Setup(unitOfWork);
+
+       var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
 
         var series = new SeriesBuilder("Test")
+           .WithLibraryId(library.Id)
             .WithVolume(new VolumeBuilder(API.Services.Tasks.Scanner.Parser.Parser.LooseLeafVolume)
                 .WithChapter(new ChapterBuilder(API.Services.Tasks.Scanner.Parser.Parser.DefaultChapter)
                     .WithPages(1)
                     .Build())
                 .Build())
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
+
 
         context.Series.Add(series);
 
@@ -183,9 +198,14 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
     public async Task MarkChaptersAsReadTest()
     {
         var (unitOfWork, context, _) = await CreateDatabase();
-        var readerService = Setup(unitOfWork);
+                var readerService = Setup(unitOfWork);
+
+       var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
 
         var series = new SeriesBuilder("Test")
+           .WithLibraryId(library.Id)
             .WithVolume(new VolumeBuilder(API.Services.Tasks.Scanner.Parser.Parser.LooseLeafVolume)
                 .WithChapter(new ChapterBuilder(API.Services.Tasks.Scanner.Parser.Parser.DefaultChapter)
                     .WithPages(1)
@@ -195,7 +215,7 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
                     .Build())
                 .Build())
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
+
 
         context.Series.Add(series);
 
@@ -224,9 +244,14 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
     public async Task MarkChapterAsUnreadTest()
     {
         var (unitOfWork, context, _) = await CreateDatabase();
-        var readerService = Setup(unitOfWork);
+                var readerService = Setup(unitOfWork);
+
+       var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
 
         var series = new SeriesBuilder("Test")
+           .WithLibraryId(library.Id)
             .WithVolume(new VolumeBuilder(API.Services.Tasks.Scanner.Parser.Parser.LooseLeafVolume)
                 .WithChapter(new ChapterBuilder(API.Services.Tasks.Scanner.Parser.Parser.DefaultChapter)
                     .WithPages(1)
@@ -236,7 +261,7 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
                     .Build())
                 .Build())
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
+
 
         context.Series.Add(series);
 
@@ -272,9 +297,14 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
     {
         // V1 -> V2
         var (unitOfWork, context, _) = await CreateDatabase();
-        var readerService = Setup(unitOfWork);
+                var readerService = Setup(unitOfWork);
+
+       var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
 
         var series = new SeriesBuilder("Test")
+           .WithLibraryId(library.Id)
             .WithVolume(new VolumeBuilder("1")
                 .WithChapter(new ChapterBuilder("1").Build())
                 .WithChapter(new ChapterBuilder("2").Build())
@@ -290,7 +320,7 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
                 .WithChapter(new ChapterBuilder("32").Build())
                 .Build())
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
+
 
         context.Series.Add(series);
 
@@ -314,9 +344,14 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
     {
         // V1 -> V2
         var (unitOfWork, context, _) = await CreateDatabase();
-        var readerService = Setup(unitOfWork);
+                var readerService = Setup(unitOfWork);
+
+       var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
 
         var series = new SeriesBuilder("Test")
+           .WithLibraryId(library.Id)
             .WithVolume(new VolumeBuilder("1-2")
                 .WithChapter(new ChapterBuilder(API.Services.Tasks.Scanner.Parser.Parser.DefaultChapter).Build())
                 .Build())
@@ -325,7 +360,7 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
                 .WithChapter(new ChapterBuilder("1").Build())
                 .Build())
             .Build();
-        series.Library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+
 
         context.Series.Add(series);
 
@@ -348,9 +383,14 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
     {
         // V1 -> V2
         var (unitOfWork, context, _) = await CreateDatabase();
-        var readerService = Setup(unitOfWork);
+                var readerService = Setup(unitOfWork);
+
+       var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
 
         var series = new SeriesBuilder("Test")
+           .WithLibraryId(library.Id)
             .WithVolume(new VolumeBuilder("1.0")
                 .WithChapter(new ChapterBuilder("1").Build())
                 .Build())
@@ -369,7 +409,7 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
 
 
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
+
 
         context.Series.Add(series);
 
@@ -392,9 +432,14 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
     public async Task GetNextChapterIdAsync_ShouldRollIntoNextVolume()
     {
         var (unitOfWork, context, _) = await CreateDatabase();
-        var readerService = Setup(unitOfWork);
+                var readerService = Setup(unitOfWork);
+
+       var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
 
         var series = new SeriesBuilder("Test")
+           .WithLibraryId(library.Id)
             .WithVolume(new VolumeBuilder("1")
                 .WithChapter(new ChapterBuilder("1").Build())
                 .WithChapter(new ChapterBuilder("2").Build())
@@ -410,7 +455,7 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
                 .WithChapter(new ChapterBuilder("32").Build())
                 .Build())
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
+
 
         context.Series.Add(series);
 
@@ -432,9 +477,14 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
     public async Task GetNextChapterIdAsync_ShouldRollIntoNextVolumeWithFloat()
     {
         var (unitOfWork, context, _) = await CreateDatabase();
-        var readerService = Setup(unitOfWork);
+                var readerService = Setup(unitOfWork);
+
+       var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
 
         var series = new SeriesBuilder("Test")
+           .WithLibraryId(library.Id)
             .WithVolume(new VolumeBuilder("1")
                 .WithChapter(new ChapterBuilder("1").Build())
                 .WithChapter(new ChapterBuilder("2").Build())
@@ -450,7 +500,7 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
                 .WithChapter(new ChapterBuilder("32").Build())
                 .Build())
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
+
 
         context.Series.Add(series);
 
@@ -473,9 +523,14 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
     public async Task GetNextChapterIdAsync_ShouldRollIntoChaptersFromVolume()
     {
         var (unitOfWork, context, _) = await CreateDatabase();
-        var readerService = Setup(unitOfWork);
+                var readerService = Setup(unitOfWork);
+
+       var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
 
         var series = new SeriesBuilder("Test")
+           .WithLibraryId(library.Id)
             .WithVolume(new VolumeBuilder(API.Services.Tasks.Scanner.Parser.Parser.LooseLeafVolume)
                 .WithChapter(new ChapterBuilder("21").Build())
                 .WithChapter(new ChapterBuilder("22").Build())
@@ -486,7 +541,7 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
                 .WithChapter(new ChapterBuilder("2").Build())
                 .Build())
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
+
 
         context.Series.Add(series);
 
@@ -508,9 +563,14 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
     public async Task GetNextChapterIdAsync_ShouldRollIntoNextChapter_WhenVolumesAreOnlyOneChapter_AndNextChapterIs0()
     {
         var (unitOfWork, context, _) = await CreateDatabase();
-        var readerService = Setup(unitOfWork);
+                var readerService = Setup(unitOfWork);
+
+       var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
 
         var series = new SeriesBuilder("Test")
+           .WithLibraryId(library.Id)
             .WithVolume(new VolumeBuilder(API.Services.Tasks.Scanner.Parser.Parser.LooseLeafVolume)
                 .WithChapter(new ChapterBuilder("66").Build())
                 .WithChapter(new ChapterBuilder("67").Build())
@@ -524,7 +584,7 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
                 .WithChapter(new ChapterBuilder(API.Services.Tasks.Scanner.Parser.Parser.DefaultChapter).Build())
                 .Build())
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
+
 
         context.Series.Add(series);
 
@@ -549,9 +609,14 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
     public async Task GetNextChapterIdAsync_ShouldFindNoNextChapterFromSpecial()
     {
         var (unitOfWork, context, _) = await CreateDatabase();
-        var readerService = Setup(unitOfWork);
+                var readerService = Setup(unitOfWork);
+
+       var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
 
         var series = new SeriesBuilder("Test")
+           .WithLibraryId(library.Id)
             .WithVolume(new VolumeBuilder("1")
                 .WithChapter(new ChapterBuilder("1").Build())
                 .WithChapter(new ChapterBuilder("2").Build())
@@ -562,7 +627,7 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
                 .WithChapter(new ChapterBuilder("B.cbz").WithIsSpecial(true).WithSortOrder(API.Services.Tasks.Scanner.Parser.Parser.SpecialVolumeNumber + 1).Build())
                 .Build())
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
+
 
         context.Series.Add(series);
         context.AppUser.Add(new AppUser()
@@ -580,15 +645,20 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
     public async Task GetNextChapterIdAsync_ShouldFindNoNextChapterFromVolume()
     {
         var (unitOfWork, context, _) = await CreateDatabase();
-        var readerService = Setup(unitOfWork);
+                var readerService = Setup(unitOfWork);
+
+       var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
 
         var series = new SeriesBuilder("Test")
+           .WithLibraryId(library.Id)
             .WithVolume(new VolumeBuilder("1")
                 .WithChapter(new ChapterBuilder("1").Build())
                 .WithChapter(new ChapterBuilder("2").Build())
                 .Build())
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
+
 
         context.Series.Add(series);
         context.AppUser.Add(new AppUser()
@@ -606,15 +676,20 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
     public async Task GetNextChapterIdAsync_ShouldFindNoNextChapterFromLastChapter_NoSpecials()
     {
         var (unitOfWork, context, _) = await CreateDatabase();
-        var readerService = Setup(unitOfWork);
+                var readerService = Setup(unitOfWork);
+
+       var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
 
         var series = new SeriesBuilder("Test")
+           .WithLibraryId(library.Id)
             .WithVolume(new VolumeBuilder(API.Services.Tasks.Scanner.Parser.Parser.LooseLeafVolume)
                 .WithChapter(new ChapterBuilder("1").Build())
                 .WithChapter(new ChapterBuilder("2").Build())
                 .Build())
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
+
 
         context.Series.Add(series);
         context.AppUser.Add(new AppUser()
@@ -633,9 +708,14 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
     public async Task GetNextChapterIdAsync_ShouldFindNoNextChapterFromLastChapter_NoSpecials_FirstIsVolume()
     {
         var (unitOfWork, context, _) = await CreateDatabase();
-        var readerService = Setup(unitOfWork);
+                var readerService = Setup(unitOfWork);
+
+       var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
 
         var series = new SeriesBuilder("Test")
+           .WithLibraryId(library.Id)
             .WithVolume(new VolumeBuilder(API.Services.Tasks.Scanner.Parser.Parser.LooseLeafVolume)
                 .WithChapter(new ChapterBuilder("1").Build())
                 .WithChapter(new ChapterBuilder("2").Build())
@@ -644,7 +724,7 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
                 .WithChapter(new ChapterBuilder(API.Services.Tasks.Scanner.Parser.Parser.DefaultChapter).Build())
                 .Build())
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
+
 
         context.Series.Add(series);
         context.AppUser.Add(new AppUser()
@@ -662,9 +742,14 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
     public async Task GetNextChapterIdAsync_ShouldFindNoNextChapterFromLastChapter_WithSpecials()
     {
         var (unitOfWork, context, _) = await CreateDatabase();
-        var readerService = Setup(unitOfWork);
+                var readerService = Setup(unitOfWork);
+
+       var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
 
         var series = new SeriesBuilder("Test")
+           .WithLibraryId(library.Id)
             .WithVolume(new VolumeBuilder(API.Services.Tasks.Scanner.Parser.Parser.LooseLeafVolume)
                 .WithChapter(new ChapterBuilder("1").Build())
                 .WithChapter(new ChapterBuilder("2").Build())
@@ -681,7 +766,7 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
                 .WithChapter(new ChapterBuilder("2").Build())
                 .Build())
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
+
 
         context.Series.Add(series);
         context.AppUser.Add(new AppUser()
@@ -701,9 +786,14 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
     public async Task GetNextChapterIdAsync_ShouldMoveFromVolumeToSpecial_NoLooseLeafChapters()
     {
         var (unitOfWork, context, _) = await CreateDatabase();
-        var readerService = Setup(unitOfWork);
+                var readerService = Setup(unitOfWork);
+
+       var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
 
         var series = new SeriesBuilder("Test")
+           .WithLibraryId(library.Id)
             .WithVolume(new VolumeBuilder("1")
                 .WithChapter(new ChapterBuilder("1").Build())
                 .WithChapter(new ChapterBuilder("2").Build())
@@ -720,7 +810,7 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
                     .Build())
                 .Build())
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
+
 
         context.Series.Add(series);
 
@@ -743,9 +833,14 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
     public async Task GetNextChapterIdAsync_ShouldMoveFromLooseLeafChapterToSpecial()
     {
         var (unitOfWork, context, _) = await CreateDatabase();
-        var readerService = Setup(unitOfWork);
+                var readerService = Setup(unitOfWork);
+
+       var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
 
         var series = new SeriesBuilder("Test")
+           .WithLibraryId(library.Id)
             .WithVolume(new VolumeBuilder(API.Services.Tasks.Scanner.Parser.Parser.LooseLeafVolume)
                 .WithChapter(new ChapterBuilder("1").Build())
                 .WithChapter(new ChapterBuilder("2").Build())
@@ -759,7 +854,7 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
                     .Build())
                 .Build())
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
+
 
         context.Series.Add(series);
 
@@ -782,9 +877,14 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
     public async Task GetNextChapterIdAsync_ShouldFindNoNextChapterFromSpecial_WithVolumeAndLooseLeafChapters()
     {
         var (unitOfWork, context, _) = await CreateDatabase();
-        var readerService = Setup(unitOfWork);
+                var readerService = Setup(unitOfWork);
+
+       var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
 
         var series = new SeriesBuilder("Test")
+           .WithLibraryId(library.Id)
             .WithVolume(new VolumeBuilder(API.Services.Tasks.Scanner.Parser.Parser.LooseLeafVolume)
                 .WithChapter(new ChapterBuilder("1").Build())
                 .WithChapter(new ChapterBuilder("2").Build())
@@ -802,7 +902,7 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
                     .Build())
                 .Build())
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
+
 
         context.Series.Add(series);
 
@@ -822,9 +922,14 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
     public async Task GetNextChapterIdAsync_ShouldMoveFromSpecialToSpecial()
     {
         var (unitOfWork, context, _) = await CreateDatabase();
-        var readerService = Setup(unitOfWork);
+                var readerService = Setup(unitOfWork);
+
+       var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
 
         var series = new SeriesBuilder("Test")
+           .WithLibraryId(library.Id)
             .WithVolume(new VolumeBuilder("1")
                 .WithChapter(new ChapterBuilder("1").Build())
                 .WithChapter(new ChapterBuilder("2").Build())
@@ -840,7 +945,7 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
                     .Build())
                 .Build())
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
+
 
         context.Series.Add(series);
 
@@ -863,9 +968,14 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
     public async Task GetNextChapterIdAsync_ShouldRollIntoNextVolume_WhenAllVolumesHaveAChapterToo()
     {
         var (unitOfWork, context, _) = await CreateDatabase();
-        var readerService = Setup(unitOfWork);
+                var readerService = Setup(unitOfWork);
+
+       var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
 
         var series = new SeriesBuilder("Test")
+           .WithLibraryId(library.Id)
             .WithVolume(new VolumeBuilder("1")
                 .WithChapter(new ChapterBuilder("12").Build())
                 .Build())
@@ -874,7 +984,7 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
                 .WithChapter(new ChapterBuilder("12").Build())
                 .Build())
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
+
 
         context.Series.Add(series);
 
@@ -903,9 +1013,14 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
     {
         // V1 -> V2
         var (unitOfWork, context, _) = await CreateDatabase();
-        var readerService = Setup(unitOfWork);
+                var readerService = Setup(unitOfWork);
+
+       var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
 
         var series = new SeriesBuilder("Test")
+           .WithLibraryId(library.Id)
             .WithVolume(new VolumeBuilder("1")
                 .WithChapter(new ChapterBuilder("1").Build())
                 .WithChapter(new ChapterBuilder("2").Build())
@@ -921,7 +1036,7 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
                 .WithChapter(new ChapterBuilder("32").Build())
                 .Build())
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
+
 
         context.Series.Add(series);
 
@@ -945,9 +1060,14 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
     {
         // V1 -> V2
         var (unitOfWork, context, _) = await CreateDatabase();
-        var readerService = Setup(unitOfWork);
+                var readerService = Setup(unitOfWork);
+
+       var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
 
         var series = new SeriesBuilder("Test")
+           .WithLibraryId(library.Id)
             .WithVolume(new VolumeBuilder("1")
                 .WithChapter(new ChapterBuilder("1").Build())
                 .WithChapter(new ChapterBuilder("2").Build())
@@ -963,7 +1083,7 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
                 .WithChapter(new ChapterBuilder("32").Build())
                 .Build())
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
+
         context.Series.Add(series);
         context.AppUser.Add(new AppUser()
         {
@@ -984,9 +1104,14 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
     public async Task GetPrevChapterIdAsync_ShouldGetPrevVolume_2()
     {
         var (unitOfWork, context, _) = await CreateDatabase();
-        var readerService = Setup(unitOfWork);
+                var readerService = Setup(unitOfWork);
+
+       var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
 
         var series = new SeriesBuilder("Test")
+           .WithLibraryId(library.Id)
             .WithVolume(new VolumeBuilder(API.Services.Tasks.Scanner.Parser.Parser.LooseLeafVolume)
                 .WithChapter(new ChapterBuilder("40").WithPages(1).Build())
                 .WithChapter(new ChapterBuilder("50").WithPages(1).Build())
@@ -1013,7 +1138,7 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
                 .WithChapter(new ChapterBuilder("31").WithPages(1).Build())
                 .Build())
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
+
         context.Series.Add(series);
         context.AppUser.Add(new AppUser()
         {
@@ -1036,9 +1161,14 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
     public async Task GetPrevChapterIdAsync_ShouldRollIntoPrevVolume()
     {
         var (unitOfWork, context, _) = await CreateDatabase();
-        var readerService = Setup(unitOfWork);
+                var readerService = Setup(unitOfWork);
+
+       var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
 
         var series = new SeriesBuilder("Test")
+           .WithLibraryId(library.Id)
             .WithVolume(new VolumeBuilder("1")
                 .WithChapter(new ChapterBuilder("1").WithPages(1).Build())
                 .WithChapter(new ChapterBuilder("2").WithPages(1).Build())
@@ -1054,7 +1184,7 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
                 .WithChapter(new ChapterBuilder("32").WithPages(1).Build())
                 .Build())
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
+
 
         context.Series.Add(series);
 
@@ -1078,9 +1208,14 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
     public async Task GetPrevChapterIdAsync_ShouldMoveFromSpecialToVolume()
     {
         var (unitOfWork, context, _) = await CreateDatabase();
-        var readerService = Setup(unitOfWork);
+                var readerService = Setup(unitOfWork);
+
+       var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
 
         var series = new SeriesBuilder("Test")
+           .WithLibraryId(library.Id)
             .WithVolume(new VolumeBuilder("1")
                 .WithChapter(new ChapterBuilder("1").Build())
                 .WithChapter(new ChapterBuilder("2").Build())
@@ -1091,7 +1226,7 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
                 .WithChapter(new ChapterBuilder("B.cbz").WithIsSpecial(true).WithSortOrder(API.Services.Tasks.Scanner.Parser.Parser.SpecialVolumeNumber + 2).Build())
                 .Build())
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
+
 
         context.Series.Add(series);
 
@@ -1118,13 +1253,17 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
         var (unitOfWork, context, _) = await CreateDatabase();
         var readerService = Setup(unitOfWork);
 
+        var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
+
         var series = new SeriesBuilder("Test")
+            .WithLibraryId(library.Id)
             .WithVolume(new VolumeBuilder("1")
                 .WithChapter(new ChapterBuilder("1").Build())
                 .WithChapter(new ChapterBuilder("2").Build())
                 .Build())
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
 
         context.Series.Add(series);
 
@@ -1134,8 +1273,6 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
         });
 
         await context.SaveChangesAsync();
-
-
 
 
         var prevChapter = await readerService.GetPrevChapterIdAsync(1, 1, 1, 1);
@@ -1148,12 +1285,16 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
         var (unitOfWork, context, _) = await CreateDatabase();
         var readerService = Setup(unitOfWork);
 
+        var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
+
         var series = new SeriesBuilder("Test")
             .WithVolume(new VolumeBuilder("1")
                 .WithChapter(new ChapterBuilder(API.Services.Tasks.Scanner.Parser.Parser.DefaultChapter).Build())
                 .Build())
+            .WithLibraryId(library.Id)
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
 
         context.Series.Add(series);
 
@@ -1177,6 +1318,10 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
         var (unitOfWork, context, _) = await CreateDatabase();
         var readerService = Setup(unitOfWork);
 
+        var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
+
         var series = new SeriesBuilder("Test")
             .WithVolume(new VolumeBuilder(API.Services.Tasks.Scanner.Parser.Parser.LooseLeafVolume)
                 .WithChapter(new ChapterBuilder("1").Build())
@@ -1186,8 +1331,8 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
             .WithVolume(new VolumeBuilder("1")
                 .WithChapter(new ChapterBuilder(API.Services.Tasks.Scanner.Parser.Parser.DefaultChapter).Build())
                 .Build())
+            .WithLibraryId(library.Id)
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
 
         context.Series.Add(series);
 
@@ -1208,6 +1353,10 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
         var (unitOfWork, context, _) = await CreateDatabase();
         var readerService = Setup(unitOfWork);
 
+        var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
+
         var series = new SeriesBuilder("Test")
             .WithVolume(new VolumeBuilder(API.Services.Tasks.Scanner.Parser.Parser.LooseLeafVolume)
                 .WithChapter(new ChapterBuilder("5").Build())
@@ -1224,8 +1373,8 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
                 .WithChapter(new ChapterBuilder("3").Build())
                 .WithChapter(new ChapterBuilder("4").Build())
                 .Build())
+            .WithLibraryId(library.Id)
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
 
         context.Series.Add(series);
 
@@ -1254,13 +1403,17 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
         var (unitOfWork, context, _) = await CreateDatabase();
         var readerService = Setup(unitOfWork);
 
+        var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
+
         var series = new SeriesBuilder("Test")
             .WithVolume(new VolumeBuilder(API.Services.Tasks.Scanner.Parser.Parser.LooseLeafVolume)
                 .WithChapter(new ChapterBuilder("1").Build())
                 .WithChapter(new ChapterBuilder("2").Build())
                 .Build())
+            .WithLibraryId(library.Id)
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
 
         context.Series.Add(series);
 
@@ -1284,6 +1437,10 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
         var (unitOfWork, context, _) = await CreateDatabase();
         var readerService = Setup(unitOfWork);
 
+        var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
+
         var series = new SeriesBuilder("Test")
             .WithVolume(new VolumeBuilder("1")
                 .WithChapter(new ChapterBuilder("1").Build())
@@ -1299,8 +1456,9 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
                     .WithSortOrder(API.Services.Tasks.Scanner.Parser.Parser.SpecialVolumeNumber + 2)
                     .Build())
                 .Build())
+            .WithLibraryId(library.Id)
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
+
 
         context.Series.Add(series);
 
@@ -1328,6 +1486,10 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
         var (unitOfWork, context, _) = await CreateDatabase();
         var readerService = Setup(unitOfWork);
 
+        var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
+
         var series = new SeriesBuilder("Test")
             .WithVolume(new VolumeBuilder(API.Services.Tasks.Scanner.Parser.Parser.LooseLeafVolume)
                 .WithChapter(new ChapterBuilder("1").Build())
@@ -1337,9 +1499,9 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
                 .WithChapter(new ChapterBuilder("21").Build())
                 .WithChapter(new ChapterBuilder("22").Build())
                 .Build())
-
+            .WithLibraryId(library.Id)
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
+
 
         context.Series.Add(series);
 
@@ -1363,6 +1525,10 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
         var (unitOfWork, context, _) = await CreateDatabase();
         var readerService = Setup(unitOfWork);
 
+        var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
+
         var series = new SeriesBuilder("Test")
             .WithVolume(new VolumeBuilder("1")
                 .WithChapter(new ChapterBuilder("12").Build())
@@ -1371,8 +1537,8 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
             .WithVolume(new VolumeBuilder("2")
                 .WithChapter(new ChapterBuilder("12").Build())
                 .Build())
+            .WithLibraryId(library.Id)
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
 
         context.Series.Add(series);
 
@@ -1396,6 +1562,11 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
     {
         var (unitOfWork, context, _) = await CreateDatabase();
         var readerService = Setup(unitOfWork);
+
+        var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
+
         var series = new SeriesBuilder("Test")
             .WithVolume(new VolumeBuilder(API.Services.Tasks.Scanner.Parser.Parser.LooseLeafVolume)
                 .WithChapter(new ChapterBuilder("95").Build())
@@ -1413,9 +1584,9 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
                 .WithChapter(new ChapterBuilder("31").Build())
                 .WithChapter(new ChapterBuilder("32").Build())
                 .Build())
-
+            .WithLibraryId(library.Id)
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
+
 
         context.Series.Add(series);
 
@@ -1440,6 +1611,10 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
     {
         var (unitOfWork, context, _) = await CreateDatabase();
         var readerService = Setup(unitOfWork);
+        var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
+
         var series = new SeriesBuilder("Test")
             .WithVolume(new VolumeBuilder("1")
                 .WithChapter(new ChapterBuilder("1").WithPages(3).Build())
@@ -1448,8 +1623,8 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
                 .WithChapter(new ChapterBuilder(API.Services.Tasks.Scanner.Parser.Parser.DefaultChapter).WithPages(1).Build())
                 .Build())
             .WithPages(4)
+            .WithLibraryId(library.Id)
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
 
         context.Series.Add(series);
 
@@ -1480,6 +1655,11 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
     {
         var (unitOfWork, context, _) = await CreateDatabase();
         var readerService = Setup(unitOfWork);
+
+        var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
+
         var series = new SeriesBuilder("Test")
             .WithVolume(new VolumeBuilder("1")
                 .WithChapter(new ChapterBuilder("1", "1-11").WithPages(3).Build())
@@ -1488,8 +1668,9 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
                 .WithChapter(new ChapterBuilder(API.Services.Tasks.Scanner.Parser.Parser.DefaultChapter).WithPages(1).Build())
                 .Build())
             .WithPages(4)
+            .WithLibraryId(library.Id)
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
+
 
         context.Series.Add(series);
 
@@ -1520,6 +1701,11 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
     {
         var (unitOfWork, context, _) = await CreateDatabase();
         var readerService = Setup(unitOfWork);
+
+        var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
+
         var series = new SeriesBuilder("Test")
             .WithVolume(new VolumeBuilder("1")
                 .WithChapter(new ChapterBuilder("1").WithPages(1).Build())
@@ -1534,8 +1720,9 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
                 .WithChapter(new ChapterBuilder("31").WithPages(1).Build())
                 .WithChapter(new ChapterBuilder("32").WithPages(1).Build())
                 .Build())
+            .WithLibraryId(library.Id)
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
+
 
         context.Series.Add(series);
 
@@ -1586,6 +1773,11 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
     {
         var (unitOfWork, context, _) = await CreateDatabase();
         var readerService = Setup(unitOfWork);
+
+        var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
+
         var series = new SeriesBuilder("Test")
             // Loose chapters
             .WithVolume(new VolumeBuilder(API.Services.Tasks.Scanner.Parser.Parser.LooseLeafVolume)
@@ -1614,8 +1806,8 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
                 .WithChapter(new ChapterBuilder("31").WithPages(1).Build())
                 .WithChapter(new ChapterBuilder("32").WithPages(1).Build())
                 .Build())
+            .WithLibraryId(library.Id)
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
 
         context.Series.Add(series);
 
@@ -1661,6 +1853,11 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
     {
         var (unitOfWork, context, _) = await CreateDatabase();
         var readerService = Setup(unitOfWork);
+
+        var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
+
         var series = new SeriesBuilder("Test")
             // Loose chapters
             .WithVolume(new VolumeBuilder(API.Services.Tasks.Scanner.Parser.Parser.LooseLeafVolume)
@@ -1670,8 +1867,9 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
             .WithVolume(new VolumeBuilder(API.Services.Tasks.Scanner.Parser.Parser.SpecialVolume)
                 .WithChapter(new ChapterBuilder("Prologue").WithIsSpecial(true).WithSortOrder(API.Services.Tasks.Scanner.Parser.Parser.SpecialVolumeNumber + 1).WithPages(1).Build())
                 .Build())
+            .WithLibraryId(library.Id)
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
+
 
         context.Series.Add(series);
 
@@ -1692,6 +1890,11 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
     {
         var (unitOfWork, context, _) = await CreateDatabase();
         var readerService = Setup(unitOfWork);
+
+        var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
+
         var series = new SeriesBuilder("Test")
             .WithVolume(new VolumeBuilder("1")
                 .WithChapter(new ChapterBuilder("1").WithPages(1).Build())
@@ -1704,8 +1907,8 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
                 .WithChapter(new ChapterBuilder("31").WithPages(1).Build())
                 .WithChapter(new ChapterBuilder("32").WithPages(1).Build())
                 .Build())
+            .WithLibraryId(library.Id)
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
 
         context.Series.Add(series);
 
@@ -1754,6 +1957,11 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
     {
         var (unitOfWork, context, _) = await CreateDatabase();
         var readerService = Setup(unitOfWork);
+
+        var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
+
         var series = new SeriesBuilder("Test")
             .WithVolume(new VolumeBuilder(API.Services.Tasks.Scanner.Parser.Parser.LooseLeafVolume)
                 .WithChapter(new ChapterBuilder("230").WithPages(1).Build())
@@ -1767,8 +1975,9 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
             .WithVolume(new VolumeBuilder("2")
                 .WithChapter(new ChapterBuilder("21").WithPages(1).Build())
                 .Build())
+            .WithLibraryId(library.Id)
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
+
 
         context.Series.Add(series);
 
@@ -1791,7 +2000,13 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
     {
         var (unitOfWork, context, _) = await CreateDatabase();
         var readerService = Setup(unitOfWork);
+
+        var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
+
         var series = new SeriesBuilder("Test")
+            .WithLibraryId(library.Id)
             .WithVolume(new VolumeBuilder(API.Services.Tasks.Scanner.Parser.Parser.LooseLeafVolume)
                 .WithChapter(new ChapterBuilder("100").WithPages(1).Build())
                 .WithChapter(new ChapterBuilder("101").WithPages(1).Build())
@@ -1807,7 +2022,6 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
                 .WithChapter(new ChapterBuilder(API.Services.Tasks.Scanner.Parser.Parser.DefaultChapter).WithPages(1).Build())
                 .Build())
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
 
         context.Series.Add(series);
 
@@ -1847,7 +2061,13 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
     {
         var (unitOfWork, context, _) = await CreateDatabase();
         var readerService = Setup(unitOfWork);
+
+        var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
+
         var series = new SeriesBuilder("Test")
+            .WithLibraryId(library.Id)
             .WithVolume(new VolumeBuilder(API.Services.Tasks.Scanner.Parser.Parser.LooseLeafVolume)
                 .WithChapter(new ChapterBuilder("100").WithPages(1).Build())
                 .WithChapter(new ChapterBuilder("101").WithPages(1).Build())
@@ -1862,7 +2082,7 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
                 .WithChapter(new ChapterBuilder("21").WithPages(1).Build())
                 .Build())
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
+
 
         context.Series.Add(series);
 
@@ -1906,7 +2126,13 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
     {
         var (unitOfWork, context, _) = await CreateDatabase();
         var readerService = Setup(unitOfWork);
+
+        var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
+
         var series = new SeriesBuilder("Test")
+            .WithLibraryId(library.Id)
             .WithVolume(new VolumeBuilder("1")
                 .WithChapter(new ChapterBuilder("1").WithPages(1).Build())
                 .WithChapter(new ChapterBuilder("2").WithPages(1).Build())
@@ -1916,7 +2142,7 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
                 .WithChapter(new ChapterBuilder("21").WithPages(1).Build())
                 .Build())
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
+
 
         context.Series.Add(series);
 
@@ -1964,7 +2190,13 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
     {
         var (unitOfWork, context, _) = await CreateDatabase();
         var readerService = Setup(unitOfWork);
+
+        var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
+
         var series = new SeriesBuilder("Test")
+            .WithLibraryId(library.Id)
 
             .WithVolume(new VolumeBuilder(API.Services.Tasks.Scanner.Parser.Parser.LooseLeafVolume)
                 .WithChapter(new ChapterBuilder("1").WithPages(1).Build())
@@ -1977,7 +2209,7 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
                 .WithChapter(new ChapterBuilder("22").WithPages(1).Build())
                 .Build())
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
+
 
         context.Series.Add(series);
 
@@ -2005,7 +2237,13 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
     {
         var (unitOfWork, context, _) = await CreateDatabase();
         var readerService = Setup(unitOfWork);
+
+        var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
+
         var series = new SeriesBuilder("Test")
+            .WithLibraryId(library.Id)
 
             .WithVolume(new VolumeBuilder(API.Services.Tasks.Scanner.Parser.Parser.LooseLeafVolume)
                 .WithChapter(new ChapterBuilder("1").WithPages(1).Build())
@@ -2016,7 +2254,7 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
                 .WithChapter(new ChapterBuilder("Some Special Title").WithIsSpecial(true).WithSortOrder(API.Services.Tasks.Scanner.Parser.Parser.SpecialVolumeNumber + 1).WithPages(1).Build())
                 .Build())
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
+
 
         context.Series.Add(series);
 
@@ -2064,7 +2302,13 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
     {
         var (unitOfWork, context, _) = await CreateDatabase();
         var readerService = Setup(unitOfWork);
+
+        var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
+
         var series = new SeriesBuilder("Test")
+            .WithLibraryId(library.Id)
 
             .WithVolume(new VolumeBuilder(API.Services.Tasks.Scanner.Parser.Parser.LooseLeafVolume)
                 .WithChapter(new ChapterBuilder("230").WithPages(1).Build())
@@ -2080,7 +2324,7 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
                 //.WithChapter(new ChapterBuilder("14.9").WithPages(1).Build()) (added later)
                 .Build())
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
+
 
         context.Series.Add(series);
 
@@ -2117,12 +2361,18 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
     {
         var (unitOfWork, context, _) = await CreateDatabase();
         var readerService = Setup(unitOfWork);
+
+
+        var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
+
         var readChapter1 = new ChapterBuilder(API.Services.Tasks.Scanner.Parser.Parser.DefaultChapter).WithPages(1).Build();
         var readChapter2 = new ChapterBuilder(API.Services.Tasks.Scanner.Parser.Parser.DefaultChapter).WithPages(1).Build();
         var volume = new VolumeBuilder("3").WithChapter(new ChapterBuilder(API.Services.Tasks.Scanner.Parser.Parser.DefaultChapter).WithPages(1).Build()).Build();
 
         var series = new SeriesBuilder("Test")
-
+            .WithLibraryId(library.Id)
             .WithVolume(new VolumeBuilder(API.Services.Tasks.Scanner.Parser.Parser.LooseLeafVolume)
                 .WithChapter(new ChapterBuilder("51").WithPages(1).Build())
                 .WithChapter(new ChapterBuilder("52").WithPages(1).Build())
@@ -2144,7 +2394,7 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
                 .WithChapter(new ChapterBuilder("41").WithPages(1).Build())
                 .Build())
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
+
 
         context.Series.Add(series);
 
@@ -2184,7 +2434,13 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
     {
         var (unitOfWork, context, _) = await CreateDatabase();
         var readerService = Setup(unitOfWork);
+
+        var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
+
         var series = new SeriesBuilder("Test")
+            .WithLibraryId(library.Id)
             .WithVolume(new VolumeBuilder("1")
                 .WithChapter(new ChapterBuilder("1").WithPages(1).Build())
                 .Build())
@@ -2201,7 +2457,7 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
                 .WithChapter(new ChapterBuilder("Special").WithIsSpecial(true).WithSortOrder(API.Services.Tasks.Scanner.Parser.Parser.SpecialVolumeNumber + 1).WithPages(1).Build())
                 .Build())
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
+
 
         context.Series.Add(series);
 
@@ -2280,7 +2536,13 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
     {
         var (unitOfWork, context, _) = await CreateDatabase();
         var readerService = Setup(unitOfWork);
+
+        var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
+
         var series = new SeriesBuilder("Test")
+            .WithLibraryId(library.Id)
             .WithVolume(new VolumeBuilder("1")
                 .WithChapter(new ChapterBuilder("1").WithPages(1).Build())
                 .WithChapter(new ChapterBuilder("2").WithPages(1).Build())
@@ -2296,7 +2558,7 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
                 .WithChapter(new ChapterBuilder("32").WithPages(1).Build())
                 .Build())
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
+
 
         context.Series.Add(series);
 
@@ -2363,7 +2625,13 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
     {
         var (unitOfWork, context, _) = await CreateDatabase();
         var readerService = Setup(unitOfWork);
+
+        var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
+
         var series = new SeriesBuilder("Test")
+            .WithLibraryId(library.Id)
 
             .WithVolume(new VolumeBuilder(API.Services.Tasks.Scanner.Parser.Parser.LooseLeafVolume)
                 .WithChapter(new ChapterBuilder("1").WithPages(1).Build())
@@ -2374,7 +2642,7 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
                 .WithChapter(new ChapterBuilder("Some Special Title").WithSortOrder(API.Services.Tasks.Scanner.Parser.Parser.SpecialVolumeNumber + 1).WithIsSpecial(true).WithPages(1).Build())
                 .Build())
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
+
 
         context.Series.Add(series);
 
@@ -2403,7 +2671,13 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
     {
         var (unitOfWork, context, _) = await CreateDatabase();
         var readerService = Setup(unitOfWork);
+
+        var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
+
         var series = new SeriesBuilder("Test")
+            .WithLibraryId(library.Id)
 
             .WithVolume(new VolumeBuilder(API.Services.Tasks.Scanner.Parser.Parser.LooseLeafVolume)
                 .WithChapter(new ChapterBuilder("1").WithPages(1).Build())
@@ -2415,7 +2689,7 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
                     .WithChapter(new ChapterBuilder("Some Special Title").WithSortOrder(API.Services.Tasks.Scanner.Parser.Parser.SpecialVolumeNumber + 1).WithIsSpecial(true).WithPages(1).Build())
                     .Build())
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
+
 
         context.Series.Add(series);
 
@@ -2445,7 +2719,13 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
     {
         var (unitOfWork, context, _) = await CreateDatabase();
         var readerService = Setup(unitOfWork);
+
+        var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
+
         var series = new SeriesBuilder("Test")
+            .WithLibraryId(library.Id)
 
             .WithVolume(new VolumeBuilder("1")
                 .WithChapter(new ChapterBuilder(API.Services.Tasks.Scanner.Parser.Parser.DefaultChapter).WithPages(1).Build())
@@ -2454,7 +2734,7 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
                 .WithChapter(new ChapterBuilder(API.Services.Tasks.Scanner.Parser.Parser.DefaultChapter).WithPages(1).Build())
                 .Build())
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
+
 
         context.Series.Add(series);
 
@@ -2481,7 +2761,13 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
     {
         var (unitOfWork, context, _) = await CreateDatabase();
         var readerService = Setup(unitOfWork);
+
+        var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
+
         var series = new SeriesBuilder("Test")
+            .WithLibraryId(library.Id)
 
             .WithVolume(new VolumeBuilder(API.Services.Tasks.Scanner.Parser.Parser.LooseLeafVolume)
                 .WithChapter(new ChapterBuilder("45").WithPages(5).Build())
@@ -2507,7 +2793,7 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
                 .WithChapter(new ChapterBuilder("14").WithPages(5).Build())
                 .Build())
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
+
 
         context.Series.Add(series);
 
@@ -2551,8 +2837,12 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
         var (unitOfWork, context, _) = await CreateDatabase();
         var readerService = Setup(unitOfWork);
 
-        var series = new SeriesBuilder("Test")
+        var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
 
+        var series = new SeriesBuilder("Test")
+            .WithLibraryId(library.Id)
             .WithVolume(new VolumeBuilder("1")
                 .WithChapter(new ChapterBuilder(API.Services.Tasks.Scanner.Parser.Parser.DefaultChapter).WithPages(1).Build())
                 .WithChapter(new ChapterBuilder("1").WithPages(2).Build())
@@ -2562,7 +2852,7 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
                 .WithChapter(new ChapterBuilder("1").WithPages(2).Build())
                 .Build())
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
+
 
         context.Series.Add(series);
 
@@ -2591,14 +2881,20 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
     {
         var (unitOfWork, context, _) = await CreateDatabase();
         var readerService = Setup(unitOfWork);
+
+        var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
+
         var series = new SeriesBuilder("Test")
+            .WithLibraryId(library.Id)
 
             .WithVolume(new VolumeBuilder(API.Services.Tasks.Scanner.Parser.Parser.LooseLeafVolume)
                 .WithChapter(new ChapterBuilder(API.Services.Tasks.Scanner.Parser.Parser.DefaultChapter).WithPages(1).Build())
                 .WithChapter(new ChapterBuilder("1").WithPages(2).Build())
                 .Build())
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
+
 
         context.Series.Add(series);
 
@@ -2665,7 +2961,13 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
     {
         var (unitOfWork, context, _) = await CreateDatabase();
         var readerService = Setup(unitOfWork);
+
+        var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
+
         var series = new SeriesBuilder("Test")
+            .WithLibraryId(library.Id)
 
             .WithVolume(new VolumeBuilder(API.Services.Tasks.Scanner.Parser.Parser.LooseLeafVolume)
                 .WithChapter(new ChapterBuilder("10").WithPages(1).Build())
@@ -2687,7 +2989,7 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
                 .WithChapter(new ChapterBuilder(API.Services.Tasks.Scanner.Parser.Parser.DefaultChapter).WithPages(1).Build())
                 .Build())
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
+
 
         context.Series.Add(series);
 
@@ -2723,7 +3025,13 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
     {
         var (unitOfWork, context, _) = await CreateDatabase();
         var readerService = Setup(unitOfWork);
+
+        var library = new LibraryBuilder("Test Lib", LibraryType.Manga).Build();
+        context.Library.Add(library);
+        await context.SaveChangesAsync();
+
         var series = new SeriesBuilder("Test")
+            .WithLibraryId(library.Id)
             .WithVolume(new VolumeBuilder(API.Services.Tasks.Scanner.Parser.Parser.LooseLeafVolume)
                 .WithChapter(new ChapterBuilder("10").WithPages(1).Build())
                 .WithChapter(new ChapterBuilder("20").WithPages(1).Build())
@@ -2744,7 +3052,7 @@ public class ReaderServiceTests(ITestOutputHelper testOutputHelper) : AbstractDb
                 .WithChapter(new ChapterBuilder("3").WithPages(1).Build())
                 .Build())
             .Build();
-        series.Library = new LibraryBuilder("Test LIb", LibraryType.Manga).Build();
+
 
         context.Series.Add(series);
 

--- a/API.Tests/Services/ReadingProfileServiceTest.cs
+++ b/API.Tests/Services/ReadingProfileServiceTest.cs
@@ -24,7 +24,7 @@ public class ReadingProfileServiceTest(ITestOutputHelper outputHelper): Abstract
     /// Does not add a default reading profile
     /// </summary>
     /// <returns></returns>
-    public async Task<(ReadingProfileService, AppUser, Library, Series)> Setup(IUnitOfWork unitOfWork, DataContext context, IMapper mapper)
+    private static async Task<(ReadingProfileService, AppUser, Library, Series)> Setup(IUnitOfWork unitOfWork, DataContext context, IMapper mapper)
     {
         var user = new AppUserBuilder("amelia", "amelia@localhost").Build();
         context.AppUser.Add(user);
@@ -37,6 +37,12 @@ public class ReadingProfileServiceTest(ITestOutputHelper outputHelper): Abstract
             .Build();
 
         user.Libraries.Add(library);
+
+        context.AppUserReadingProfiles.Add(new AppUserReadingProfileBuilder(user!.Id)
+            .WithName("Global")
+            .WithKind(ReadingProfileKind.Default)
+            .Build());
+
         await unitOfWork.CommitAsync();
 
         var rps = new ReadingProfileService(unitOfWork, Substitute.For<ILocalizationService>(), mapper);
@@ -45,11 +51,13 @@ public class ReadingProfileServiceTest(ITestOutputHelper outputHelper): Abstract
         return (rps, user, library, series);
     }
 
+    #region Pre-Device Tests - Must of course keep passing
+
     [Fact]
     public async Task ImplicitProfileFirst()
     {
         var (unitOfWork, context, mapper) = await CreateDatabase();
-        var (rps, user, library, series) = await Setup(unitOfWork, context, mapper);
+        var (rps, user, _, series) = await Setup(unitOfWork, context, mapper);
 
         var profile = new AppUserReadingProfileBuilder(user.Id)
             .WithKind(ReadingProfileKind.Implicit)
@@ -66,12 +74,12 @@ public class ReadingProfileServiceTest(ITestOutputHelper outputHelper): Abstract
         user.ReadingProfiles.Add(profile2);
         await unitOfWork.CommitAsync();
 
-        var seriesProfile = await rps.GetReadingProfileDtoForSeries(user.Id, series.Id);
+        var seriesProfile = await rps.GetReadingProfileDtoForSeries(user.Id, series.LibraryId, series.Id, null);
         Assert.NotNull(seriesProfile);
         Assert.Equal("Implicit Profile", seriesProfile.Name);
 
         // Find parent
-        seriesProfile = await rps.GetReadingProfileDtoForSeries(user.Id, series.Id, true);
+        seriesProfile = await rps.GetReadingProfileDtoForSeries(user.Id, series.LibraryId, series.Id, null, true);
         Assert.NotNull(seriesProfile);
         Assert.Equal("Non-implicit Profile", seriesProfile.Name);
     }
@@ -82,11 +90,10 @@ public class ReadingProfileServiceTest(ITestOutputHelper outputHelper): Abstract
         var (unitOfWork, context, mapper) = await CreateDatabase();
         var (rps, user, _, _) = await Setup(unitOfWork, context, mapper);
 
-        var profile = new AppUserReadingProfileBuilder(user.Id)
-            .WithKind(ReadingProfileKind.Default)
-            .Build();
-        context.AppUserReadingProfiles.Add(profile);
-        await unitOfWork.CommitAsync();
+        var profile = await context.AppUserReadingProfiles
+            .FirstOrDefaultAsync(rp => rp.Kind == ReadingProfileKind.Default);
+
+        Assert.NotNull(profile);
 
         await Assert.ThrowsAsync<KavitaException>(async () =>
         {
@@ -117,9 +124,9 @@ public class ReadingProfileServiceTest(ITestOutputHelper outputHelper): Abstract
             WidthOverride = 53,
         };
 
-        await rps.UpdateImplicitReadingProfile(user.Id, series.Id, dto);
+        await rps.UpdateImplicitReadingProfile(user.Id, series.LibraryId, series.Id, dto, null);
 
-        var profile = await rps.GetReadingProfileForSeries(user.Id, series.Id);
+        var profile = await rps.GetReadingProfileForSeries(user.Id, series.LibraryId, series.Id, null);
         Assert.NotNull(profile);
         Assert.Contains(profile.SeriesIds, s => s == series.Id);
         Assert.Equal(ReadingProfileKind.Implicit, profile.Kind);
@@ -138,9 +145,9 @@ public class ReadingProfileServiceTest(ITestOutputHelper outputHelper): Abstract
             WidthOverride = 53,
         };
 
-        await rps.UpdateImplicitReadingProfile(user.Id, series.Id, dto);
+        await rps.UpdateImplicitReadingProfile(user.Id, series.LibraryId, series.Id, dto, null);
 
-        var profile =  await rps.GetReadingProfileForSeries(user.Id, series.Id);
+        var profile =  await rps.GetReadingProfileForSeries(user.Id, series.LibraryId, series.Id, null);
         Assert.NotNull(profile);
         Assert.Contains(profile.SeriesIds, s => s == series.Id);
         Assert.Equal(ReadingProfileKind.Implicit, profile.Kind);
@@ -150,8 +157,8 @@ public class ReadingProfileServiceTest(ITestOutputHelper outputHelper): Abstract
             ReaderMode = ReaderMode.LeftRight,
         };
 
-        await rps.UpdateImplicitReadingProfile(user.Id, series.Id, dto);
-        profile =  await rps.GetReadingProfileForSeries(user.Id, series.Id);
+        await rps.UpdateImplicitReadingProfile(user.Id, series.LibraryId, series.Id, dto, null);
+        profile =  await rps.GetReadingProfileForSeries(user.Id, series.LibraryId, series.Id, null);
         Assert.NotNull(profile);
         Assert.Contains(profile.SeriesIds, s => s == series.Id);
         Assert.Equal(ReadingProfileKind.Implicit, profile.Kind);
@@ -177,13 +184,8 @@ public class ReadingProfileServiceTest(ITestOutputHelper outputHelper): Abstract
             .WithLibrary(lib)
             .WithName("Library Specific")
             .Build();
-        var profile3 = new AppUserReadingProfileBuilder(user.Id)
-            .WithKind(ReadingProfileKind.Default)
-            .WithName("Global")
-            .Build();
         context.AppUserReadingProfiles.Add(profile);
         context.AppUserReadingProfiles.Add(profile2);
-        context.AppUserReadingProfiles.Add(profile3);
 
         var series2 = new SeriesBuilder("Rainbows After Storms").Build();
         lib.Series.Add(series2);
@@ -195,15 +197,15 @@ public class ReadingProfileServiceTest(ITestOutputHelper outputHelper): Abstract
         user.Libraries.Add(lib2);
         await unitOfWork.CommitAsync();
 
-        var p = await rps.GetReadingProfileDtoForSeries(user.Id, series.Id);
+        var p = await rps.GetReadingProfileDtoForSeries(user.Id, series.LibraryId, series.Id, null);
         Assert.NotNull(p);
         Assert.Equal("Series Specific", p.Name);
 
-        p = await rps.GetReadingProfileDtoForSeries(user.Id, series2.Id);
+        p = await rps.GetReadingProfileDtoForSeries(user.Id, series2.LibraryId, series2.Id, null);
         Assert.NotNull(p);
         Assert.Equal("Library Specific", p.Name);
 
-        p = await rps.GetReadingProfileDtoForSeries(user.Id, series3.Id);
+        p = await rps.GetReadingProfileDtoForSeries(user.Id, series3.LibraryId, series3.Id, null);
         Assert.NotNull(p);
         Assert.Equal("Global", p.Name);
     }
@@ -212,7 +214,7 @@ public class ReadingProfileServiceTest(ITestOutputHelper outputHelper): Abstract
     public async Task ReplaceReadingProfile()
     {
         var (unitOfWork, context, mapper) = await CreateDatabase();
-        var (rps, user, lib, series) = await Setup(unitOfWork, context, mapper);
+        var (rps, user, _, series) = await Setup(unitOfWork, context, mapper);
 
         var profile1 = new AppUserReadingProfileBuilder(user.Id)
             .WithSeries(series)
@@ -227,12 +229,12 @@ public class ReadingProfileServiceTest(ITestOutputHelper outputHelper): Abstract
         context.AppUserReadingProfiles.Add(profile2);
         await unitOfWork.CommitAsync();
 
-        var profile = await rps.GetReadingProfileDtoForSeries(user.Id, series.Id);
+        var profile = await rps.GetReadingProfileDtoForSeries(user.Id, series.LibraryId, series.Id, null);
         Assert.NotNull(profile);
         Assert.Equal("Profile 1", profile.Name);
 
-        await rps.AddProfileToSeries(user.Id, profile2.Id, series.Id);
-        profile = await rps.GetReadingProfileDtoForSeries(user.Id, series.Id);
+        await rps.SetSeriesProfiles(user.Id, [profile2.Id], series.Id);
+        profile = await rps.GetReadingProfileDtoForSeries(user.Id, series.LibraryId, series.Id, null);
         Assert.NotNull(profile);
         Assert.Equal("Profile 2", profile.Name);
     }
@@ -241,7 +243,7 @@ public class ReadingProfileServiceTest(ITestOutputHelper outputHelper): Abstract
     public async Task DeleteReadingProfile()
     {
         var (unitOfWork, context, mapper) = await CreateDatabase();
-        var (rps, user, lib, series) = await Setup(unitOfWork, context, mapper);
+        var (rps, user, _, series) = await Setup(unitOfWork, context, mapper);
 
         var profile1 = new AppUserReadingProfileBuilder(user.Id)
             .WithSeries(series)
@@ -283,22 +285,22 @@ public class ReadingProfileServiceTest(ITestOutputHelper outputHelper): Abstract
 
         await unitOfWork.CommitAsync();
 
-        var someSeriesIds = lib.Series.Take(lib.Series.Count / 2).Select(s => s.Id).ToList();
-        await rps.BulkAddProfileToSeries(user.Id, profile.Id, someSeriesIds);
+        var someSeriesIds = lib.Series.Take(lib.Series.Count / 2).Select(s => new {s.Id, s.LibraryId}).ToList();
+        await rps.BulkSetSeriesProfiles(user.Id, [profile.Id], someSeriesIds.Select(x => x.Id).ToList());
 
-        foreach (var id in someSeriesIds)
+        foreach (var x in someSeriesIds)
         {
-            var foundProfile = await rps.GetReadingProfileDtoForSeries(user.Id, id);
+            var foundProfile = await rps.GetReadingProfileDtoForSeries(user.Id, x.LibraryId, x.Id, null);
             Assert.NotNull(foundProfile);
             Assert.Equal(profile.Id, foundProfile.Id);
         }
 
-        var allIds = lib.Series.Select(s => s.Id).ToList();
-        await rps.BulkAddProfileToSeries(user.Id, profile2.Id, allIds);
+        var allIds = lib.Series.Select(s => new {s.Id, s.LibraryId}).ToList();
+        await rps.BulkSetSeriesProfiles(user.Id, [profile2.Id], allIds.Select(x => x.Id).ToList());
 
-        foreach (var id in allIds)
+        foreach (var x in allIds)
         {
-            var foundProfile = await rps.GetReadingProfileDtoForSeries(user.Id, id);
+            var foundProfile = await rps.GetReadingProfileDtoForSeries(user.Id, x.LibraryId, x.Id, null);
             Assert.NotNull(foundProfile);
             Assert.Equal(profile2.Id, foundProfile.Id);
         }
@@ -310,7 +312,7 @@ public class ReadingProfileServiceTest(ITestOutputHelper outputHelper): Abstract
     public async Task BulkAssignDeletesImplicit()
     {
         var (unitOfWork, context, mapper) = await CreateDatabase();
-        var (rps, user, lib, series) = await Setup(unitOfWork, context, mapper);
+        var (rps, user, lib, _) = await Setup(unitOfWork, context, mapper);
 
         var implicitProfile = mapper.Map<UserReadingProfileDto>(new AppUserReadingProfileBuilder(user.Id)
             .Build());
@@ -327,21 +329,21 @@ public class ReadingProfileServiceTest(ITestOutputHelper outputHelper): Abstract
         }
         await unitOfWork.CommitAsync();
 
-        var ids = lib.Series.Select(s => s.Id).ToList();
+        var ids = lib.Series.Select(s => new {s.Id, s.LibraryId}).ToList();
 
-        foreach (var id in ids)
+        foreach (var x in ids)
         {
-            await rps.UpdateImplicitReadingProfile(user.Id, id, implicitProfile);
-            var seriesProfile = await rps.GetReadingProfileDtoForSeries(user.Id, id);
+            await rps.UpdateImplicitReadingProfile(user.Id, x.LibraryId, x.Id, implicitProfile, null);
+            var seriesProfile = await rps.GetReadingProfileDtoForSeries(user.Id, x.LibraryId, x.Id, null);
             Assert.NotNull(seriesProfile);
             Assert.Equal(ReadingProfileKind.Implicit, seriesProfile.Kind);
         }
 
-        await rps.BulkAddProfileToSeries(user.Id, profile.Id, ids);
+        await rps.BulkSetSeriesProfiles(user.Id, [profile.Id], ids.Select(x => x.Id).ToList());
 
-        foreach (var id in ids)
+        foreach (var x in ids)
         {
-            var seriesProfile = await rps.GetReadingProfileDtoForSeries(user.Id, id);
+            var seriesProfile = await rps.GetReadingProfileDtoForSeries(user.Id, x.LibraryId, x.Id, null);
             Assert.NotNull(seriesProfile);
             Assert.Equal(ReadingProfileKind.User, seriesProfile.Kind);
         }
@@ -356,7 +358,7 @@ public class ReadingProfileServiceTest(ITestOutputHelper outputHelper): Abstract
     public async Task AddDeletesImplicit()
     {
         var (unitOfWork, context, mapper) = await CreateDatabase();
-        var (rps, user, lib, series) = await Setup(unitOfWork, context, mapper);
+        var (rps, user, _, series) = await Setup(unitOfWork, context, mapper);
 
         var implicitProfile = mapper.Map<UserReadingProfileDto>(new AppUserReadingProfileBuilder(user.Id)
             .WithKind(ReadingProfileKind.Implicit)
@@ -368,15 +370,15 @@ public class ReadingProfileServiceTest(ITestOutputHelper outputHelper): Abstract
         context.AppUserReadingProfiles.Add(profile);
         await unitOfWork.CommitAsync();
 
-        await rps.UpdateImplicitReadingProfile(user.Id, series.Id, implicitProfile);
+        await rps.UpdateImplicitReadingProfile(user.Id, series.LibraryId, series.Id, implicitProfile, null);
 
-        var seriesProfile = await rps.GetReadingProfileDtoForSeries(user.Id, series.Id);
+        var seriesProfile = await rps.GetReadingProfileDtoForSeries(user.Id, series.LibraryId, series.Id, null);
         Assert.NotNull(seriesProfile);
         Assert.Equal(ReadingProfileKind.Implicit, seriesProfile.Kind);
 
-        await rps.AddProfileToSeries(user.Id, profile.Id, series.Id);
+        await rps.SetSeriesProfiles(user.Id, [profile.Id], series.Id);
 
-        seriesProfile = await rps.GetReadingProfileDtoForSeries(user.Id, series.Id);
+        seriesProfile = await rps.GetReadingProfileDtoForSeries(user.Id, series.LibraryId, series.Id, null);
         Assert.NotNull(seriesProfile);
         Assert.Equal(ReadingProfileKind.User, seriesProfile.Kind);
 
@@ -390,7 +392,7 @@ public class ReadingProfileServiceTest(ITestOutputHelper outputHelper): Abstract
     public async Task CreateReadingProfile()
     {
         var (unitOfWork, context, mapper) = await CreateDatabase();
-        var (rps, user, lib, series) = await Setup(unitOfWork, context, mapper);
+        var (rps, user, _, _) = await Setup(unitOfWork, context, mapper);
 
         var dto = new UserReadingProfileDto
         {
@@ -423,7 +425,7 @@ public class ReadingProfileServiceTest(ITestOutputHelper outputHelper): Abstract
         });
 
         var allProfiles = context.AppUserReadingProfiles.ToList();
-        Assert.Equal(2, allProfiles.Count);
+        Assert.Equal(3, allProfiles.Count);
     }
 
     [Fact]
@@ -452,7 +454,10 @@ public class ReadingProfileServiceTest(ITestOutputHelper outputHelper): Abstract
 
         await rps.ClearSeriesProfile(user.Id, series.Id);
 
-        var remainingProfiles = await context.AppUserReadingProfiles.ToListAsync();
+        var remainingProfiles = await context.AppUserReadingProfiles
+            .Where(p => p.Kind != ReadingProfileKind.Default)
+            .ToListAsync();
+
         Assert.Single(remainingProfiles);
         Assert.Equal("Explicit Profile", remainingProfiles[0].Name);
         Assert.Empty(remainingProfiles[0].SeriesIds);
@@ -473,7 +478,7 @@ public class ReadingProfileServiceTest(ITestOutputHelper outputHelper): Abstract
         context.AppUserReadingProfiles.Add(profile);
         await unitOfWork.CommitAsync();
 
-        await rps.AddProfileToLibrary(user.Id, profile.Id, lib.Id);
+        await rps.SetLibraryProfiles(user.Id, [profile.Id], lib.Id);
         await unitOfWork.CommitAsync();
 
         var linkedProfile = (await unitOfWork.AppUserReadingProfileRepository.GetProfilesForUser(user.Id))
@@ -487,7 +492,7 @@ public class ReadingProfileServiceTest(ITestOutputHelper outputHelper): Abstract
         context.AppUserReadingProfiles.Add(newProfile);
         await unitOfWork.CommitAsync();
 
-        await rps.AddProfileToLibrary(user.Id, newProfile.Id, lib.Id);
+        await rps.SetLibraryProfiles(user.Id, [newProfile.Id], lib.Id);
         await unitOfWork.CommitAsync();
 
         linkedProfile = (await unitOfWork.AppUserReadingProfileRepository.GetProfilesForUser(user.Id))
@@ -496,38 +501,1505 @@ public class ReadingProfileServiceTest(ITestOutputHelper outputHelper): Abstract
         Assert.Equal(newProfile.Id, linkedProfile.Id);
     }
 
+    #endregion
+
+    #region Tests with devices - Get profile
+
     [Fact]
-    public async Task ClearLibraryProfile_RemovesImplicitOrUnlinksExplicit()
+    public async Task GetCorrectProfile_WithMatchingDevice()
+    {
+        var (unitOfWork, context, mapper) = await CreateDatabase();
+        var (rps, user, lib, series) = await Setup(unitOfWork, context, mapper);
+
+        const int deviceId = 1;
+
+        var profileSeriesDevice = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithDeviceId(deviceId)
+            .WithName("Series Specific (Device)")
+            .Build();
+        var profileSeriesNoDevice = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithName("Series Specific (No Device)")
+            .Build();
+        var profileLibraryDevice = new AppUserReadingProfileBuilder(user.Id)
+            .WithLibrary(lib)
+            .WithDeviceId(deviceId)
+            .WithName("Library Specific (Device)")
+            .Build();
+        var profileLibraryNoDevice = new AppUserReadingProfileBuilder(user.Id)
+            .WithLibrary(lib)
+            .WithName("Library Specific (No Device)")
+            .Build();
+
+        context.AppUserReadingProfiles.Add(profileSeriesDevice);
+        context.AppUserReadingProfiles.Add(profileSeriesNoDevice);
+        context.AppUserReadingProfiles.Add(profileLibraryDevice);
+        context.AppUserReadingProfiles.Add(profileLibraryNoDevice);
+        await unitOfWork.CommitAsync();
+
+        // Should get series-specific profile with matching device
+        var p = await rps.GetReadingProfileDtoForSeries(user.Id, series.LibraryId, series.Id, deviceId);
+        Assert.NotNull(p);
+        Assert.Equal("Series Specific (Device)", p.Name);
+    }
+
+    [Fact]
+    public async Task GetCorrectProfile_WithNonMatchingDevice()
+    {
+        var (unitOfWork, context, mapper) = await CreateDatabase();
+        var (rps, user, lib, series) = await Setup(unitOfWork, context, mapper);
+
+        const int deviceId = 1;
+        const int otherDeviceId = 2;
+
+        var profileSeriesWrongDevice = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithDeviceId(otherDeviceId)
+            .WithName("Series Specific (Wrong Device)")
+            .Build();
+        var profileSeriesNoDevice = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithName("Series Specific (No Device)")
+            .Build();
+        var profileLibraryDevice = new AppUserReadingProfileBuilder(user.Id)
+            .WithLibrary(lib)
+            .WithDeviceId(deviceId)
+            .WithName("Library Specific (Device)")
+            .Build();
+
+        context.AppUserReadingProfiles.Add(profileSeriesWrongDevice);
+        context.AppUserReadingProfiles.Add(profileSeriesNoDevice);
+        context.AppUserReadingProfiles.Add(profileLibraryDevice);
+        await unitOfWork.CommitAsync();
+
+        // Should skip series profile with wrong device, get series profile with no device
+        var p = await rps.GetReadingProfileDtoForSeries(user.Id, series.LibraryId, series.Id, deviceId);
+        Assert.NotNull(p);
+        Assert.Equal("Series Specific (No Device)", p.Name);
+    }
+
+    [Fact]
+    public async Task GetCorrectProfile_DeviceVsNoDevice_SeriesLevel()
+    {
+        var (unitOfWork, context, mapper) = await CreateDatabase();
+        var (rps, user, _, series) = await Setup(unitOfWork, context, mapper);
+
+        const int deviceId = 1;
+
+        var profileSeriesDevice = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithDeviceId(deviceId)
+            .WithName("Series (Device)")
+            .Build();
+        var profileSeriesNoDevice = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithName("Series (No Device)")
+            .Build();
+
+        context.AppUserReadingProfiles.Add(profileSeriesDevice);
+        context.AppUserReadingProfiles.Add(profileSeriesNoDevice);
+        await unitOfWork.CommitAsync();
+
+        // With matching device, should prefer device-specific
+        var p = await rps.GetReadingProfileDtoForSeries(user.Id, series.LibraryId, series.Id, deviceId);
+        Assert.NotNull(p);
+        Assert.Equal("Series (Device)", p.Name);
+
+        // Without device specified, should get no-device profile
+        p = await rps.GetReadingProfileDtoForSeries(user.Id, series.LibraryId, series.Id, null);
+        Assert.NotNull(p);
+        Assert.Equal("Series (No Device)", p.Name);
+    }
+
+    [Fact]
+    public async Task GetCorrectProfile_DeviceVsNoDevice_LibraryLevel()
+    {
+        var (unitOfWork, context, mapper) = await CreateDatabase();
+        var (rps, user, lib, series) = await Setup(unitOfWork, context, mapper);
+
+        const int deviceId = 1;
+
+        var profileLibraryDevice = new AppUserReadingProfileBuilder(user.Id)
+            .WithLibrary(lib)
+            .WithDeviceId(deviceId)
+            .WithName("Library (Device)")
+            .Build();
+        var profileLibraryNoDevice = new AppUserReadingProfileBuilder(user.Id)
+            .WithLibrary(lib)
+            .WithName("Library (No Device)")
+            .Build();
+
+        context.AppUserReadingProfiles.Add(profileLibraryDevice);
+        context.AppUserReadingProfiles.Add(profileLibraryNoDevice);
+        await unitOfWork.CommitAsync();
+
+        // With matching device, should prefer device-specific
+        var p = await rps.GetReadingProfileDtoForSeries(user.Id, series.LibraryId, series.Id, deviceId);
+        Assert.NotNull(p);
+        Assert.Equal("Library (Device)", p.Name);
+
+        // Without device specified, should get no-device profile
+        p = await rps.GetReadingProfileDtoForSeries(user.Id, series.LibraryId, series.Id, null);
+        Assert.NotNull(p);
+        Assert.Equal("Library (No Device)", p.Name);
+    }
+
+    [Fact]
+    public async Task GetCorrectProfile_ImplicitWithDevice()
+    {
+        var (unitOfWork, context, mapper) = await CreateDatabase();
+        var (rps, user, _, series) = await Setup(unitOfWork, context, mapper);
+
+        const int deviceId = 1;
+
+        var profileImplicitDevice = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithDeviceId(deviceId)
+            .WithName("Implicit (Device)")
+            .WithKind(ReadingProfileKind.Implicit)
+            .Build();
+        var profileImplicitNoDevice = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithName("Implicit (No Device)")
+            .WithKind(ReadingProfileKind.Implicit)
+            .Build();
+        var profileSeriesDevice = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithDeviceId(deviceId)
+            .WithName("Series (Device)")
+            .Build();
+
+        context.AppUserReadingProfiles.Add(profileImplicitDevice);
+        context.AppUserReadingProfiles.Add(profileImplicitNoDevice);
+        context.AppUserReadingProfiles.Add(profileSeriesDevice);
+        await unitOfWork.CommitAsync();
+
+        // Implicit with device should win over everything else
+        var p = await rps.GetReadingProfileDtoForSeries(user.Id, series.LibraryId, series.Id, deviceId);
+        Assert.NotNull(p);
+        Assert.Equal("Implicit (Device)", p.Name);
+
+        // Without device, implicit no-device should win
+        p = await rps.GetReadingProfileDtoForSeries(user.Id, series.LibraryId, series.Id, null);
+        Assert.NotNull(p);
+        Assert.Equal("Implicit (No Device)", p.Name);
+    }
+
+    [Fact]
+    public async Task GetCorrectProfile_ComplexHierarchy_WithDevice()
+    {
+        var (unitOfWork, context, mapper) = await CreateDatabase();
+        var (rps, user, lib, series) = await Setup(unitOfWork, context, mapper);
+
+        const int deviceId = 1;
+        const int otherDeviceId = 2;
+
+        var series2 = new SeriesBuilder("Rainbows After Storms").Build();
+        lib.Series.Add(series2);
+
+        var lib2 = new LibraryBuilder("Manga2").Build();
+        var series3 = new SeriesBuilder("A Tropical Fish Yearns for Snow").Build();
+        lib2.Series.Add(series3);
+        user.Libraries.Add(lib2);
+
+        // Series 1: has series-specific profile with device
+        var profileSeries1Device = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithDeviceId(deviceId)
+            .WithName("Series 1 (Device)")
+            .Build();
+
+        // Series 2: has library profile with device, and series profile with wrong device
+        var profileSeries2WrongDevice = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series2)
+            .WithDeviceId(otherDeviceId)
+            .WithName("Series 2 (Wrong Device)")
+            .Build();
+        var profileLibDevice = new AppUserReadingProfileBuilder(user.Id)
+            .WithLibrary(lib)
+            .WithDeviceId(deviceId)
+            .WithName("Library (Device)")
+            .Build();
+
+        // Series 3: has library profile with wrong device, should fall back to global
+        var profileLib2WrongDevice = new AppUserReadingProfileBuilder(user.Id)
+            .WithLibrary(lib2)
+            .WithDeviceId(otherDeviceId)
+            .WithName("Library 2 (Wrong Device)")
+            .Build();
+
+        context.AppUserReadingProfiles.Add(profileSeries1Device);
+        context.AppUserReadingProfiles.Add(profileSeries2WrongDevice);
+        context.AppUserReadingProfiles.Add(profileLibDevice);
+        context.AppUserReadingProfiles.Add(profileLib2WrongDevice);
+        await unitOfWork.CommitAsync();
+
+        // Series 1 should get series-specific with device
+        var p = await rps.GetReadingProfileDtoForSeries(user.Id, series.LibraryId, series.Id, deviceId);
+        Assert.NotNull(p);
+        Assert.Equal("Series 1 (Device)", p.Name);
+
+        // Series 2 should skip wrong device, get library with device
+        p = await rps.GetReadingProfileDtoForSeries(user.Id, series2.LibraryId, series2.Id, deviceId);
+        Assert.NotNull(p);
+        Assert.Equal("Library (Device)", p.Name);
+
+        // Series 3 should skip wrong device library profile, fall back to global
+        p = await rps.GetReadingProfileDtoForSeries(user.Id, series3.LibraryId, series3.Id, deviceId);
+        Assert.NotNull(p);
+        Assert.Equal("Global", p.Name);
+    }
+
+    [Fact]
+    public async Task GetCorrectProfile_ComplexHierarchy_NoDevice()
+    {
+        var (unitOfWork, context, mapper) = await CreateDatabase();
+        var (rps, user, lib, series) = await Setup(unitOfWork, context, mapper);
+
+        const int deviceId = 1;
+
+        var series2 = new SeriesBuilder("Rainbows After Storms").Build();
+        lib.Series.Add(series2);
+
+        var lib2 = new LibraryBuilder("Manga2").Build();
+        var series3 = new SeriesBuilder("A Tropical Fish Yearns for Snow").Build();
+        lib2.Series.Add(series3);
+        user.Libraries.Add(lib2);
+
+        // Mix of device and non-device profiles
+        var profileSeries1NoDevice = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithName("Series 1 (No Device)")
+            .Build();
+        var profileSeries1Device = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithDeviceId(deviceId)
+            .WithName("Series 1 (Device)")
+            .Build();
+
+        var profileLibNoDevice = new AppUserReadingProfileBuilder(user.Id)
+            .WithLibrary(lib)
+            .WithName("Library (No Device)")
+            .Build();
+        var profileLibDevice = new AppUserReadingProfileBuilder(user.Id)
+            .WithLibrary(lib)
+            .WithDeviceId(deviceId)
+            .WithName("Library (Device)")
+            .Build();
+
+        context.AppUserReadingProfiles.Add(profileSeries1NoDevice);
+        context.AppUserReadingProfiles.Add(profileSeries1Device);
+        context.AppUserReadingProfiles.Add(profileLibNoDevice);
+        context.AppUserReadingProfiles.Add(profileLibDevice);
+        await unitOfWork.CommitAsync();
+
+        // Without device specified, should always get no-device profiles
+        var p = await rps.GetReadingProfileDtoForSeries(user.Id, series.LibraryId, series.Id, null);
+        Assert.NotNull(p);
+        Assert.Equal("Series 1 (No Device)", p.Name);
+
+        p = await rps.GetReadingProfileDtoForSeries(user.Id, series2.LibraryId, series2.Id, null);
+        Assert.NotNull(p);
+        Assert.Equal("Library (No Device)", p.Name);
+
+        p = await rps.GetReadingProfileDtoForSeries(user.Id, series3.LibraryId, series3.Id, null);
+        Assert.NotNull(p);
+        Assert.Equal("Global", p.Name);
+    }
+
+    [Fact]
+    public async Task GetCorrectProfile_OnlyDeviceProfiles_NoMatch()
+    {
+        var (unitOfWork, context, mapper) = await CreateDatabase();
+        var (rps, user, lib, series) = await Setup(unitOfWork, context, mapper);
+
+        const int deviceId = 1;
+        const int otherDeviceId = 2;
+
+        // Only profiles with specific devices exist
+        var profileSeriesDevice = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithDeviceId(otherDeviceId)
+            .WithName("Series (Other Device)")
+            .Build();
+        var profileLibDevice = new AppUserReadingProfileBuilder(user.Id)
+            .WithLibrary(lib)
+            .WithDeviceId(otherDeviceId)
+            .WithName("Library (Other Device)")
+            .Build();
+
+        context.AppUserReadingProfiles.Add(profileSeriesDevice);
+        context.AppUserReadingProfiles.Add(profileLibDevice);
+        await unitOfWork.CommitAsync();
+
+        // Should skip all device-specific profiles and fall back to global
+        var p = await rps.GetReadingProfileDtoForSeries(user.Id, series.LibraryId, series.Id, deviceId);
+        Assert.NotNull(p);
+        Assert.Equal("Global", p.Name);
+    }
+
+    #endregion
+
+    #region Tests with devices - Promote implicit profile
+
+    [Fact]
+    public async Task PromoteImplicitProfile_ConvertsImplicitToUser()
+    {
+        var (unitOfWork, context, mapper) = await CreateDatabase();
+        var (rps, user, _, series) = await Setup(unitOfWork, context, mapper);
+
+        var implicitProfile = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithName("Implicit Profile")
+            .WithKind(ReadingProfileKind.Implicit)
+            .Build();
+
+        context.AppUserReadingProfiles.Add(implicitProfile);
+        await unitOfWork.CommitAsync();
+
+        var result = await rps.PromoteImplicitProfile(user.Id, implicitProfile.Id, null);
+
+        Assert.NotNull(result);
+        Assert.Equal(ReadingProfileKind.User, result.Kind);
+
+        // Verify in database
+        var updatedProfile = await context.AppUserReadingProfiles.FindAsync(implicitProfile.Id);
+        Assert.NotNull(updatedProfile);
+        Assert.Equal(ReadingProfileKind.User, updatedProfile.Kind);
+    }
+
+    [Fact]
+    public async Task PromoteImplicitProfile_WithDevice_OnlyRemovesFromMatchingDeviceProfiles()
+    {
+        var (unitOfWork, context, mapper) = await CreateDatabase();
+        var (rps, user, _, series) = await Setup(unitOfWork, context, mapper);
+
+        const int deviceId = 1;
+        const int otherDeviceId = 2;
+
+        var implicitProfile = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithDeviceId(deviceId)
+            .WithName("Implicit Profile (Device 1)")
+            .WithKind(ReadingProfileKind.Implicit)
+            .Build();
+
+        var profileSameDevice = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithDeviceId(deviceId)
+            .WithName("Profile (Device 1)")
+            .Build();
+
+        var profileOtherDevice = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithDeviceId(otherDeviceId)
+            .WithName("Profile (Device 2)")
+            .Build();
+
+        var profileNoDevice = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithName("Profile (No Device)")
+            .Build();
+
+        context.AppUserReadingProfiles.Add(implicitProfile);
+        context.AppUserReadingProfiles.Add(profileSameDevice);
+        context.AppUserReadingProfiles.Add(profileOtherDevice);
+        context.AppUserReadingProfiles.Add(profileNoDevice);
+        await unitOfWork.CommitAsync();
+
+        await rps.PromoteImplicitProfile(user.Id, implicitProfile.Id, deviceId);
+
+        // Same device profile should have series removed
+        var updatedSameDevice = await context.AppUserReadingProfiles
+            .FirstAsync(rp => rp.Id == profileSameDevice.Id);
+        Assert.DoesNotContain(series.Id, updatedSameDevice.SeriesIds);
+
+        // Other device profile should still have series
+        var updatedOtherDevice = await context.AppUserReadingProfiles
+            .FirstAsync(rp => rp.Id == profileOtherDevice.Id);
+        Assert.Contains(series.Id, updatedOtherDevice.SeriesIds);
+
+        // No device profile should still have series
+        var updatedNoDevice = await context.AppUserReadingProfiles
+            .FirstAsync(rp => rp.Id == profileNoDevice.Id);
+        Assert.Contains(series.Id, updatedNoDevice.SeriesIds);
+    }
+
+    [Fact]
+    public async Task PromoteImplicitProfile_DoesNotAffectOtherUsersProfiles()
+    {
+        var (unitOfWork, context, mapper) = await CreateDatabase();
+        var (rps, user, lib, series) = await Setup(unitOfWork, context, mapper);
+
+        var otherUser = new AppUserBuilder("otheruser", "other@email.com").Build();
+        context.AppUser.Add(otherUser);
+        otherUser.Libraries.Add(lib);
+        await unitOfWork.CommitAsync();
+
+        var implicitProfile = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithName("User1 Implicit")
+            .WithKind(ReadingProfileKind.Implicit)
+            .Build();
+
+        var otherUserProfile = new AppUserReadingProfileBuilder(otherUser.Id)
+            .WithSeries(series)
+            .WithName("User2 Profile")
+            .Build();
+
+        context.AppUserReadingProfiles.Add(implicitProfile);
+        context.AppUserReadingProfiles.Add(otherUserProfile);
+        await unitOfWork.CommitAsync();
+
+        await rps.PromoteImplicitProfile(user.Id, implicitProfile.Id, null);
+
+        // Other user's profile should not be affected
+        var updatedOtherUserProfile = await context.AppUserReadingProfiles
+            .FirstAsync(rp => rp.Id == otherUserProfile.Id);
+        Assert.Contains(series.Id, updatedOtherUserProfile.SeriesIds);
+    }
+
+    [Fact]
+    public async Task PromoteImplicitProfile_DoesNotRemoveFromPromotedProfile()
+    {
+        var (unitOfWork, context, mapper) = await CreateDatabase();
+        var (rps, user, _, series) = await Setup(unitOfWork, context, mapper);
+
+        var implicitProfile = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithName("Implicit Profile")
+            .WithKind(ReadingProfileKind.Implicit)
+            .Build();
+
+        context.AppUserReadingProfiles.Add(implicitProfile);
+        await unitOfWork.CommitAsync();
+
+        await rps.PromoteImplicitProfile(user.Id, implicitProfile.Id, null);
+
+        var updatedProfile = await context.AppUserReadingProfiles
+            .FirstAsync(rp => rp.Id == implicitProfile.Id);
+        Assert.Contains(series.Id, updatedProfile.SeriesIds);
+    }
+
+    [Fact]
+    public async Task PromoteImplicitProfile_ThrowsIfProfileDoesNotBelongToUser()
+    {
+        var (unitOfWork, context, mapper) = await CreateDatabase();
+        var (rps, user, _, series) = await Setup(unitOfWork, context, mapper);
+
+        var otherUser = new AppUserBuilder("otheruser", "other@email.com").Build();
+        context.AppUser.Add(otherUser);
+        await unitOfWork.CommitAsync();
+
+        var implicitProfile = new AppUserReadingProfileBuilder(otherUser.Id)
+            .WithSeries(series)
+            .WithName("Other User's Implicit")
+            .WithKind(ReadingProfileKind.Implicit)
+            .Build();
+
+        context.AppUserReadingProfiles.Add(implicitProfile);
+        await unitOfWork.CommitAsync();
+
+        // Should throw when trying to promote another user's profile
+        await Assert.ThrowsAsync<KavitaException>(async () =>
+            await rps.PromoteImplicitProfile(user.Id, implicitProfile.Id, null));
+    }
+
+    [Fact]
+    public async Task PromoteImplicitProfile_ThrowsIfProfileIsNotImplicit()
+    {
+        var (unitOfWork, context, mapper) = await CreateDatabase();
+        var (rps, user, _, series) = await Setup(unitOfWork, context, mapper);
+
+        var userProfile = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithName("User Profile")
+            .WithKind(ReadingProfileKind.User)
+            .Build();
+
+        context.AppUserReadingProfiles.Add(userProfile);
+        await unitOfWork.CommitAsync();
+
+        // Should throw when trying to promote a non-implicit profile
+        await Assert.ThrowsAsync<KavitaException>(async () =>
+            await rps.PromoteImplicitProfile(user.Id, userProfile.Id, null));
+    }
+
+    #endregion
+
+    #region Tests with devices - Update parent profile
+
+    [Fact]
+    public async Task UpdateParent_WithDevice_OnlyRemovesMatchingImplicitProfiles()
+    {
+        var (unitOfWork, context, mapper) = await CreateDatabase();
+        var (rps, user, lib, series) = await Setup(unitOfWork, context, mapper);
+
+        const int deviceId = 1;
+        const int otherDeviceId = 2;
+
+        var seriesProfile = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithDeviceId(deviceId)
+            .WithName("Series Profile (Device 1)")
+            .Build();
+
+        var implicitSameDevice = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithDeviceId(deviceId)
+            .WithName("Implicit (Device 1)")
+            .WithKind(ReadingProfileKind.Implicit)
+            .Build();
+
+        var implicitOtherDevice = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithDeviceId(otherDeviceId)
+            .WithName("Implicit (Device 2)")
+            .WithKind(ReadingProfileKind.Implicit)
+            .Build();
+
+        var implicitNoDevice = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithName("Implicit (No Device)")
+            .WithKind(ReadingProfileKind.Implicit)
+            .Build();
+
+        context.AppUserReadingProfiles.Add(seriesProfile);
+        context.AppUserReadingProfiles.Add(implicitSameDevice);
+        context.AppUserReadingProfiles.Add(implicitOtherDevice);
+        context.AppUserReadingProfiles.Add(implicitNoDevice);
+        await unitOfWork.CommitAsync();
+
+        var dto = new UserReadingProfileDto
+        {
+            Id = implicitSameDevice.Id,
+            Name = "Updated Series Profile",
+        };
+
+        await rps.UpdateParent(user.Id, lib.Id, series.Id, dto, deviceId);
+
+        // Implicit with same device should be removed
+        var implicitSameExists = await context.AppUserReadingProfiles
+            .AnyAsync(rp => rp.Id == implicitSameDevice.Id);
+        Assert.False(implicitSameExists);
+
+        // Implicit with other device should still exist
+        var implicitOtherExists = await context.AppUserReadingProfiles
+            .AnyAsync(rp => rp.Id == implicitOtherDevice.Id);
+        Assert.True(implicitOtherExists);
+
+        // Implicit with no device should still exist (it's a fallback for other devices)
+        var implicitNoDeviceExists = await context.AppUserReadingProfiles
+            .AnyAsync(rp => rp.Id == implicitNoDevice.Id);
+        Assert.True(implicitNoDeviceExists);
+    }
+
+    [Fact]
+    public async Task UpdateParent_NoDevice_OnlyRemovesNoDeviceImplicitProfiles()
+    {
+        var (unitOfWork, context, mapper) = await CreateDatabase();
+        var (rps, user, lib, series) = await Setup(unitOfWork, context, mapper);
+
+        const int deviceId = 1;
+
+        var seriesProfile = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithName("Series Profile (No Device)")
+            .Build();
+
+        var implicitWithDevice = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithDeviceId(deviceId)
+            .WithName("Implicit (Device)")
+            .WithKind(ReadingProfileKind.Implicit)
+            .Build();
+
+        var implicitNoDevice = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithName("Implicit (No Device)")
+            .WithKind(ReadingProfileKind.Implicit)
+            .Build();
+
+        context.AppUserReadingProfiles.Add(seriesProfile);
+        context.AppUserReadingProfiles.Add(implicitWithDevice);
+        context.AppUserReadingProfiles.Add(implicitNoDevice);
+        await unitOfWork.CommitAsync();
+
+        var dto = new UserReadingProfileDto
+        {
+            Id = implicitNoDevice.Id,
+            Name = "Updated Series Profile",
+        };
+
+        await rps.UpdateParent(user.Id, lib.Id, series.Id, dto, null);
+
+        // Implicit with no device should be removed
+        var implicitNoDeviceExists = await context.AppUserReadingProfiles
+            .AnyAsync(rp => rp.Id == implicitNoDevice.Id);
+        Assert.False(implicitNoDeviceExists);
+
+        // Implicit with device should still exist (other devices may use it)
+        var implicitWithDeviceExists = await context.AppUserReadingProfiles
+            .AnyAsync(rp => rp.Id == implicitWithDevice.Id);
+        Assert.True(implicitWithDeviceExists);
+    }
+
+    [Fact]
+    public async Task UpdateParent_WithDevice_AllowsMultipleDeviceSpecificImplicits()
+    {
+        var (unitOfWork, context, mapper) = await CreateDatabase();
+        var (rps, user, lib, series) = await Setup(unitOfWork, context, mapper);
+
+        const int device1 = 1;
+        const int device2 = 2;
+        const int device3 = 3;
+
+        var seriesProfile = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithDeviceId(device1)
+            .WithName("Series Profile (Device 1)")
+            .Build();
+
+        var implicitDevice1 = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithDeviceId(device1)
+            .WithName("Implicit (Device 1)")
+            .WithKind(ReadingProfileKind.Implicit)
+            .Build();
+
+        var implicitDevice2 = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithDeviceId(device2)
+            .WithName("Implicit (Device 2)")
+            .WithKind(ReadingProfileKind.Implicit)
+            .Build();
+
+        var implicitDevice3 = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithDeviceId(device3)
+            .WithName("Implicit (Device 3)")
+            .WithKind(ReadingProfileKind.Implicit)
+            .Build();
+
+        var implicitNoDevice = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithName("Implicit (No Device - Fallback)")
+            .WithKind(ReadingProfileKind.Implicit)
+            .Build();
+
+        context.AppUserReadingProfiles.Add(seriesProfile);
+        context.AppUserReadingProfiles.Add(implicitDevice1);
+        context.AppUserReadingProfiles.Add(implicitDevice2);
+        context.AppUserReadingProfiles.Add(implicitDevice3);
+        context.AppUserReadingProfiles.Add(implicitNoDevice);
+        await unitOfWork.CommitAsync();
+
+        var dto = new UserReadingProfileDto
+        {
+            Id = implicitDevice1.Id,
+            Name = "Updated Series Profile",
+        };
+
+        await rps.UpdateParent(user.Id, lib.Id, series.Id, dto, device1);
+
+        // Only implicit for device 1 should be removed
+        var implicit1Exists = await context.AppUserReadingProfiles
+            .AnyAsync(rp => rp.Id == implicitDevice1.Id);
+        Assert.False(implicit1Exists);
+
+        // Other device-specific implicits should remain
+        var implicit2Exists = await context.AppUserReadingProfiles
+            .AnyAsync(rp => rp.Id == implicitDevice2.Id);
+        Assert.True(implicit2Exists);
+
+        var implicit3Exists = await context.AppUserReadingProfiles
+            .AnyAsync(rp => rp.Id == implicitDevice3.Id);
+        Assert.True(implicit3Exists);
+
+        // Fallback (no device) should remain
+        var implicitNoDeviceExists = await context.AppUserReadingProfiles
+            .AnyAsync(rp => rp.Id == implicitNoDevice.Id);
+        Assert.True(implicitNoDeviceExists);
+    }
+
+    #endregion
+
+    #region Tests with devices - AddToProfile
+
+    [Fact]
+    public async Task AddProfileToSeries_WithDevice_OnlyRemovesImplicitWithSameDevice()
+    {
+        var (unitOfWork, context, mapper) = await CreateDatabase();
+        var (rps, user, _, series) = await Setup(unitOfWork, context, mapper);
+
+        const int deviceId = 1;
+        const int otherDeviceId = 2;
+
+        var profile = new AppUserReadingProfileBuilder(user.Id)
+            .WithDeviceId(deviceId)
+            .WithName("Profile (Device 1)")
+            .Build();
+
+        var implicitSameDevice = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithDeviceId(deviceId)
+            .WithName("Implicit (Device 1)")
+            .WithKind(ReadingProfileKind.Implicit)
+            .Build();
+
+        var implicitOtherDevice = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithDeviceId(otherDeviceId)
+            .WithName("Implicit (Device 2)")
+            .WithKind(ReadingProfileKind.Implicit)
+            .Build();
+
+        var implicitNoDevice = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithName("Implicit (No Device)")
+            .WithKind(ReadingProfileKind.Implicit)
+            .Build();
+
+        context.AppUserReadingProfiles.Add(profile);
+        context.AppUserReadingProfiles.Add(implicitSameDevice);
+        context.AppUserReadingProfiles.Add(implicitOtherDevice);
+        context.AppUserReadingProfiles.Add(implicitNoDevice);
+        await unitOfWork.CommitAsync();
+
+        await rps.SetSeriesProfiles(user.Id, [profile.Id], series.Id);
+
+        // Implicit with same device should be removed
+        var implicitSameExists = await context.AppUserReadingProfiles
+            .AnyAsync(rp => rp.Id == implicitSameDevice.Id);
+        Assert.False(implicitSameExists);
+
+        // Implicit with other device should still exist
+        var implicitOtherExists = await context.AppUserReadingProfiles
+            .AnyAsync(rp => rp.Id == implicitOtherDevice.Id);
+        Assert.True(implicitOtherExists);
+
+        // Implicit with no device should still exist (fallback for other devices)
+        var implicitNoDeviceExists = await context.AppUserReadingProfiles
+            .AnyAsync(rp => rp.Id == implicitNoDevice.Id);
+        Assert.True(implicitNoDeviceExists);
+    }
+
+    [Fact]
+    public async Task AddProfileToSeries_NoDevice_OnlyRemovesImplicitWithNoDevice()
+    {
+        var (unitOfWork, context, mapper) = await CreateDatabase();
+        var (rps, user, _, series) = await Setup(unitOfWork, context, mapper);
+
+        const int deviceId = 1;
+
+        var profile = new AppUserReadingProfileBuilder(user.Id)
+            .WithName("Profile (No Device)")
+            .Build();
+
+        var implicitWithDevice = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithDeviceId(deviceId)
+            .WithName("Implicit (Device)")
+            .WithKind(ReadingProfileKind.Implicit)
+            .Build();
+
+        var implicitNoDevice = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithName("Implicit (No Device)")
+            .WithKind(ReadingProfileKind.Implicit)
+            .Build();
+
+        context.AppUserReadingProfiles.Add(profile);
+        context.AppUserReadingProfiles.Add(implicitWithDevice);
+        context.AppUserReadingProfiles.Add(implicitNoDevice);
+        await unitOfWork.CommitAsync();
+
+        await rps.SetSeriesProfiles(user.Id, [profile.Id], series.Id);
+
+        // Implicit with no device should be removed
+        var implicitNoDeviceExists = await context.AppUserReadingProfiles
+            .AnyAsync(rp => rp.Id == implicitNoDevice.Id);
+        Assert.False(implicitNoDeviceExists);
+
+        // Implicit with device should still exist (for that specific device)
+        var implicitWithDeviceExists = await context.AppUserReadingProfiles
+            .AnyAsync(rp => rp.Id == implicitWithDevice.Id);
+        Assert.True(implicitWithDeviceExists);
+    }
+
+    [Fact]
+    public async Task AddProfileToSeries_WithMultipleDevices_RemovesImplicitsForAllDevices()
+    {
+        var (unitOfWork, context, mapper) = await CreateDatabase();
+        var (rps, user, _, series) = await Setup(unitOfWork, context, mapper);
+
+        const int device1 = 1;
+        const int device2 = 2;
+        const int device3 = 3;
+
+        var profile = new AppUserReadingProfileBuilder(user.Id)
+            .WithDeviceId(device1)
+            .WithDeviceId(device2)
+            .WithName("Profile (Device 1 & 2)")
+            .Build();
+
+        var implicitDevice1 = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithDeviceId(device1)
+            .WithName("Implicit (Device 1)")
+            .WithKind(ReadingProfileKind.Implicit)
+            .Build();
+
+        var implicitDevice2 = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithDeviceId(device2)
+            .WithName("Implicit (Device 2)")
+            .WithKind(ReadingProfileKind.Implicit)
+            .Build();
+
+        var implicitDevice3 = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithDeviceId(device3)
+            .WithName("Implicit (Device 3)")
+            .WithKind(ReadingProfileKind.Implicit)
+            .Build();
+
+        var implicitNoDevice = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithName("Implicit (No Device)")
+            .WithKind(ReadingProfileKind.Implicit)
+            .Build();
+
+        context.AppUserReadingProfiles.Add(profile);
+        context.AppUserReadingProfiles.Add(implicitDevice1);
+        context.AppUserReadingProfiles.Add(implicitDevice2);
+        context.AppUserReadingProfiles.Add(implicitDevice3);
+        context.AppUserReadingProfiles.Add(implicitNoDevice);
+        await unitOfWork.CommitAsync();
+
+        await rps.SetSeriesProfiles(user.Id, [profile.Id], series.Id);
+
+        // Implicits for device 1 and 2 should be removed
+        var implicit1Exists = await context.AppUserReadingProfiles
+            .AnyAsync(rp => rp.Id == implicitDevice1.Id);
+        Assert.False(implicit1Exists);
+
+        var implicit2Exists = await context.AppUserReadingProfiles
+            .AnyAsync(rp => rp.Id == implicitDevice2.Id);
+        Assert.False(implicit2Exists);
+
+        // Implicit for device 3 should still exist
+        var implicit3Exists = await context.AppUserReadingProfiles
+            .AnyAsync(rp => rp.Id == implicitDevice3.Id);
+        Assert.True(implicit3Exists);
+
+        // Implicit with no device should still exist (fallback)
+        var implicitNoDeviceExists = await context.AppUserReadingProfiles
+            .AnyAsync(rp => rp.Id == implicitNoDevice.Id);
+        Assert.True(implicitNoDeviceExists);
+    }
+
+    [Fact]
+    public async Task AddProfileToSeries_ImplicitWithMultipleDevices_RemovedIfAnyDeviceMatches()
+    {
+        var (unitOfWork, context, mapper) = await CreateDatabase();
+        var (rps, user, _, series) = await Setup(unitOfWork, context, mapper);
+
+        const int device1 = 1;
+        const int device2 = 2;
+        const int device3 = 3;
+
+        var profile = new AppUserReadingProfileBuilder(user.Id)
+            .WithDeviceId(device1)
+            .WithName("Profile (Device 1)")
+            .Build();
+
+        // Implicit with multiple devices including device1
+        var implicitMultiDevice = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithDeviceId(device1)
+            .WithDeviceId(device2)
+            .WithName("Implicit (Device 1 & 2)")
+            .WithKind(ReadingProfileKind.Implicit)
+            .Build();
+
+        // Implicit with multiple devices NOT including device1
+        var implicitOtherDevices = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithDeviceId(device2)
+            .WithDeviceId(device3)
+            .WithName("Implicit (Device 2 & 3)")
+            .WithKind(ReadingProfileKind.Implicit)
+            .Build();
+
+        context.AppUserReadingProfiles.Add(profile);
+        context.AppUserReadingProfiles.Add(implicitMultiDevice);
+        context.AppUserReadingProfiles.Add(implicitOtherDevices);
+        await unitOfWork.CommitAsync();
+
+        await rps.SetSeriesProfiles(user.Id, [profile.Id], series.Id);
+
+        // Implicit with device1 (among others) should be removed
+        var implicitMultiExists = await context.AppUserReadingProfiles
+            .AnyAsync(rp => rp.Id == implicitMultiDevice.Id);
+        Assert.False(implicitMultiExists);
+
+        // Implicit without device1 should still exist
+        var implicitOtherExists = await context.AppUserReadingProfiles
+            .AnyAsync(rp => rp.Id == implicitOtherDevices.Id);
+        Assert.True(implicitOtherExists);
+    }
+
+    [Fact]
+    public async Task AddProfileToSeries_ThrowsIfProfileDoesNotBelongToUser()
+    {
+        var (unitOfWork, context, mapper) = await CreateDatabase();
+        var (rps, user, _, series) = await Setup(unitOfWork, context, mapper);
+
+        var otherUser = new AppUserBuilder("otheruser", "other@email.com").Build();
+        context.AppUser.Add(otherUser);
+        await unitOfWork.CommitAsync();
+
+        var otherUserProfile = new AppUserReadingProfileBuilder(otherUser.Id)
+            .WithName("Other User's Profile")
+            .Build();
+
+        context.AppUserReadingProfiles.Add(otherUserProfile);
+        await unitOfWork.CommitAsync();
+
+        // Should throw when trying to add series to another user's profile
+        await Assert.ThrowsAsync<KavitaException>(async () =>
+            await rps.SetSeriesProfiles(user.Id, [otherUserProfile.Id], series.Id));
+    }
+
+    #endregion
+
+    #region Tests with devices - ClearSeriesProfile
+
+    [Fact]
+    public async Task ClearSeriesProfile_RemovesAllProfilesForSeriesRegardlessOfKindOrDevice()
+    {
+        var (unitOfWork, context, mapper) = await CreateDatabase();
+        var (rps, user, _, series) = await Setup(unitOfWork, context, mapper);
+
+        var userProfileDevice1 = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithDeviceId(1)
+            .WithName("User (Device 1)")
+            .Build();
+
+        var userProfileDevice2 = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithDeviceId(2)
+            .WithName("User (Device 2)")
+            .Build();
+
+        var implicitProfileDevice1 = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithDeviceId(1)
+            .WithName("Implicit (Device 1)")
+            .WithKind(ReadingProfileKind.Implicit)
+            .Build();
+
+        var implicitProfileNoDevice = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithName("Implicit (No Device)")
+            .WithKind(ReadingProfileKind.Implicit)
+            .Build();
+
+        context.AppUserReadingProfiles.AddRange(
+            userProfileDevice1,
+            userProfileDevice2,
+            implicitProfileDevice1,
+            implicitProfileNoDevice
+        );
+        await unitOfWork.CommitAsync();
+
+        await rps.ClearSeriesProfile(user.Id, series.Id);
+
+        var remainingProfiles = await context.AppUserReadingProfiles
+            .Where(rp => rp.SeriesIds.Contains(series.Id))
+            .ToListAsync();
+
+        Assert.Empty(remainingProfiles);
+    }
+
+
+    #endregion
+
+    #region Tests with devices - SetProfileDevices
+
+    [Fact]
+    public async Task SetProfileDevices_Basic()
+    {
+        var (unitOfWork, context, mapper) = await CreateDatabase();
+        var (rps, user, _, series) = await Setup(unitOfWork, context, mapper);
+
+        const int device1 = 1;
+        const int device2 = 2;
+        const int device3 = 3;
+
+        var profile = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithDeviceId(device1)
+            .WithDeviceId(device2)
+            .WithName("Profile")
+            .Build();
+
+        context.AppUserReadingProfiles.Add(profile);
+        await unitOfWork.CommitAsync();
+
+        // Sets both
+        await rps.SetProfileDevices(user.Id, profile.Id, [device1, device2]);
+
+        var updated = await context.AppUserReadingProfiles
+            .FirstAsync(rp => rp.Id == profile.Id);
+
+        Assert.Equal(2, updated.DeviceIds.Count);
+        Assert.Contains(device1, updated.DeviceIds);
+        Assert.Contains(device2, updated.DeviceIds);
+
+        // Full replace
+        await rps.SetProfileDevices(user.Id, profile.Id, [device3]);
+
+        updated = await context.AppUserReadingProfiles
+
+            .FirstAsync(rp => rp.Id == profile.Id);
+
+        Assert.Single(updated.DeviceIds);
+        Assert.Contains(device3, updated.DeviceIds);
+        Assert.DoesNotContain(device1, updated.DeviceIds);
+        Assert.DoesNotContain(device2, updated.DeviceIds);
+
+        // Allow empty
+        await rps.SetProfileDevices(user.Id, profile.Id, []);
+
+        updated = await context.AppUserReadingProfiles
+
+            .FirstAsync(rp => rp.Id == profile.Id);
+
+        Assert.Empty(updated.DeviceIds);
+    }
+
+    [Fact]
+    public async Task SetProfileDevices_RemovesDuplicateSeriesLinks_SameDevice()
+    {
+        var (unitOfWork, context, mapper) = await CreateDatabase();
+        var (rps, user, _, series) = await Setup(unitOfWork, context, mapper);
+
+        const int device1 = 1;
+
+        var profile1 = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithDeviceId(device1)
+            .WithName("Profile 1")
+            .Build();
+
+        var profile2 = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithName("Profile 2 (will get device 1)")
+            .Build();
+
+        context.AppUserReadingProfiles.Add(profile1);
+        context.AppUserReadingProfiles.Add(profile2);
+        await unitOfWork.CommitAsync();
+
+        // Add device1 to profile2, which should remove series from profile1
+        await rps.SetProfileDevices(user.Id, profile2.Id, [device1]);
+
+        var updatedProfile1 = await context.AppUserReadingProfiles
+
+            .FirstAsync(rp => rp.Id == profile1.Id);
+
+        Assert.DoesNotContain(series.Id, updatedProfile1.SeriesIds);
+
+        var updatedProfile2 = await context.AppUserReadingProfiles
+
+            .FirstAsync(rp => rp.Id == profile2.Id);
+
+        Assert.Contains(series.Id, updatedProfile2.SeriesIds);
+    }
+
+    [Fact]
+    public async Task SetProfileDevices_RemovesDuplicateSeriesLinks_MultipleDevices()
+    {
+        var (unitOfWork, context, mapper) = await CreateDatabase();
+        var (rps, user, _, series) = await Setup(unitOfWork, context, mapper);
+
+        const int device1 = 1;
+        const int device2 = 2;
+        const int device3 = 3;
+
+        var profile1 = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithDeviceId(device1)
+            .WithDeviceId(device2)
+            .WithName("Profile 1 (Device 1 & 2)")
+            .Build();
+
+        var profile2 = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithDeviceId(device3)
+            .WithName("Profile 2 (will get Device 2)")
+            .Build();
+
+        context.AppUserReadingProfiles.Add(profile1);
+        context.AppUserReadingProfiles.Add(profile2);
+        await unitOfWork.CommitAsync();
+
+        // Add device2 to profile2, which should remove series from profile1 only for device2
+        await rps.SetProfileDevices(user.Id, profile2.Id, [device2]);
+
+        var updatedProfile1 = await context.AppUserReadingProfiles
+
+
+            .FirstAsync(rp => rp.Id == profile1.Id);
+
+        // Profile1 should no longer have the series since device2 now conflicts
+        Assert.DoesNotContain(series.Id, updatedProfile1.SeriesIds);
+    }
+
+    [Fact]
+    public async Task SetProfileDevices_RemovesDuplicateLibraryLinks()
     {
         var (unitOfWork, context, mapper) = await CreateDatabase();
         var (rps, user, lib, _) = await Setup(unitOfWork, context, mapper);
 
-        var implicitProfile = new AppUserReadingProfileBuilder(user.Id)
-            .WithKind(ReadingProfileKind.Implicit)
+        const int device1 = 1;
+
+        var profile1 = new AppUserReadingProfileBuilder(user.Id)
             .WithLibrary(lib)
+            .WithDeviceId(device1)
+            .WithName("Profile 1")
             .Build();
-        context.AppUserReadingProfiles.Add(implicitProfile);
+
+        var profile2 = new AppUserReadingProfileBuilder(user.Id)
+            .WithLibrary(lib)
+            .WithName("Profile 2 (will get device 1)")
+            .Build();
+
+        context.AppUserReadingProfiles.Add(profile1);
+        context.AppUserReadingProfiles.Add(profile2);
         await unitOfWork.CommitAsync();
 
-        await rps.ClearLibraryProfile(user.Id, lib.Id);
-        var profile = (await unitOfWork.AppUserReadingProfileRepository.GetProfilesForUser(user.Id))
-            .FirstOrDefault(rp => rp.LibraryIds.Contains(lib.Id));
-        Assert.Null(profile);
+        await rps.SetProfileDevices(user.Id, profile2.Id, [device1]);
 
-        var explicitProfile = new AppUserReadingProfileBuilder(user.Id)
-            .WithLibrary(lib)
-            .Build();
-        context.AppUserReadingProfiles.Add(explicitProfile);
-        await unitOfWork.CommitAsync();
+        var updatedProfile1 = await context.AppUserReadingProfiles
 
-        await rps.ClearLibraryProfile(user.Id, lib.Id);
-        profile = (await unitOfWork.AppUserReadingProfileRepository.GetProfilesForUser(user.Id))
-            .FirstOrDefault(rp => rp.LibraryIds.Contains(lib.Id));
-        Assert.Null(profile);
+            .FirstAsync(rp => rp.Id == profile1.Id);
 
-        var stillExists = await context.AppUserReadingProfiles.FindAsync(explicitProfile.Id);
-        Assert.NotNull(stillExists);
+        Assert.DoesNotContain(lib.Id, updatedProfile1.LibraryIds);
+
+        var updatedProfile2 = await context.AppUserReadingProfiles
+
+            .FirstAsync(rp => rp.Id == profile2.Id);
+
+        Assert.Contains(lib.Id, updatedProfile2.LibraryIds);
     }
+
+    [Fact]
+    public async Task SetProfileDevices_RemovesDuplicates_BothSeriesAndLibrary()
+    {
+        var (unitOfWork, context, mapper) = await CreateDatabase();
+        var (rps, user, _, series) = await Setup(unitOfWork, context, mapper);
+
+        var lib2 = new LibraryBuilder("Library 2").Build();
+        user.Libraries.Add(lib2);
+
+        const int device1 = 1;
+
+        var profile1 = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithLibrary(lib2)
+            .WithDeviceId(device1)
+            .WithName("Profile 1")
+            .Build();
+
+        var profile2 = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithLibrary(lib2)
+            .WithName("Profile 2 (will get device 1)")
+            .Build();
+
+        context.AppUserReadingProfiles.Add(profile1);
+        context.AppUserReadingProfiles.Add(profile2);
+        await unitOfWork.CommitAsync();
+
+        await rps.SetProfileDevices(user.Id, profile2.Id, [device1]);
+
+        var updatedProfile1 = await context.AppUserReadingProfiles
+
+
+            .FirstAsync(rp => rp.Id == profile1.Id);
+
+        Assert.DoesNotContain(series.Id, updatedProfile1.SeriesIds);
+        Assert.DoesNotContain(lib2.Id, updatedProfile1.LibraryIds);
+    }
+
+    [Fact]
+    public async Task SetProfileDevices_OnlyRemovesConflictingDeviceLinks()
+    {
+        var (unitOfWork, context, mapper) = await CreateDatabase();
+        var (rps, user, lib, series) = await Setup(unitOfWork, context, mapper);
+
+        var series2 = new SeriesBuilder("Series 2").Build();
+        lib.Series.Add(series2);
+        await unitOfWork.CommitAsync();
+
+        const int device1 = 1;
+
+        var profile1 = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithSeries(series2)
+            .WithDeviceId(device1)
+            .WithName("Profile 1 (Device 1)")
+            .Build();
+
+        var profile2 = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithName("Profile 2 (will get device 1)")
+            .Build();
+
+        context.AppUserReadingProfiles.Add(profile1);
+        context.AppUserReadingProfiles.Add(profile2);
+        await unitOfWork.CommitAsync();
+
+        await rps.SetProfileDevices(user.Id, profile2.Id, [device1]);
+
+        var updatedProfile1 = await context.AppUserReadingProfiles
+            .FirstAsync(rp => rp.Id == profile1.Id);
+
+        // Only series1 should be removed, series2 should remain
+        Assert.DoesNotContain(series.Id, updatedProfile1.SeriesIds);
+        Assert.Contains(series2.Id, updatedProfile1.SeriesIds);
+    }
+
+    [Fact]
+    public async Task SetProfileDevices_DoesNotAffectNoDeviceProfiles()
+    {
+        var (unitOfWork, context, mapper) = await CreateDatabase();
+        var (rps, user, _, series) = await Setup(unitOfWork, context, mapper);
+
+        const int device1 = 1;
+
+        var profile1 = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithName("Profile 1 (No Device - Fallback)")
+            .Build();
+
+        var profile2 = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithName("Profile 2 (will get device 1)")
+            .Build();
+
+        context.AppUserReadingProfiles.Add(profile1);
+        context.AppUserReadingProfiles.Add(profile2);
+        await unitOfWork.CommitAsync();
+
+        await rps.SetProfileDevices(user.Id, profile2.Id, [device1]);
+
+        var updatedProfile1 = await context.AppUserReadingProfiles
+            .FirstAsync(rp => rp.Id == profile1.Id);
+
+        // Profile1 has no devices, so it's a fallback and should not be affected
+        Assert.Contains(series.Id, updatedProfile1.SeriesIds);
+    }
+
+    [Fact]
+    public async Task SetProfileDevices_SettingToNoDevice_RemovesDuplicatesWithNoDevice()
+    {
+        var (unitOfWork, context, mapper) = await CreateDatabase();
+        var (rps, user, _, series) = await Setup(unitOfWork, context, mapper);
+
+        const int device1 = 1;
+
+        var profile1 = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithName("Profile 1 (No Device)")
+            .Build();
+
+        var profile2 = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithDeviceId(device1)
+            .WithName("Profile 2 (Device 1, will remove device)")
+            .Build();
+
+        context.AppUserReadingProfiles.Add(profile1);
+        context.AppUserReadingProfiles.Add(profile2);
+        await unitOfWork.CommitAsync();
+
+        // Set profile2 to no devices, which conflicts with profile1's no-device fallback
+        await rps.SetProfileDevices(user.Id, profile2.Id, []);
+
+        var updatedProfile1 = await context.AppUserReadingProfiles
+
+            .FirstAsync(rp => rp.Id == profile1.Id);
+
+        Assert.DoesNotContain(series.Id, updatedProfile1.SeriesIds);
+    }
+
+    [Fact]
+    public async Task SetProfileDevices_RemovesMultipleConflicts()
+    {
+        var (unitOfWork, context, mapper) = await CreateDatabase();
+        var (rps, user, _, series) = await Setup(unitOfWork, context, mapper);
+
+        const int device1 = 1;
+
+        var profile1 = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithDeviceId(device1)
+            .WithName("Profile 1")
+            .Build();
+
+        var profile2 = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithDeviceId(device1)
+            .WithName("Profile 2")
+            .Build();
+
+        var profile3 = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithName("Profile 3 (will get device 1)")
+            .Build();
+
+        context.AppUserReadingProfiles.Add(profile1);
+        context.AppUserReadingProfiles.Add(profile2);
+        context.AppUserReadingProfiles.Add(profile3);
+        await unitOfWork.CommitAsync();
+
+        await rps.SetProfileDevices(user.Id, profile3.Id, [device1]);
+
+        var updatedProfile1 = await context.AppUserReadingProfiles
+
+            .FirstAsync(rp => rp.Id == profile1.Id);
+
+        var updatedProfile2 = await context.AppUserReadingProfiles
+
+            .FirstAsync(rp => rp.Id == profile2.Id);
+
+        // Both profile1 and profile2 should have series removed
+        Assert.DoesNotContain(series.Id, updatedProfile1.SeriesIds);
+        Assert.DoesNotContain(series.Id, updatedProfile2.SeriesIds);
+    }
+
+    [Fact]
+    public async Task SetProfileDevices_DoesNotRemoveImplicitProfiles()
+    {
+        var (unitOfWork, context, mapper) = await CreateDatabase();
+        var (rps, user, _, series) = await Setup(unitOfWork, context, mapper);
+
+        const int device1 = 1;
+
+        var implicitProfile = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithDeviceId(device1)
+            .WithName("Implicit Profile")
+            .WithKind(ReadingProfileKind.Implicit)
+            .Build();
+
+        var userProfile = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithName("User Profile (will get device 1)")
+            .Build();
+
+        context.AppUserReadingProfiles.Add(implicitProfile);
+        context.AppUserReadingProfiles.Add(userProfile);
+        await unitOfWork.CommitAsync();
+
+        await rps.SetProfileDevices(user.Id, userProfile.Id, [device1]);
+
+        var updatedImplicit = await context.AppUserReadingProfiles
+            .FirstAsync(rp => rp.Id == implicitProfile.Id);
+
+        // Implicit profiles should not be affected by duplicate removal
+        Assert.Contains(series.Id, updatedImplicit.SeriesIds);
+    }
+
+    [Fact]
+    public async Task SetProfileDevices_WorksWithComplexScenario()
+    {
+        var (unitOfWork, context, mapper) = await CreateDatabase();
+        var (rps, user, lib, series) = await Setup(unitOfWork, context, mapper);
+
+        var series2 = new SeriesBuilder("Series 2").Build();
+        var series3 = new SeriesBuilder("Series 3").Build();
+        lib.Series.Add(series2);
+        lib.Series.Add(series3);
+        await unitOfWork.CommitAsync();
+
+        const int device1 = 1;
+        const int device2 = 2;
+        const int device3 = 3;
+
+        var profile1 = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithSeries(series2)
+            .WithDeviceId(device1)
+            .WithDeviceId(device2)
+            .WithName("Profile 1 (Device 1 & 2)")
+            .Build();
+
+        var profile2 = new AppUserReadingProfileBuilder(user.Id)
+            .WithSeries(series)
+            .WithSeries(series3)
+            .WithDeviceId(device3)
+            .WithName("Profile 2 (will get Device 2)")
+            .Build();
+
+        context.AppUserReadingProfiles.Add(profile1);
+        context.AppUserReadingProfiles.Add(profile2);
+        await unitOfWork.CommitAsync();
+
+        // Set profile2 to device2, which conflicts with profile1
+        await rps.SetProfileDevices(user.Id, profile2.Id, [device2]);
+
+        var updatedProfile1 = await context.AppUserReadingProfiles
+
+            .FirstAsync(rp => rp.Id == profile1.Id);
+
+        // Profile1 should lose series1 (conflicts), but keep series2 (no conflict)
+        Assert.DoesNotContain(series.Id, updatedProfile1.SeriesIds);
+        Assert.Contains(series2.Id, updatedProfile1.SeriesIds);
+
+        var updatedProfile2 = await context.AppUserReadingProfiles
+
+
+            .FirstAsync(rp => rp.Id == profile2.Id);
+
+        // Profile2 should have device2 and keep both series
+        Assert.Single(updatedProfile2.DeviceIds);
+        Assert.Contains(device2, updatedProfile2.DeviceIds);
+        Assert.Contains(series.Id, updatedProfile2.SeriesIds);
+        Assert.Contains(series3.Id, updatedProfile2.SeriesIds);
+    }
+
+    [Fact]
+    public async Task SetProfileDevices_ThrowsIfProfileDoesNotBelongToUser()
+    {
+        var (unitOfWork, context, mapper) = await CreateDatabase();
+        var (rps, user, _, _) = await Setup(unitOfWork, context, mapper);
+
+        var otherUser = new AppUserBuilder("otheruser", "other@email.com").Build();
+        context.AppUser.Add(otherUser);
+        await unitOfWork.CommitAsync();
+
+        const int device1 = 1;
+
+        var otherUserProfile = new AppUserReadingProfileBuilder(otherUser.Id)
+            .WithName("Other User's Profile")
+            .Build();
+
+        context.AppUserReadingProfiles.Add(otherUserProfile);
+        await unitOfWork.CommitAsync();
+
+        // Should throw when trying to set devices on another user's profile
+        await Assert.ThrowsAsync<KavitaException>(async () =>
+            await rps.SetProfileDevices(user.Id, otherUserProfile.Id, [device1]));
+    }
+
+    #endregion
 
     /// <summary>
     /// As response to #3793, I'm not sure if we want to keep this. It's not the most nice. But I think the idea of this test
@@ -538,22 +2010,18 @@ public class ReadingProfileServiceTest(ITestOutputHelper outputHelper): Abstract
     {
         var (_, _, mapper) = await CreateDatabase();
 
-        // Repeat to ensure booleans are flipped and actually tested
-        for (int i = 0; i < 10; i++)
-        {
-            var profile = new AppUserReadingProfile();
-            var dto = new UserReadingProfileDto();
+        var profile = new AppUserReadingProfile();
+        var dto = new UserReadingProfileDto();
 
-            RandfHelper.SetRandomValues(profile);
-            RandfHelper.SetRandomValues(dto);
+        RandfHelper.SetRandomValues(profile);
+        RandfHelper.SetRandomValues(dto);
 
-            ReadingProfileService.UpdateReaderProfileFields(profile, dto);
+        ReadingProfileService.UpdateReaderProfileFields(profile, dto);
 
-            var newDto = mapper.Map<UserReadingProfileDto>(profile);
+        var newDto = mapper.Map<UserReadingProfileDto>(profile);
 
-            Assert.True(RandfHelper.AreSimpleFieldsEqual(dto, newDto,
-                ["<Id>k__BackingField", "<UserId>k__BackingField"]));
-        }
+        Assert.True(RandfHelper.AreSimpleFieldsEqual(dto, newDto,
+            ["<Id>k__BackingField", "<UserId>k__BackingField"]));
     }
 
 }

--- a/API/API.csproj
+++ b/API/API.csproj
@@ -53,6 +53,7 @@
 
   <!-- Override vulnerable transitive dependencies -->
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="10.0.1" />
     <PackageReference Include="NeoSmart.Caching.Sqlite.AspNetCore" Version="9.0.1" />
   </ItemGroup>
 

--- a/API/Constants/ResponseCacheProfiles.cs
+++ b/API/Constants/ResponseCacheProfiles.cs
@@ -2,7 +2,6 @@
 
 public static class ResponseCacheProfiles
 {
-    public const string Images = "Images";
     public const string Hour = "Hour";
     public const string TenMinute = "10Minute";
     public const string FiveMinute = "5Minute";

--- a/API/Controllers/AccountController.cs
+++ b/API/Controllers/AccountController.cs
@@ -351,6 +351,7 @@ public class AccountController : BaseApiController
     /// <param name="tokenRequestDto"></param>
     /// <returns></returns>
     [AllowAnonymous]
+    [SkipDeviceTracking]
     [HttpPost("refresh-token")]
     public async Task<ActionResult<TokenRequestDto>> RefreshToken([FromBody] TokenRequestDto tokenRequestDto)
     {

--- a/API/Controllers/AccountController.cs
+++ b/API/Controllers/AccountController.cs
@@ -104,7 +104,6 @@ public class AccountController : BaseApiController
     /// <returns></returns>
     /// <exception cref="UnauthorizedAccessException"></exception>
     /// <remarks>Does not return tokens for the user</remarks>
-    /// <remarks>Updates the last active date for the user</remarks>
     [HttpGet]
     public async Task<ActionResult<UserDto>> GetCurrentUserAsync()
     {
@@ -113,15 +112,6 @@ public class AccountController : BaseApiController
 
         var roles = await _userManager.GetRolesAsync(user);
         if (!roles.Contains(PolicyConstants.LoginRole) && !roles.Contains(PolicyConstants.AdminRole)) return Unauthorized(await _localizationService.Translate(user.Id, "disabled-account"));
-
-        try
-        {
-            await _unitOfWork.UserRepository.UpdateUserAsActive(user.Id);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to update last active for {UserName}", user.UserName);
-        }
 
         return Ok(await ConstructUserDto(user, roles, false));
     }

--- a/API/Controllers/BaseApiController.cs
+++ b/API/Controllers/BaseApiController.cs
@@ -1,9 +1,13 @@
-﻿using API.Middleware;
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
 using API.Services.Store;
-using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
+using MimeTypes;
 
 namespace API.Controllers;
 
@@ -31,5 +35,66 @@ public class BaseApiController : ControllerBase
     /// </summary>
     /// <remarks>Warning! Username's can contain .. and /, do not use folders or filenames explicitly with the Username</remarks>
     protected string? Username => UserContext.GetUsername();
+
+    /// <summary>
+    /// Returns a physical file with proper HTTP caching headers and ETag support.
+    /// Automatically handles conditional requests (If-None-Match) returning 304 Not Modified when appropriate.
+    /// </summary>
+    /// <param name="path">The absolute path to the file on disk.</param>
+    /// <param name="maxAge">Cache duration in seconds. Default is 86400 (1 day).</param>
+    /// <returns>
+    /// <see cref="NotFoundResult"/> if path is null/empty or file doesn't exist.
+    /// <see cref="StatusCodeResult"/> with 304 if client's cached version is current.
+    /// <see cref="PhysicalFileResult"/> with the file content and caching headers otherwise.
+    /// </returns>
+    protected ActionResult CachedFile(string? path, int maxAge = 86400)
+    {
+        if (string.IsNullOrEmpty(path) || !System.IO.File.Exists(path))
+            return NotFound();
+
+        var lastWrite = System.IO.File.GetLastWriteTimeUtc(path);
+        var etag = $"\"{lastWrite.Ticks:x}-{path.GetHashCode():x}\"";
+
+        if (Request.Headers.IfNoneMatch.ToString() == etag)
+            return StatusCode(304);
+
+        Response.Headers.ETag = etag;
+        Response.Headers.CacheControl = $"private, max-age={maxAge}";
+
+        var contentType = MimeTypeMap.GetMimeType(Path.GetExtension(path));
+        return PhysicalFile(path, contentType, Path.GetFileName(path), enableRangeProcessing: true);
+    }
+
+    /// <summary>
+    /// Returns a file from byte[] content with proper HTTP caching headers and ETag support.
+    /// ETag is generated from SHA256 hash of the content.
+    /// Automatically handles conditional requests (If-None-Match) returning 304 Not Modified when appropriate.
+    /// </summary>
+    /// <param name="content">The file content as byte array.</param>
+    /// <param name="contentType">The MIME type of the content.</param>
+    /// <param name="fileName">Optional filename for Content-Disposition header.</param>
+    /// <param name="maxAge">Cache duration in seconds. Default is 86400 (1 day).</param>
+    /// <returns>
+    /// <see cref="NotFoundResult"/> if content is null or empty.
+    /// <see cref="StatusCodeResult"/> with 304 if client's cached version is current.
+    /// <see cref="FileContentResult"/> with the content and caching headers otherwise.
+    /// </returns>
+    protected ActionResult CachedContent(byte[]? content, string contentType, string? fileName = null, int maxAge = 86400)
+    {
+        if (content is not { Length: > 0 })
+            return NotFound();
+
+        var etag = $"\"{Convert.ToHexString(SHA256.HashData(content))}\"";
+
+        if (Request.Headers.IfNoneMatch.ToString() == etag)
+            return StatusCode(304);
+
+        Response.Headers.ETag = etag;
+        Response.Headers.CacheControl = $"private, max-age={maxAge}";
+
+        return fileName is not null
+            ? File(content, contentType, fileName)
+            : File(content, contentType);
+    }
 
 }

--- a/API/Controllers/BookController.cs
+++ b/API/Controllers/BookController.cs
@@ -6,6 +6,7 @@ using API.Constants;
 using API.Data;
 using API.DTOs.Reader;
 using API.Entities.Enums;
+using API.Middleware;
 using API.Services;
 using Kavita.Common;
 using Microsoft.AspNetCore.Authorization;
@@ -104,9 +105,10 @@ public class BookController : BaseApiController
     /// <param name="chapterId"></param>
     /// <param name="file"></param>
     /// <returns></returns>
+    [AllowAnonymous]
+    [SkipDeviceTracking]
     [HttpGet("{chapterId}/book-resources")]
     [ResponseCache(Duration = 60 * 1, Location = ResponseCacheLocation.Client, NoStore = false)]
-    [AllowAnonymous]
     public async Task<ActionResult> GetBookPageResources(int chapterId, [FromQuery] string file)
     {
         if (chapterId <= 0) return BadRequest(await _localizationService.Get("en", "chapter-doesnt-exist"));

--- a/API/Controllers/FontController.cs
+++ b/API/Controllers/FontController.cs
@@ -69,11 +69,9 @@ public class FontController : BaseApiController
 
         if (font.Provider == FontProvider.System) return BadRequest("System provided fonts are not loaded by API");
 
-
-        var contentType = MimeTypeMap.GetMimeType(Path.GetExtension(font.FileName));
         var path = Path.Join(_directoryService.EpubFontDirectory, font.FileName);
 
-        return PhysicalFile(path, contentType, true);
+        return CachedFile(path);
     }
 
     /// <summary>

--- a/API/Controllers/FontController.cs
+++ b/API/Controllers/FontController.cs
@@ -59,6 +59,7 @@ public class FontController : BaseApiController
     /// <returns></returns>
     [HttpGet]
     [AllowAnonymous]
+    [SkipDeviceTracking]
     public async Task<IActionResult> GetFont(int fontId, string apiKey)
     {
         var userId = await _unitOfWork.UserRepository.GetUserIdByAuthKeyAsync(apiKey);

--- a/API/Controllers/OPDSController.cs
+++ b/API/Controllers/OPDSController.cs
@@ -715,9 +715,6 @@ public class OpdsController : BaseApiController
             var content = await _directoryService.ReadFileAsync(path);
             var format = Path.GetExtension(path);
 
-            // Calculates SHA1 Hash for byte[]
-            Response.AddCacheHeader(content);
-
             // Save progress for the user (except Panels, they will use a direct connection)
             var userAgent = Request.Headers.UserAgent.ToString();
 
@@ -745,7 +742,7 @@ public class OpdsController : BaseApiController
                 }, userId);
             }
 
-            return File(content, MimeTypeMap.GetMimeType(format));
+            return CachedContent(content, MimeTypeMap.GetMimeType(format));
         }
         catch (Exception)
         {

--- a/API/Controllers/OPDSController.cs
+++ b/API/Controllers/OPDSController.cs
@@ -53,10 +53,6 @@ public class OpdsController : BaseApiController
         _xmlOpenSearchSerializer = new XmlSerializer(typeof(OpenSearchDescription));
     }
 
-    private int GetUserIdFromContext()
-    {
-        return _userContext.GetUserIdOrThrow();
-    }
 
     /// <summary>
     /// Returns the Catalogue for Kavita's OPDS Service
@@ -75,7 +71,7 @@ public class OpdsController : BaseApiController
             ApiKey = apiKey,
             Prefix = prefix,
             BaseUrl =  baseUrl,
-            UserId = GetUserIdFromContext()
+            UserId = UserId
         });
 
 
@@ -103,7 +99,7 @@ public class OpdsController : BaseApiController
     [Produces("application/xml")]
     public async Task<IActionResult> GetSmartFilter(string apiKey, int filterId, [FromQuery] int pageNumber = OpdsService.FirstPageNumber)
     {
-        var userId = GetUserIdFromContext();
+        var userId = UserId;
         var (baseUrl, prefix) = await GetPrefix();
 
         var feed = await _opdsService.GetSeriesFromSmartFilter(new OpdsItemsFromEntityIdRequest()
@@ -132,7 +128,7 @@ public class OpdsController : BaseApiController
     {
         try
         {
-            var userId = GetUserIdFromContext();
+            var userId = UserId;
             var (baseUrl, prefix) = await GetPrefix();
 
             var feed = await _opdsService.GetSmartFilters(new OpdsPaginatedCatalogueRequest()
@@ -170,7 +166,7 @@ public class OpdsController : BaseApiController
             {
                 BaseUrl = baseUrl,
                 Prefix = prefix,
-                UserId = GetUserIdFromContext(),
+                UserId = UserId,
                 ApiKey = apiKey,
                 PageNumber = pageNumber
             });
@@ -201,7 +197,7 @@ public class OpdsController : BaseApiController
             {
                 BaseUrl = baseUrl,
                 Prefix = prefix,
-                UserId = GetUserIdFromContext(),
+                UserId = UserId,
                 ApiKey = apiKey,
                 PageNumber = pageNumber
             });
@@ -232,7 +228,7 @@ public class OpdsController : BaseApiController
             {
                 BaseUrl = baseUrl,
                 Prefix = prefix,
-                UserId = GetUserIdFromContext(),
+                UserId = UserId,
                 ApiKey = apiKey,
                 PageNumber = pageNumber
             });
@@ -264,7 +260,7 @@ public class OpdsController : BaseApiController
             {
                 BaseUrl = baseUrl,
                 Prefix = prefix,
-                UserId = GetUserIdFromContext(),
+                UserId = UserId,
                 ApiKey = apiKey,
                 PageNumber = pageNumber,
                 EntityId = collectionId
@@ -296,7 +292,7 @@ public class OpdsController : BaseApiController
             {
                 BaseUrl = baseUrl,
                 Prefix = prefix,
-                UserId = GetUserIdFromContext(),
+                UserId = UserId,
                 ApiKey = apiKey,
                 PageNumber = pageNumber
             });
@@ -328,7 +324,7 @@ public class OpdsController : BaseApiController
             {
                 BaseUrl = baseUrl,
                 Prefix = prefix,
-                UserId = GetUserIdFromContext(),
+                UserId = UserId,
                 ApiKey = apiKey,
                 PageNumber = pageNumber,
                 EntityId = readingListId
@@ -362,7 +358,7 @@ public class OpdsController : BaseApiController
             {
                 BaseUrl = baseUrl,
                 Prefix = prefix,
-                UserId = GetUserIdFromContext(),
+                UserId = UserId,
                 ApiKey = apiKey,
                 PageNumber = pageNumber,
                 EntityId = libraryId
@@ -393,7 +389,7 @@ public class OpdsController : BaseApiController
             {
                 BaseUrl = baseUrl,
                 Prefix = prefix,
-                UserId = GetUserIdFromContext(),
+                UserId = UserId,
                 ApiKey = apiKey,
                 PageNumber = pageNumber,
             });
@@ -424,7 +420,7 @@ public class OpdsController : BaseApiController
             {
                 BaseUrl = baseUrl,
                 Prefix = prefix,
-                UserId = GetUserIdFromContext(),
+                UserId = UserId,
                 ApiKey = apiKey,
                 PageNumber = pageNumber,
                 EntityId = genreId
@@ -455,7 +451,7 @@ public class OpdsController : BaseApiController
             {
                 BaseUrl = baseUrl,
                 Prefix = prefix,
-                UserId = GetUserIdFromContext(),
+                UserId = UserId,
                 ApiKey = apiKey,
                 PageNumber = pageNumber,
             });
@@ -485,7 +481,7 @@ public class OpdsController : BaseApiController
             {
                 BaseUrl = baseUrl,
                 Prefix = prefix,
-                UserId = GetUserIdFromContext(),
+                UserId = UserId,
                 ApiKey = apiKey,
                 PageNumber = pageNumber,
             });
@@ -515,7 +511,7 @@ public class OpdsController : BaseApiController
             {
                 BaseUrl = baseUrl,
                 Prefix = prefix,
-                UserId = GetUserIdFromContext(),
+                UserId = UserId,
                 ApiKey = apiKey,
                 Query = query,
             });
@@ -532,7 +528,7 @@ public class OpdsController : BaseApiController
     [Produces("application/xml")]
     public async Task<IActionResult> GetSearchDescriptor(string apiKey)
     {
-        var userId = GetUserIdFromContext();
+        var userId = UserId;
         var (_, prefix) = await GetPrefix();
 
         var feed = new OpenSearchDescription()
@@ -570,7 +566,7 @@ public class OpdsController : BaseApiController
             {
                 BaseUrl = baseUrl,
                 Prefix = prefix,
-                UserId = GetUserIdFromContext(),
+                UserId = UserId,
                 ApiKey = apiKey,
                 EntityId = seriesId
             });
@@ -602,7 +598,7 @@ public class OpdsController : BaseApiController
             {
                 BaseUrl = baseUrl,
                 Prefix = prefix,
-                UserId = GetUserIdFromContext(),
+                UserId = UserId,
                 ApiKey = apiKey,
                 SeriesId = seriesId,
                 VolumeId = volumeId
@@ -636,7 +632,7 @@ public class OpdsController : BaseApiController
             {
                 BaseUrl = baseUrl,
                 Prefix = prefix,
-                UserId = GetUserIdFromContext(),
+                UserId = UserId,
                 ApiKey = apiKey,
                 SeriesId = seriesId,
                 VolumeId = volumeId,
@@ -663,7 +659,7 @@ public class OpdsController : BaseApiController
     [HttpGet("{apiKey}/series/{seriesId}/volume/{volumeId}/chapter/{chapterId}/download/{filename}")]
     public async Task<ActionResult> DownloadFile(string apiKey, int seriesId, int volumeId, int chapterId, string filename)
     {
-        var userId = GetUserIdFromContext();
+        var userId = UserId;
         var user = await _unitOfWork.UserRepository.GetUserByIdAsync(userId);
         if (!await _accountService.HasDownloadPermission(user))
         {
@@ -701,7 +697,7 @@ public class OpdsController : BaseApiController
     public async Task<ActionResult> GetPageStreamedImage(string apiKey, [FromQuery] int libraryId, [FromQuery] int seriesId,
         [FromQuery] int volumeId,[FromQuery] int chapterId, [FromQuery] int pageNumber, [FromQuery] bool saveProgress = true)
     {
-        var userId = GetUserIdFromContext();
+        var userId = UserId;
         if (pageNumber < 0) return BadRequest(await _localizationService.Translate(userId, "greater-0", "Page"));
         var chapter = await _cacheService.Ensure(chapterId, true);
         if (chapter == null) return BadRequest(await _localizationService.Translate(userId, "cache-file-find"));
@@ -755,9 +751,9 @@ public class OpdsController : BaseApiController
     [ResponseCache(Duration = 60 * 60, Location = ResponseCacheLocation.Client, NoStore = false)]
     public async Task<ActionResult> GetFavicon(string apiKey)
     {
-        var userId = GetUserIdFromContext();
+        var userId = UserId;
         var files = _directoryService.GetFilesWithExtension(Path.Join(Directory.GetCurrentDirectory(), ".."), @"\.ico");
-        if (files.Length == 0) return BadRequest(await _localizationService.Translate(userId, "favicon-doesnt-exist"));
+        if (files.Length == 0) return BadRequest(await _localizationService.Translate(UserId, "favicon-doesnt-exist"));
 
         var path = files[0];
         var content = await _directoryService.ReadFileAsync(path);

--- a/API/Controllers/SettingsController.cs
+++ b/API/Controllers/SettingsController.cs
@@ -34,10 +34,11 @@ public class SettingsController : BaseApiController
     private readonly ILocalizationService _localizationService;
     private readonly ISettingsService _settingsService;
     private readonly IAuthenticationSchemeProvider _authenticationSchemeProvider;
+    private readonly IOidcService _oidcService;
 
     public SettingsController(ILogger<SettingsController> logger, IUnitOfWork unitOfWork, IMapper mapper,
         IEmailService emailService, ILocalizationService localizationService, ISettingsService settingsService,
-        IAuthenticationSchemeProvider authenticationSchemeProvider)
+        IAuthenticationSchemeProvider authenticationSchemeProvider, IOidcService oidcService)
     {
         _logger = logger;
         _unitOfWork = unitOfWork;
@@ -46,6 +47,7 @@ public class SettingsController : BaseApiController
         _localizationService = localizationService;
         _settingsService = settingsService;
         _authenticationSchemeProvider = authenticationSchemeProvider;
+        _oidcService = oidcService;
     }
 
     /// <summary>
@@ -292,6 +294,15 @@ public class SettingsController : BaseApiController
                                !string.IsNullOrEmpty(settings.Secret);
 
         return Ok(publicConfig);
+    }
+
+    [Authorize(PolicyGroups.AdminPolicy)]
+    [HttpPost("reset-external-ids")]
+    public async Task<IActionResult> ResetExternalIds()
+    {
+        await _oidcService.ClearOidcIds();
+
+        return Ok();
     }
 
     /// <summary>

--- a/API/DTOs/Filtering/SortField.cs
+++ b/API/DTOs/Filtering/SortField.cs
@@ -1,4 +1,4 @@
-﻿namespace API.DTOs.Filtering;
+namespace API.DTOs.Filtering;
 
 public enum SortField
 {
@@ -38,6 +38,11 @@ public enum SortField
     /// Randomise the order
     /// </summary>
     Random = 9,
+    /// <summary>
+    /// By user rating
+    /// </summary>
+    UserRating = 10,
+
 }
 
 public enum AnnotationSortField

--- a/API/DTOs/Progress/ClientDeviceDto.cs
+++ b/API/DTOs/Progress/ClientDeviceDto.cs
@@ -10,6 +10,8 @@ public sealed record ClientDeviceDto
     /// </summary>
     public string FriendlyName { get; set; } = string.Empty;
 
+    public string? UiFingerprint { get; set; }
+
     /// <summary>
     /// Most recent stable ClientInfoData (excluding IP/timestamp changes)
     /// </summary>

--- a/API/DTOs/Settings/ServerSettingDTO.cs
+++ b/API/DTOs/Settings/ServerSettingDTO.cs
@@ -88,6 +88,10 @@ public sealed record ServerSettingDto
     /// </summary>
     public CoverImageSize CoverImageSize { get; set; }
     /// <summary>
+    /// How large rendered PDF images should be
+    /// </summary>
+    public PdfRenderResolution PdfRenderResolution { get; set; }
+    /// <summary>
     /// SMTP Configuration
     /// </summary>
     public SmtpConfigDto SmtpConfig { get; set; }

--- a/API/DTOs/Statistics/ServerStatisticsDto.cs
+++ b/API/DTOs/Statistics/ServerStatisticsDto.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace API.DTOs.Statistics;
+﻿namespace API.DTOs.Statistics;
 #nullable enable
 
 public sealed record ServerStatisticsDto

--- a/API/DTOs/Stats/V3/UserStatV3.cs
+++ b/API/DTOs/Stats/V3/UserStatV3.cs
@@ -70,6 +70,14 @@ public sealed record UserStatV3
     /// </summary>
     public bool IsSharingReviews { get; set; }
     /// <summary>
+    /// Is the user sharing their profile
+    /// </summary>
+    public bool IsSharingProfile { get; set; }
+    /// <summary>
+    /// Is the user sharing annotations
+    /// </summary>
+    public bool IsSharingAnnotations { get; set; }
+    /// <summary>
     /// The number of devices setup and their platforms
     /// </summary>
     public ICollection<EmailDevicePlatform> DevicePlatforms { get; set; }
@@ -81,6 +89,25 @@ public sealed record UserStatV3
     /// Who manages the user (OIDC, Kavita)
     /// </summary>
     public IdentityProvider IdentityProvider { get; set; }
+    /// <summary>
+    /// Total seconds read
+    /// </summary>
+    /// <remarks>Powers Top Reader badges</remarks>
+    public long TotalSecondsRead { get; set; }
+    /// <summary>
+    /// Total pages read
+    /// </summary>
+    /// <remarks>Powers Top Reader badges</remarks>
+    public long TotalPagesRead { get; set; }
+    /// <summary>
+    /// Total words read
+    /// </summary>
+    /// <remarks>Powers Top Reader badges</remarks>
+    public long TotalWordsRead { get; set; }
+    /// <summary>
+    /// An anonymous identifier for the social badges feature. This is the InstallId (which is malleable) and UserId from DB.
+    /// </summary>
+    public string UserId { get; set; }
 
 
 }

--- a/API/DTOs/UserReadingProfileDto.cs
+++ b/API/DTOs/UserReadingProfileDto.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using API.Entities;
 using API.Entities.Enums;
@@ -13,6 +14,9 @@ public sealed record UserReadingProfileDto
 
     public string Name { get; init; }
     public ReadingProfileKind Kind { get; init; }
+    public List<int> DeviceIds { get; init; }
+    public List<int> SeriesIds { get; init; }
+    public List<int> LibraryIds { get; init; }
 
     #region MangaReader
 

--- a/API/Data/DataContext.cs
+++ b/API/Data/DataContext.cs
@@ -19,6 +19,7 @@ using API.Entities.Scrobble;
 using API.Entities.User;
 using API.Extensions;
 using Hangfire.Storage.SQLite.Entities;
+using Microsoft.AspNetCore.DataProtection.EntityFrameworkCore;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
@@ -28,7 +29,7 @@ namespace API.Data;
 
 public sealed class DataContext : IdentityDbContext<AppUser, AppRole, int,
     IdentityUserClaim<int>, AppUserRole, IdentityUserLogin<int>,
-    IdentityRoleClaim<int>, IdentityUserToken<int>>
+    IdentityRoleClaim<int>, IdentityUserToken<int>>, IDataProtectionKeyContext
 {
     public DataContext(DbContextOptions options) : base(options)
     {
@@ -96,6 +97,8 @@ public sealed class DataContext : IdentityDbContext<AppUser, AppRole, int,
     public DbSet<ClientDevice> ClientDevice { get; set; } = null!;
     public DbSet<ClientDeviceHistory> ClientDeviceHistory { get; set; } = null!;
     public DbSet<AppUserAuthKey> AppUserAuthKey { get; set; } = null!;
+
+    public DbSet<DataProtectionKey> DataProtectionKeys { get; set; } = null!;
 
 
     protected override void OnModelCreating(ModelBuilder builder)

--- a/API/Data/DataContext.cs
+++ b/API/Data/DataContext.cs
@@ -270,13 +270,14 @@ public sealed class DataContext : IdentityDbContext<AppUser, AppRole, int,
             .HasDefaultValue(true);
 
         builder.Entity<AppUserReadingProfile>()
-            .Property(rp => rp.LibraryIds)
-            .HasJsonConversion([])
-            .HasColumnType("TEXT");
+            .PrimitiveCollection(p => p.LibraryIds)
+            .HasDefaultValue(new List<int>());
         builder.Entity<AppUserReadingProfile>()
-            .Property(rp => rp.SeriesIds)
-            .HasJsonConversion([])
-            .HasColumnType("TEXT");
+            .PrimitiveCollection(p => p.SeriesIds)
+            .HasDefaultValue(new List<int>());
+        builder.Entity<AppUserReadingProfile>()
+            .PrimitiveCollection(p => p.DeviceIds)
+            .HasDefaultValue(new List<int>());
         #endregion
 
         #region AppUser Streams

--- a/API/Data/Migrations/20251224133055_AddDataProtectionKeys.Designer.cs
+++ b/API/Data/Migrations/20251224133055_AddDataProtectionKeys.Designer.cs
@@ -6,6 +6,7 @@ using API.Entities.MetadataMatching;
 using API.Entities.Progress;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -13,9 +14,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace API.Data.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20251224133055_AddDataProtectionKeys")]
+    partial class AddDataProtectionKeys
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.1");

--- a/API/Data/Migrations/20251224133055_AddDataProtectionKeys.cs
+++ b/API/Data/Migrations/20251224133055_AddDataProtectionKeys.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace API.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDataProtectionKeys : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "DataProtectionKeys",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    FriendlyName = table.Column<string>(type: "TEXT", nullable: true),
+                    Xml = table.Column<string>(type: "TEXT", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DataProtectionKeys", x => x.Id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "DataProtectionKeys");
+        }
+    }
+}

--- a/API/Data/Migrations/20251229144718_AddDeviceIdsToReadingProfiles.Designer.cs
+++ b/API/Data/Migrations/20251229144718_AddDeviceIdsToReadingProfiles.Designer.cs
@@ -6,6 +6,7 @@ using API.Entities.MetadataMatching;
 using API.Entities.Progress;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -13,9 +14,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace API.Data.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20251229144718_AddDeviceIdsToReadingProfiles")]
+    partial class AddDeviceIdsToReadingProfiles
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.1");

--- a/API/Data/Migrations/20251229144718_AddDeviceIdsToReadingProfiles.cs
+++ b/API/Data/Migrations/20251229144718_AddDeviceIdsToReadingProfiles.cs
@@ -1,0 +1,69 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace API.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDeviceIdsToReadingProfiles : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "SeriesIds",
+                table: "AppUserReadingProfiles",
+                type: "TEXT",
+                nullable: true,
+                defaultValue: "[]",
+                oldClrType: typeof(string),
+                oldType: "TEXT",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "LibraryIds",
+                table: "AppUserReadingProfiles",
+                type: "TEXT",
+                nullable: true,
+                defaultValue: "[]",
+                oldClrType: typeof(string),
+                oldType: "TEXT",
+                oldNullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "DeviceIds",
+                table: "AppUserReadingProfiles",
+                type: "TEXT",
+                nullable: true,
+                defaultValue: "[]");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DeviceIds",
+                table: "AppUserReadingProfiles");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "SeriesIds",
+                table: "AppUserReadingProfiles",
+                type: "TEXT",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "TEXT",
+                oldNullable: true,
+                oldDefaultValue: "[]");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "LibraryIds",
+                table: "AppUserReadingProfiles",
+                type: "TEXT",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "TEXT",
+                oldNullable: true,
+                oldDefaultValue: "[]");
+        }
+    }
+}

--- a/API/Data/Repositories/SeriesRepository.cs
+++ b/API/Data/Repositories/SeriesRepository.cs
@@ -467,7 +467,9 @@ public class SeriesRepository : ISeriesRepository
             .Where(p => _context.SeriesMetadataPeople
                 .Any(smp => smp.PersonId == p.Id &&
                             seriesIdsSubquery.Contains(smp.SeriesMetadata.SeriesId) &&
-                            EF.Functions.Like(p.NormalizedName, $"%{searchQueryNormalized}%")))
+                            (EF.Functions.Like(p.NormalizedName, $"%{searchQueryNormalized}%")
+                             || p.Aliases.Any(a => EF.Functions.Like(a.NormalizedAlias, $"%{searchQueryNormalized}%"))
+                             )))
             .OrderBy(p => p.NormalizedName.Length)
             .ThenBy(p => p.NormalizedName)
             .Take(maxRecords)

--- a/API/Data/Seed.cs
+++ b/API/Data/Seed.cs
@@ -405,6 +405,7 @@ public static class Seed
                 new() {Key = ServerSettingKey.OnDeckProgressDays, Value = "30"},
                 new() {Key = ServerSettingKey.OnDeckUpdateDays, Value = "7"},
                 new() {Key = ServerSettingKey.CoverImageSize, Value = nameof(CoverImageSize.Default)},
+                new() {Key = ServerSettingKey.PdfRenderResolution, Value = nameof(PdfRenderResolution.Default)},
                 new() {
                     Key = ServerSettingKey.CacheSize, Value = Configuration.DefaultCacheMemory + string.Empty
                 }, // Not used from DB, but DB is sync with appSettings.json

--- a/API/Entities/Enums/PdfRenderResolution.cs
+++ b/API/Entities/Enums/PdfRenderResolution.cs
@@ -1,0 +1,17 @@
+﻿namespace API.Entities.Enums;
+
+public enum PdfRenderResolution
+{
+    /// <summary>
+    /// Default Size: 1080x1920 (wxh)
+    /// </summary>
+    Default = 1,
+    /// <summary>
+    /// 1920x2560
+    /// </summary>
+    High = 2,
+    /// <summary>
+    /// 2160x3840
+    /// </summary>
+    Ultra = 3,
+}

--- a/API/Entities/Enums/PdfRenderResolutionExtensions.cs
+++ b/API/Entities/Enums/PdfRenderResolutionExtensions.cs
@@ -1,0 +1,15 @@
+﻿namespace API.Entities.Enums;
+
+public static class PdfRenderResolutionExtensions
+{
+    public static (int dim1, int dim2) GetDimensions(this PdfRenderResolution size)
+    {
+        return size switch
+        {
+            PdfRenderResolution.Default => (1080, 1920),
+            PdfRenderResolution.High => (1920, 2560),
+            PdfRenderResolution.Ultra => (2160, 3840),
+            _ => (1080, 1920)
+        };
+    }
+}

--- a/API/Entities/Enums/ServerSettingKey.cs
+++ b/API/Entities/Enums/ServerSettingKey.cs
@@ -202,5 +202,9 @@ public enum ServerSettingKey
     /// </summary>
     [Description("OidcConfiguration")]
     OidcConfiguration = 40,
-
+    /// <summary>
+    /// The resolution to render PDFs as when delivering them as images.
+    /// </summary>
+    [Description("pdfRenderResolution")]
+    PdfRenderResolution = 41,
 }

--- a/API/Entities/Enums/UserPreferences/KeyBindTarget.cs
+++ b/API/Entities/Enums/UserPreferences/KeyBindTarget.cs
@@ -42,4 +42,7 @@ public enum KeyBindTarget
 
     [Description(nameof(PageDown))]
     PageDown = 12,
+
+    [Description(nameof(OffsetDoublePage))]
+    OffsetDoublePage = 13,
 }

--- a/API/Entities/User/AppUserReadingProfile.cs
+++ b/API/Entities/User/AppUserReadingProfile.cs
@@ -31,6 +31,7 @@ public class AppUserReadingProfile
     public ReadingProfileKind Kind { get; set; }
     public List<int> LibraryIds { get; set; }
     public List<int> SeriesIds { get; set; }
+    public List<int> DeviceIds { get; set; }
 
     #region MangaReader
 

--- a/API/Entities/User/ClientDevice.cs
+++ b/API/Entities/User/ClientDevice.cs
@@ -30,6 +30,7 @@ public class ClientDevice
     /// <summary>
     /// Most recent stable ClientInfoData (excluding IP/timestamp changes)
     /// </summary>
+    /// <remarks>JSON Column</remarks>
     public ClientInfoData CurrentClientInfo { get; set; } = new();
 
     public DateTime FirstSeenUtc { get; set; }

--- a/API/Extensions/HttpExtensions.cs
+++ b/API/Extensions/HttpExtensions.cs
@@ -42,23 +42,7 @@ public static class HttpExtensions
     {
         if (content is not {Length: > 0}) return;
         response.Headers.Append(HeaderNames.ETag, string.Concat(SHA256.HashData(content).Select(x => x.ToString("X2"))));
-        response.Headers.CacheControl =  $"private,max-age=100";
+        response.Headers.CacheControl =  $"private, max-age=100";
     }
 
-    /// <summary>
-    /// Calculates SHA256 hash for a cover image filename and sets as ETag. Ensures Cache-Control: private header is added.
-    /// </summary>
-    /// <param name="response"></param>
-    /// <param name="filename"></param>
-    /// <param name="maxAge">Maximum amount of seconds to set for Cache-Control</param>
-    public static void AddCacheHeader(this HttpResponse response, string filename, int maxAge = 10)
-    {
-        if (filename is not {Length: > 0}) return;
-        var hashContent = filename + File.GetLastWriteTimeUtc(filename);
-        response.Headers.Append("ETag", string.Concat(SHA256.HashData(Encoding.UTF8.GetBytes(hashContent)).Select(x => x.ToString("X2"))));
-        if (maxAge != 10)
-        {
-            response.Headers.CacheControl =  $"max-age={maxAge}";
-        }
-    }
 }

--- a/API/Extensions/QueryExtensions/Filtering/SeriesSort.cs
+++ b/API/Extensions/QueryExtensions/Filtering/SeriesSort.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using API.DTOs.Filtering;
 using API.Entities;
 using Microsoft.EntityFrameworkCore;
@@ -36,6 +36,8 @@ public static class SeriesSort
                 .Max(), sortOptions),
             SortField.AverageRating => query.DoOrderBy(s => s.ExternalSeriesMetadata.ExternalRatings
                 .Where(p => p.SeriesId == s.Id).Average(p => p.AverageScore), sortOptions),
+            SortField.UserRating => query.DoOrderBy(s => s.Ratings.Where(r => r.SeriesId == s.Id && r.AppUserId == userId).Max(r => r.Rating), sortOptions)
+                .ThenBy(s => s.SortName.ToLower()),
             SortField.Random => query.DoOrderBy(s => EF.Functions.Random(), sortOptions),
             _ => query
         };

--- a/API/Extensions/QueryExtensions/QueryableExtensions.cs
+++ b/API/Extensions/QueryExtensions/QueryableExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
@@ -350,7 +350,7 @@ public static class QueryableExtensions
     /// <param name="keySelector"></param>
     /// <param name="sortOptions"></param>
     /// <returns></returns>
-    public static IQueryable<T> DoOrderBy<T, TKey>(this IQueryable<T> query, Expression<Func<T, TKey>> keySelector, SortOptions sortOptions)
+    public static IOrderedQueryable<T> DoOrderBy<T, TKey>(this IQueryable<T> query, Expression<Func<T, TKey>> keySelector, SortOptions sortOptions)
     {
         return sortOptions.IsAscending ? query.OrderBy(keySelector) : query.OrderByDescending(keySelector);
     }

--- a/API/Helpers/Builders/AppUserReadingProfileBuilder.cs
+++ b/API/Helpers/Builders/AppUserReadingProfileBuilder.cs
@@ -21,7 +21,8 @@ public class AppUserReadingProfileBuilder
             AppUserId = userId,
             Kind = ReadingProfileKind.User,
             SeriesIds = [],
-            LibraryIds = []
+            LibraryIds = [],
+            DeviceIds = [],
         };
     }
 
@@ -47,6 +48,14 @@ public class AppUserReadingProfileBuilder
     {
         _profile.Name = name;
         _profile.NormalizedName = name.ToNormalized();
+        return this;
+    }
+
+    public AppUserReadingProfileBuilder WithDeviceId(int deviceId)
+    {
+        if (_profile.DeviceIds.Contains(deviceId)) return this;
+        _profile.DeviceIds.Add(deviceId);
+
         return this;
     }
 

--- a/API/Helpers/Converters/ServerSettingConverter.cs
+++ b/API/Helpers/Converters/ServerSettingConverter.cs
@@ -82,6 +82,9 @@ public class ServerSettingConverter : ITypeConverter<IEnumerable<ServerSetting>,
                 case ServerSettingKey.CoverImageSize:
                     destination.CoverImageSize = Enum.Parse<CoverImageSize>(row.Value);
                     break;
+                case ServerSettingKey.PdfRenderResolution:
+                    destination.PdfRenderResolution = Enum.Parse<PdfRenderResolution>(row.Value);
+                    break;
                 case ServerSettingKey.EncodeMediaAs:
                     destination.EncodeMediaAs = Enum.Parse<EncodeFormat>(row.Value);
                     break;

--- a/API/Services/BookService.cs
+++ b/API/Services/BookService.cs
@@ -61,7 +61,7 @@ public interface IBookService
     Task<string> GetBookPage(int page, int chapterId, string cachedEpubPath, string baseUrl, List<PersonalToCDto> ptocBookmarks, List<AnnotationDto> annotations);
     Task<Dictionary<string, int>> CreateKeyToPageMappingAsync(EpubBookRef book);
     Task<IDictionary<int, int>?> GetWordCountsPerPage(string bookFilePath);
-    Task<int> GetWordCountBetweenXPaths(string bookFilePath, string startXpath, string endXpath);
+    Task<int> GetWordCountBetweenXPaths(string bookFilePath, string startXpath, int startPage, string endXpath, int endPage);
     Task<string> CopyImageToTempFromBook(int chapterId, BookmarkDto bookmarkDto, string cachedBookPath);
     Task<BookResourceResultDto> GetResourceAsync(string bookFilePath, string requestedKey);
 
@@ -1010,65 +1010,85 @@ public partial class BookService : IBookService
     /// </summary>
     /// <param name="bookFilePath"></param>
     /// <param name="startXpath"></param>
+    /// <param name="startPage">Page number of starting xpath</param>
     /// <param name="endXpath"></param>
+    /// <param name="endPage">Page number of ending xpath</param>
     /// <returns></returns>
-    public async Task<int> GetWordCountBetweenXPaths(string bookFilePath, string? startXpath, string endXpath)
+    public async Task<int> GetWordCountBetweenXPaths(string bookFilePath, string startXpath, int startPage, string endXpath, int endPage)
     {
         if (string.IsNullOrEmpty(endXpath)) return 0;
+        if (endPage < startPage) return 0;
 
         var totalCharacters = 0;
-        var foundStart = string.IsNullOrEmpty(startXpath); // If no start, begin counting immediately
-        var foundEnd = false;
 
         try
         {
             using var book = await EpubReader.OpenBookAsync(bookFilePath, LenientBookReaderOptions);
             var doc = new HtmlDocument { OptionFixNestedTags = true };
-
             var bookPages = await book.GetReadingOrderAsync();
+            var pageList = bookPages.ToList();
 
-            foreach (var contentFileRef in bookPages)
+            // Validate page bounds
+            if (startPage < 0 || endPage >= pageList.Count) return 0;
+
+            for (var pageIndex = startPage; pageIndex <= endPage; pageIndex++)
             {
-                if (foundEnd) break; // Stop processing once we've found the end
-
+                var contentFileRef = pageList[pageIndex];
                 var content = await contentFileRef.ReadContentAsync();
                 doc.LoadHtml(content);
 
                 var body = GetBodyOrCreate(doc, book);
 
-                var startNode = string.IsNullOrEmpty(startXpath) ? null : body.SelectSingleNode(startXpath);
-                var endNode = body.SelectSingleNode(endXpath);
+                var isStartPage = pageIndex == startPage;
+                var isEndPage = pageIndex == endPage;
 
-                // Case 1: Both start and end are on the same page
-                // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
-                if (startNode != null && endNode != null)
+                // Case 1: Start and end on the same page
+                if (isStartPage && isEndPage)
                 {
-                    totalCharacters += CountLettersBetweenNodes(body, startNode, endNode);
-                    foundEnd = true;
+                    var startNode = string.IsNullOrEmpty(startXpath) ? null : body.SelectSingleNode(startXpath);
+                    var endNode = body.SelectSingleNode(endXpath);
+
+                    if (startNode != null && endNode != null)
+                    {
+                        totalCharacters += CountLettersBetweenNodes(body, startNode, endNode);
+                    }
+                    else if (endNode != null)
+                    {
+                        // No start xpath, count from beginning to end node
+                        totalCharacters += CountLettersUpToNode(body, endNode);
+                    }
                     break;
                 }
 
-                // Case 2: Found start node - begin counting from this point to end of page
-                if (startNode != null)
+                // Case 2: Start page - count from start node to end of page
+                if (isStartPage)
                 {
-                    foundStart = true;
-                    totalCharacters += CountLettersFromNode(body, startNode);
+                    if (string.IsNullOrEmpty(startXpath))
+                    {
+                        totalCharacters += CountLettersInBody(body);
+                    }
+                    else
+                    {
+                        var startNode = body.SelectSingleNode(startXpath);
+                        totalCharacters += startNode != null
+                            ? CountLettersFromNode(body, startNode)
+                            : CountLettersInBody(body);
+                    }
                     continue;
                 }
 
-                // Case 3: Found end node - count from beginning of page up to this point and stop
-                if (endNode != null && foundStart)
+                // Case 3: End page - count from beginning to end node
+                if (isEndPage)
                 {
-                    foundEnd = true;
-                    totalCharacters += CountLettersUpToNode(body, endNode);
+                    var endNode = body.SelectSingleNode(endXpath);
+                    totalCharacters += endNode != null
+                        ? CountLettersUpToNode(body, endNode)
+                        : CountLettersInBody(body);
                     break;
                 }
 
-                // Case 4: Between start and end - count entire page
-                if (foundStart && !foundEnd)
-                {
-                    totalCharacters += CountLettersInBody(body);
-                }
+                // Case 4: Middle page - count entire page
+                totalCharacters += CountLettersInBody(body);
             }
         }
         catch (Exception ex)

--- a/API/Services/BookService.cs
+++ b/API/Services/BookService.cs
@@ -333,6 +333,7 @@ public partial class BookService : IBookService
                         BookReaderBodyScope,
                         "//BODY").ToLowerInvariant();
                 var elem = doc.DocumentNode.SelectSingleNode(unscopedSelector);
+                // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
                 if (elem == null) continue;
 
                 elem.PrependChild(HtmlNode.CreateNode(
@@ -378,16 +379,7 @@ public partial class BookService : IBookService
 
         foreach (var image in images)
         {
-
-            string? key = null;
-            if (image.Attributes["src"] != null)
-            {
-                key = "src";
-            }
-            else if (image.Attributes["xlink:href"] != null)
-            {
-                key = "xlink:href";
-            }
+            var key = GetImageSrcAttributeName(image);
 
             if (string.IsNullOrEmpty(key)) continue;
 
@@ -410,22 +402,6 @@ public partial class BookService : IBookService
         }
     }
 
-    private static void InjectImages(HtmlDocument doc, EpubBookRef book, string apiBase)
-    {
-        var images = doc.DocumentNode.SelectNodes("//img")
-                     ?? doc.DocumentNode.SelectNodes("//image") ?? doc.DocumentNode.SelectNodes("//svg");
-
-        if (images == null) return;
-
-        var parent = images[0].ParentNode;
-
-        foreach (var image in images)
-        {
-            // TODO: How do I make images clickable with state?
-            //image.AddClass("kavita-scale-width");
-        }
-
-    }
 
     /// <summary>
     /// Returns the image key associated with the file. Contains some basic fallback logic.
@@ -461,6 +437,7 @@ public partial class BookService : IBookService
     {
         // Check if any classes on the html node (some r2l books do this) and move them to body tag for scoping
         var htmlNode = doc.DocumentNode.SelectSingleNode("//html");
+        // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
         if (htmlNode == null) return body.InnerHtml;
 
         var bodyClasses = body.Attributes.Contains("class") ? body.Attributes["class"].Value : string.Empty;
@@ -477,6 +454,7 @@ public partial class BookService : IBookService
 
     {
         var anchors = doc.DocumentNode.SelectNodes("//a");
+        // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
         if (anchors == null) return;
 
         foreach (var anchor in anchors)
@@ -488,6 +466,7 @@ public partial class BookService : IBookService
     private async Task InlineStyles(HtmlDocument doc, EpubBookRef book, string apiBase, HtmlNode body)
     {
         var inlineStyles = doc.DocumentNode.SelectNodes("//style");
+        // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
         if (inlineStyles != null)
         {
             foreach (var inlineStyle in inlineStyles)
@@ -498,6 +477,7 @@ public partial class BookService : IBookService
         }
 
         var styleNodes = doc.DocumentNode.SelectNodes("/html/head/link[@href]");
+        // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
         if (styleNodes != null)
         {
             foreach (var styleLinks in styleNodes)
@@ -522,8 +502,8 @@ public partial class BookService : IBookService
                     var cssFile = book.Content.Css.GetLocalFileRefByKey(key);
 
                     var stylesheetHtml = await cssFile.ReadContentAsync();
-                    var styleContent = await ScopeStyles(stylesheetHtml, apiBase,
-                        cssFile.FilePath, book);
+                    var styleContent = await ScopeStyles(stylesheetHtml, apiBase, cssFile.FilePath, book);
+                    // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
                     if (styleContent != null)
                     {
                         body.PrependChild(HtmlNode.CreateNode($"<style>{styleContent}</style>"));
@@ -547,56 +527,58 @@ public partial class BookService : IBookService
         {
             epubBook = OpenEpubWithFallback(filePath, epubBook);
 
-            var publicationDate =
-                epubBook.Schema.Package.Metadata.Dates.Find(pDate => pDate.Event == "publication")?.Date;
+            var publicationDate = epubBook?.Schema.Package.Metadata.Dates.Find(pDate => pDate.Event == "publication")?.Date;
 
             if (string.IsNullOrEmpty(publicationDate))
             {
-                publicationDate = epubBook.Schema.Package.Metadata.Dates.FirstOrDefault()?.Date;
+                publicationDate = epubBook?.Schema.Package.Metadata.Dates.FirstOrDefault()?.Date;
             }
 
             var (year, month, day) = GetPublicationDate(publicationDate);
 
-            var summary = epubBook.Schema.Package.Metadata.Descriptions.FirstOrDefault();
+            var summary = epubBook?.Schema.Package.Metadata.Descriptions.FirstOrDefault();
             var info = new ComicInfo
             {
                 Summary = string.IsNullOrEmpty(summary?.Description) ? string.Empty : summary.Description,
-                Publisher = string.Join(",", epubBook.Schema.Package.Metadata.Publishers.Select(p => p.Publisher)),
+                Publisher = string.Join(",", epubBook?.Schema.Package.Metadata.Publishers.Select(p => p.Publisher) ?? []),
                 Month = month,
                 Day = day,
                 Year = year,
-                Title = epubBook.Title,
+                Title = epubBook?.Title ?? string.Empty,
                 Genre = string.Join(",",
-                    epubBook.Schema.Package.Metadata.Subjects.Select(s => s.Subject.ToLower().Trim())),
-                LanguageISO = ValidateLanguage(epubBook.Schema.Package.Metadata.Languages
+                    epubBook?.Schema.Package.Metadata.Subjects.Select(s => s.Subject.ToLower().Trim()) ?? []),
+                LanguageISO = ValidateLanguage(epubBook?.Schema.Package.Metadata.Languages
                     .Select(l => l.Language)
                     .FirstOrDefault())
             };
             ComicInfo.CleanComicInfo(info);
 
             var weblinks = new List<string>();
-            foreach (var identifier in epubBook.Schema.Package.Metadata.Identifiers)
+            if (epubBook?.Schema.Package.Metadata.Identifiers != null)
             {
-                if (string.IsNullOrEmpty(identifier.Identifier)) continue;
-                if (!string.IsNullOrEmpty(identifier.Scheme) &&
-                    identifier.Scheme.Equals("ISBN", StringComparison.InvariantCultureIgnoreCase))
+                foreach (var identifier in epubBook.Schema.Package.Metadata.Identifiers)
                 {
-                    var isbn = identifier.Identifier.Replace("urn:isbn:", string.Empty).Replace("isbn:", string.Empty);
-                    if (!ArticleNumberHelper.IsValidIsbn10(isbn) && !ArticleNumberHelper.IsValidIsbn13(isbn))
+                    if (string.IsNullOrEmpty(identifier.Identifier)) continue;
+                    if (!string.IsNullOrEmpty(identifier.Scheme) &&
+                        identifier.Scheme.Equals("ISBN", StringComparison.InvariantCultureIgnoreCase))
                     {
-                        _logger.LogDebug("[BookService] {File} has invalid ISBN number", filePath);
-                        continue;
+                        var isbn = identifier.Identifier.Replace("urn:isbn:", string.Empty).Replace("isbn:", string.Empty);
+                        if (!ArticleNumberHelper.IsValidIsbn10(isbn) && !ArticleNumberHelper.IsValidIsbn13(isbn))
+                        {
+                            _logger.LogDebug("[BookService] {File} has invalid ISBN number", filePath);
+                            continue;
+                        }
+
+                        info.Isbn = isbn;
                     }
 
-                    info.Isbn = isbn;
-                }
-
-                if ((!string.IsNullOrEmpty(identifier.Scheme) &&
-                     identifier.Scheme.Equals("URL", StringComparison.InvariantCultureIgnoreCase)) ||
-                    identifier.Identifier.StartsWith("url:"))
-                {
-                    var url = identifier.Identifier.Replace("url:", string.Empty);
-                    weblinks.Add(url.Trim());
+                    if ((!string.IsNullOrEmpty(identifier.Scheme) &&
+                         identifier.Scheme.Equals("URL", StringComparison.InvariantCultureIgnoreCase)) ||
+                        identifier.Identifier.StartsWith("url:"))
+                    {
+                        var url = identifier.Identifier.Replace("url:", string.Empty);
+                        weblinks.Add(url.Trim());
+                    }
                 }
             }
 
@@ -606,72 +588,76 @@ public partial class BookService : IBookService
             }
 
             // Parse tags not exposed via Library
-            foreach (var metadataItem in epubBook.Schema.Package.Metadata.MetaItems)
+            if (epubBook?.Schema.Package.Metadata.MetaItems != null)
             {
-                // EPUB 2 and 3
-                switch (metadataItem.Name)
+                foreach (var metadataItem in epubBook.Schema.Package.Metadata.MetaItems)
                 {
-                    case "calibre:rating":
-                        info.UserRating = metadataItem.Content.AsFloat();
-                        break;
-                    case "calibre:title_sort":
-                        info.TitleSort = metadataItem.Content;
-                        break;
-                    case "calibre:series":
-                        info.Series = metadataItem.Content;
-                        if (string.IsNullOrEmpty(info.SeriesSort))
-                        {
-                            info.SeriesSort = metadataItem.Content;
-                        }
+                    // EPUB 2 and 3
+                    switch (metadataItem.Name)
+                    {
+                        case "calibre:rating":
+                            info.UserRating = metadataItem.Content.AsFloat();
+                            break;
+                        case "calibre:title_sort":
+                            info.TitleSort = metadataItem.Content;
+                            break;
+                        case "calibre:series":
+                            info.Series = metadataItem.Content;
+                            if (string.IsNullOrEmpty(info.SeriesSort))
+                            {
+                                info.SeriesSort = metadataItem.Content;
+                            }
 
-                        break;
-                    case "calibre:series_index":
-                        info.Volume = metadataItem.Content;
-                        break;
-                }
+                            break;
+                        case "calibre:series_index":
+                            info.Volume = metadataItem.Content;
+                            break;
+                    }
 
 
-                // EPUB 3.2+ only
-                switch (metadataItem.Property)
-                {
-                    case "group-position":
-                        info.Volume = metadataItem.Content;
-                        break;
-                    case "belongs-to-collection":
-                        info.Series = metadataItem.Content;
-                        if (string.IsNullOrEmpty(info.SeriesSort))
-                        {
-                            info.SeriesSort = metadataItem.Content;
-                        }
+                    // EPUB 3.2+ only
+                    switch (metadataItem.Property)
+                    {
+                        case "group-position":
+                            info.Volume = metadataItem.Content;
+                            break;
+                        case "belongs-to-collection":
+                            info.Series = metadataItem.Content;
+                            if (string.IsNullOrEmpty(info.SeriesSort))
+                            {
+                                info.SeriesSort = metadataItem.Content;
+                            }
 
-                        break;
-                    case "collection-type":
-                        // These look to be genres from https://manual.calibre-ebook.com/sub_groups.html or can be "series"
-                        break;
-                    case "role":
-                        if (metadataItem.Scheme != null && !metadataItem.Scheme.Equals("marc:relators")) break;
+                            break;
+                        case "collection-type":
+                            // These look to be genres from https://manual.calibre-ebook.com/sub_groups.html or can be "series"
+                            break;
+                        case "role":
+                            if (metadataItem.Scheme != null && !metadataItem.Scheme.Equals("marc:relators")) break;
 
-                        var creatorId = metadataItem.Refines?.Replace("#", string.Empty);
-                        var person = epubBook.Schema.Package.Metadata.Creators
-                            .SingleOrDefault(c => c.Id == creatorId);
-                        if (person == null) break;
+                            var creatorId = metadataItem.Refines?.Replace("#", string.Empty);
+                            var person = epubBook.Schema.Package.Metadata.Creators
+                                .SingleOrDefault(c => c.Id == creatorId);
+                            if (person == null) break;
 
-                        PopulatePerson(metadataItem, info, person);
-                        break;
-                    case "title-type":
-                        if (metadataItem.Content.Equals("collection"))
-                        {
-                            ExtractCollectionOrReadingList(metadataItem, epubBook, info);
-                        }
+                            PopulatePerson(metadataItem, info, person);
+                            break;
+                        case "title-type":
+                            if (metadataItem.Content.Equals("collection"))
+                            {
+                                ExtractCollectionOrReadingList(metadataItem, epubBook, info);
+                            }
 
-                        if (metadataItem.Content.Equals("main"))
-                        {
-                            ExtractSortTitle(metadataItem, epubBook, info);
-                        }
+                            if (metadataItem.Content.Equals("main"))
+                            {
+                                ExtractSortTitle(metadataItem, epubBook, info);
+                            }
 
-                        break;
+                            break;
+                    }
                 }
             }
+
 
             // If this is a single book and not a collection, set publication status to Completed
             if (string.IsNullOrEmpty(info.Volume) &&
@@ -682,7 +668,7 @@ public partial class BookService : IBookService
 
             // Include regular Writer as well, for cases where there is no special tag
             info.Writer = string.Join(",",
-                epubBook.Schema.Package.Metadata.Creators.Select(c => Parser.CleanAuthor(c.Creator)));
+                epubBook?.Schema.Package.Metadata.Creators.Select(c => Parser.CleanAuthor(c.Creator)) ?? []);
 
             var hasVolumeInSeries = !Parser.ParseVolume(info.Title, LibraryType.Manga)
                 .Equals(Parser.LooseLeafVolume);
@@ -972,6 +958,7 @@ public partial class BookService : IBookService
     {
         var body = doc.DocumentNode.SelectSingleNode("//body");
 
+        // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
         if (body == null)
         {
             _logger.LogError("{FilePath} has no body tag! Generating one for support. Book may be skewed", book.FilePath);
@@ -1053,6 +1040,7 @@ public partial class BookService : IBookService
                 var endNode = body.SelectSingleNode(endXpath);
 
                 // Case 1: Both start and end are on the same page
+                // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
                 if (startNode != null && endNode != null)
                 {
                     totalCharacters += CountLettersBetweenNodes(body, startNode, endNode);
@@ -1206,15 +1194,7 @@ public partial class BookService : IBookService
             var targetImage = images[bookmarkDto.ImageOffset];
 
             // Get the image source attribute
-            string? srcAttributeName = null;
-            if (targetImage.Attributes["src"] != null)
-            {
-                srcAttributeName = "src";
-            }
-            else if (targetImage.Attributes["xlink:href"] != null)
-            {
-                srcAttributeName = "xlink:href";
-            }
+            var srcAttributeName = GetImageSrcAttributeName(targetImage);
 
             if (string.IsNullOrEmpty(srcAttributeName))
             {
@@ -1272,6 +1252,22 @@ public partial class BookService : IBookService
         }
 
         throw new KavitaException($"Page {bookmarkDto.Page} not found in epub");
+    }
+
+    private static string? GetImageSrcAttributeName(HtmlNode targetImage)
+    {
+        // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
+        if (targetImage.Attributes["src"] != null)
+        {
+            return "src";
+        }
+        // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
+        if (targetImage.Attributes["xlink:href"] != null)
+        {
+            return "xlink:href";
+        }
+
+        return null;
     }
 
     /// <summary>
@@ -1473,8 +1469,6 @@ public partial class BookService : IBookService
 
         ScopeImages(doc, book, apiBase);
 
-        InjectImages(doc, book, apiBase);
-
         // Inject PTOC Bookmark Icons
         InjectTextBookmarks(doc, ptocBookmarks);
 
@@ -1580,6 +1574,7 @@ public partial class BookService : IBookService
         doc.LoadHtml(content);
 
         var anchors = doc.DocumentNode.SelectNodes("//a");
+        // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
         if (anchors == null) return chaptersList;
 
         foreach (var anchor in anchors)
@@ -1718,6 +1713,7 @@ public partial class BookService : IBookService
 
                 var body = doc.DocumentNode.SelectSingleNode("//body");
 
+                // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
                 if (body == null)
                 {
                     if (doc.ParseErrors.Any())
@@ -1741,39 +1737,6 @@ public partial class BookService : IBookService
 
         throw new KavitaException("epub-html-missing");
     }
-
-    // private static void CreateToCChapter(EpubBookRef book, EpubNavigationItemRef navigationItem, IList<BookChapterItem> nestedChapters,
-    //     ICollection<BookChapterItem> chaptersList, IReadOnlyDictionary<string, int> mappings)
-    // {
-    //     if (navigationItem.Link == null)
-    //     {
-    //         var item = new BookChapterItem
-    //         {
-    //             Title = navigationItem.Title,
-    //             Children = nestedChapters
-    //         };
-    //         if (nestedChapters.Count > 0)
-    //         {
-    //             item.Page = nestedChapters[0].Page;
-    //         }
-    //
-    //         chaptersList.Add(item);
-    //     }
-    //     else
-    //     {
-    //         var groupKey = CoalesceKey(book, mappings, navigationItem.Link.ContentFilePath);
-    //         if (mappings.ContainsKey(groupKey))
-    //         {
-    //             chaptersList.Add(new BookChapterItem
-    //             {
-    //                 Title = navigationItem.Title,
-    //                 Page = mappings[groupKey],
-    //                 Children = nestedChapters
-    //             });
-    //         }
-    //     }
-    // }
-
 
     /// <summary>
     /// Extracts the cover image to covers directory and returns file path back

--- a/API/Services/BookService.cs
+++ b/API/Services/BookService.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using API.Data;
 using API.Data.Metadata;
 using API.DTOs.Reader;
 using API.Entities;
@@ -78,6 +79,7 @@ public partial class BookService : IBookService
     private const string BookApiUrl = "book-resources?file=";
     public const string BookReaderBodyScope = "//BODY/APP-ROOT[1]/DIV[1]/DIV[1]/DIV[1]/APP-BOOK-READER[1]/DIV[1]/DIV[2]/DIV[1]/DIV[1]/DIV[1]";
     private readonly PdfComicInfoExtractor _pdfComicInfoExtractor;
+    private readonly IUnitOfWork _unitOfWork;
 
     /// <summary>
     /// Setup the most lenient book parsing options possible as people have some really bad epubs
@@ -124,9 +126,10 @@ public partial class BookService : IBookService
         }
     };
 
-    public BookService(ILogger<BookService> logger, IDirectoryService directoryService, IImageService imageService, IMediaErrorService mediaErrorService)
+    public BookService(ILogger<BookService> logger, IDirectoryService directoryService, IImageService imageService, IMediaErrorService mediaErrorService, IUnitOfWork unitOfWork)
     {
         _logger = logger;
+        _unitOfWork = unitOfWork;
         _directoryService = directoryService;
         _imageService = imageService;
         _mediaErrorService = mediaErrorService;
@@ -1415,7 +1418,10 @@ public partial class BookService : IBookService
     {
         _directoryService.ExistOrCreate(targetDirectory);
 
-        using var docReader = DocLib.Instance.GetDocReader(fileFilePath, new PageDimensions(1080, 1920));
+        var settings = _unitOfWork.SettingsRepository.GetSettingsDtoAsync().Result;
+        var dims = settings.PdfRenderResolution.GetDimensions();
+
+        using var docReader = DocLib.Instance.GetDocReader(fileFilePath, new PageDimensions(dims.dim1, dims.dim2));
         var pages = docReader.GetPageCount();
         Parallel.For(0, pages, pageNumber =>
         {

--- a/API/Services/BookService.cs
+++ b/API/Services/BookService.cs
@@ -1418,16 +1418,36 @@ public partial class BookService : IBookService
     {
         _directoryService.ExistOrCreate(targetDirectory);
 
-        var settings = _unitOfWork.SettingsRepository.GetSettingsDtoAsync().Result;
+        var settings = _unitOfWork.SettingsRepository.GetSettingsDtoAsync().GetAwaiter().GetResult();
         var dims = settings.PdfRenderResolution.GetDimensions();
+        var pageDimensions = new PageDimensions(dims.dim1, dims.dim2);
 
-        using var docReader = DocLib.Instance.GetDocReader(fileFilePath, new PageDimensions(dims.dim1, dims.dim2));
-        var pages = docReader.GetPageCount();
-        Parallel.For(0, pages, pageNumber =>
+        int pages;
+        using (var countReader = DocLib.Instance.GetDocReader(fileFilePath, pageDimensions))
         {
+            pages = countReader.GetPageCount();
+        }
+
+        var parallelOptions = new ParallelOptions
+        {
+            MaxDegreeOfParallelism = Math.Min(Environment.ProcessorCount, 4)
+        };
+
+        Parallel.For(0, pages, parallelOptions, pageNumber =>
+        {
+            using var docReader = DocLib.Instance.GetDocReader(fileFilePath, pageDimensions);
             using var stream = StreamManager.GetStream("BookService.GetPdfPage");
+
             GetPdfPage(docReader, pageNumber, stream);
-            using var fileStream = File.Create(Path.Combine(targetDirectory, "Page-" + pageNumber + ".png"));
+
+            var outputPath = Path.Combine(targetDirectory, $"Page-{pageNumber}.png");
+            using var fileStream = new FileStream(
+                outputPath,
+                FileMode.Create,
+                FileAccess.Write,
+                FileShare.None,
+                bufferSize: 81920);
+
             stream.Seek(0, SeekOrigin.Begin);
             stream.CopyTo(fileStream);
         });

--- a/API/Services/ClientDeviceService.cs
+++ b/API/Services/ClientDeviceService.cs
@@ -420,8 +420,8 @@ public class ClientDeviceService(DataContext context, IMapper mapper, ILogger<Cl
             // Their LastSeenUtc is equally valid
             logger.LogDebug(ex, "Concurrency conflict updating device {DeviceId}, ignoring", device.Id);
 
-            // Detach to prevent tracking issues
-            context.Entry(device).State = EntityState.Detached;
+            // Reload the entity from database to get current state
+            await context.Entry(device).ReloadAsync();
         }
     }
 

--- a/API/Services/ClientDeviceService.cs
+++ b/API/Services/ClientDeviceService.cs
@@ -399,6 +399,7 @@ public class ClientDeviceService(DataContext context, IMapper mapper, ILogger<Cl
     private async Task UpdateDeviceActivityAsync(ClientDevice device, ClientInfoData? newClientInfo)
     {
         device.LastSeenUtc = DateTime.UtcNow;
+        context.Entry(device).State = EntityState.Modified;
 
         if (HasMeaningfulChanges(device.CurrentClientInfo, newClientInfo))
         {

--- a/API/Services/DeviceService.cs
+++ b/API/Services/DeviceService.cs
@@ -29,12 +29,14 @@ public class DeviceService : IDeviceService
     private readonly IUnitOfWork _unitOfWork;
     private readonly ILogger<DeviceService> _logger;
     private readonly IEmailService _emailService;
+    private readonly IReadingProfileService _readingProfileService;
 
-    public DeviceService(IUnitOfWork unitOfWork, ILogger<DeviceService> logger, IEmailService emailService)
+    public DeviceService(IUnitOfWork unitOfWork, ILogger<DeviceService> logger, IEmailService emailService, IReadingProfileService readingProfileService)
     {
         _unitOfWork = unitOfWork;
         _logger = logger;
         _emailService = emailService;
+        _readingProfileService = readingProfileService;
     }
 
     public async Task<Device?> Create(CreateEmailDeviceDto dto, AppUser userWithDevices)
@@ -95,6 +97,9 @@ public class DeviceService : IDeviceService
         {
             userWithDevices.Devices = userWithDevices.Devices.Where(d => d.Id != deviceId).ToList();
             _unitOfWork.UserRepository.Update(userWithDevices);
+
+            await _readingProfileService.RemoveDeviceLinks(userWithDevices.Id, deviceId);
+
             if (!_unitOfWork.HasChanges()) return true;
             if (await _unitOfWork.CommitAsync()) return true;
         }

--- a/API/Services/Reading/ReadingSessionService.cs
+++ b/API/Services/Reading/ReadingSessionService.cs
@@ -375,21 +375,24 @@ public class ReadingSessionService : IReadingSessionService, IDisposable, IAsync
         var context = scope.ServiceProvider.GetRequiredService<DataContext>();
         var eventHub = scope.ServiceProvider.GetRequiredService<IEventHub>();
 
-        // Get the actual last activity time from the session itself
-        var sessionData = await context.AppUserReadingSession
-            .Where(s => s.Id == sessionId)
-            .Select(s => new { s.LastModified, s.LastModifiedUtc })
-            .FirstOrDefaultAsync();
+        // Get the actual last activity end time from ActivityData
+        var lastActivityTime = await context.AppUserReadingSessionActivityData
+            .Where(ad => ad.AppUserReadingSessionId == sessionId && ad.EndTime.HasValue)
+            .MaxAsync(ad => (DateTime?)ad.EndTime);
 
-        if (sessionData == null) return;
+        var lastActivityTimeUtc = await context.AppUserReadingSessionActivityData
+            .Where(ad => ad.AppUserReadingSessionId == sessionId && ad.EndTimeUtc.HasValue)
+            .MaxAsync(ad => (DateTime?)ad.EndTimeUtc);
+
+        if (lastActivityTime == null) return;
 
         // Use the session's LastModified as the EndTime (the actual last activity) and mark session as inactive
         await context.AppUserReadingSession
             .Where(s => s.Id == sessionId)
             .ExecuteUpdateAsync(s => s
                 .SetProperty(x => x.IsActive, false)
-                .SetProperty(x => x.EndTime, sessionData.LastModified)
-                .SetProperty(x => x.EndTimeUtc, sessionData.LastModifiedUtc)
+                .SetProperty(x => x.EndTime, lastActivityTime)
+                .SetProperty(x => x.EndTimeUtc, lastActivityTimeUtc)
                 .SetProperty(x => x.LastModified, DateTime.Now)
                 .SetProperty(x => x.LastModifiedUtc, DateTime.UtcNow));
 

--- a/API/Services/Reading/ReadingSessionService.cs
+++ b/API/Services/Reading/ReadingSessionService.cs
@@ -375,14 +375,21 @@ public class ReadingSessionService : IReadingSessionService, IDisposable, IAsync
         var context = scope.ServiceProvider.GetRequiredService<DataContext>();
         var eventHub = scope.ServiceProvider.GetRequiredService<IEventHub>();
 
+        // Get the actual last activity time from the session itself
+        var sessionData = await context.AppUserReadingSession
+            .Where(s => s.Id == sessionId)
+            .Select(s => new { s.LastModified, s.LastModifiedUtc })
+            .FirstOrDefaultAsync();
 
-        // Mark session as inactive in DB
+        if (sessionData == null) return;
+
+        // Use the session's LastModified as the EndTime (the actual last activity) and mark session as inactive
         await context.AppUserReadingSession
             .Where(s => s.Id == sessionId)
             .ExecuteUpdateAsync(s => s
                 .SetProperty(x => x.IsActive, false)
-                .SetProperty(x => x.EndTime, DateTime.Now.Subtract(TimeSpan.FromMinutes(_defaultTimeoutMinutes)))
-                .SetProperty(x => x.EndTimeUtc, DateTime.UtcNow.Subtract(TimeSpan.FromMinutes(_defaultTimeoutMinutes)))
+                .SetProperty(x => x.EndTime, sessionData.LastModified)
+                .SetProperty(x => x.EndTimeUtc, sessionData.LastModifiedUtc)
                 .SetProperty(x => x.LastModified, DateTime.Now)
                 .SetProperty(x => x.LastModifiedUtc, DateTime.UtcNow));
 

--- a/API/Services/Reading/ReadingSessionService.cs
+++ b/API/Services/Reading/ReadingSessionService.cs
@@ -131,7 +131,9 @@ public sealed class ReadingSessionService : IReadingSessionService, IDisposable,
                         existingChapterActivity.WordsRead = await bookService.GetWordCountBetweenXPaths(
                             cachedFilePath,
                             existingChapterActivity.StartBookScrollId,
-                            progressDto.BookScrollId
+                            existingChapterActivity.StartPage,
+                            progressDto.BookScrollId,
+                            progressDto.PageNum
                         );
                     }
                     catch (Exception ex)

--- a/API/Services/Reading/ReadingSessionService.cs
+++ b/API/Services/Reading/ReadingSessionService.cs
@@ -28,12 +28,12 @@ internal sealed record SessionTimeout<T>
     /// <summary>
     /// Expiration time in Utc
     /// </summary>
-    public DateTime Expiration { get; set; }
+    public DateTime ExpirationUtc { get; set; }
     public DateTime LastTimerRefresh { get; set; }
     public Timer? TimeoutTimer { get; set; }
 }
 
-public class ReadingSessionService : IReadingSessionService, IDisposable, IAsyncDisposable
+public sealed class ReadingSessionService : IReadingSessionService, IDisposable, IAsyncDisposable
 {
     private readonly IServiceScopeFactory _serviceScopeFactory;
     private readonly ILogger<ReadingSessionService> _logger;
@@ -78,6 +78,9 @@ public class ReadingSessionService : IReadingSessionService, IDisposable, IAsync
         // If Chapter doesn't exist already, add
         var existingChapterActivity = session.ActivityData.FirstOrDefault(d => d.ChapterId == progressDto.ChapterId);
 
+        // Use cached chapter format to avoid repeated DB queries
+        var chapterFormat = await GetChapterFormatAsync(progressDto.ChapterId, context);
+
         if (existingChapterActivity != null)
         {
             existingChapterActivity.PagesRead = progressDto.PageNum - existingChapterActivity.StartPage;
@@ -102,8 +105,6 @@ public class ReadingSessionService : IReadingSessionService, IDisposable, IAsync
             var cacheService = scope.ServiceProvider.GetRequiredService<ICacheService>();
             var chapter = await cacheService.Ensure(progressDto.ChapterId);
 
-            // Use cached chapter format to avoid repeated DB queries
-            var chapterFormat = await GetChapterFormatAsync(progressDto.ChapterId, context);
 
             // Store total pages/words in case it changes in the future
             existingChapterActivity.TotalPages = chapter?.Pages ?? 0;
@@ -146,7 +147,7 @@ public class ReadingSessionService : IReadingSessionService, IDisposable, IAsync
         else
         {
             // Add new ActivityData for a different chapter in the same session
-            var newActivity = NewActivityData(progressDto);
+            var newActivity = NewActivityData(progressDto, chapterFormat);
             if (clientInfo != null)
             {
                 newActivity.ClientInfo = clientInfo;
@@ -232,7 +233,7 @@ public class ReadingSessionService : IReadingSessionService, IDisposable, IAsync
         var cacheKey = GenerateCacheKey(userId, dto.ChapterId);
         if (_activeSessions.TryGetValue(cacheKey, out var sessionTimeout))
         {
-            if (sessionTimeout.Expiration <= DateTime.Now)
+            if (sessionTimeout.ExpirationUtc <= DateTime.UtcNow)
             {
                 // Expired - close it and create new one
                 await CloseSession(cacheKey, sessionTimeout.Value);
@@ -261,6 +262,8 @@ public class ReadingSessionService : IReadingSessionService, IDisposable, IAsync
             return dbSession;
         }
 
+        var chapterFormat = await GetChapterFormatAsync(dto.ChapterId, context);
+
         // Create a new session and return it
         var newSession = new AppUserReadingSession()
             {
@@ -270,7 +273,7 @@ public class ReadingSessionService : IReadingSessionService, IDisposable, IAsync
                 IsActive = true,
                 ActivityData =
                 [
-                    NewActivityData(dto),
+                    NewActivityData(dto, chapterFormat),
                 ]
             };
 
@@ -282,15 +285,16 @@ public class ReadingSessionService : IReadingSessionService, IDisposable, IAsync
         return newSession;
     }
 
-    private static AppUserReadingSessionActivityData NewActivityData(ProgressDto dto)
+    private static AppUserReadingSessionActivityData NewActivityData(ProgressDto dto, MangaFormat format)
     {
+        var page = format == MangaFormat.Epub ? dto.PageNum : Math.Max(dto.PageNum - 1, 0);
         return new AppUserReadingSessionActivityData
         {
             ChapterId = dto.ChapterId,
             VolumeId = dto.VolumeId,
             SeriesId = dto.SeriesId,
             LibraryId = dto.LibraryId,
-            StartPage = dto.PageNum,
+            StartPage = page,
             EndPage = dto.PageNum,
             StartTime = DateTime.Now,
             StartTimeUtc = DateTime.UtcNow,
@@ -312,7 +316,7 @@ public class ReadingSessionService : IReadingSessionService, IDisposable, IAsync
             key => new SessionTimeout<int>()
             {
                 Value = sessionId,
-                Expiration = now.AddMinutes(_defaultTimeoutMinutes),
+                ExpirationUtc = now.AddMinutes(_defaultTimeoutMinutes),
                 LastTimerRefresh = now,
                 TimeoutTimer = CreateSessionTimer(key, sessionId)
             },
@@ -320,7 +324,7 @@ public class ReadingSessionService : IReadingSessionService, IDisposable, IAsync
             (_, existing) =>
             {
                 // Always update expiration
-                existing.Expiration = now.AddMinutes(_defaultTimeoutMinutes);
+                existing.ExpirationUtc = now.AddMinutes(_defaultTimeoutMinutes);
 
                 // Debounce timer refresh (avoid excessive timer churn)
                 var secondsSinceLastRefresh = (now - existing.LastTimerRefresh).TotalSeconds;
@@ -527,7 +531,7 @@ public class ReadingSessionService : IReadingSessionService, IDisposable, IAsync
         GC.SuppressFinalize(this);
     }
 
-    protected virtual void Dispose(bool disposing)
+    private void Dispose(bool disposing)
     {
         if (_disposed) return;
 
@@ -545,7 +549,7 @@ public class ReadingSessionService : IReadingSessionService, IDisposable, IAsync
         _disposed = true;
     }
 
-    protected virtual async ValueTask DisposeAsyncCore()
+    private async ValueTask DisposeAsyncCore()
     {
         if (_disposed) return;
 

--- a/API/Services/ReadingProfileService.cs
+++ b/API/Services/ReadingProfileService.cs
@@ -10,7 +10,9 @@ using API.Entities.Enums;
 using API.Extensions;
 using API.Helpers.Builders;
 using AutoMapper;
+using AutoMapper.QueryableExtensions;
 using Kavita.Common;
+using Microsoft.EntityFrameworkCore;
 
 namespace API.Services;
 #nullable enable
@@ -22,10 +24,12 @@ public interface IReadingProfileService
     /// Series (Implicit) -> Series (User) -> Library (User) -> Default
     /// </summary>
     /// <param name="userId"></param>
+    /// <param name="libraryId"></param>
     /// <param name="seriesId"></param>
+    /// <param name="activeDeviceId"></param>
     /// <param name="skipImplicit"></param>
     /// <returns></returns>
-    Task<UserReadingProfileDto> GetReadingProfileDtoForSeries(int userId, int seriesId, bool skipImplicit = false);
+    Task<UserReadingProfileDto> GetReadingProfileDtoForSeries(int userId, int libraryId, int seriesId, int? activeDeviceId, bool skipImplicit = false);
 
     /// <summary>
     /// Creates a new reading profile for a user. Name must be unique per user
@@ -34,25 +38,38 @@ public interface IReadingProfileService
     /// <param name="dto"></param>
     /// <returns></returns>
     Task<UserReadingProfileDto> CreateReadingProfile(int userId, UserReadingProfileDto dto);
-    Task<UserReadingProfileDto> PromoteImplicitProfile(int userId, int profileId);
+    /// <summary>
+    /// Given an implicit profile, promotes it to a profile of kind <see cref="ReadingProfileKind.User"/>, then removes
+    /// all links to the series this implicit profile was created for from other reading profiles (if the device id matches
+    /// if given)
+    /// </summary>
+    /// <param name="userId"></param>
+    /// <param name="profileId"></param>
+    /// <param name="activeDeviceId"></param>
+    /// <returns></returns>
+    Task<UserReadingProfileDto> PromoteImplicitProfile(int userId, int profileId, int? activeDeviceId);
 
     /// <summary>
     /// Updates the implicit reading profile for a series, creates one if none exists
     /// </summary>
     /// <param name="userId"></param>
+    /// <param name="libraryId"></param>
     /// <param name="seriesId"></param>
     /// <param name="dto"></param>
+    /// <param name="activeDeviceId"></param>
     /// <returns></returns>
-    Task<UserReadingProfileDto> UpdateImplicitReadingProfile(int userId, int seriesId, UserReadingProfileDto dto);
+    Task<UserReadingProfileDto> UpdateImplicitReadingProfile(int userId, int libraryId, int seriesId, UserReadingProfileDto dto, int? activeDeviceId);
 
     /// <summary>
     /// Updates the non-implicit reading profile for the given series, and removes implicit profiles
     /// </summary>
     /// <param name="userId"></param>
+    /// <param name="libraryId"></param>
     /// <param name="seriesId"></param>
     /// <param name="dto"></param>
+    /// <param name="activeDeviceId"></param>
     /// <returns></returns>
-    Task<UserReadingProfileDto> UpdateParent(int userId, int seriesId, UserReadingProfileDto dto);
+    Task<UserReadingProfileDto> UpdateParent(int userId, int libraryId, int seriesId, UserReadingProfileDto dto, int? activeDeviceId);
 
     /// <summary>
     /// Updates a given reading profile for a user
@@ -77,18 +94,20 @@ public interface IReadingProfileService
     /// Binds the reading profile to the series, and remove the implicit RP from the series if it exists
     /// </summary>
     /// <param name="userId"></param>
-    /// <param name="profileId"></param>
+    /// <param name="profileIds"></param>
     /// <param name="seriesId"></param>
     /// <returns></returns>
-    Task AddProfileToSeries(int userId, int profileId, int seriesId);
+    Task SetSeriesProfiles(int userId, List<int> profileIds, int seriesId);
+
     /// <summary>
     /// Binds the reading profile to many series, and remove the implicit RP from the series if it exists
     /// </summary>
     /// <param name="userId"></param>
-    /// <param name="profileId"></param>
+    /// <param name="profileIds"></param>
     /// <param name="seriesIds"></param>
     /// <returns></returns>
-    Task BulkAddProfileToSeries(int userId, int profileId, IList<int> seriesIds);
+    Task BulkSetSeriesProfiles(int userId, List<int> profileIds, List<int> seriesIds);
+
     /// <summary>
     /// Remove all reading profiles bound to the series
     /// </summary>
@@ -101,10 +120,11 @@ public interface IReadingProfileService
     /// Bind the reading profile to the library
     /// </summary>
     /// <param name="userId"></param>
-    /// <param name="profileId"></param>
+    /// <param name="profileIds"></param>
     /// <param name="libraryId"></param>
     /// <returns></returns>
-    Task AddProfileToLibrary(int userId, int profileId, int libraryId);
+    Task SetLibraryProfiles(int userId, List<int> profileIds, int libraryId);
+
     /// <summary>
     /// Remove the reading profile bound to the library, if it exists
     /// </summary>
@@ -112,66 +132,71 @@ public interface IReadingProfileService
     /// <param name="libraryId"></param>
     /// <returns></returns>
     Task ClearLibraryProfile(int userId, int libraryId);
+
     /// <summary>
-    /// Returns the bound Reading Profile to a Library
+    /// Returns the all bound Reading Profile to a Library
     /// </summary>
     /// <param name="userId"></param>
     /// <param name="libraryId"></param>
     /// <returns></returns>
-    Task<UserReadingProfileDto?> GetReadingProfileDtoForLibrary(int userId, int libraryId);
+    Task<List<UserReadingProfileDto>> GetReadingProfileDtosForLibrary(int userId, int libraryId);
+
+    /// <summary>
+    /// Returns the all bound Reading Profile to a Series
+    /// </summary>
+    /// <param name="userId"></param>
+    /// <param name="seriesId"></param>
+    /// <returns></returns>
+    Task<List<UserReadingProfileDto>> GetReadingProfileDtosForSeries(int userId, int seriesId);
+
+    /// <summary>
+    /// Set the assigned devices for the given reading profile. Then removes all duplicate links, ensuring each series
+    /// and library only has one profile per device
+    /// </summary>
+    /// <param name="userId"></param>
+    /// <param name="profileId"></param>
+    /// <param name="deviceIds"></param>
+    /// <returns></returns>
+    Task SetProfileDevices(int userId, int profileId, List<int> deviceIds);
+
+    /// <summary>
+    /// Remove device ids from all profiles, does **NOT** commit
+    /// </summary>
+    /// <param name="userId"></param>
+    /// <param name="deviceId"></param>
+    /// <returns></returns>
+    Task RemoveDeviceLinks(int userId, int deviceId);
 }
 
 public class ReadingProfileService(IUnitOfWork unitOfWork, ILocalizationService localizationService, IMapper mapper): IReadingProfileService
 {
-    /// <summary>
-    /// Tries to resolve the Reading Profile for a given Series. Will first check (optionally) Implicit profiles, then check for a bound Series profile, then a bound
-    /// Library profile, then default to the default profile.
-    /// </summary>
-    /// <param name="userId"></param>
-    /// <param name="seriesId"></param>
-    /// <param name="skipImplicit"></param>
-    /// <returns></returns>
-    /// <exception cref="KavitaException"></exception>
-    public async Task<AppUserReadingProfile> GetReadingProfileForSeries(int userId, int seriesId, bool skipImplicit = false)
+    public async Task<AppUserReadingProfile> GetReadingProfileForSeries(int userId, int libraryId, int seriesId,
+        int? activeDeviceId, bool skipImplicit = false)
     {
-        var profiles = await unitOfWork.AppUserReadingProfileRepository.GetProfilesForUser(userId, skipImplicit);
-
-        // If there is an implicit, send back
-        var implicitProfile =
-            profiles.FirstOrDefault(p => p.SeriesIds.Contains(seriesId) && p.Kind == ReadingProfileKind.Implicit);
-        if (implicitProfile != null) return  implicitProfile;
-
-        // Next check for a bound Series profile
-        var seriesProfile = profiles
-            .FirstOrDefault(p => p.SeriesIds.Contains(seriesId) && p.Kind != ReadingProfileKind.Implicit);
-        if (seriesProfile != null) return seriesProfile;
-
-        // Check for a library bound profile
-        var series = await unitOfWork.SeriesRepository.GetSeriesByIdAsync(seriesId);
-        if (series == null) throw new KavitaException(await localizationService.Translate(userId, "series-doesnt-exist"));
-
-        var libraryProfile = profiles
-            .FirstOrDefault(p => p.LibraryIds.Contains(series.LibraryId) && p.Kind != ReadingProfileKind.Implicit);
-        if (libraryProfile != null) return libraryProfile;
-
-        // Fallback to the default profile
-        return profiles.First(p => p.Kind == ReadingProfileKind.Default);
+        return await unitOfWork.AppUserReadingProfileRepository.GetProfileForSeries(userId, libraryId, seriesId,
+            activeDeviceId, skipImplicit);
     }
 
-    public async Task<UserReadingProfileDto> GetReadingProfileDtoForSeries(int userId, int seriesId, bool skipImplicit = false)
+    public async Task<UserReadingProfileDto> GetReadingProfileDtoForSeries(int userId, int libraryId, int seriesId,
+        int? activeDeviceId, bool skipImplicit = false)
     {
-        return mapper.Map<UserReadingProfileDto>(await GetReadingProfileForSeries(userId, seriesId, skipImplicit));
+        return mapper.Map<UserReadingProfileDto>(await GetReadingProfileForSeries(userId, libraryId, seriesId,
+            activeDeviceId, skipImplicit));
     }
 
-    public async Task<UserReadingProfileDto> UpdateParent(int userId, int seriesId, UserReadingProfileDto dto)
+    public async Task<UserReadingProfileDto> UpdateParent(int userId, int libraryId, int seriesId,
+        UserReadingProfileDto dto, int? activeDeviceId)
     {
-        var parentProfile = await GetReadingProfileForSeries(userId, seriesId, true);
+        var profile = await unitOfWork.AppUserReadingProfileRepository.GetUserProfile(userId, dto.Id);
+        if (profile == null) throw new KavitaException("profile-does-not-exist");
+
+        var parentProfile = await GetReadingProfileForSeries(userId, libraryId, seriesId, activeDeviceId, true);
 
         UpdateReaderProfileFields(parentProfile, dto, false);
         unitOfWork.AppUserReadingProfileRepository.Update(parentProfile);
 
-        // Remove the implicit profile when we UpdateParent (from reader) as it is implied that we are already bound with a non-implicit profile
-        await DeleteImplicateReadingProfilesForSeries(userId, [seriesId]);
+        // Delete profile as we'll be using the parent now
+        unitOfWork.AppUserReadingProfileRepository.Remove(profile);
 
         await unitOfWork.CommitAsync();
         return mapper.Map<UserReadingProfileDto>(parentProfile);
@@ -207,21 +232,23 @@ public class ReadingProfileService(IUnitOfWork unitOfWork, ILocalizationService 
         return mapper.Map<UserReadingProfileDto>(newProfile);
     }
 
-    /// <summary>
-    /// Promotes the implicit profile to a user profile. Removes the series from other profiles.
-    /// </summary>
-    /// <param name="userId"></param>
-    /// <param name="profileId"></param>
-    /// <returns></returns>
-    public async Task<UserReadingProfileDto> PromoteImplicitProfile(int userId, int profileId)
+    public async Task<UserReadingProfileDto> PromoteImplicitProfile(int userId, int profileId, int? activeDeviceId)
     {
         // Get all the user's profiles including the implicit
-        var allUserProfiles = await unitOfWork.AppUserReadingProfileRepository.GetProfilesForUser(userId, false);
-        var profileToPromote = allUserProfiles.First(r => r.Id == profileId);
+        var allUserProfiles = await unitOfWork.AppUserReadingProfileRepository.GetProfilesForUser(userId);
+        var profileToPromote = allUserProfiles.FirstOrDefault(rp => rp.Id == profileId);
+
+        if (profileToPromote == null) throw new KavitaException("profile-does-not-exist");
+        if (profileToPromote.Kind != ReadingProfileKind.Implicit) throw new KavitaException("profile-not-implicit");
+
         var seriesId = profileToPromote.SeriesIds[0]; // An Implicit series can only be bound to 1 Series
 
-        // Check if there are any reading profiles (Series) already bound to the series
-        var existingSeriesProfile = allUserProfiles.FirstOrDefault(r => r.SeriesIds.Contains(seriesId) && r.Kind == ReadingProfileKind.User);
+        // Check if there are any reading profiles (Series) already bound to the series (and device)
+        var existingSeriesProfile = allUserProfiles
+            .Where(rp => rp.Kind == ReadingProfileKind.User)
+            .Where(rp => activeDeviceId == null || rp.DeviceIds.Contains(activeDeviceId.Value))
+            .FirstOrDefault(rp => rp.SeriesIds.Contains(seriesId));
+
         if (existingSeriesProfile != null)
         {
             existingSeriesProfile.SeriesIds.Remove(seriesId);
@@ -256,13 +283,14 @@ public class ReadingProfileService(IUnitOfWork unitOfWork, ILocalizationService 
         return newName;
     }
 
-    public async Task<UserReadingProfileDto> UpdateImplicitReadingProfile(int userId, int seriesId, UserReadingProfileDto dto)
+    public async Task<UserReadingProfileDto> UpdateImplicitReadingProfile(int userId, int libraryId, int seriesId,
+        UserReadingProfileDto dto, int? activeDeviceId)
     {
         var user = await unitOfWork.UserRepository.GetUserByIdAsync(userId, AppUserIncludes.UserPreferences);
         if (user == null) throw new UnauthorizedAccessException();
 
-        var profiles =  await unitOfWork.AppUserReadingProfileRepository.GetProfilesForUser(userId);
-        var existingProfile = profiles.FirstOrDefault(rp => rp.Kind == ReadingProfileKind.Implicit && rp.SeriesIds.Contains(seriesId));
+        var existingProfile = await unitOfWork.AppUserReadingProfileRepository
+            .GetProfileForSeries(userId, libraryId, seriesId, activeDeviceId);
 
         // Series already had an implicit profile, update it
         if (existingProfile is {Kind: ReadingProfileKind.Implicit})
@@ -284,6 +312,10 @@ public class ReadingProfileService(IUnitOfWork unitOfWork, ILocalizationService 
         UpdateReaderProfileFields(newProfile, dto, false);
         newProfile.Name = $"Implicit Profile for {seriesId}";
         newProfile.NormalizedName = newProfile.Name.ToNormalized();
+        if (activeDeviceId != null)
+        {
+            newProfile.DeviceIds.Add(activeDeviceId.Value);
+        }
 
         user.ReadingProfiles.Add(newProfile);
         await unitOfWork.CommitAsync();
@@ -302,60 +334,95 @@ public class ReadingProfileService(IUnitOfWork unitOfWork, ILocalizationService 
         await unitOfWork.CommitAsync();
     }
 
-    public async Task AddProfileToSeries(int userId, int profileId, int seriesId)
+    public async Task SetSeriesProfiles(int userId, List<int> profileIds, int seriesId)
     {
-        var profile = await unitOfWork.AppUserReadingProfileRepository.GetUserProfile(userId, profileId);
-        if (profile == null) throw new KavitaException("profile-doesnt-exist");
+        var profiles = await unitOfWork.AppUserReadingProfileRepository.GetProfilesForUser(userId);
 
-        await DeleteImplicitAndRemoveFromUserProfiles(userId, [seriesId], []);
+        var selectedProfiles = profiles
+            .Where(rp => profileIds.Contains(rp.Id))
+            .ToList();
+        if (selectedProfiles.Count != profileIds.Count) throw new KavitaException("profile-doesnt-exist");
 
-        profile.SeriesIds.Add(seriesId);
-        unitOfWork.AppUserReadingProfileRepository.Update(profile);
+        DeviceOverlapGuard(selectedProfiles);
+
+        var allDeviceIds = selectedProfiles.SelectMany(p => p.DeviceIds).Distinct().ToList();
+
+        DeleteImplicitAndRemoveFromUserProfiles(profiles, [seriesId], [], allDeviceIds);
+
+        foreach (var profile in selectedProfiles)
+        {
+            profile.SeriesIds.Add(seriesId);
+            unitOfWork.AppUserReadingProfileRepository.Update(profile);
+        }
 
         await unitOfWork.CommitAsync();
     }
 
-    public async Task BulkAddProfileToSeries(int userId, int profileId, IList<int> seriesIds)
+    public async Task BulkSetSeriesProfiles(int userId, List<int> profileIds, List<int> seriesIds)
     {
-        var profile = await unitOfWork.AppUserReadingProfileRepository.GetUserProfile(userId, profileId);
-        if (profile == null) throw new KavitaException("profile-doesnt-exist");
+        var profiles = await unitOfWork.AppUserReadingProfileRepository.GetProfilesForUser(userId);
 
-        await DeleteImplicitAndRemoveFromUserProfiles(userId, seriesIds, []);
+        var selectedProfiles = profiles
+            .Where(rp => profileIds.Contains(rp.Id))
+            .ToList();
+        if (selectedProfiles.Count != profileIds.Count) throw new KavitaException("profile-doesnt-exist");
 
-        profile.SeriesIds.AddRange(seriesIds.Except(profile.SeriesIds));
-        unitOfWork.AppUserReadingProfileRepository.Update(profile);
+        DeviceOverlapGuard(selectedProfiles);
+
+        var allDeviceIds = selectedProfiles.SelectMany(p => p.DeviceIds).Distinct().ToList();
+
+        DeleteImplicitAndRemoveFromUserProfiles(profiles, seriesIds, [], allDeviceIds);
+
+        foreach (var profile in selectedProfiles)
+        {
+            profile.SeriesIds.AddRange(seriesIds.Except(profile.SeriesIds));
+            unitOfWork.AppUserReadingProfileRepository.Update(profile);
+        }
 
         await unitOfWork.CommitAsync();
     }
 
     public async Task ClearSeriesProfile(int userId, int seriesId)
     {
-        await DeleteImplicitAndRemoveFromUserProfiles(userId, [seriesId], []);
+        // Null device ids, delete all
+        var profiles = await unitOfWork.AppUserReadingProfileRepository.GetProfilesForUser(userId);
+        DeleteImplicitAndRemoveFromUserProfiles(profiles, [seriesId], [], null);
         await unitOfWork.CommitAsync();
     }
 
-    public async Task AddProfileToLibrary(int userId, int profileId, int libraryId)
+    public async Task SetLibraryProfiles(int userId, List<int> profileIds, int libraryId)
     {
-        var profile = await unitOfWork.AppUserReadingProfileRepository.GetUserProfile(userId, profileId);
-        if (profile == null) throw new KavitaException("profile-doesnt-exist");
+        var profiles = await unitOfWork.AppUserReadingProfileRepository.GetProfilesForUser(userId);
 
-        await DeleteImplicitAndRemoveFromUserProfiles(userId, [], [libraryId]);
+        var selectedProfiles = profiles
+            .Where(rp => profileIds.Contains(rp.Id))
+            .ToList();
+        if (selectedProfiles.Count != profileIds.Count) throw new KavitaException("profile-doesnt-exist");
 
-        profile.LibraryIds.Add(libraryId);
-        unitOfWork.AppUserReadingProfileRepository.Update(profile);
+        DeviceOverlapGuard(selectedProfiles);
+
+        var allDeviceIds = selectedProfiles.SelectMany(p => p.DeviceIds).Distinct().ToList();
+
+        DeleteImplicitAndRemoveFromUserProfiles(profiles, [], [libraryId], allDeviceIds);
+
+        foreach (var profile in selectedProfiles)
+        {
+            profile.LibraryIds.Add(libraryId);
+            unitOfWork.AppUserReadingProfileRepository.Update(profile);
+        }
+
         await unitOfWork.CommitAsync();
     }
 
     public async Task ClearLibraryProfile(int userId, int libraryId)
     {
-        var profiles =  await unitOfWork.AppUserReadingProfileRepository.GetProfilesForUser(userId);
-        var libraryProfile = profiles.FirstOrDefault(p => p.LibraryIds.Contains(libraryId));
-        if (libraryProfile != null)
-        {
-            libraryProfile.LibraryIds.Remove(libraryId);
-            unitOfWork.AppUserReadingProfileRepository.Update(libraryProfile);
-        }
+        var profiles = await unitOfWork.AppUserReadingProfileRepository.GetProfilesForLibrary(userId, libraryId);
 
+        foreach (var profile in profiles)
+        {
+            profile.LibraryIds.Remove(libraryId);
+            unitOfWork.AppUserReadingProfileRepository.Update(profile);
+        }
 
         if (unitOfWork.HasChanges())
         {
@@ -363,22 +430,105 @@ public class ReadingProfileService(IUnitOfWork unitOfWork, ILocalizationService 
         }
     }
 
-    public async Task<UserReadingProfileDto?> GetReadingProfileDtoForLibrary(int userId, int libraryId)
+    public Task<List<UserReadingProfileDto>> GetReadingProfileDtosForLibrary(int userId, int libraryId)
     {
-        var profiles = await unitOfWork.AppUserReadingProfileRepository.GetProfilesForUser(userId, true);
-        return mapper.Map<UserReadingProfileDto>(profiles.FirstOrDefault(p => p.LibraryIds.Contains(libraryId)));
+        return unitOfWork.DataContext.AppUserReadingProfiles
+            .Where(rp => rp.AppUserId == userId && rp.LibraryIds.Contains(libraryId))
+            .Where(rp => rp.Kind == ReadingProfileKind.User)
+            .ProjectTo<UserReadingProfileDto>(mapper.ConfigurationProvider)
+            .ToListAsync();
     }
 
-    private async Task DeleteImplicitAndRemoveFromUserProfiles(int userId, IList<int> seriesIds, IList<int> libraryIds)
+    public Task<List<UserReadingProfileDto>> GetReadingProfileDtosForSeries(int userId, int seriesId)
     {
-        var profiles =  await unitOfWork.AppUserReadingProfileRepository.GetProfilesForUser(userId);
+        return unitOfWork.DataContext.AppUserReadingProfiles
+            .Where(rp => rp.AppUserId == userId && rp.SeriesIds.Contains(seriesId))
+            .Where(rp => rp.Kind == ReadingProfileKind.User)
+            .ProjectTo<UserReadingProfileDto>(mapper.ConfigurationProvider)
+            .ToListAsync();
+    }
+
+    public async Task SetProfileDevices(int userId, int profileId, List<int> deviceIds)
+    {
+        var profile = await unitOfWork.AppUserReadingProfileRepository.GetUserProfile(userId, profileId);
+        if (profile == null) throw new KavitaException("profile-doesnt-exist");
+
+        if (profile.Kind == ReadingProfileKind.Default) throw new KavitaException("cant-assign-devices-to-default");
+
+        profile.DeviceIds = deviceIds;
+        unitOfWork.AppUserReadingProfileRepository.Update(profile);
+
+        await unitOfWork.CommitAsync();
+
+        // Remove series & library links from profiles where there is now overlap with devices
+        // E.g. for the same series there are now two profiles that would match
+        var profiles = await unitOfWork.AppUserReadingProfileRepository.GetProfilesForUser(userId);
+
+        var overlappingProfiles = profiles
+            .Where(rp => rp.Id != profileId)
+            .Where(rp => rp.Kind == ReadingProfileKind.User)
+            .Where(rp => (rp.DeviceIds.Count == 0 && deviceIds.Count == 0)
+                         || rp.DeviceIds.Intersect(deviceIds).Any())
+            .Where(rp => rp.SeriesIds.Intersect(profile.SeriesIds).Any()
+                         || rp.LibraryIds.Intersect(profile.LibraryIds).Any());
+
+        foreach (var overlap in overlappingProfiles)
+        {
+            overlap.SeriesIds.RemoveAll(profile.SeriesIds.Contains);
+            overlap.LibraryIds.RemoveAll(profile.LibraryIds.Contains);
+
+            unitOfWork.AppUserReadingProfileRepository.Update(overlap);
+        }
+
+        await unitOfWork.CommitAsync();
+    }
+
+    public async Task RemoveDeviceLinks(int userId, int deviceId)
+    {
+        var profiles = await unitOfWork.DataContext.AppUserReadingProfiles
+            .Where(rp => rp.AppUserId == userId && rp.DeviceIds.Contains(deviceId))
+            .ToListAsync();
+
+        foreach (var profile in profiles)
+        {
+            profile.DeviceIds.Remove(deviceId);
+            unitOfWork.AppUserReadingProfileRepository.Update(profile);
+        }
+    }
+
+    private static void DeviceOverlapGuard(List<AppUserReadingProfile> profiles)
+    {
+        var anyOverlap = profiles
+            .Any(rp => profiles
+                .Where(other => other.Id != rp.Id)
+                .Any(other => other.DeviceIds.Intersect(rp.DeviceIds).Any()));
+
+        if (anyOverlap)
+        {
+            throw new KavitaException("reading-profiles-device-overlap");
+        }
+    }
+
+    /// <summary>
+    /// Deletes all implicit profiles with overlapping ids (For devices 0 overlaps with 0). And removes links with
+    /// series & libraries
+    /// </summary>
+    /// <param name="profiles"></param>
+    /// <param name="seriesIds"></param>
+    /// <param name="libraryIds"></param>
+    /// <param name="deviceIds"></param>
+    private void DeleteImplicitAndRemoveFromUserProfiles(IList<AppUserReadingProfile> profiles, IList<int> seriesIds, IList<int> libraryIds, List<int>? deviceIds)
+    {
         var implicitProfiles = profiles
+            .Where(DeviceIdFilter)
             .Where(rp => rp.SeriesIds.Intersect(seriesIds).Any())
             .Where(rp => rp.Kind == ReadingProfileKind.Implicit)
             .ToList();
+
         unitOfWork.AppUserReadingProfileRepository.RemoveRange(implicitProfiles);
 
         var nonImplicitProfiles = profiles
+            .Where(DeviceIdFilter)
             .Where(rp => rp.SeriesIds.Intersect(seriesIds).Any() || rp.LibraryIds.Intersect(libraryIds).Any())
             .Where(rp => rp.Kind != ReadingProfileKind.Implicit);
 
@@ -386,29 +536,21 @@ public class ReadingProfileService(IUnitOfWork unitOfWork, ILocalizationService 
         {
             profile.SeriesIds.RemoveAll(seriesIds.Contains);
             profile.LibraryIds.RemoveAll(libraryIds.Contains);
+
             unitOfWork.AppUserReadingProfileRepository.Update(profile);
         }
-    }
 
-    private async Task DeleteImplicateReadingProfilesForSeries(int userId, IList<int> seriesIds)
-    {
-        var profiles =  await unitOfWork.AppUserReadingProfileRepository.GetProfilesForUser(userId);
-        var implicitProfiles = profiles
-            .Where(rp => rp.SeriesIds.Intersect(seriesIds).Any())
-            .Where(rp => rp.Kind == ReadingProfileKind.Implicit)
-            .ToList();
-        unitOfWork.AppUserReadingProfileRepository.RemoveRange(implicitProfiles);
-    }
+        return;
 
-    private async Task RemoveSeriesFromUserProfiles(int userId, IList<int> seriesIds)
-    {
-        var profiles =  await unitOfWork.AppUserReadingProfileRepository.GetProfilesForUser(userId);
-        var userProfiles = profiles
-            .Where(rp => rp.SeriesIds.Intersect(seriesIds).Any())
-            .Where(rp => rp.Kind == ReadingProfileKind.User)
-            .ToList();
+        bool DeviceIdFilter(AppUserReadingProfile rp)
+        {
+            // We should clean all
+            if (deviceIds == null) return true;
 
-        unitOfWork.AppUserReadingProfileRepository.RemoveRange(userProfiles);
+            if (deviceIds.Count == 0 && rp.DeviceIds.Count == 0) return true;
+
+            return rp.DeviceIds.Intersect(deviceIds).Any();
+        }
     }
 
     public static void UpdateReaderProfileFields(AppUserReadingProfile existingProfile, UserReadingProfileDto dto, bool updateName = true)

--- a/API/Services/SettingsService.cs
+++ b/API/Services/SettingsService.cs
@@ -405,6 +405,12 @@ public class SettingsService : ISettingsService
                 setting.Value = ((int)updateSettingsDto.CoverImageSize).ToString();
                 _unitOfWork.SettingsRepository.Update(setting);
             }
+            if (setting.Key == ServerSettingKey.PdfRenderResolution &&
+                ((int)updateSettingsDto.PdfRenderResolution).ToString() != setting.Value)
+            {
+                setting.Value = ((int)updateSettingsDto.PdfRenderResolution).ToString();
+                _unitOfWork.SettingsRepository.Update(setting);
+            }
 
             if (setting.Key == ServerSettingKey.HostName && updateSettingsDto.HostName + string.Empty != setting.Value)
             {

--- a/API/Services/StatisticService.cs
+++ b/API/Services/StatisticService.cs
@@ -1224,8 +1224,6 @@ public class StatisticService(ILogger<StatisticService> logger, DataContext cont
         filter.StartDate ??= sessionRecordedSince.RanAt;
         filter.StartDate = filter.StartDate < sessionRecordedSince.RanAt ? sessionRecordedSince.RanAt : filter.StartDate;
 
-        var daysSinceCounting = (DateTime.UtcNow - filter.StartDate).Value.Days;
-
         var sessions = await context.AppUserReadingSessionActivityData
             .ApplyStatsFilter(filter, userId, socialPreferences, requestingUser, isAggregate: true)
             .Where(session => session.ReadingSession.CreatedUtc > sessionRecordedSince.RanAt)
@@ -1261,7 +1259,7 @@ public class StatisticService(ILogger<StatisticService> logger, DataContext cont
             .GroupBy(x => x.hour)
             .ToDictionary(
                 g => g.Key,
-                g => g.Sum(x => x.totalTimeSpent) / daysSinceCounting
+                g => g.Sum(x => x.totalTimeSpent) / g.Count()
             );
 
         var data = Enumerable.Range(0, 24)

--- a/API/Services/StatisticService.cs
+++ b/API/Services/StatisticService.cs
@@ -1221,7 +1221,10 @@ public class StatisticService(ILogger<StatisticService> logger, DataContext cont
             return null;
         }
 
-        var daysSinceCounting = (DateTime.UtcNow - sessionRecordedSince.RanAt).Days;
+        filter.StartDate ??= sessionRecordedSince.RanAt;
+        filter.StartDate = filter.StartDate < sessionRecordedSince.RanAt ? sessionRecordedSince.RanAt : filter.StartDate;
+
+        var daysSinceCounting = (DateTime.UtcNow - filter.StartDate).Value.Days;
 
         var sessions = await context.AppUserReadingSessionActivityData
             .ApplyStatsFilter(filter, userId, socialPreferences, requestingUser, isAggregate: true)

--- a/API/Services/StatisticService.cs
+++ b/API/Services/StatisticService.cs
@@ -396,7 +396,9 @@ public class StatisticService(ILogger<StatisticService> logger, DataContext cont
                 Volumes = context.Volume.Count(v => Math.Abs(v.MinNumber - Parser.LooseLeafVolumeNumber) > 0.001f),
                 TotalBytes = context.MangaFile.Sum(m => m.Bytes)
             })
-            .FirstAsync();
+            .FirstOrDefaultAsync();
+
+        if (counts == null) return new ServerStatisticsDto();
 
         var totalReadingHours = await context.AppUserReadingSessionActivityData
             .Where(a => a.EndTimeUtc != null)

--- a/API/Services/Tasks/BackupService.cs
+++ b/API/Services/Tasks/BackupService.cs
@@ -87,7 +87,7 @@ public class BackupService : IBackupService
         await SendProgress(0F, "Started backup");
         await SendProgress(0.1F, "Copying core files");
 
-        var dateString = $@"{DateTime.UtcNow:yyyy_MM_dd_HH\H_mm\M}";
+        var dateString = $"{DateTime.UtcNow.ToShortDateString()}_{DateTime.UtcNow:s}Z".Replace("/", "_").Replace(":", "_");
         var zipPath = _directoryService.FileSystem.Path.Join(backupDirectory, $"kavita_backup_v{BuildInfo.Version}_{dateString}.zip");
 
         if (File.Exists(zipPath))

--- a/API/Services/Tasks/BackupService.cs
+++ b/API/Services/Tasks/BackupService.cs
@@ -10,6 +10,7 @@ using API.Logging;
 using API.SignalR;
 using Hangfire;
 using Kavita.Common.EnvironmentInfo;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
 namespace API.Services.Tasks;
@@ -44,10 +45,7 @@ public class BackupService : IBackupService
 
         _backupFiles = new List<string>()
         {
-            "appsettings.json",
-            "kavita.db",
-            "kavita.db-shm", // This wont always be there
-            "kavita.db-wal" // This wont always be there
+            "appsettings.json"
         };
     }
 
@@ -104,7 +102,10 @@ public class BackupService : IBackupService
         _directoryService.ExistOrCreate(tempDirectory);
         _directoryService.ClearDirectory(tempDirectory);
 
-        await SendProgress(0.1F, "Copying config files");
+        await SendProgress(0.1F, "Backing up database");
+        await BackupDatabaseFile(tempDirectory);
+
+        await SendProgress(0.15F, "Copying config files");
         _directoryService.CopyFilesToDirectory(
             _backupFiles.Select(file => _directoryService.FileSystem.Path.Join(_directoryService.ConfigDirectory, file)), tempDirectory);
 
@@ -151,6 +152,39 @@ public class BackupService : IBackupService
     {
         var files = GetLogFiles();
         _directoryService.CopyFilesToDirectory(files, _directoryService.FileSystem.Path.Join(tempDirectory, "logs"));
+    }
+
+    /// <summary>
+    /// Creates a backup of the SQLite database using VACUUM INTO command.
+    /// This method safely backs up the database while it's in use, without locking issues.
+    /// </summary>
+    /// <param name="tempDirectory">The directory where the backup file will be created</param>
+    private async Task BackupDatabaseFile(string tempDirectory)
+    {
+        var backupPath = _directoryService.FileSystem.Path.Join(tempDirectory, "kavita.db");
+
+        // Validate the backup path to prevent SQL injection
+        // The path must not contain single quotes which could break the SQL command
+        if (backupPath.Contains('\''))
+        {
+            throw new ArgumentException("Backup path contains invalid characters", nameof(tempDirectory));
+        }
+
+        try
+        {
+            // Use VACUUM INTO to create a safe backup of the database while it's running
+            // This creates a consistent snapshot without locking the main database
+            // Note: VACUUM INTO requires a literal path and cannot use SQL parameters
+            #pragma warning disable EF1002 // The backup path is validated above to not contain SQL injection characters
+            await _unitOfWork.DataContext.Database.ExecuteSqlRawAsync($"VACUUM INTO '{backupPath}'");
+            #pragma warning restore EF1002
+            _logger.LogDebug("Database backup created successfully at {BackupPath}", backupPath);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to create database backup using VACUUM INTO at {BackupPath}", backupPath);
+            throw new InvalidOperationException($"Failed to create database backup at {backupPath}", ex);
+        }
     }
 
     private void CopyFaviconsToBackupDirectory(string tempDirectory)

--- a/API/Services/Tasks/BackupService.cs
+++ b/API/Services/Tasks/BackupService.cs
@@ -43,10 +43,10 @@ public class BackupService : IBackupService
         _directoryService = directoryService;
         _eventHub = eventHub;
 
-        _backupFiles = new List<string>()
-        {
+        _backupFiles =
+        [
             "appsettings.json"
-        };
+        ];
     }
 
     /// <summary>
@@ -62,12 +62,12 @@ public class BackupService : IBackupService
         var files = rollFiles
             ? _directoryService.GetFiles(_directoryService.LogDirectory,
                 $@"{_directoryService.FileSystem.Path.GetFileNameWithoutExtension(fi.Name)}{multipleFileRegex}\.log")
-            : new[] {_directoryService.FileSystem.Path.Join(_directoryService.LogDirectory, "kavita.log")};
+            : [_directoryService.FileSystem.Path.Join(_directoryService.LogDirectory, "kavita.log")];
         return files;
     }
 
     /// <summary>
-    /// Will backup anything that needs to be backed up. This includes logs, setting files, bare minimum cover images (just locked and first cover).
+    /// Will back up anything that needs to be backed up. This includes logs, setting files, bare minimum cover images (just locked and first cover).
     /// </summary>
     [AutomaticRetry(Attempts = 3, LogEvents = false, OnAttemptsExceeded = AttemptsExceededAction.Fail)]
     public async Task BackupDatabase()
@@ -87,8 +87,8 @@ public class BackupService : IBackupService
         await SendProgress(0F, "Started backup");
         await SendProgress(0.1F, "Copying core files");
 
-        var dateString = $"{DateTime.UtcNow.ToShortDateString()}_{DateTime.UtcNow:s}Z".Replace("/", "_").Replace(":", "_");
-        var zipPath = _directoryService.FileSystem.Path.Join(backupDirectory, $"kavita_backup_{dateString}_v{BuildInfo.Version}.zip");
+        var dateString = $@"{DateTime.UtcNow:yyyy_MM_dd_HH\H_mm\M}";
+        var zipPath = _directoryService.FileSystem.Path.Join(backupDirectory, $"kavita_backup_v{BuildInfo.Version}_{dateString}.zip");
 
         if (File.Exists(zipPath))
         {
@@ -136,7 +136,7 @@ public class BackupService : IBackupService
 
         try
         {
-            ZipFile.CreateFromDirectory(tempDirectory, zipPath);
+            await ZipFile.CreateFromDirectoryAsync(tempDirectory, zipPath);
         }
         catch (AggregateException ex)
         {

--- a/API/Services/Tasks/CleanupService.cs
+++ b/API/Services/Tasks/CleanupService.cs
@@ -65,12 +65,12 @@ public class CleanupService : ICleanupService
     /// <summary>
     /// Cleans up Temp, cache, deleted cover images,  and old database backups
     /// </summary>
-    [AutomaticRetry(Attempts = 3, LogEvents = false, OnAttemptsExceeded = AttemptsExceededAction.Fail)]
+    [AutomaticRetry(Attempts = 3, LogEvents = false, OnAttemptsExceeded = AttemptsExceededAction.Fail, DelaysInSeconds = [120, 300, 300])]
     public async Task Cleanup()
     {
-        if (TaskScheduler.HasAlreadyEnqueuedTask(BookmarkService.Name, "ConvertAllCoverToEncoding", Array.Empty<object>(),
+        if (TaskScheduler.HasAlreadyEnqueuedTask(BookmarkService.Name, "ConvertAllCoverToEncoding", [],
                 TaskScheduler.DefaultQueue, true) ||
-            TaskScheduler.HasAlreadyEnqueuedTask(BookmarkService.Name, "ConvertAllBookmarkToEncoding", Array.Empty<object>(),
+            TaskScheduler.HasAlreadyEnqueuedTask(BookmarkService.Name, "ConvertAllBookmarkToEncoding", [],
                 TaskScheduler.DefaultQueue, true))
         {
             _logger.LogInformation("Cleanup put on hold as a media conversion in progress");

--- a/API/Services/TokenService.cs
+++ b/API/Services/TokenService.cs
@@ -116,15 +116,6 @@ public class TokenService : ITokenService
                 TokenOptions.DefaultProvider,
                 RefreshTokenName);
 
-            try
-            {
-                await _unitOfWork.UserRepository.UpdateUserAsActive(user.Id);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to update last active for {UserName}", user.UserName);
-            }
-
             return new TokenRequestDto()
             {
                 Token = await CreateToken(user),

--- a/API/Startup.cs
+++ b/API/Startup.cs
@@ -64,11 +64,9 @@ public class Startup
         services.Configure<AppSettingsDto>(_config);
         services.AddApplicationServices(_config, _env);
 
-        // Store keys inside config, such that cookies can be de-crypted between container recreations
-        // Without needing user to manually mount the default directory
-        var keysLocation = Path.Combine(Directory.GetCurrentDirectory(), "config", "DataProtection-Keys");
+        // Store keys inside database, such that cookies can be decrypted between container restarts
         services.AddDataProtection()
-            .PersistKeysToFileSystem(new DirectoryInfo(keysLocation))
+            .PersistKeysToDbContext<DataContext>()
             .SetApplicationName(BuildInfo.AppName);
 
         services.AddControllers(options =>

--- a/API/Startup.cs
+++ b/API/Startup.cs
@@ -25,6 +25,7 @@ using HtmlAgilityPack;
 using Kavita.Common;
 using Kavita.Common.EnvironmentInfo;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.HttpOverrides;
@@ -62,6 +63,13 @@ public class Startup
     {
         services.Configure<AppSettingsDto>(_config);
         services.AddApplicationServices(_config, _env);
+
+        // Store keys inside config, such that cookies can be de-crypted between container recreations
+        // Without needing user to manually mount the default directory
+        var keysLocation = Path.Combine(Directory.GetCurrentDirectory(), "config", "DataProtection-Keys");
+        services.AddDataProtection()
+            .PersistKeysToFileSystem(new DirectoryInfo(keysLocation))
+            .SetApplicationName(BuildInfo.AppName);
 
         services.AddControllers(options =>
         {

--- a/API/Startup.cs
+++ b/API/Startup.cs
@@ -103,13 +103,6 @@ public class Startup
                     Duration = _env.IsDevelopment() ? 0 : 60 * 60 * 6,
                     Location = ResponseCacheLocation.Client,
                 });
-            options.CacheProfiles.Add(ResponseCacheProfiles.Images,
-                new CacheProfile()
-                {
-                    Duration = 60,
-                    Location = ResponseCacheLocation.Client,
-                    NoStore = false
-                });
             options.CacheProfiles.Add(ResponseCacheProfiles.Month,
                 new CacheProfile()
                 {

--- a/UI/Web/.gitignore
+++ b/UI/Web/.gitignore
@@ -3,3 +3,4 @@ test-results/
 playwright-report/
 i18n-cache-busting.json
 e2e-tests/environments/environment.local.ts
+dead-i18n-keys.json

--- a/UI/Web/find-dead-localization-keys.js
+++ b/UI/Web/find-dead-localization-keys.js
@@ -1,0 +1,222 @@
+const fs = require('fs');
+const path = require('path');
+
+// Configuration
+const CONFIG = {
+    i18nFile: './src/assets/langs/en.json',
+    searchDirs: ['./src'],
+    extensions: ['.ts', '.html'],
+    // Patterns that reference i18n keys
+    usagePatterns: [
+        // Transloco patterns
+        /(?:^|[^a-zA-Z0-9_])t\(['"`]([a-zA-Z0-9._-]+)['"`]/g,  // t('key') or t('key', {params})
+        /translocoService\.translate\(['"`]([a-zA-Z0-9._-]+)['"`]/g,  // translocoService.translate('key')
+        /translocoService\.selectTranslate\(['"`]([a-zA-Z0-9._-]+)['"`]/g,
+        /\|\s*transloco(?:\s*:\s*\{[^}]*\})?/g,            // | transloco pipe (key before pipe)
+        /\[transloco\]=['"`]([a-zA-Z0-9._-]+)['"`]/g,      // [transloco]="key"
+
+        // String literals in component metadata / configs (description:, tooltip:, etc.)
+        /:\s*['"`]([a-zA-Z0-9][a-zA-Z0-9_-]*(?:-[a-zA-Z0-9_]+)+)['"`]/g,  // kebab-case keys as values
+
+        // ngx-translate fallback patterns
+        /['"`]([a-zA-Z0-9._-]+)['"]\s*\|\s*translate/g,
+        /translate\.instant\(['"`]([a-zA-Z0-9._-]+)['"`]/g,
+        /translate\.get\(['"`]([a-zA-Z0-9._-]+)['"`]/g,
+    ],
+    // Pattern for interpolated keys within i18n values: {{key.path}}
+    interpolationPattern: /\{\{([a-zA-Z0-9._-]+)\}\}/g,
+};
+
+// Flatten nested JSON to dot-notation keys
+function flattenKeys(obj, prefix = '') {
+    const keys = [];
+    for (const [k, v] of Object.entries(obj)) {
+        const fullKey = prefix ? `${prefix}.${k}` : k;
+        if (typeof v === 'object' && v !== null && !Array.isArray(v)) {
+            keys.push(...flattenKeys(v, fullKey));
+        } else {
+            keys.push({ key: fullKey, value: v });
+        }
+    }
+    return keys;
+}
+
+// Recursively get all files with given extensions
+function getFiles(dir, exts, files = []) {
+    if (!fs.existsSync(dir)) return files;
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const fullPath = path.join(dir, entry.name);
+        if (entry.isDirectory() && !entry.name.startsWith('.') && entry.name !== 'node_modules') {
+            getFiles(fullPath, exts, files);
+        } else if (entry.isFile() && exts.includes(path.extname(entry.name))) {
+            files.push(fullPath);
+        }
+    }
+    return files;
+}
+
+// Extract Transloco prefixes from a file
+function extractPrefixes(content) {
+    const prefixes = [];
+
+    // *transloco="let t; prefix: 'namespace'"
+    const structuralPattern = /\*transloco\s*=\s*["'][^"']*prefix\s*:\s*['"]([a-zA-Z0-9._-]+)['"][^"']*["']/g;
+    let match;
+    while ((match = structuralPattern.exec(content)) !== null) {
+        prefixes.push(match[1]);
+    }
+
+    // Also check for @Component transloco scope in .ts files
+    // providers: [{ provide: TRANSLOCO_SCOPE, useValue: 'namespace' }]
+    const scopePattern = /TRANSLOCO_SCOPE\s*,\s*useValue\s*:\s*['"]([a-zA-Z0-9._-]+)['"]/g;
+    while ((match = scopePattern.exec(content)) !== null) {
+        prefixes.push(match[1]);
+    }
+
+    return prefixes;
+}
+
+// Extract all i18n key usages from source files
+function findUsedKeys(files, allI18nKeys) {
+    const used = new Set();
+
+    for (const file of files) {
+        const content = fs.readFileSync(file, 'utf-8');
+        const prefixes = extractPrefixes(content);
+
+        // Apply regex patterns
+        for (const pattern of CONFIG.usagePatterns) {
+            pattern.lastIndex = 0;
+            let match;
+            while ((match = pattern.exec(content)) !== null) {
+                if (match[1]) {
+                    const key = match[1];
+                    // Add the raw key (for fully qualified keys)
+                    used.add(key);
+                    // Add prefixed versions
+                    for (const prefix of prefixes) {
+                        used.add(`${prefix}.${key}`);
+                    }
+                }
+            }
+        }
+
+        // Direct string matching: check if any i18n key appears as a quoted string
+        for (const key of allI18nKeys) {
+            const shortKey = key.includes('.') ? key.split('.').slice(1).join('.') : key;
+
+            if (content.includes(`'${key}'`) ||
+                content.includes(`"${key}"`) ||
+                content.includes(`\`${key}\``)) {
+                used.add(key);
+            }
+            // Also check for the unprefixed version with valid prefixes
+            if (shortKey !== key && prefixes.length > 0) {
+                if (content.includes(`'${shortKey}'`) ||
+                    content.includes(`"${shortKey}"`) ||
+                    content.includes(`\`${shortKey}\``)) {
+                    for (const prefix of prefixes) {
+                        if (key.startsWith(prefix + '.')) {
+                            used.add(key);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return used;
+}
+
+// Extract keys referenced via interpolation in i18n values
+function findInterpolatedKeys(entries) {
+    const referenced = new Set();
+    for (const { value } of entries) {
+        if (typeof value !== 'string') continue;
+        let match;
+        CONFIG.interpolationPattern.lastIndex = 0;
+        while ((match = CONFIG.interpolationPattern.exec(value)) !== null) {
+            referenced.add(match[1]);
+        }
+    }
+    return referenced;
+}
+
+// Check if a key or any of its ancestors is used (prefix matching)
+function isKeyUsed(key, usedKeys) {
+    // Direct match
+    if (usedKeys.has(key)) return true;
+    // Check if this key is a prefix of any used key (parent namespace)
+    for (const used of usedKeys) {
+        if (used.startsWith(key + '.')) return true;
+    }
+    // Check if any used key is a prefix (dynamic access pattern)
+    for (const used of usedKeys) {
+        if (key.startsWith(used + '.')) return true;
+    }
+    return false;
+}
+
+// Group dead keys by their parent namespace
+function groupByParent(deadKeys) {
+    const grouped = {};
+    for (const key of deadKeys) {
+        const parts = key.split('.');
+        if (parts.length === 1) {
+            grouped['_root'] = grouped['_root'] || [];
+            grouped['_root'].push(key);
+        } else {
+            const leaf = parts.pop();
+            const parent = parts.join('.');
+            grouped[parent] = grouped[parent] || [];
+            grouped[parent].push(leaf);
+        }
+    }
+    return grouped;
+}
+
+// Main
+function main() {
+    console.log('Loading i18n file...');
+    const i18n = JSON.parse(fs.readFileSync(CONFIG.i18nFile, 'utf-8'));
+    const entries = flattenKeys(i18n);
+    const allKeys = new Set(entries.map(e => e.key));
+    console.log(`Found ${allKeys.size} i18n keys`);
+
+    console.log('Scanning source files...');
+    const files = CONFIG.searchDirs.flatMap(dir => getFiles(dir, CONFIG.extensions));
+    console.log(`Scanning ${files.length} files...`);
+
+    const usedInCode = findUsedKeys(files, [...allKeys]);
+    console.log(`Found ${usedInCode.size} key references in code`);
+
+    const interpolated = findInterpolatedKeys(entries);
+    console.log(`Found ${interpolated.size} interpolated key references`);
+
+    const allUsed = new Set([...usedInCode, ...interpolated]);
+
+    console.log('Finding dead keys...');
+    const deadKeys = [];
+    for (const key of allKeys) {
+        if (!isKeyUsed(key, allUsed)) {
+            deadKeys.push(key);
+        }
+    }
+
+    console.log(`\nFound ${deadKeys.length} potentially dead keys`);
+
+    const result = groupByParent(deadKeys.sort());
+
+    const outputFile = 'dead-i18n-keys.json';
+    fs.writeFileSync(outputFile, JSON.stringify(result, null, 2));
+    console.log(`Results written to ${outputFile}`);
+
+    // Also print summary
+    if (deadKeys.length > 0) {
+        console.log('\nDead keys by namespace:');
+        for (const [ns, keys] of Object.entries(result)) {
+            console.log(`  ${ns}: ${keys.length} keys`);
+        }
+    }
+}
+
+main();

--- a/UI/Web/find-dead-localization-keys.js
+++ b/UI/Web/find-dead-localization-keys.js
@@ -6,17 +6,24 @@ const CONFIG = {
     i18nFile: './src/assets/langs/en.json',
     searchDirs: ['./src'],
     extensions: ['.ts', '.html'],
+    // Namespaces to skip entirely (dynamic usage too complex to trace)
+    blacklistedNamespaces: [
+        'month-label-pipe',
+        'ordinal-date-pipe',
+    ],
     // Patterns that reference i18n keys
     usagePatterns: [
         // Transloco patterns
         /(?:^|[^a-zA-Z0-9_])t\(['"`]([a-zA-Z0-9._-]+)['"`]/g,  // t('key') or t('key', {params})
         /translocoService\.translate\(['"`]([a-zA-Z0-9._-]+)['"`]/g,  // translocoService.translate('key')
         /translocoService\.selectTranslate\(['"`]([a-zA-Z0-9._-]+)['"`]/g,
-        /\|\s*transloco(?:\s*:\s*\{[^}]*\})?/g,            // | transloco pipe (key before pipe)
+        /(?:^|[^a-zA-Z0-9_.])translate\(['"`]([a-zA-Z0-9._-]+)['"`]/g,  // translate('key') standalone function
+        /transloco\.translate\(['"`]([a-zA-Z0-9._-]+)['"`]/g,  // this.transloco.translate('key')
         /\[transloco\]=['"`]([a-zA-Z0-9._-]+)['"`]/g,      // [transloco]="key"
 
-        // String literals in component metadata / configs (description:, tooltip:, etc.)
-        /:\s*['"`]([a-zA-Z0-9][a-zA-Z0-9_-]*(?:-[a-zA-Z0-9_]+)+)['"`]/g,  // kebab-case keys as values
+        // Template literal translate: translate(`namespace.${var}`) or translate(`key`)
+        /translate\(`([a-zA-Z0-9._-]+)`\)/g,
+        /transloco\.translate\(`([a-zA-Z0-9._-]+)\./g,  // transloco.translate(`namespace. - captures namespace
 
         // ngx-translate fallback patterns
         /['"`]([a-zA-Z0-9._-]+)['"]\s*\|\s*translate/g,
@@ -25,7 +32,26 @@ const CONFIG = {
     ],
     // Pattern for interpolated keys within i18n values: {{key.path}}
     interpolationPattern: /\{\{([a-zA-Z0-9._-]+)\}\}/g,
+    // Patterns indicating dynamic key construction - mark whole namespace as used
+    dynamicKeyPatterns: [
+        /translate\(['"`]([a-zA-Z0-9._-]+)\.\s*['"`]\s*\+/g,  // translate('namespace.' +
+        /t\(['"`]([a-zA-Z0-9._-]+)\.\s*['"`]\s*\+/g,          // t('namespace.' +
+        /translate\([a-zA-Z0-9_]+\s*\+\s*['"`]\.([a-zA-Z0-9._-]+)['"`]/g,  // translate(variable + '.suffix') - captures suffix
+        /\+\s*['"`]\.([a-zA-Z0-9_-]+)['"]\s*[,)]/g,           // + '.suffix', or + '.suffix') - generic dynamic suffix
+        /translate\(`([a-zA-Z0-9._-]+)\.\$\{/g,               // translate(`namespace.${...}`) - template literal dynamic
+        /transloco\.translate\(`([a-zA-Z0-9._-]+)\.\$\{/g,    // this.transloco.translate(`namespace.${...}`)
+    ],
 };
+
+// Check if a key belongs to a blacklisted namespace
+function isBlacklisted(key) {
+    for (const ns of CONFIG.blacklistedNamespaces) {
+        if (key === ns || key.startsWith(ns + '.')) {
+            return true;
+        }
+    }
+    return false;
+}
 
 // Flatten nested JSON to dot-notation keys
 function flattenKeys(obj, prefix = '') {
@@ -55,8 +81,8 @@ function getFiles(dir, exts, files = []) {
     return files;
 }
 
-// Extract Transloco prefixes from a file
-function extractPrefixes(content) {
+// Extract Transloco prefixes from a file (and its sibling template/component)
+function extractPrefixes(filePath, content, fileContentsCache) {
     const prefixes = [];
 
     // *transloco="let t; prefix: 'namespace'"
@@ -73,16 +99,93 @@ function extractPrefixes(content) {
         prefixes.push(match[1]);
     }
 
-    return prefixes;
+    // If this is a .ts file, check sibling .html for prefix
+    if (filePath.endsWith('.ts')) {
+        const htmlPath = filePath.replace(/\.ts$/, '.html');
+        const htmlContent = fileContentsCache.get(htmlPath);
+        if (htmlContent) {
+            structuralPattern.lastIndex = 0;
+            while ((match = structuralPattern.exec(htmlContent)) !== null) {
+                prefixes.push(match[1]);
+            }
+        }
+    }
+
+    // If this is a .html file, check sibling .ts for TRANSLOCO_SCOPE
+    if (filePath.endsWith('.html')) {
+        const tsPath = filePath.replace(/\.html$/, '.ts');
+        const tsContent = fileContentsCache.get(tsPath);
+        if (tsContent) {
+            scopePattern.lastIndex = 0;
+            while ((match = scopePattern.exec(tsContent)) !== null) {
+                prefixes.push(match[1]);
+            }
+        }
+    }
+
+    return [...new Set(prefixes)]; // dedupe
+}
+
+// Extract namespaces that use dynamic key construction
+function extractDynamicNamespaces(content, allI18nKeys) {
+    const namespaces = new Set();
+
+    // Pattern: translate('namespace.' + or t('namespace.' +
+    for (const pattern of CONFIG.dynamicKeyPatterns.slice(0, 2)) {
+        pattern.lastIndex = 0;
+        let match;
+        while ((match = pattern.exec(content)) !== null) {
+            namespaces.add(match[1]);
+        }
+    }
+
+    // Pattern: translate(variable + '.suffix') - find all namespaces that have this suffix
+    for (const pattern of CONFIG.dynamicKeyPatterns.slice(2)) {
+        pattern.lastIndex = 0;
+        let match;
+        while ((match = pattern.exec(content)) !== null) {
+            const suffix = match[1];
+            // Find all namespaces that contain a key ending with this suffix
+            for (const key of allI18nKeys) {
+                if (key.endsWith('.' + suffix)) {
+                    const ns = key.substring(0, key.lastIndexOf('.'));
+                    // Only add top-level namespace
+                    const topNs = ns.includes('.') ? ns.split('.')[0] : ns;
+                    namespaces.add(topNs);
+                }
+            }
+        }
+    }
+
+    return namespaces;
 }
 
 // Extract all i18n key usages from source files
-function findUsedKeys(files, allI18nKeys) {
+function findUsedKeys(files, allI18nKeys, debug = false) {
     const used = new Set();
+    const dynamicNamespaces = new Set();
+
+    // Pre-load all file contents for sibling lookup
+    const fileContentsCache = new Map();
+    for (const file of files) {
+        fileContentsCache.set(file, fs.readFileSync(file, 'utf-8'));
+    }
 
     for (const file of files) {
-        const content = fs.readFileSync(file, 'utf-8');
-        const prefixes = extractPrefixes(content);
+        const content = fileContentsCache.get(file);
+        const prefixes = extractPrefixes(file, content, fileContentsCache);
+
+        // Debug: check specific file
+        if (debug && file.includes('metadata-filter-row')) {
+            console.log(`\n[DEBUG] File: ${file}`);
+            console.log(`[DEBUG] Prefixes found: ${JSON.stringify(prefixes)}`);
+            console.log(`[DEBUG] Contains 'disclaimer-file-size': ${content.includes('disclaimer-file-size')}`);
+        }
+
+        // Collect dynamic namespaces
+        for (const ns of extractDynamicNamespaces(content, allI18nKeys)) {
+            dynamicNamespaces.add(ns);
+        }
 
         // Apply regex patterns
         for (const pattern of CONFIG.usagePatterns) {
@@ -91,9 +194,7 @@ function findUsedKeys(files, allI18nKeys) {
             while ((match = pattern.exec(content)) !== null) {
                 if (match[1]) {
                     const key = match[1];
-                    // Add the raw key (for fully qualified keys)
                     used.add(key);
-                    // Add prefixed versions
                     for (const prefix of prefixes) {
                         used.add(`${prefix}.${key}`);
                     }
@@ -118,12 +219,25 @@ function findUsedKeys(files, allI18nKeys) {
                     for (const prefix of prefixes) {
                         if (key.startsWith(prefix + '.')) {
                             used.add(key);
+                            if (debug && key.includes('disclaimer-file-size')) {
+                                console.log(`[DEBUG] Matched ${key} via prefix ${prefix} in ${file}`);
+                            }
                         }
                     }
                 }
             }
         }
     }
+
+    // Mark all keys under dynamic namespaces as used
+    for (const key of allI18nKeys) {
+        for (const ns of dynamicNamespaces) {
+            if (key.startsWith(ns + '.')) {
+                used.add(key);
+            }
+        }
+    }
+
     return used;
 }
 
@@ -176,6 +290,8 @@ function groupByParent(deadKeys) {
 
 // Main
 function main() {
+    const DEBUG = process.argv.includes('--debug');
+
     console.log('Loading i18n file...');
     const i18n = JSON.parse(fs.readFileSync(CONFIG.i18nFile, 'utf-8'));
     const entries = flattenKeys(i18n);
@@ -186,7 +302,7 @@ function main() {
     const files = CONFIG.searchDirs.flatMap(dir => getFiles(dir, CONFIG.extensions));
     console.log(`Scanning ${files.length} files...`);
 
-    const usedInCode = findUsedKeys(files, [...allKeys]);
+    const usedInCode = findUsedKeys(files, [...allKeys], DEBUG);
     console.log(`Found ${usedInCode.size} key references in code`);
 
     const interpolated = findInterpolatedKeys(entries);
@@ -197,6 +313,7 @@ function main() {
     console.log('Finding dead keys...');
     const deadKeys = [];
     for (const key of allKeys) {
+        if (isBlacklisted(key)) continue;
         if (!isKeyUsed(key, allUsed)) {
             deadKeys.push(key);
         }

--- a/UI/Web/package-lock.json
+++ b/UI/Web/package-lock.json
@@ -1316,6 +1316,7 @@
       "version": "21.0.6",
       "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-21.0.6.tgz",
       "integrity": "sha512-UcIUx+fbn0VLlCBCIYxntAzWG3zPRUo0K7wvuK0MC6ZFCWawgewx9SdLLZTqcaWe1g5FRQlQeVQcFgHAO5R2Mw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "7.28.4",
@@ -1348,6 +1349,7 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
       "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -1360,6 +1362,7 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
       "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^7.2.0",
@@ -1374,6 +1377,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
       "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^10.3.0",
@@ -1391,6 +1395,7 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
       "integrity": "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.2.1",
@@ -1408,6 +1413,7 @@
       "version": "18.0.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
       "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^9.0.1",
@@ -1425,6 +1431,7 @@
       "version": "22.0.0",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
       "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=23"
@@ -6375,6 +6382,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "readdirp": "^4.0.1"
@@ -6497,7 +6505,8 @@
     "node_modules/convert-source-map": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "dev": true
     },
     "node_modules/cookie": {
       "version": "0.7.2",
@@ -6798,6 +6807,31 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
+    "node_modules/encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/entities": {
@@ -9971,6 +10005,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.18.0"
@@ -9983,7 +10018,8 @@
     "node_modules/reflect-metadata": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
-      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "dev": true
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
@@ -10195,6 +10231,7 @@
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
       "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -10881,7 +10918,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/UI/Web/src/app/_models/client-device.ts
+++ b/UI/Web/src/app/_models/client-device.ts
@@ -6,6 +6,7 @@ import {ClientInfo} from "../_services/client-info.service";
 export interface ClientDevice {
   id: number;
   friendlyName: string;
+  uiFingerprint?: string;
   currentClientInfo: ClientInfo;
   firstSeenUtc: string;
   lastSeenUtc: string;

--- a/UI/Web/src/app/_models/metadata/series-filter.ts
+++ b/UI/Web/src/app/_models/metadata/series-filter.ts
@@ -20,7 +20,8 @@ export enum SortField {
    * Kavita+ only
    */
   AverageRating = 8,
-  Random = 9
+  Random = 9,
+  UserRating = 10,
 }
 
 export const allSeriesSortFields = Object.keys(SortField)

--- a/UI/Web/src/app/_models/preferences/preferences.ts
+++ b/UI/Web/src/app/_models/preferences/preferences.ts
@@ -69,6 +69,7 @@ export enum KeyBindTarget {
   Escape = 'Escape',
   PageUp = 'PageUp',
   PageDown = 'PageDown',
+  OffsetDoublePage = 'OffsetDoublePage',
 }
 
 export interface OpdsPreferences {

--- a/UI/Web/src/app/_models/preferences/reading-profiles.ts
+++ b/UI/Web/src/app/_models/preferences/reading-profiles.ts
@@ -24,6 +24,7 @@ export interface ReadingProfile {
   name: string;
   normalizedName: string;
   kind: ReadingProfileKind;
+  deviceIds: number[];
 
   // Manga Reader
   readingDirection: ReadingDirection;

--- a/UI/Web/src/app/_models/preferences/reading-profiles.ts
+++ b/UI/Web/src/app/_models/preferences/reading-profiles.ts
@@ -39,7 +39,6 @@ export interface ReadingProfile {
   allowAutomaticWebtoonReaderDetection: boolean;
   widthOverride?: number;
   disableWidthOverride: UserBreakpoint;
-  pageOffset: boolean;
 
   // Book Reader
   bookReaderMargin: number;

--- a/UI/Web/src/app/_models/preferences/reading-profiles.ts
+++ b/UI/Web/src/app/_models/preferences/reading-profiles.ts
@@ -39,6 +39,7 @@ export interface ReadingProfile {
   allowAutomaticWebtoonReaderDetection: boolean;
   widthOverride?: number;
   disableWidthOverride: UserBreakpoint;
+  pageOffset: boolean;
 
   // Book Reader
   bookReaderMargin: number;

--- a/UI/Web/src/app/_pipes/cbl-conflict-reason.pipe.ts
+++ b/UI/Web/src/app/_pipes/cbl-conflict-reason.pipe.ts
@@ -1,6 +1,6 @@
 import {inject, Pipe, PipeTransform} from '@angular/core';
-import { CblBookResult } from 'src/app/_models/reading-list/cbl/cbl-book-result';
-import { CblImportReason } from 'src/app/_models/reading-list/cbl/cbl-import-reason.enum';
+import {CblBookResult} from 'src/app/_models/reading-list/cbl/cbl-book-result';
+import {CblImportReason} from 'src/app/_models/reading-list/cbl/cbl-import-reason.enum';
 import {TranslocoService} from "@jsverse/transloco";
 import {APP_BASE_HREF} from "@angular/common";
 
@@ -35,7 +35,7 @@ export class CblConflictReasonPipe implements PipeTransform {
       case CblImportReason.AllChapterMissing:
         return failIcon + this.translocoService.translate('cbl-conflict-reason-pipe.all-chapter-missing');
       case CblImportReason.Success:
-        return successIcon + this.translocoService.translate('cbl-conflict-reason-pipe.volume-missing', {series: result.series, volume: result.volume, chapter: result.number});
+        return successIcon + this.translocoService.translate('cbl-conflict-reason-pipe.success');
       case CblImportReason.InvalidFile:
         return failIcon + this.translocoService.translate('cbl-conflict-reason-pipe.invalid-file');
     }

--- a/UI/Web/src/app/_pipes/keybind-setting-description.pipe.ts
+++ b/UI/Web/src/app/_pipes/keybind-setting-description.pipe.ts
@@ -35,7 +35,7 @@ export class KeybindSettingDescriptionPipe implements PipeTransform {
       case KeyBindTarget.PageUp:
         return this.create('key-bind-title-page-up', 'key-bind-tooltip-page-up');
       case KeyBindTarget.PageDown:
-        return this.create('key-bind-title-page-down', 'key-bind-tooltip-page-up');
+        return this.create('key-bind-title-page-down', 'key-bind-tooltip-page-down');
       case KeyBindTarget.OffsetDoublePage:
         return this.create('key-bind-title-offset-double-page', 'key-bind-tooltip-offset-double-page');
     }

--- a/UI/Web/src/app/_pipes/keybind-setting-description.pipe.ts
+++ b/UI/Web/src/app/_pipes/keybind-setting-description.pipe.ts
@@ -36,6 +36,8 @@ export class KeybindSettingDescriptionPipe implements PipeTransform {
         return this.create('key-bind-title-page-up', 'key-bind-tooltip-page-up');
       case KeyBindTarget.PageDown:
         return this.create('key-bind-title-page-down', 'key-bind-tooltip-page-up');
+      case KeyBindTarget.OffsetDoublePage:
+        return this.create('key-bind-title-offset-double-page', 'key-bind-tooltip-offset-double-page');
     }
   }
 

--- a/UI/Web/src/app/_pipes/pdf-render-resolution.pipe.ts
+++ b/UI/Web/src/app/_pipes/pdf-render-resolution.pipe.ts
@@ -1,0 +1,20 @@
+﻿import {Pipe, PipeTransform} from '@angular/core';
+import {PdfRenderResolution} from "../admin/_models/pdf-render-resolution";
+import {translate} from "@jsverse/transloco";
+
+@Pipe({
+  name: 'pdfRenderResolution',
+  standalone: true
+})
+export class PdfRenderResolutionPipe implements PipeTransform {
+  transform(value: PdfRenderResolution): string {
+    switch (value) {
+      case PdfRenderResolution.Default:
+        return translate('pdf-render-resolution.default');
+      case PdfRenderResolution.High:
+        return translate('pdf-render-resolution.high');
+      case PdfRenderResolution.Ultra:
+        return translate('pdf-render-resolution.ultra');
+    }
+  }
+}

--- a/UI/Web/src/app/_pipes/sort-field.pipe.ts
+++ b/UI/Web/src/app/_pipes/sort-field.pipe.ts
@@ -71,7 +71,9 @@ export class SortFieldPipe implements PipeTransform {
         return this.translocoService.translate('sort-field-pipe.average-rating');
       case SortField.Random:
         return this.translocoService.translate('sort-field-pipe.random');
-    }
+      case SortField.UserRating:
+          return this.translocoService.translate('sort-field-pipe.user-rating');
+      }
   }
 
 }

--- a/UI/Web/src/app/_resolvers/reading-profile.resolver.ts
+++ b/UI/Web/src/app/_resolvers/reading-profile.resolver.ts
@@ -12,5 +12,6 @@ export const readingProfileResolver: ResolveFn<ReadingProfile> = (
 
   // Extract seriesId from route params or parent route
   const seriesId = route.params['seriesId'] || route.parent?.params['seriesId'];
-  return readingProfileService.getForSeries(seriesId);
+  const libraryId = route.params['libraryId'] || route.parent?.params['libraryId'];
+  return readingProfileService.getForSeries(libraryId, seriesId);
 };

--- a/UI/Web/src/app/_services/action.service.ts
+++ b/UI/Web/src/app/_services/action.service.ts
@@ -800,7 +800,6 @@ export class ActionService {
 
     this.readingListModalRef = this.modalService.open(BulkSetReadingProfileModalComponent, { scrollable: true, size: 'md', fullscreen: 'md' });
     this.readingListModalRef.componentInstance.seriesIds = series.map(s => s.id)
-    this.readingListModalRef.componentInstance.title = '';
 
     this.readingListModalRef.closed.subscribe(() => {
       this.readingListModalRef = null;
@@ -826,7 +825,6 @@ export class ActionService {
 
     this.readingListModalRef = this.modalService.open(BulkSetReadingProfileModalComponent, { scrollable: true, size: 'md', fullscreen: 'md' });
     this.readingListModalRef.componentInstance.libraryId = library.id;
-    this.readingListModalRef.componentInstance.title = ""
 
     this.readingListModalRef.closed.subscribe(() => {
       this.readingListModalRef = null;

--- a/UI/Web/src/app/_services/device.service.ts
+++ b/UI/Web/src/app/_services/device.service.ts
@@ -8,6 +8,7 @@ import {TextResonse} from '../_types/text-response';
 import {AccountService} from './account.service';
 import {ClientDevice} from "../_models/client-device";
 import {map} from "rxjs/operators";
+import {toSignal} from "@angular/core/rxjs-interop";
 
 @Injectable({
   providedIn: 'root'
@@ -21,6 +22,7 @@ export class DeviceService {
 
   private readonly devicesSource: ReplaySubject<Device[]> = new ReplaySubject<Device[]>(1);
   public readonly devices$ = this.devicesSource.asObservable().pipe(shareReplay());
+  public readonly devicesSignal = toSignal(this.devices$, { initialValue: [] });
 
 
 

--- a/UI/Web/src/app/_services/epub-reader-menu.service.ts
+++ b/UI/Web/src/app/_services/epub-reader-menu.service.ts
@@ -141,13 +141,14 @@ export class EpubReaderMenuService {
   }
 
 
-  openSettingsDrawer(chapterId: number, seriesId: number, readingProfile: ReadingProfile, readerSettingsService: EpubReaderSettingsService) {
+  openSettingsDrawer(chapterId: number, seriesId: number, libraryId: number, readingProfile: ReadingProfile, readerSettingsService: EpubReaderSettingsService) {
     if (this.offcanvasService.hasOpenOffcanvas()) {
       this.offcanvasService.dismiss();
     }
     const ref = this.offcanvasService.open(EpubSettingDrawerComponent, {position: 'start', panelClass: ''});
     ref.componentInstance.chapterId.set(chapterId);
     ref.componentInstance.seriesId.set(seriesId);
+    ref.componentInstance.libraryId.set(libraryId);
     ref.componentInstance.readingProfile.set(readingProfile);
     ref.componentInstance.readerSettingsService.set(readerSettingsService);
 

--- a/UI/Web/src/app/_services/key-bind.service.ts
+++ b/UI/Web/src/app/_services/key-bind.service.ts
@@ -127,6 +127,7 @@ export const DefaultKeyBinds: Readonly<Record<KeyBindTarget, KeyBind[]>> = {
   [KeyBindTarget.Escape]: [{key: KeyCode.Escape}],
   [KeyBindTarget.PageUp]: [{key: KeyCode.ArrowUp}],
   [KeyBindTarget.PageDown]: [{key: KeyCode.ArrowDown}],
+  [KeyBindTarget.OffsetDoublePage]: [{key: KeyCode.KeyO}],
 } as const;
 
 type KeyBindGroup = {
@@ -161,6 +162,7 @@ export const KeyBindGroups: KeyBindGroup[] = [
       {target: KeyBindTarget.PageLeft},
       {target: KeyBindTarget.PageUp},
       {target: KeyBindTarget.PageDown},
+      {target: KeyBindTarget.OffsetDoublePage},
     ],
   }
 ];

--- a/UI/Web/src/app/_services/key-bind.service.ts
+++ b/UI/Web/src/app/_services/key-bind.service.ts
@@ -278,6 +278,7 @@ export class KeyBindService {
 
   private handleKeyEvent(event: KeyboardEvent) {
     if (this.disabled()) return;
+    if (!event.hasOwnProperty('key')) return;
 
     const eventKey = event.key.toLowerCase() as KeyCode;
 

--- a/UI/Web/src/app/_services/reader.service.ts
+++ b/UI/Web/src/app/_services/reader.service.ts
@@ -703,7 +703,7 @@ export class ReaderService {
 
     options.push({label: translate('reread-modal.cancel'), value: RereadPromptResult.Cancel});
 
-    component.items.set(options);
+    component.inputItems.set(options);
 
     return modal.closed.pipe(
       takeUntil(modal.dismissed),

--- a/UI/Web/src/app/_services/reading-profile.service.ts
+++ b/UI/Web/src/app/_services/reading-profile.service.ts
@@ -11,20 +11,24 @@ export class ReadingProfileService {
   private readonly httpClient = inject(HttpClient);
   baseUrl = environment.apiUrl;
 
-  getForSeries(seriesId: number, skipImplicit: boolean = false) {
-    return this.httpClient.get<ReadingProfile>(this.baseUrl + `reading-profile/${seriesId}?skipImplicit=${skipImplicit}`);
+  getForSeries(libraryId: number, seriesId: number, skipImplicit: boolean = false) {
+    return this.httpClient.get<ReadingProfile>(this.baseUrl + `reading-profile/${libraryId}/${seriesId}?skipImplicit=${skipImplicit}`);
+  }
+
+  getAllForSeries(seriesId: number) {
+    return this.httpClient.get<ReadingProfile[]>(this.baseUrl + `reading-profile/series?seriesId=${seriesId}`);
   }
 
   getForLibrary(libraryId: number) {
-    return this.httpClient.get<ReadingProfile | null>(this.baseUrl + `reading-profile/library?libraryId=${libraryId}`);
+    return this.httpClient.get<ReadingProfile[]>(this.baseUrl + `reading-profile/library?libraryId=${libraryId}`);
   }
 
   updateProfile(profile: ReadingProfile) {
     return this.httpClient.post<ReadingProfile>(this.baseUrl + 'reading-profile', profile);
   }
 
-  updateParentProfile(seriesId: number, profile: ReadingProfile) {
-    return this.httpClient.post<ReadingProfile>(this.baseUrl + `reading-profile/update-parent?seriesId=${seriesId}`, profile);
+  updateParentProfile(libraryId: number, seriesId: number, profile: ReadingProfile) {
+    return this.httpClient.post<ReadingProfile>(this.baseUrl + `reading-profile/update-parent?seriesId=${seriesId}&libraryId=${libraryId}`, profile);
   }
 
   createProfile(profile: ReadingProfile) {
@@ -35,8 +39,8 @@ export class ReadingProfileService {
     return this.httpClient.post<ReadingProfile>(this.baseUrl + "reading-profile/promote?profileId=" + profileId, {});
   }
 
-  updateImplicit(profile: ReadingProfile, seriesId: number) {
-    return this.httpClient.post<ReadingProfile>(this.baseUrl + "reading-profile/series?seriesId="+seriesId, profile);
+  updateImplicit(libraryId: number, seriesId: number, profile: ReadingProfile) {
+    return this.httpClient.post<ReadingProfile>(this.baseUrl + `reading-profile/series?seriesId=${seriesId}&libraryId=${libraryId}`, profile);
   }
 
   getAllProfiles() {
@@ -47,24 +51,30 @@ export class ReadingProfileService {
     return this.httpClient.delete(this.baseUrl + `reading-profile?profileId=${id}`);
   }
 
-  addToSeries(id: number, seriesId: number) {
-    return this.httpClient.post(this.baseUrl + `reading-profile/series/${seriesId}?profileId=${id}`, {});
+  addToSeries(ids: number[], seriesId: number) {
+    return this.httpClient.post(this.baseUrl + `reading-profile/series/${seriesId}`, ids);
   }
 
   clearSeriesProfiles(seriesId: number) {
     return this.httpClient.delete(this.baseUrl + `reading-profile/series/${seriesId}`, {});
   }
 
-  addToLibrary(id: number, libraryId: number) {
-    return this.httpClient.post(this.baseUrl + `reading-profile/library/${libraryId}?profileId=${id}`, {});
+  addToLibrary(ids: number[], libraryId: number) {
+    return this.httpClient.post(this.baseUrl + `reading-profile/library/${libraryId}`, ids);
   }
 
   clearLibraryProfiles(libraryId: number) {
     return this.httpClient.delete(this.baseUrl + `reading-profile/library/${libraryId}`, {});
   }
 
-  bulkAddToSeries(id: number, seriesIds: number[]) {
-    return this.httpClient.post(this.baseUrl + `reading-profile/bulk?profileId=${id}`, seriesIds);
+  bulkAddToSeries(ids: number[], seriesIds: number[]) {
+    const body = {profileIds: ids, seriesIds: seriesIds};
+
+    return this.httpClient.post(this.baseUrl + `reading-profile/bulk`, body);
+  }
+
+  setDevices(id: number, deviceIds: number[]) {
+    return this.httpClient.post(this.baseUrl + `reading-profile/set-devices?profileId=${id}`, deviceIds);
   }
 
 }

--- a/UI/Web/src/app/_single-module/actionable-modal/actionable-modal.component.ts
+++ b/UI/Web/src/app/_single-module/actionable-modal/actionable-modal.component.ts
@@ -47,23 +47,26 @@ export class ActionableModalComponent implements OnInit {
   user!: User | undefined;
 
   ngOnInit() {
-    this.currentItems = this.translateOptions(this.actions);
+    const actionItems = this.actions;
 
     // On Mobile, surface download
-    const otherActionIndex = this.currentItems.findIndex(i => i.action === Action.Submenu && i.title === 'actionable.other')
+    const otherActionIndex = actionItems.findIndex(i => i.action === Action.Submenu && i.title === 'others')
     if (otherActionIndex >= 0) {
-      const downloadActionIndex = this.currentItems[otherActionIndex].children.findIndex(a => a.action === Action.Download);
+      const downloadActionIndex = actionItems[otherActionIndex].children.findIndex(a => a.action === Action.Download);
 
       if (downloadActionIndex >= 0) {
-        const downloadAction = this.currentItems[otherActionIndex].children.splice(downloadActionIndex, 1)[0];
-        this.currentItems.push(downloadAction);
+        const downloadAction = actionItems[otherActionIndex].children.splice(downloadActionIndex, 1)[0];
+        actionItems.push(downloadAction);
 
         // Check if Other has any other children, else remove
-        if (this.currentItems[otherActionIndex].children.length === 0) {
-          this.currentItems.splice(otherActionIndex, 1);
+        if (actionItems[otherActionIndex].children.length === 0) {
+          actionItems.splice(otherActionIndex, 1);
         }
       }
     }
+
+    this.actions = actionItems;
+    this.currentItems = this.translateOptions(this.actions)
 
     this.accountService.currentUser$.pipe(tap(user => {
       this.user = user;

--- a/UI/Web/src/app/_single-module/actionable-modal/actionable-modal.component.ts
+++ b/UI/Web/src/app/_single-module/actionable-modal/actionable-modal.component.ts
@@ -47,7 +47,8 @@ export class ActionableModalComponent implements OnInit {
   user!: User | undefined;
 
   ngOnInit() {
-    const actionItems = this.actions;
+    // Copy as the list may be shared between entities
+    const actionItems = this.actions.map(action => this.utilityService.copyActionItem(action));
 
     // On Mobile, surface download
     const otherActionIndex = actionItems.findIndex(i => i.action === Action.Submenu && i.title === 'others')

--- a/UI/Web/src/app/_single-module/activity-card/activity-card.component.html
+++ b/UI/Web/src/app/_single-module/activity-card/activity-card.component.html
@@ -18,14 +18,6 @@
           <div class="media-info">
             <span class="badge bg-secondary platform-badge">{{ activeData.clientInfo?.platform | clientDevicePlatform }}</span>
             <span class="badge bg-primary device-badge">{{activeData.clientInfo?.clientType | clientDeviceClientType}}</span>
-            <span class="quantity-badge">
-              @let wordCount = totalWords();
-
-              {{t('pages-count', {num: totalPages()})}}
-              @if (wordCount > 0) {
-                <span> ({{t('words-count', {num: wordCount})}})</span>
-              }
-          </span>
           </div>
         </div>
 
@@ -36,15 +28,15 @@
           </div>
 
           <div class="metadata-row">
-            <span class="label text-uppercase">{{t('active-pages-label')}}</span>
-            <span class="value">{{activeData.pagesRead | defaultValue}}</span>
+            <span class="label text-uppercase">{{t('total-pages-label')}}</span>
+            <span class="value">{{totalPages() | defaultValue}}</span>
           </div>
 
 
-          @if (activeData.wordsRead > 0) {
+          @if (totalWords() > 0) {
             <div class="metadata-row">
-              <span class="label text-uppercase">{{t('active-words-label')}}</span>
-              <span class="value">{{activeData.wordsRead | defaultValue}}</span>
+              <span class="label text-uppercase">{{t('total-words-label')}}</span>
+              <span class="value">{{totalWords() | defaultValue}}</span>
             </div>
           }
 

--- a/UI/Web/src/app/_single-module/activity-card/activity-card.component.html
+++ b/UI/Web/src/app/_single-module/activity-card/activity-card.component.html
@@ -16,9 +16,9 @@
       <div class="activity-details">
         <div class="activity-header">
           <div class="media-info">
-            <span class="badge bg-secondary product-badge">{{ activeData.clientInfo?.platform | clientDevicePlatform }}</span>
-            <span class="badge bg-primary player-badge">{{activeData.clientInfo?.clientType | clientDeviceClientType}}</span>
-            <span class="quality-badge">
+            <span class="badge bg-secondary platform-badge">{{ activeData.clientInfo?.platform | clientDevicePlatform }}</span>
+            <span class="badge bg-primary device-badge">{{activeData.clientInfo?.clientType | clientDeviceClientType}}</span>
+            <span class="quantity-badge">
               @let wordCount = totalWords();
 
               {{t('pages-count', {num: totalPages()})}}

--- a/UI/Web/src/app/_single-module/activity-card/activity-card.component.html
+++ b/UI/Web/src/app/_single-module/activity-card/activity-card.component.html
@@ -19,10 +19,12 @@
             <span class="badge bg-secondary product-badge">{{ activeData.clientInfo?.platform | clientDevicePlatform }}</span>
             <span class="badge bg-primary player-badge">{{activeData.clientInfo?.clientType | clientDeviceClientType}}</span>
             <span class="quality-badge">
-            {{t('pages-count', {num: activeData.pagesRead})}}
-            @if (activeData.wordsRead > 0) {
-              <span> ({{t('words-count', {num: activeData.wordsRead})}})</span>
-            }
+              @let wordCount = totalWords();
+
+              {{t('pages-count', {num: totalPages()})}}
+              @if (wordCount > 0) {
+                <span> ({{t('words-count', {num: wordCount})}})</span>
+              }
           </span>
           </div>
         </div>
@@ -31,6 +33,24 @@
           <div class="metadata-row">
             <span class="label text-uppercase">{{t('started-label')}}</span>
             <span class="value">{{activeData.startTimeUtc | utcToLocalDate | timeAgo}}</span>
+          </div>
+
+          <div class="metadata-row">
+            <span class="label text-uppercase">{{t('active-pages-label')}}</span>
+            <span class="value">{{activeData.pagesRead | defaultValue}}</span>
+          </div>
+
+
+          @if (activeData.wordsRead > 0) {
+            <div class="metadata-row">
+              <span class="label text-uppercase">{{t('active-words-label')}}</span>
+              <span class="value">{{activeData.wordsRead | defaultValue}}</span>
+            </div>
+          }
+
+          <div class="metadata-row">
+            <span class="label text-uppercase">{{t('total-chapters-label')}}</span>
+            <span class="value">{{distinctChapters() | defaultValue}}</span>
           </div>
         </div>
 

--- a/UI/Web/src/app/_single-module/activity-card/activity-card.component.scss
+++ b/UI/Web/src/app/_single-module/activity-card/activity-card.component.scss
@@ -82,11 +82,6 @@
     padding: 4px 8px;
   }
 
-  .quantity-badge {
-    color: var(--activity-card-client-quantity-badge-bg-color);
-    font-size: 12px;
-    font-weight: 500;
-  }
 
   .session-metadata {
     margin-bottom: 12px;

--- a/UI/Web/src/app/_single-module/activity-card/activity-card.component.scss
+++ b/UI/Web/src/app/_single-module/activity-card/activity-card.component.scss
@@ -1,7 +1,8 @@
 
 
+
 .activity-card {
-  background: #1a1a1a;
+  background: var(--elevation-layer1-dark-solid);
   border-radius: 8px;
   overflow: hidden;
   margin-bottom: 20px;
@@ -9,7 +10,7 @@
 
   &:hover {
     transform: translateY(-2px);
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    box-shadow: 0 4px 12px var(--elevation-layer10-dark);
   }
 
   .activity-content {
@@ -37,9 +38,9 @@
       width: 60px;
       height: 85px;
       object-fit: cover;
-      border: 2px solid #1a1a1a;
+      border: 2px solid var(--elevation-layer1-dark-solid);
       border-radius: 4px;
-      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.5);
+      box-shadow: 0 2px 8px var(--elevation-layer11-dark);
     }
   }
 
@@ -48,7 +49,7 @@
     padding: 16px;
     display: flex;
     flex-direction: column;
-    background: linear-gradient(to right, rgba(0, 0, 0, 0.8), #1a1a1a);
+    background: linear-gradient(to right, var(--elevation-layer11-dark), var(--elevation-layer1-dark-solid));
     min-width: 0; // Allow text truncation
   }
 
@@ -68,33 +69,23 @@
     align-items: center;
   }
 
-  .product-badge {
-    background: #8b5cf6 !important;
+  .platform-badge {
+    background: var(--activity-card-client-platform-badge-bg-color) !important;
     font-size: 11px;
     padding: 4px 8px;
     font-weight: 600;
   }
 
-  .player-badge {
-    background: #3b82f6 !important;
+  .device-badge {
+    background: var(--activity-card-client-device-badge-bg-color);
     font-size: 11px;
     padding: 4px 8px;
   }
 
-  .quality-badge {
-    color: #cbd5e1;
+  .quantity-badge {
+    color: var(--activity-card-client-quantity-badge-bg-color);
     font-size: 12px;
     font-weight: 500;
-  }
-
-  .badge-stream {
-    background: #22c55e;
-    color: white;
-    font-size: 11px;
-    padding: 4px 10px;
-    border-radius: 4px;
-    text-transform: uppercase;
-    font-weight: 600;
   }
 
   .session-metadata {
@@ -107,14 +98,10 @@
       font-size: 12px;
 
       .label {
-        color: #94a3b8;
+        color: var(--offwhite-text-color);
         text-transform: uppercase;
         font-weight: 600;
         min-width: 80px;
-      }
-
-      .value {
-        color: #e2e8f0;
       }
     }
   }
@@ -123,7 +110,7 @@
     margin-bottom: 12px;
 
     .progress {
-      background: #334155;
+      background: var(--progress-bg-color);
       border-radius: 2px;
     }
 
@@ -132,7 +119,7 @@
       justify-content: flex-end;
       margin-top: 4px;
       font-size: 11px;
-      color: #94a3b8;
+      color: var(--offwhite-text-color);
     }
   }
 
@@ -145,7 +132,7 @@
 
     .play-icon {
       font-size: 24px;
-      color: #f59e0b;
+      color: var(--primary-color);
       flex-shrink: 0;
     }
 
@@ -155,7 +142,7 @@
     }
 
     .series-title {
-      color: #f1f5f9;
+      color: var(--primary-color);
       font-size: 16px;
       font-weight: 600;
       white-space: nowrap;
@@ -164,7 +151,7 @@
     }
 
     .chapter-info {
-      color: #94a3b8;
+      color: var(--offwhite-text-color);
       font-size: 13px;
       white-space: nowrap;
       overflow: hidden;
@@ -177,10 +164,10 @@
     justify-content: flex-end;
     align-items: center;
     padding-top: 8px;
-    border-top: 1px solid #334155;
+    border-top: 1px solid var(--offwhite-text-color);
 
     .username {
-      color: #cbd5e1;
+      color: var(--offwhite-text-color);
       font-size: 13px;
       font-weight: 500;
     }

--- a/UI/Web/src/app/_single-module/activity-card/activity-card.component.ts
+++ b/UI/Web/src/app/_single-module/activity-card/activity-card.component.ts
@@ -1,4 +1,4 @@
-import {ChangeDetectionStrategy, Component, inject, input} from '@angular/core';
+import {ChangeDetectionStrategy, Component, computed, inject, input} from '@angular/core';
 import {TranslocoDirective} from "@jsverse/transloco";
 import {ReadingSession} from "../../_models/progress/reading-session";
 import {ImageService} from "../../_services/image.service";
@@ -31,5 +31,19 @@ export class ActivityCardComponent {
   protected readonly imageService = inject(ImageService);
 
   session = input.required<ReadingSession>();
+
+  totalPages = computed(() => {
+    return this.session().activityData.reduce((sum, curr) => sum + curr.pagesRead, 0);
+  });
+
+  totalWords = computed(() => {
+    return this.session().activityData.reduce((sum, curr) => sum + curr.wordsRead, 0);
+  });
+
+  distinctChapters = computed(() => {
+    return new Set(this.session().activityData.map(d => d.chapterId)).size;
+  });
+
+
 
 }

--- a/UI/Web/src/app/_single-module/annotations-tab/annotations-tab.component.html
+++ b/UI/Web/src/app/_single-module/annotations-tab/annotations-tab.component.html
@@ -1,4 +1,4 @@
-<div class="mb-3" *transloco="let t;prefix:'annotations-tab'">
+<div class="mb-3">
   <virtual-scroller #scroll [items]="annotations()"  [parentScroll]="scrollingBlock()" [childHeight]="1">
     <div class="card-container row g-0" #container>
       @for(item of scroll.viewPortItems; let idx = $index; track item.id) {

--- a/UI/Web/src/app/_single-module/annotations-tab/annotations-tab.component.ts
+++ b/UI/Web/src/app/_single-module/annotations-tab/annotations-tab.component.ts
@@ -1,5 +1,4 @@
 import {ChangeDetectionStrategy, Component, input} from '@angular/core';
-import {TranslocoDirective} from "@jsverse/transloco";
 import {Annotation} from "../../book-reader/_models/annotations/annotation";
 import {
   AnnotationCardComponent
@@ -9,7 +8,6 @@ import {VirtualScrollerModule} from "@iharbeck/ngx-virtual-scroller";
 @Component({
   selector: 'app-annotations-tab',
   imports: [
-    TranslocoDirective,
     AnnotationCardComponent,
     VirtualScrollerModule
   ],

--- a/UI/Web/src/app/_single-module/card-actionables/card-actionables.component.html
+++ b/UI/Web/src/app/_single-module/card-actionables/card-actionables.component.html
@@ -26,11 +26,11 @@
                 @for(dynamicItem of dList; track dynamicItem.title) {
                   <button ngbDropdownItem (click)="performDynamicClick($event, action, dynamicItem)">{{dynamicItem.title}}</button>
                 }
-              } @else if (willRenderAction(action, this.currentUser!)) {
+              } @else if (willRenderAction(action, this.currentUser()!)) {
                 <button ngbDropdownItem (click)="performAction($event, action)">{{t(action.title)}}</button>
               }
             } @else {
-              @if (shouldRenderSubMenu(action, action.children?.[0].dynamicList | async) && hasRenderableChildren(action, this.currentUser!)) {
+              @if (shouldRenderSubMenu(action, action.children?.[0].dynamicList | async) && hasRenderableChildren(action, this.currentUser()!)) {
                 <!-- Submenu items -->
                 <div ngbDropdown #subMenuHover="ngbDropdown" placement="right left"
                      (click)="openSubmenu(action.title, subMenuHover)"
@@ -39,7 +39,7 @@
                      class="submenu-wrapper">
 
                   <!-- Check to ensure the submenu has items -->
-                  @if (willRenderAction(action, this.currentUser!)) {
+                  @if (willRenderAction(action, this.currentUser()!)) {
                     <button id="actions-{{action.title}}" class="submenu-toggle" ngbDropdownToggle>
                       {{t(action.title)}} <i class="fa-solid fa-angle-right submenu-icon"></i>
                     </button>

--- a/UI/Web/src/app/_single-module/card-actionables/card-actionables.component.scss
+++ b/UI/Web/src/app/_single-module/card-actionables/card-actionables.component.scss
@@ -42,3 +42,7 @@
     float: right;
     padding: var(--bs-dropdown-item-padding-y) 0;
 }
+
+:host .dropdown-toggle.btn:disabled {
+  border: none;
+}

--- a/UI/Web/src/app/_single-module/card-actionables/card-actionables.component.ts
+++ b/UI/Web/src/app/_single-module/card-actionables/card-actionables.component.ts
@@ -32,7 +32,7 @@ import {User} from "../../_models/user/user";
   styleUrls: ['./card-actionables.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class CardActionablesComponent implements OnChanges, OnDestroy {
+export class CardActionablesComponent implements OnDestroy {
 
   private readonly cdRef = inject(ChangeDetectorRef);
   private readonly accountService = inject(AccountService);
@@ -43,7 +43,7 @@ export class CardActionablesComponent implements OnChanges, OnDestroy {
 
   iconClass = input<string>('fa-ellipsis-v');
   btnClass = input<string>('');
-  inputActions = input<ActionItem<any>[]>([]);
+  actions = input<ActionItem<any>[]>([]);
   labelBy = input<string>('card');
   /**
    * Text to display as if actionable was a button
@@ -57,29 +57,9 @@ export class CardActionablesComponent implements OnChanges, OnDestroy {
    */
   @Output() actionHandler = new EventEmitter<ActionItem<any>>();
 
-
-  actions = model<ActionItem<ActionableEntity>[]>([]);
-  currentUser: User | undefined = undefined;
+  currentUser = this.accountService.currentUserSignal;
   submenu: {[key: string]: NgbDropdown} = {};
   private closeTimeout: any = null;
-
-  constructor() {
-    effect(() => {
-      const user = this.accountService.currentUserSignal();
-      if (!user) return;
-
-      this.currentUser = user;
-      this.actions.set(this.inputActions().filter(a => this.willRenderAction(a, user)));
-      this.cdRef.markForCheck();
-    });
-  }
-
-  ngOnChanges() {
-    if (!this.currentUser) return; // We can safely return as actionables will never be visible if there is no user
-
-    this.actions.set(this.inputActions().filter(a => this.willRenderAction(a, this.currentUser!)));
-    this.cdRef.markForCheck();
-  }
 
   ngOnDestroy() {
     this.cancelCloseSubmenus();

--- a/UI/Web/src/app/_single-module/card-actionables/card-actionables.component.ts
+++ b/UI/Web/src/app/_single-module/card-actionables/card-actionables.component.ts
@@ -1,16 +1,4 @@
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  effect,
-  EventEmitter,
-  inject,
-  input,
-  model,
-  OnChanges,
-  OnDestroy,
-  Output
-} from '@angular/core';
+import {ChangeDetectionStrategy, Component, EventEmitter, inject, input, OnDestroy, Output} from '@angular/core';
 import {NgbDropdown, NgbDropdownItem, NgbDropdownMenu, NgbDropdownToggle, NgbModal} from '@ng-bootstrap/ng-bootstrap';
 import {AccountService} from 'src/app/_services/account.service';
 import {ActionableEntity, ActionItem} from 'src/app/_services/action-factory.service';
@@ -34,7 +22,6 @@ import {User} from "../../_models/user/user";
 })
 export class CardActionablesComponent implements OnDestroy {
 
-  private readonly cdRef = inject(ChangeDetectorRef);
   private readonly accountService = inject(AccountService);
   protected readonly utilityService = inject(UtilityService);
   protected readonly modalService = inject(NgbModal);

--- a/UI/Web/src/app/_single-module/client-device-card/client-device-card.component.html
+++ b/UI/Web/src/app/_single-module/client-device-card/client-device-card.component.html
@@ -24,15 +24,10 @@
                 {{clientDevice().currentClientInfo.authType | clientDeviceAuthType}}
               </span>
               <span class="ms-2">{{clientDevice().ownerUsername}}</span>
-              <!--TODO: I'm not happy with how ip address renders out-->
-<!--              <span class="ms-1">-->
-<!--                <i class="fa-solid fa-network-wired" aria-hidden="true"></i>-->
-<!--                {{ ipAddress() | defaultValue }}-->
-<!--              </span>-->
             </div>
           </div>
           <div class="text-end">
-            <app-card-actionables [actions]="actions()" [entity]="clientDevice()" />
+            <app-card-actionables [actions]="actions()" [entity]="clientDevice()" [disabled]="clientDevice().ownerUserId != currentUserId()" />
           </div>
         </div>
 

--- a/UI/Web/src/app/_single-module/client-device-card/client-device-card.component.html
+++ b/UI/Web/src/app/_single-module/client-device-card/client-device-card.component.html
@@ -17,6 +17,9 @@
               }
             </h5>
             <div class="text-muted small">
+              @if (clientDevice().uiFingerprint === clientInfoService.getDeviceId()) {
+                <span class="badge bg-primary me-2">{{t('active')}}</span>
+              }
               <span class="badge" [class]="clientTypeBadgeClass()">
                 {{clientDevice().currentClientInfo.clientType | clientDeviceClientType}}
               </span>

--- a/UI/Web/src/app/_single-module/client-device-card/client-device-card.component.html
+++ b/UI/Web/src/app/_single-module/client-device-card/client-device-card.component.html
@@ -32,7 +32,7 @@
             </div>
           </div>
           <div class="text-end">
-            <app-card-actionables [inputActions]="actions()" [entity]="clientDevice()" />
+            <app-card-actionables [actions]="actions()" [entity]="clientDevice()" />
           </div>
         </div>
 

--- a/UI/Web/src/app/_single-module/client-device-card/client-device-card.component.ts
+++ b/UI/Web/src/app/_single-module/client-device-card/client-device-card.component.ts
@@ -65,6 +65,10 @@ export class ClientDeviceCardComponent {
     name: new FormControl('', [Validators.required]),
   });
 
+  currentUserId = computed(() => {
+    return this.accountService.currentUserSignal()?.id;
+  });
+
   ipAddress = computed(() => {
     const address = this.clientDevice().currentClientInfo.ipAddress;
     if (!address) return null;

--- a/UI/Web/src/app/_single-module/client-device-card/client-device-card.component.ts
+++ b/UI/Web/src/app/_single-module/client-device-card/client-device-card.component.ts
@@ -2,7 +2,7 @@ import {ChangeDetectionStrategy, Component, computed, HostListener, inject, inpu
 import {ClientDevice} from "../../_models/client-device";
 import {translate, TranslocoDirective} from "@jsverse/transloco";
 import {TimeAgoPipe} from "../../_pipes/time-ago.pipe";
-import {ClientDeviceType} from "../../_services/client-info.service";
+import {ClientDeviceType, ClientInfoService} from "../../_services/client-info.service";
 import {ClientDeviceAuthTypePipe} from "../../_pipes/client-device-authtype.pipe";
 import {DefaultValuePipe} from "../../_pipes/default-value.pipe";
 import {ClientDevicePlatformPipe} from "../../_pipes/client-device-platform.pipe";
@@ -46,6 +46,7 @@ export class ClientDeviceCardComponent {
   private readonly deviceService = inject(DeviceService);
   private readonly document = inject(DOCUMENT);
   private readonly accountService = inject(AccountService);
+  protected readonly clientInfoService = inject(ClientInfoService);
 
   clientDevice = input.required<ClientDevice>();
 

--- a/UI/Web/src/app/_single-module/edit-chapter-modal/edit-chapter-modal.component.html
+++ b/UI/Web/src/app/_single-module/edit-chapter-modal/edit-chapter-modal.component.html
@@ -472,9 +472,30 @@
                   </div>
                 </div>
 
-                <!-- translator -->
+                <!-- editor & translator -->
                 <div class="row">
-                  <div class="col-lg-12 col-md-12 pe-2">
+                  <div class="col-lg-6 col-md-12 pe-2">
+                    <div class="mb-3">
+                      @if(getPersonsSettings(PersonRole.Editor); as settings) {
+                        <app-setting-item [title]="t('editor-label')" [toggleOnViewClick]="false" [showEdit]="false">
+                          <ng-template #view>
+                            <app-typeahead (selectedData)="updatePerson($event, PersonRole.Editor);chapter.editorLocked = true" [settings]="settings"
+                                           [(locked)]="chapter.editorLocked" (onUnlock)="chapter.editorLocked = false"
+                                           (newItemAdded)="chapter.editorLocked = true">
+                              <ng-template #badgeItem let-item let-position="idx">
+                                {{item.name}}
+                              </ng-template>
+                              <ng-template #optionItem let-item let-position="idx">
+                                {{item.name}}
+                              </ng-template>
+                            </app-typeahead>
+                          </ng-template>
+                        </app-setting-item>
+                      }
+                    </div>
+                  </div>
+
+                  <div class="col-lg-6 col-md-12 pe-2">
                     <div class="mb-3">
                       @if(getPersonsSettings(PersonRole.Translator); as settings) {
                         <app-setting-item [title]="t('translator-label')" [toggleOnViewClick]="false" [showEdit]="false">

--- a/UI/Web/src/app/_single-module/edit-chapter-modal/edit-chapter-modal.component.ts
+++ b/UI/Web/src/app/_single-module/edit-chapter-modal/edit-chapter-modal.component.ts
@@ -45,7 +45,8 @@ enum TabID {
   Info = 'info-tab',
   People = 'people-tab',
   Tasks = 'tasks-tab',
-  Tags = 'tags-tab'
+  Tags = 'tags-tab',
+  Weblinks = 'weblinks-tab', // TODO: Weblinks are not implemented
 }
 
 export interface EditChapterModalCloseResult {

--- a/UI/Web/src/app/admin/_models/pdf-render-resolution.ts
+++ b/UI/Web/src/app/admin/_models/pdf-render-resolution.ts
@@ -1,0 +1,9 @@
+﻿export enum PdfRenderResolution {
+  Default = 1,
+  High = 2,
+  Ultra = 3,
+}
+
+export const allPdfRenderResolutions = Object.keys(PdfRenderResolution)
+  .filter(key => !isNaN(Number(key)) && parseInt(key, 10) >= 0)
+  .map(key => parseInt(key, 10)) as PdfRenderResolution[];

--- a/UI/Web/src/app/admin/_models/server-settings.ts
+++ b/UI/Web/src/app/admin/_models/server-settings.ts
@@ -1,6 +1,7 @@
 import {EncodeFormat} from "./encode-format";
 import {CoverImageSize} from "./cover-image-size";
 import {SmtpConfig} from "./smtp-config";
+import {PdfRenderResolution} from "./pdf-render-resolution";
 import {OidcConfig} from "./oidc-config";
 
 export interface ServerSettings {
@@ -25,6 +26,7 @@ export interface ServerSettings {
     onDeckProgressDays: number;
     onDeckUpdateDays: number;
     coverImageSize: CoverImageSize;
+    pdfRenderResolution: PdfRenderResolution;
     smtpConfig: SmtpConfig;
     oidcConfig: OidcConfig;
     installId: string;

--- a/UI/Web/src/app/admin/email-history/email-history.component.html
+++ b/UI/Web/src/app/admin/email-history/email-history.component.html
@@ -1,93 +1,97 @@
 <ng-container *transloco="let t; prefix:'email-history'">
   <p>{{t('description')}}</p>
 
-  <app-responsive-table [rows]="data" [trackByFn]="trackBy">
-    <ng-template #tableTemplate>
-      <ngx-datatable
-        class="bootstrap"
-        [rows]="data"
-        [columnMode]="ColumnMode.force"
-        rowHeight="auto"
-        [footerHeight]="50"
-      >
+  @if (data.length === 0) {
+    <p>{{t('no-data')}}</p>
+  } @else {
+    <app-responsive-table [rows]="data" [trackByFn]="trackBy">
+      <ng-template #tableTemplate>
+        <ngx-datatable
+          class="bootstrap"
+          [rows]="data"
+          [columnMode]="ColumnMode.force"
+          rowHeight="auto"
+          [footerHeight]="50"
+        >
 
-        <ngx-datatable-column prop="emailTemplate" [sortable]="true" [draggable]="false" [resizeable]="false">
-          <ng-template let-column="column" ngx-datatable-header-template>
-            {{t('template-header')}}
-          </ng-template>
-          <ng-template let-item="row" ngx-datatable-cell-template>
-            {{item.emailTemplate}}
-          </ng-template>
-        </ngx-datatable-column>
+          <ngx-datatable-column prop="emailTemplate" [sortable]="true" [draggable]="false" [resizeable]="false">
+            <ng-template let-column="column" ngx-datatable-header-template>
+              {{t('template-header')}}
+            </ng-template>
+            <ng-template let-item="row" ngx-datatable-cell-template>
+              {{item.emailTemplate}}
+            </ng-template>
+          </ngx-datatable-column>
 
 
-        <ngx-datatable-column prop="sendDate" [sortable]="true" [draggable]="false" [resizeable]="false">
-          <ng-template let-column="column" ngx-datatable-header-template>
-            {{t('date-header')}}
-          </ng-template>
-          <ng-template let-item="row" ngx-datatable-cell-template>
-            {{item.sendDate | utcToLocalTime}}
-          </ng-template>
-        </ngx-datatable-column>
+          <ngx-datatable-column prop="sendDate" [sortable]="true" [draggable]="false" [resizeable]="false">
+            <ng-template let-column="column" ngx-datatable-header-template>
+              {{t('date-header')}}
+            </ng-template>
+            <ng-template let-item="row" ngx-datatable-cell-template>
+              {{item.sendDate | utcToLocalTime}}
+            </ng-template>
+          </ngx-datatable-column>
 
-        <ngx-datatable-column prop="toUserName" [sortable]="true" [draggable]="false" [resizeable]="false">
-          <ng-template let-column="column" ngx-datatable-header-template>
-            {{t('user-header')}}
-          </ng-template>
-          <ng-template let-item="row" ngx-datatable-cell-template>
-            {{item.toUserName}}
-          </ng-template>
-        </ngx-datatable-column>
+          <ngx-datatable-column prop="toUserName" [sortable]="true" [draggable]="false" [resizeable]="false">
+            <ng-template let-column="column" ngx-datatable-header-template>
+              {{t('user-header')}}
+            </ng-template>
+            <ng-template let-item="row" ngx-datatable-cell-template>
+              {{item.toUserName}}
+            </ng-template>
+          </ngx-datatable-column>
 
-        <ngx-datatable-column prop="sent" [sortable]="true" [draggable]="false" [resizeable]="false">
-          <ng-template let-column="column" ngx-datatable-header-template>
-            {{t('sent-header')}}
-          </ng-template>
-          <ng-template let-item="row" ngx-datatable-cell-template>
-            @if (item.sent) {
-              <i class="fa-solid fa-check-circle successful-validation ms-1">
-                <span class="visually-hidden">{{t('sent-tooltip')}}</span>
-              </i>
-            } @else {
-              <i class="error fa-solid fa-exclamation-circle ms-1">
-                <span class="visually-hidden">{{t('not-sent-tooltip')}}</span>
-              </i>
-            }
-          </ng-template>
-        </ngx-datatable-column>
-      </ngx-datatable>
-    </ng-template>
-    <ng-template #cardTemplate let-item let-idx="index">
-      <div class="card mb-3">
-        <div class="card-body">
-          <!-- Header with template name and status -->
-          <div class="d-flex justify-content-between align-items-start mb-3">
-            <h5 class="card-title mb-0">{{item.emailTemplate}}</h5>
-            <div>
+          <ngx-datatable-column prop="sent" [sortable]="true" [draggable]="false" [resizeable]="false">
+            <ng-template let-column="column" ngx-datatable-header-template>
+              {{t('sent-header')}}
+            </ng-template>
+            <ng-template let-item="row" ngx-datatable-cell-template>
               @if (item.sent) {
-                <i class="fa-solid fa-check-circle text-success" aria-hidden="true"></i>
-                <span class="visually-hidden">{{t('sent-tooltip')}}</span>
+                <i class="fa-solid fa-check-circle successful-validation ms-1">
+                  <span class="visually-hidden">{{t('sent-tooltip')}}</span>
+                </i>
               } @else {
-                <i class="fa-solid fa-exclamation-circle text-danger" aria-hidden="true"></i>
-                <span class="visually-hidden">{{t('not-sent-tooltip')}}</span>
+                <i class="error fa-solid fa-exclamation-circle ms-1">
+                  <span class="visually-hidden">{{t('not-sent-tooltip')}}</span>
+                </i>
               }
+            </ng-template>
+          </ngx-datatable-column>
+        </ngx-datatable>
+      </ng-template>
+      <ng-template #cardTemplate let-item let-idx="index">
+        <div class="card mb-3">
+          <div class="card-body">
+            <!-- Header with template name and status -->
+            <div class="d-flex justify-content-between align-items-start mb-3">
+              <h5 class="card-title mb-0">{{item.emailTemplate}}</h5>
+              <div>
+                @if (item.sent) {
+                  <i class="fa-solid fa-check-circle text-success" aria-hidden="true"></i>
+                  <span class="visually-hidden">{{t('sent-tooltip')}}</span>
+                } @else {
+                  <i class="fa-solid fa-exclamation-circle text-danger" aria-hidden="true"></i>
+                  <span class="visually-hidden">{{t('not-sent-tooltip')}}</span>
+                }
+              </div>
             </div>
-          </div>
 
-          <!-- Details -->
-          <div class="row g-2">
-            <div class="col-6">
-              <div class="text-muted small">{{t('date-header')}}</div>
-              <div>{{item.sendDate | utcToLocalTime}}</div>
-            </div>
+            <!-- Details -->
+            <div class="row g-2">
+              <div class="col-6">
+                <div class="text-muted small">{{t('date-header')}}</div>
+                <div>{{item.sendDate | utcToLocalTime}}</div>
+              </div>
 
-            <div class="col-6">
-              <div class="text-muted small">{{t('user-header')}}</div>
-              <div>{{item.toUserName}}</div>
+              <div class="col-6">
+                <div class="text-muted small">{{t('user-header')}}</div>
+                <div>{{item.toUserName}}</div>
+              </div>
             </div>
           </div>
         </div>
-      </div>
-    </ng-template>
-  </app-responsive-table>
+      </ng-template>
+    </app-responsive-table>
+  }
 </ng-container>

--- a/UI/Web/src/app/admin/manage-library/manage-library.component.html
+++ b/UI/Web/src/app/admin/manage-library/manage-library.component.html
@@ -1,7 +1,7 @@
 <ng-container *transloco="let t; prefix: 'manage-library'">
   <div class="position-relative">
     <div class="d-flex gap-2 position-absolute custom-position">
-      <app-card-actionables [inputActions]="bulkActions" btnClass="btn-outline-primary" [label]="t('bulk-action-label')"
+      <app-card-actionables [actions]="bulkActions" btnClass="btn-outline-primary" [label]="t('bulk-action-label')"
                             [disabled]="bulkMode" (actionHandler)="handleBulkAction($event, null!)">
       </app-card-actionables>
       <button class="btn btn-outline-primary" (click)="addLibrary()" [title]="t('add-library')">
@@ -72,7 +72,7 @@
           <td>
             <!-- On Mobile we want to use ... for each row -->
             @if (useActionables$ | async) {
-              <app-card-actionables [entity]="library" [inputActions]="actions" />
+              <app-card-actionables [entity]="library" [actions]="actions" />
             } @else {
               <button class="btn btn-secondary me-2 btn-sm" (click)="scanLibrary(library)" placement="top" [ngbTooltip]="t('scan-library')"
                       [attr.aria-label]="t('scan-library')">

--- a/UI/Web/src/app/admin/manage-media-settings/manage-media-settings.component.html
+++ b/UI/Web/src/app/admin/manage-media-settings/manage-media-settings.component.html
@@ -28,6 +28,23 @@
         </div>
 
         <div class="row g-0 mt-2">
+          @if(settingsForm.get('pdfRenderResolution'); as formControl) {
+            <app-setting-item [title]="t('pdf-render-resolution-label')" [subtitle]="t('pdf-render-resolution-tooltip')">
+              <ng-template #view>
+                {{formControl!.value | pdfRenderResolution}}
+              </ng-template>
+              <ng-template #edit>
+                <select class="form-select" formControlName="pdfRenderResolution">
+                  @for (opt of allPdfRenderResolutions; track opt) {
+                    <option [ngValue]="opt">{{opt | pdfRenderResolution}}</option>
+                  }
+                </select>
+              </ng-template>
+            </app-setting-item>
+          }
+        </div>
+
+        <div class="row g-0 mt-2">
           @if(settingsForm.get('coverImageSize'); as formControl) {
             <app-setting-item [title]="t('cover-image-size-label')" [subtitle]="t('cover-image-size-tooltip')">
               <ng-template #view>

--- a/UI/Web/src/app/admin/manage-media-settings/manage-media-settings.component.ts
+++ b/UI/Web/src/app/admin/manage-media-settings/manage-media-settings.component.ts
@@ -9,9 +9,11 @@ import {NgbModal} from '@ng-bootstrap/ng-bootstrap';
 import {allEncodeFormats} from '../_models/encode-format';
 import {translate, TranslocoDirective, TranslocoService} from "@jsverse/transloco";
 import {allCoverImageSizes, CoverImageSize} from '../_models/cover-image-size';
+import {PdfRenderResolution, allPdfRenderResolutions} from '../_models/pdf-render-resolution';
 import {SettingItemComponent} from "../../settings/_components/setting-item/setting-item.component";
 import {EncodeFormatPipe} from "../../_pipes/encode-format.pipe";
 import {CoverImageSizePipe} from "../../_pipes/cover-image-size.pipe";
+import {PdfRenderResolutionPipe} from "../../_pipes/pdf-render-resolution.pipe"
 import {ConfirmService} from "../../shared/confirm.service";
 import {takeUntilDestroyed} from "@angular/core/rxjs-interop";
 import {pageLayoutModes} from "../../_models/preferences/reading-profiles";
@@ -21,7 +23,7 @@ import {pageLayoutModes} from "../../_models/preferences/reading-profiles";
   templateUrl: './manage-media-settings.component.html',
   styleUrls: ['./manage-media-settings.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [ReactiveFormsModule, TranslocoDirective, SettingItemComponent, EncodeFormatPipe, CoverImageSizePipe]
+  imports: [ReactiveFormsModule, TranslocoDirective, SettingItemComponent, EncodeFormatPipe, CoverImageSizePipe, PdfRenderResolutionPipe]
 })
 export class ManageMediaSettingsComponent implements OnInit {
 
@@ -35,6 +37,7 @@ export class ManageMediaSettingsComponent implements OnInit {
 
   protected readonly allEncodeFormats = allEncodeFormats;
   protected readonly allCoverImageSizes = allCoverImageSizes;
+  protected readonly allPdfRenderResolutions = allPdfRenderResolutions;
 
   serverSettings!: ServerSettings;
   settingsForm: FormGroup = new FormGroup({});
@@ -46,6 +49,8 @@ export class ManageMediaSettingsComponent implements OnInit {
       this.settingsForm.addControl('encodeMediaAs', new FormControl(this.serverSettings.encodeMediaAs, [Validators.required]));
       this.settingsForm.addControl('bookmarksDirectory', new FormControl(this.serverSettings.bookmarksDirectory, [Validators.required]));
       this.settingsForm.addControl('coverImageSize', new FormControl(this.serverSettings.coverImageSize || CoverImageSize.Default, [Validators.required]));
+      this.settingsForm.addControl('pdfRenderResolution', new FormControl(this.serverSettings.pdfRenderResolution || PdfRenderResolution.Default, [Validators.required]));
+
 
       // Automatically save settings as we edit them
       this.settingsForm.valueChanges.pipe(
@@ -89,6 +94,7 @@ export class ManageMediaSettingsComponent implements OnInit {
     this.settingsForm.get('encodeMediaAs')?.setValue(this.serverSettings.encodeMediaAs, {onlySelf: true, emitEvent: false});
     this.settingsForm.get('bookmarksDirectory')?.setValue(this.serverSettings.bookmarksDirectory, {onlySelf: true, emitEvent: false});
     this.settingsForm.get('coverImageSize')?.setValue(this.serverSettings.coverImageSize, {onlySelf: true, emitEvent: false});
+    this.settingsForm.get('pdfRenderResolution')?.setValue(this.serverSettings.pdfRenderResolution, {onlySelf: true, emitEvent: false});
     this.settingsForm.markAsPristine();
     this.cdRef.markForCheck();
   }
@@ -98,6 +104,7 @@ export class ManageMediaSettingsComponent implements OnInit {
     modelSettings.encodeMediaAs = parseInt(this.settingsForm.get('encodeMediaAs')?.value, 10);
     modelSettings.bookmarksDirectory = this.settingsForm.get('bookmarksDirectory')?.value;
     modelSettings.coverImageSize = parseInt(this.settingsForm.get('coverImageSize')?.value, 10);
+    modelSettings.pdfRenderResolution = parseInt(this.settingsForm.get('pdfRenderResolution')?.value, 10);
 
     return modelSettings;
   }

--- a/UI/Web/src/app/admin/manage-open-idconnect/manage-open-idconnect.component.html
+++ b/UI/Web/src/app/admin/manage-open-idconnect/manage-open-idconnect.component.html
@@ -1,14 +1,15 @@
 <ng-container *transloco="let t; prefix:'manage-oidc-connect'">
-
-  <div class="position-relative">
-    <button type="button" class="btn btn-primary position-absolute custom-position" (click)="save(true)">{{t('save')}}</button>
-  </div>
-
   @if (!loading()) {
     <form [formGroup]="settingsForm">
       <div class="alert alert-warning" role="alert">
         <strong>{{t('notice')}}</strong> {{t('restart-required')}}
       </div>
+
+      @if (autoSavingBlocked()) {
+        <div class="alert alert-warning" role="alert">
+          {{t('auto-save-required')}}
+        </div>
+      }
 
       <h4>{{t('provider-title')}}</h4>
       <div class="text-muted" [innerHtml]="t('provider-tooltip') | safeHtml"></div>
@@ -91,6 +92,13 @@
               </ng-template>
             </app-setting-item>
           }
+        </div>
+
+        <div class="d-flex justify-content-end">
+          <button type="button" class="btn btn-secondary" [ngbTooltip]="t('reset-tooltip')" (click)="resetIds()">
+            {{t('reset-label')}}
+          </button>
+          <button type="button" class="btn btn-primary ms-2" (click)="save(true)">{{t('save')}}</button>
         </div>
 
       </ng-container>

--- a/UI/Web/src/app/admin/manage-open-idconnect/manage-open-idconnect.component.scss
+++ b/UI/Web/src/app/admin/manage-open-idconnect/manage-open-idconnect.component.scss
@@ -1,8 +1,3 @@
 .invalid-feedback {
   display: inherit;
 }
-
-.custom-position {
-  right: 5px;
-  top: -42px;
-}

--- a/UI/Web/src/app/admin/settings.service.ts
+++ b/UI/Web/src/app/admin/settings.service.ts
@@ -90,6 +90,10 @@ export class SettingsService {
     return httpResource<boolean>(() => this.baseUrl + 'settings/opds-enabled').asReadonly();
   }
 
+  clearExternalIds() {
+    return this.http.post(this.baseUrl + 'settings/reset-external-ids', {})
+  }
+
   isValidCronExpression(val: string) {
     if (val === '' || val === undefined || val === null) return of(false);
     return this.http.get<string>(this.baseUrl + 'settings/is-valid-cron?cronExpression=' + val, TextResonse).pipe(map(d => d === 'true'));

--- a/UI/Web/src/app/book-reader/_components/_drawers/epub-setting-drawer/epub-setting-drawer.component.html
+++ b/UI/Web/src/app/book-reader/_components/_drawers/epub-setting-drawer/epub-setting-drawer.component.html
@@ -9,10 +9,11 @@
   </div>
 
   <div class="offcanvas-body">
+    @let lId = libraryId();
     @let sId = seriesId();
     @let rp = readingProfile();
-    @if (sId && rp) {
-      <app-reader-settings [seriesId]="sId"
+    @if (sId && rp && lId) {
+      <app-reader-settings [libraryId]="lId" [seriesId]="sId"
         [readingProfile]="rp"
         [readerSettingsService]="readerSettingsService()"
        />

--- a/UI/Web/src/app/book-reader/_components/_drawers/epub-setting-drawer/epub-setting-drawer.component.ts
+++ b/UI/Web/src/app/book-reader/_components/_drawers/epub-setting-drawer/epub-setting-drawer.component.ts
@@ -21,6 +21,7 @@ export class EpubSettingDrawerComponent {
 
   chapterId = model<number>();
   seriesId = model<number>();
+  libraryId = model<number>();
   readingProfile = model<ReadingProfile>();
   readerSettingsService = model.required<EpubReaderSettingsService>();
 

--- a/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.ts
+++ b/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.ts
@@ -928,7 +928,7 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       this.titleService.setTitle('Kavita - ' + this.bookTitle());
       this.cdRef.markForCheck();
 
-      await this.readerSettingsService.initialize(this.seriesId, this.readingProfile);
+      await this.readerSettingsService.initialize(this.libraryId, this.seriesId, this.readingProfile);
 
       // Ensure any changes in the reader settings are applied to the reader
       this.readerSettingsService.settingUpdates$.pipe(
@@ -2083,7 +2083,7 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
     if (drawerIsOpen) {
       this.epubMenuService.closeAll();
     } else {
-      this.epubMenuService.openSettingsDrawer(this.chapterId, this.seriesId, this.readingProfile, this.readerSettingsService);
+      this.epubMenuService.openSettingsDrawer(this.chapterId, this.seriesId, this.libraryId, this.readingProfile, this.readerSettingsService);
     }
 
     if (this.immersiveMode()) { // NOTE: Shouldn't this check if drawer is open?

--- a/UI/Web/src/app/book-reader/_components/reader-settings/reader-settings.component.ts
+++ b/UI/Web/src/app/book-reader/_components/reader-settings/reader-settings.component.ts
@@ -91,6 +91,7 @@ export class ReaderSettingsComponent implements OnInit {
 
   private readonly cdRef = inject(ChangeDetectorRef);
 
+  @Input({required:true}) libraryId!: number;
   @Input({required:true}) seriesId!: number;
   @Input({required:true}) readingProfile!: ReadingProfile;
   @Input({required:true}) readerSettingsService!: EpubReaderSettingsService;
@@ -136,7 +137,7 @@ export class ReaderSettingsComponent implements OnInit {
 
     // Initialize the service if not already done
     if (!this.readerSettingsService.getCurrentReadingProfile()) {
-      await this.readerSettingsService.initialize(this.seriesId, this.readingProfile);
+      await this.readerSettingsService.initialize(this.libraryId, this.seriesId, this.readingProfile);
     }
 
     this.settingsForm = this.readerSettingsService.getSettingsForm();

--- a/UI/Web/src/app/cards/_modals/bulk-add-to-collection/bulk-add-to-collection.component.html
+++ b/UI/Web/src/app/cards/_modals/bulk-add-to-collection/bulk-add-to-collection.component.html
@@ -11,7 +11,7 @@
           <label for="filter" class="form-label">{{t('filter-label')}}</label>
           <div class="input-group">
             <input id="filter" autocomplete="off" class="form-control" formControlName="filterQuery" type="text" aria-describedby="reset-input">
-            <button class="btn btn-outline-secondary" type="button" id="reset-input" (click)="listForm.get('filterQuery')?.setValue('');">Clear</button>
+            <button class="btn btn-outline-secondary" type="button" id="reset-input" (click)="listForm.get('filterQuery')?.setValue('');">{{t('clear')}}</button>
           </div>
         </div>
       }

--- a/UI/Web/src/app/cards/_modals/bulk-set-reading-profile-modal/bulk-set-reading-profile-modal.component.html
+++ b/UI/Web/src/app/cards/_modals/bulk-set-reading-profile-modal/bulk-set-reading-profile-modal.component.html
@@ -1,56 +1,53 @@
 <ng-container *transloco="let t; prefix: 'bulk-set-reading-profile-modal'">
 
-  <div class="modal-header">
-    <h4 class="modal-title" id="modal-basic-title">{{t('title')}}</h4>
-    <button type="button" class="btn-close" [attr.aria-label]="t('close')" (click)="close()"></button>
-  </div>
-  <form [formGroup]="profileForm">
-    <div class="modal-body">
-      @if (profiles.length >= MaxItems) {
-        <div class="mb-3">
-          <label for="filter" class="form-label">{{t('filter-label')}}</label>
-          <div class="input-group">
-            <input id="filter" autocomplete="off" class="form-control" formControlName="filterQuery" type="text" aria-describedby="reset-input">
-            <button class="btn btn-outline-secondary" type="button" id="reset-input" (click)="clear()">{{t('clear')}}</button>
-          </div>
-        </div>
-      }
+  <app-list-select-modal
+    [title]="t('title')"
+    [inputItems]="listItems()"
+    [preSelectedItems]="preSelectedListItems()"
+    [loading]="loading()"
+    [selectedText]="t('bound')"
+    hiddenTranslationKey="bulk-set-reading-profile-modal.hidden"
+    [multiSelect]="true"
+    [hideItemsWhenInvalid]="true"
+    [interceptConfirm]="addToProfile.bind(this)"
+    [isSelectionValidFunc]="validSelection.bind(this)"
+    [isValidItemFunc]="validItem.bind(this)"
+    [invalidSelectionWarning]="t('warning-duplicate')"
+    [itemTemplate]="itemTemplate()"
+  >
 
-      <ul class="list-group">
-        @for(profile of profiles | filter: filterList; let i = $index; track profile.name) {
-          <li class="list-group-item clickable" tabindex="0" role="option" (click)="addToProfile(profile)">
-            <div class="p-2 group-item d-flex justify-content-between align-items-center">
-
-              <div class="fw-bold">{{profile.name | sentenceCase}}</div>
-
-              @if (currentProfile && currentProfile.name === profile.name) {
-                <span class="pill p-1 ms-1">{{t('bound')}}</span>
-              }
-            </div>
-          </li>
-        }
-
-        @if (profiles.length === 0 && !isLoading) {
-          <li class="list-group-item">{{t('no-data')}}</li>
-        }
-
-        @if (isLoading) {
-          <li class="list-group-item">
-            <div class="spinner-border text-primary" role="status">
-              <span class="visually-hidden">{{t('loading')}}</span>
-            </div>
-          </li>
-        }
-      </ul>
-    </div>
-
-    <div class="modal-footer">
-      <button type="button" class="btn btn-secondary" (click)="close()">{{t('close')}}</button>
-    </div>
-  </form>
-
-
-
-
+  </app-list-select-modal>
 
 </ng-container>
+
+<ng-template #listItemTemplate let-item let-selectedItems="selectedItems">
+
+  <div class="d-flex flex-column flex-grow-1">
+    <div class="d-flex flex-row justify-content-between" *transloco="let t; prefix: 'bulk-set-reading-profile-modal'">
+      <div class="fw-bold">{{ item.label | sentenceCase }}</div>
+
+      @if (selectedItems && selectedItems.includes(item)) {
+        <span class="pill p-1 ms-1">{{ t('bound') }}</span>
+      }
+    </div>
+
+    @let devices = profileDevice(item.value);
+
+    <div class="mt-1 text-muted small">
+      @if (devices.length <= 3) {
+        @for (device of devices; track device.id) {
+          <span>{{ device.friendlyName }}</span>
+          @if (!$last) {<span>, </span>}
+        }
+      } @else {
+        @for (device of devices.slice(0, 3); track device.id) {
+          <span>{{ device.friendlyName }}</span>
+          @if (!$last) {<span>, </span>}
+        }
+        <span>, …</span>
+      }
+    </div>
+  </div>
+
+</ng-template>
+

--- a/UI/Web/src/app/cards/_modals/bulk-set-reading-profile-modal/bulk-set-reading-profile-modal.component.html
+++ b/UI/Web/src/app/cards/_modals/bulk-set-reading-profile-modal/bulk-set-reading-profile-modal.component.html
@@ -11,7 +11,7 @@
           <label for="filter" class="form-label">{{t('filter-label')}}</label>
           <div class="input-group">
             <input id="filter" autocomplete="off" class="form-control" formControlName="filterQuery" type="text" aria-describedby="reset-input">
-            <button class="btn btn-outline-secondary" type="button" id="reset-input" (click)="clear()">Clear</button>
+            <button class="btn btn-outline-secondary" type="button" id="reset-input" (click)="clear()">{{t('clear')}}</button>
           </div>
         </div>
       }

--- a/UI/Web/src/app/cards/_modals/bulk-set-reading-profile-modal/bulk-set-reading-profile-modal.component.ts
+++ b/UI/Web/src/app/cards/_modals/bulk-set-reading-profile-modal/bulk-set-reading-profile-modal.component.ts
@@ -1,4 +1,14 @@
-import {AfterViewInit, ChangeDetectorRef, Component, ElementRef, inject, Input, OnInit, ViewChild} from '@angular/core';
+import {
+  AfterViewInit,
+  ChangeDetectorRef,
+  Component, computed,
+  ElementRef,
+  inject,
+  Input,
+  model,
+  OnInit, signal, TemplateRef, viewChild,
+  ViewChild
+} from '@angular/core';
 import {NgbActiveModal} from "@ng-bootstrap/ng-bootstrap";
 import {ToastrService} from "ngx-toastr";
 import {FormControl, FormGroup, ReactiveFormsModule} from "@angular/forms";
@@ -7,113 +17,129 @@ import {ReadingProfileService} from "../../../_services/reading-profile.service"
 import {ReadingProfile, ReadingProfileKind} from "../../../_models/preferences/reading-profiles";
 import {FilterPipe} from "../../../_pipes/filter.pipe";
 import {SentenceCasePipe} from "../../../_pipes/sentence-case.pipe";
+import {ListSelectModalComponent} from "../../../shared/_components/list-select-modal/list-select-modal.component";
+import {ClientDevice} from "../../../_models/client-device";
+import {DeviceService} from "../../../_services/device.service";
+import {forkJoin} from "rxjs";
 
 @Component({
   selector: 'app-bulk-set-reading-profile-modal',
   imports: [
     ReactiveFormsModule,
-    FilterPipe,
     TranslocoDirective,
+    ListSelectModalComponent,
     SentenceCasePipe
   ],
   templateUrl: './bulk-set-reading-profile-modal.component.html',
   styleUrl: './bulk-set-reading-profile-modal.component.scss'
 })
-export class BulkSetReadingProfileModalComponent implements OnInit, AfterViewInit {
+export class BulkSetReadingProfileModalComponent implements OnInit {
+
   private readonly modal = inject(NgbActiveModal);
   private readonly readingProfileService = inject(ReadingProfileService);
   private readonly toastr = inject(ToastrService);
-  private readonly cdRef = inject(ChangeDetectorRef);
-  protected readonly MaxItems = 8;
+  private readonly deviceService = inject(DeviceService);
 
-  /**
-   * Modal Header - since this code is used for multiple flows
-   */
-  @Input({required: true}) title!: string;
+  itemTemplate = viewChild.required<TemplateRef<any>>('listItemTemplate');
+
   /**
    * Series Ids to add to Reading Profile
    */
   @Input() seriesIds: Array<number> = [];
   @Input() libraryId: number | undefined;
-  @ViewChild('title') inputElem!: ElementRef<HTMLInputElement>;
 
-  currentProfile: ReadingProfile | null = null;
-  profiles: Array<ReadingProfile> = [];
-  isLoading: boolean = false;
-  profileForm: FormGroup = new FormGroup({
-    filterQuery: new FormControl('', []), // Used for inline filtering when too many RPs
-  });
+  private profiles = signal<ReadingProfile[]>([]);
+  private currentlyBoundProfiles = signal<ReadingProfile[]>([]);
+  protected devices = signal<ClientDevice[]>([]);
+  protected loading = signal(true);
+
+  private  profileMap = computed(() =>
+    new Map(this.profiles().map(p => [p.id, p])));
+  protected listItems = computed(() =>
+    this.profiles().map(profile => ({label: profile.name, value: profile.id})));
+  protected preSelectedListItems = computed(() =>
+    this.currentlyBoundProfiles().map(profile => profile.id));
 
   ngOnInit(): void {
-
-    this.profileForm.addControl('title', new FormControl(this.title, []));
-
-    this.isLoading = true;
-    this.cdRef.markForCheck();
-
     if (this.libraryId !== undefined) {
-      this.readingProfileService.getForLibrary(this.libraryId).subscribe(profile => {
-        this.currentProfile = profile;
-        this.cdRef.markForCheck();
+      this.readingProfileService.getForLibrary(this.libraryId).subscribe(profiles => {
+        this.currentlyBoundProfiles.set(profiles)
       });
     } else if (this.seriesIds.length === 1) {
-      this.readingProfileService.getForSeries(this.seriesIds[0], true).subscribe(profile => {
-        this.currentProfile = profile;
-        this.cdRef.markForCheck();
+      this.readingProfileService.getAllForSeries(this.seriesIds[0]).subscribe(profiles => {
+        this.currentlyBoundProfiles.set(profiles);
       });
     }
 
-
-    this.readingProfileService.getAllProfiles().subscribe(profiles => {
-      this.profiles = profiles;
-      this.isLoading = false;
-      this.cdRef.markForCheck();
+    forkJoin([
+      this.readingProfileService.getAllProfiles(),
+      this.deviceService.getMyClientDevices(),
+    ]).subscribe(([profiles, devices]) => {
+      this.loading.set(false);
+      this.profiles.set(profiles);
+      this.devices.set(devices);
     });
   }
 
-  ngAfterViewInit() {
-    // Shift focus to input
-    if (this.inputElem) {
-      this.inputElem.nativeElement.select();
-      this.cdRef.markForCheck();
+  profileDevice(profileId: number) {
+    const profile = this.profileMap().get(profileId)!;
+
+    return this.devices().filter(device => profile.deviceIds.includes(device.id));
+  }
+
+  validItem(item: number, selection: number[]) {
+    const profile = this.profileMap().get(item)!;
+    const selectedProfiles = selection.map(id => this.profileMap().get(id)!);
+
+    const selectedDevices = new Set(selectedProfiles.flatMap(profile => profile.deviceIds));
+
+    return !profile.deviceIds.some(id => selectedDevices.has(id));
+  }
+
+  validSelection(profileIds: number[]) {
+    const profiles = (Array.isArray(profileIds) ? profileIds : [profileIds])
+      .map(id => this.profileMap().get(id)!);
+
+    const seen = new Set<number>();
+
+    for (const profile of profiles) {
+      for (const deviceId of profile.deviceIds) {
+        if (seen.has(deviceId)) {
+          return false;
+        }
+
+        seen.add(deviceId);
+      }
     }
+
+    return true;
   }
 
-  close() {
-    this.modal.close();
-  }
+  addToProfile(profileIds: number | number[]) {
+    profileIds = Array.isArray(profileIds) ? profileIds : [profileIds];
 
-  addToProfile(profile: ReadingProfile) {
     if (this.seriesIds.length == 1) {
-      this.readingProfileService.addToSeries(profile.id, this.seriesIds[0]).subscribe(() => {
-        this.toastr.success(translate('toasts.series-bound-to-reading-profile', {name: profile.name}));
+      this.readingProfileService.addToSeries(profileIds, this.seriesIds[0]).subscribe(() => {
+        this.toastr.success(translate('toasts.series-bound-to-reading-profile', {amount: profileIds.length}));
         this.modal.close();
       });
       return;
     }
 
     if (this.seriesIds.length > 1) {
-      this.readingProfileService.bulkAddToSeries(profile.id, this.seriesIds).subscribe(() => {
-        this.toastr.success(translate('toasts.series-bound-to-reading-profile', {name: profile.name}));
+      this.readingProfileService.bulkAddToSeries(profileIds, this.seriesIds).subscribe(() => {
+        this.toastr.success(translate('toasts.series-bound-to-reading-profile', {amount: profileIds.length}));
         this.modal.close();
       });
       return;
     }
 
     if (this.libraryId) {
-      this.readingProfileService.addToLibrary(profile.id, this.libraryId).subscribe(() => {
-        this.toastr.success(translate('toasts.library-bound-to-reading-profile', {name: profile.name}));
+      this.readingProfileService.addToLibrary(profileIds, this.libraryId).subscribe(() => {
+        this.toastr.success(translate('toasts.library-bound-to-reading-profile', {amount: profileIds.length}));
         this.modal.close();
       });
     }
-  }
-
-  filterList = (listItem: ReadingProfile) => {
-    return listItem.name.toLowerCase().indexOf((this.profileForm.value.filterQuery || '').toLowerCase()) >= 0;
-  }
-
-  clear() {
-    this.profileForm.get('filterQuery')?.setValue('');
   }
 
   protected readonly ReadingProfileKind = ReadingProfileKind;

--- a/UI/Web/src/app/cards/bulk-operations/bulk-operations.component.html
+++ b/UI/Web/src/app/cards/bulk-operations/bulk-operations.component.html
@@ -23,7 +23,7 @@
                   <span class="visually-hidden">{{t('mark-as-read')}}</span>
               </button>
               }
-              <app-card-actionables (actionHandler)="performAction($event)" [inputActions]="actions" labelBy="bulk-actions-header" iconClass="fa-ellipsis-h" />
+              <app-card-actionables (actionHandler)="performAction($event)" [actions]="actions" labelBy="bulk-actions-header" iconClass="fa-ellipsis-h" />
           </span>
 
             <span id="bulk-actions-header" class="visually-hidden">{{t('title')}}</span>

--- a/UI/Web/src/app/cards/card-detail-layout/card-detail-layout.component.html
+++ b/UI/Web/src/app/cards/card-detail-layout/card-detail-layout.component.html
@@ -7,7 +7,7 @@
         <h4>
           @if (actions().length > 0) {
             <span>
-              <app-card-actionables (actionHandler)="performAction($event)" [inputActions]="actions()" [labelBy]="header()" />&nbsp;
+              <app-card-actionables (actionHandler)="performAction($event)" [actions]="actions()" [labelBy]="header()" />&nbsp;
             </span>
           }
 

--- a/UI/Web/src/app/cards/card-item/card-item.component.html
+++ b/UI/Web/src/app/cards/card-item/card-item.component.html
@@ -94,7 +94,7 @@
 
         <span class="card-actions">
         @if (actions && actions.length > 0) {
-            <app-card-actionables [entity]="actionEntity" (actionHandler)="performAction($event)" [inputActions]="actions" [labelBy]="title" />
+            <app-card-actionables [entity]="actionEntity" (actionHandler)="performAction($event)" [actions]="actions" [labelBy]="title" />
         }
         </span>
       </div>

--- a/UI/Web/src/app/cards/chapter-card/chapter-card.component.html
+++ b/UI/Web/src/app/cards/chapter-card/chapter-card.component.html
@@ -89,7 +89,7 @@
       </span>
       <span class="card-actions">
         @if (actions && actions.length > 0) {
-            <app-card-actionables [entity]="chapter" [inputActions]="actions" [labelBy]="chapter.titleName" />
+            <app-card-actionables [entity]="chapter" [actions]="actions" [labelBy]="chapter.titleName" />
         }
       </span>
     </div>

--- a/UI/Web/src/app/cards/person-card/person-card.component.html
+++ b/UI/Web/src/app/cards/person-card/person-card.component.html
@@ -32,7 +32,7 @@
           </span>
           @if (actions && actions.length > 0) {
             <span class="card-actions float-end">
-              <app-card-actionables [entity]="entity" [inputActions]="actions" [labelBy]="title" />
+              <app-card-actionables [entity]="entity" [actions]="actions" [labelBy]="title" />
             </span>
           }
         </div>

--- a/UI/Web/src/app/cards/series-card/series-card.component.html
+++ b/UI/Web/src/app/cards/series-card/series-card.component.html
@@ -74,7 +74,7 @@
 
       @if (actions && actions.length > 0) {
         <span class="card-actions">
-            <app-card-actionables [entity]="series" [inputActions]="actions" [labelBy]="series.name" />
+            <app-card-actionables [entity]="series" [actions]="actions" [labelBy]="series.name" />
         </span>
       }
     </div>

--- a/UI/Web/src/app/cards/volume-card/volume-card.component.html
+++ b/UI/Web/src/app/cards/volume-card/volume-card.component.html
@@ -81,7 +81,7 @@
 
       @if (actions && actions.length > 0) {
         <span class="card-actions">
-          <app-card-actionables [entity]="volume" [inputActions]="actions" [labelBy]="volume.name" />
+          <app-card-actionables [entity]="volume" [actions]="actions" [labelBy]="volume.name" />
         </span>
       }
     </div>

--- a/UI/Web/src/app/carousel/_components/carousel-reel/carousel-reel.component.html
+++ b/UI/Web/src/app/carousel/_components/carousel-reel/carousel-reel.component.html
@@ -4,7 +4,7 @@
     <div class="carousel-container mb-3">
       <div>
         @if (actionables.length > 0) {
-          <app-card-actionables [inputActions]="actionables" (actionHandler)="performAction($event)" />
+          <app-card-actionables [actions]="actionables" (actionHandler)="performAction($event)" />
         }
         <h4 class="header" (click)="sectionClicked($event)" [ngClass]="{'non-selectable': !clickableTitle}">
           @if (titleLink !== '') {

--- a/UI/Web/src/app/chapter-detail/chapter-detail.component.html
+++ b/UI/Web/src/app/chapter-detail/chapter-detail.component.html
@@ -76,7 +76,7 @@
 
               <div class="col-auto ms-2k">
                 <div class="card-actions" [ngbTooltip]="t('more-alt')">
-                  <app-card-actionables [entity]="chapter"  [inputActions]="chapterActions" [labelBy]="series.name + ' ' + chapter.minNumber" iconClass="fa-ellipsis-h" btnClass="btn-actions btn" />
+                  <app-card-actionables [entity]="chapter"  [actions]="chapterActions" [labelBy]="series.name + ' ' + chapter.minNumber" iconClass="fa-ellipsis-h" btnClass="btn-actions btn" />
                 </div>
               </div>
 

--- a/UI/Web/src/app/collections/_components/collection-detail/collection-detail.component.html
+++ b/UI/Web/src/app/collections/_components/collection-detail/collection-detail.component.html
@@ -8,7 +8,7 @@
               <h4>
                 <app-promoted-icon [promoted]="collectionTag.promoted" />
                 <span class="ms-2">{{collectionTag.title}}</span>
-                <app-card-actionables [entity]="collectionTag" [disabled]="actionInProgress" [inputActions]="collectionTagActions" [labelBy]="collectionTag.title" iconClass="fa-ellipsis-v" />
+                <app-card-actionables [entity]="collectionTag" [disabled]="actionInProgress" [actions]="collectionTagActions" [labelBy]="collectionTag.title" iconClass="fa-ellipsis-v" />
               </h4>
             }
             <h5 subtitle class="ms-2 subtitle-with-actionables">{{t('item-count', {num: series.length})}}</h5>

--- a/UI/Web/src/app/library-detail/library-detail.component.html
+++ b/UI/Web/src/app/library-detail/library-detail.component.html
@@ -3,7 +3,7 @@
     <app-side-nav-companion-bar [hasFilter]="true" (filterOpen)="filterOpen.emit($event)" [filterActive]="filterActive">
       <h4 title>
         <span>{{libraryName}}</span>
-        <app-card-actionables [inputActions]="actions" (actionHandler)="performAction($event)" />
+        <app-card-actionables [actions]="actions" (actionHandler)="performAction($event)" />
       </h4>
       @if (active.fragment === '') {
         <h5 subtitle class="subtitle-with-actionables">{{t('common.series-count', {num: pagination.totalItems | number})}} </h5>

--- a/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.html
+++ b/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.html
@@ -255,30 +255,31 @@
                 </div>
                 <div class="col-md-3 col-sm-12">
                   <div class="mb-3">
-                    <div class="mb-3">
-                      <div class="form-check form-switch">
-                        <input type="checkbox" id="auto-close" formControlName="autoCloseMenu" class="form-check-input" switch>
-                        <label class="form-check-label" for="auto-close">{{t('auto-close-menu-label')}}</label>
-                      </div>
+                    <div class="form-check form-switch">
+                      <input type="checkbox" id="auto-close" formControlName="autoCloseMenu" class="form-check-input" switch>
+                      <label class="form-check-label" for="auto-close">{{t('auto-close-menu-label')}}</label>
                     </div>
                   </div>
 
                   <div class="mb-3">
-                    <div class="mb-3">
-                      <div class="form-check form-switch">
-                        <input type="checkbox" id="swipe-to-paginate" formControlName="swipeToPaginate" class="form-check-input" switch>
-                        <label class="form-check-label" for="swipe-to-paginate">{{t('swipe-enabled-label')}}</label>
-                      </div>
+                    <div class="form-check form-switch">
+                      <input type="checkbox" id="swipe-to-paginate" formControlName="swipeToPaginate" class="form-check-input" switch>
+                      <label class="form-check-label" for="swipe-to-paginate">{{t('swipe-enabled-label')}}</label>
                     </div>
                   </div>
                 </div>
                 <div class="col-md-3 col-sm-12">
                   <div class="mb-3">
-                    <div class="mb-3">
-                      <div class="form-check form-switch">
-                        <input type="checkbox" id="emulate-book" formControlName="emulateBook" class="form-check-input" switch>
-                        <label class="form-check-label" for="emulate-book">{{t('emulate-comic-book-label')}}</label>
-                      </div>
+                    <div class="form-check form-switch">
+                      <input type="checkbox" id="emulate-book" formControlName="emulateBook" class="form-check-input" switch>
+                      <label class="form-check-label" for="emulate-book">{{t('emulate-comic-book-label')}}</label>
+                    </div>
+                  </div>
+
+                  <div class="mb-3">
+                    <div class="form-check form-switch" [title]="generalSettingsForm.get('pageOffset')?.disabled ? t('offset-only-double') : ''">
+                      <input type="checkbox" id="page-offset" formControlName="pageOffset" class="form-check-input" switch>
+                      <label class="form-check-label" for="page-offset">{{t('page-offset-label')}}</label>
                     </div>
                   </div>
                 </div>

--- a/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.ts
+++ b/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.ts
@@ -639,7 +639,7 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
         map(_ => this.packReadingProfile()),
         distinctUntilChanged(),
         tap(newProfile => {
-          this.readingProfileService.updateImplicit(newProfile, this.seriesId).subscribe({
+          this.readingProfileService.updateImplicit(this.libraryId, this.seriesId, newProfile).subscribe({
             next: updatedProfile => {
               this.readingProfile = updatedProfile;
               this.cdRef.markForCheck();
@@ -725,7 +725,7 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
   setupReaderSettings() {
 
     if (this.readingProfile.kind === ReadingProfileKind.Implicit) {
-      this.readingProfileService.getForSeries(this.seriesId, true).subscribe(parent => {
+      this.readingProfileService.getForSeries(this.libraryId, this.seriesId, true).subscribe(parent => {
         this.parentReadingProfile = parent;
         this.cdRef.markForCheck();
       })
@@ -1938,7 +1938,7 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       return;
     }
 
-    this.readingProfileService.updateParentProfile(this.seriesId, this.packReadingProfile()).subscribe(newProfile => {
+    this.readingProfileService.updateParentProfile(this.libraryId, this.seriesId, this.packReadingProfile()).subscribe(newProfile => {
       this.readingProfile = newProfile;
       this.toastr.success(translate('manga-reader.reading-profile-updated'));
       this.cdRef.markForCheck();

--- a/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.ts
+++ b/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.ts
@@ -542,6 +542,9 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
           case KeyBindTarget.BookmarkPage:
             this.bookmarkPage();
             break;
+          case KeyBindTarget.OffsetDoublePage:
+            this.togglePageOffset();
+            break;
           case KeyBindTarget.GoTo:
             const goToPageNum = await this.promptForPage();
             if (goToPageNum === null) { return; }
@@ -558,7 +561,7 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       [
         KeyBindTarget.ToggleFullScreen, KeyBindTarget.BookmarkPage, KeyBindTarget.OpenHelp, KeyBindTarget.GoTo,
         KeyBindTarget.ToggleMenu, KeyBindTarget.PageRight, KeyBindTarget.PageLeft, KeyBindTarget.Escape,
-        KeyBindTarget.PageUp, KeyBindTarget.PageDown,
+        KeyBindTarget.PageUp, KeyBindTarget.PageDown, KeyBindTarget.OffsetDoublePage,
       ],
     );
 
@@ -747,7 +750,8 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       layoutMode: new FormControl(this.layoutMode),
       darkness: new FormControl(100),
       emulateBook: new FormControl(this.readingProfile.emulateBook),
-      swipeToPaginate: new FormControl(this.readingProfile.swipeToPaginate)
+      swipeToPaginate: new FormControl(this.readingProfile.swipeToPaginate),
+      pageOffset: new FormControl(this.readingProfile.pageOffset),
     });
 
     this.readerModeSubject.next(this.readerMode);
@@ -793,6 +797,7 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
         this.generalSettingsForm.get('widthSlider')?.enable();
         this.generalSettingsForm.get('fittingOption')?.enable();
         this.generalSettingsForm.get('emulateBook')?.enable();
+        this.generalSettingsForm.get('pageOffset')?.disable();
       } else {
         this.generalSettingsForm.get('pageSplitOption')?.setValue(PageSplitOption.NoSplit);
         this.generalSettingsForm.get('pageSplitOption')?.disable();
@@ -800,6 +805,7 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
         this.generalSettingsForm.get('fittingOption')?.setValue(this.mangaReaderService.translateScalingOption(ScalingOption.FitToHeight));
         this.generalSettingsForm.get('fittingOption')?.disable();
         this.generalSettingsForm.get('emulateBook')?.enable();
+        this.generalSettingsForm.get('pageOffset')?.enable();
       }
       this.cdRef.markForCheck();
 
@@ -813,6 +819,14 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
     this.generalSettingsForm.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
       this.autoCloseMenu = this.generalSettingsForm.get('autoCloseMenu')?.value;
       this.pageSplitOption = parseInt(this.generalSettingsForm.get('pageSplitOption')?.value, 10);
+      const pageOffset = this.generalSettingsForm.get('pageOffset')?.value;
+      if (pageOffset !== undefined) {
+        this.mangaReaderService.setPageOffset(pageOffset);
+        const adjustedPage = this.mangaReaderService.adjustForDoubleReader(this.pageNum);
+        this.pageNumSubject.next({pageNum: adjustedPage, maxPages: this.maxPages});
+        this.pageNum = adjustedPage;
+        this.goToPage(this.pageNum);
+      }
 
       const needsSplitting = this.mangaReaderService.isWidePage(this.readerService.imageUrlToPageNum(this.canvasImage.src));
       // If we need to split on a menu change, then we need to re-render.
@@ -1770,6 +1784,15 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       });
   }
 
+  togglePageOffset() {
+    if (this.layoutMode === LayoutMode.Single || this.readerMode === ReaderMode.Webtoon) {
+      return;
+    }
+
+    const currentValue = this.generalSettingsForm.get('pageOffset')?.value;
+    this.generalSettingsForm.patchValue({pageOffset: !currentValue});
+  }
+
   // This is menu only code
   toggleReaderMode() {
     switch(this.readerMode) {
@@ -1805,6 +1828,7 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       this.generalSettingsForm.get('pageSplitOption')?.disable()
       this.generalSettingsForm.get('fittingOption')?.disable()
       this.generalSettingsForm.get('layoutMode')?.disable();
+      this.generalSettingsForm.get('pageOffset')?.disable();
     } else {
       this.generalSettingsForm.get('fittingOption')?.enable()
       this.generalSettingsForm.get('pageSplitOption')?.enable();
@@ -1813,6 +1837,9 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       if (this.layoutMode !== LayoutMode.Single) {
         this.generalSettingsForm.get('pageSplitOption')?.disable();
         this.generalSettingsForm.get('fittingOption')?.disable();
+        this.generalSettingsForm.get('pageOffset')?.enable();
+      } else {
+        this.generalSettingsForm.get('pageOffset')?.disable();
       }
     }
     this.cdRef.markForCheck();
@@ -1898,6 +1925,7 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       {keyBindTarget: KeyBindTarget.ToggleMenu},
       {keyBindTarget: KeyBindTarget.OpenHelp},
       {keyBindTarget: KeyBindTarget.BookmarkPage, description: 'bookmark'},
+      {keyBindTarget: KeyBindTarget.OffsetDoublePage, description: 'offset-double-page'},
       {key: translate('shortcuts-modal.double-click'), description: 'bookmark'},
     ];
 

--- a/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.ts
+++ b/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.ts
@@ -751,7 +751,7 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       darkness: new FormControl(100),
       emulateBook: new FormControl(this.readingProfile.emulateBook),
       swipeToPaginate: new FormControl(this.readingProfile.swipeToPaginate),
-      pageOffset: new FormControl(this.readingProfile.pageOffset),
+      pageOffset: new FormControl(false),
     });
 
     this.readerModeSubject.next(this.readerMode);

--- a/UI/Web/src/app/manga-reader/_service/manga-reader.service.ts
+++ b/UI/Web/src/app/manga-reader/_service/manga-reader.service.ts
@@ -17,6 +17,7 @@ export class MangaReaderService {
   private pageDimensions: DimensionMap = {};
   private pairs: {[key: number]: number} = {};
   private renderer: Renderer2;
+  private hasPageOffset: boolean = false;
 
   constructor() {
     const rendererFactory = inject(RendererFactory2);
@@ -33,9 +34,13 @@ export class MangaReaderService {
       };
     });
     this.pairs = chapterInfo.doublePairs!;
+    this.hasPageOffset = false;
   }
 
   adjustForDoubleReader(page: number) {
+    if (this.hasPageOffset === true) {
+      return Math.floor(page / 2) * 2;
+    }
     if (!this.pairs.hasOwnProperty(page)) return page;
     return this.pairs[page];
   }
@@ -71,7 +76,20 @@ export class MangaReaderService {
    * @returns
    */
   isCoverImage(pageNumber: number) {
+    if (this.hasPageOffset) return false;
     return pageNumber === 0;
+  }
+
+  togglePageOffset() {
+    this.hasPageOffset = !this.hasPageOffset;
+  }
+
+  getPageOffset() {
+    return this.hasPageOffset;
+  }
+
+  setPageOffset(toggle: boolean) {
+    this.hasPageOffset = toggle;
   }
 
   /**

--- a/UI/Web/src/app/manga-reader/_service/manga-reader.service.ts
+++ b/UI/Web/src/app/manga-reader/_service/manga-reader.service.ts
@@ -1,4 +1,4 @@
-import { ElementRef, Injectable, Renderer2, RendererFactory2, inject } from '@angular/core';
+import {ElementRef, inject, Injectable, Renderer2, RendererFactory2} from '@angular/core';
 import {PageSplitOption} from 'src/app/_models/preferences/page-split-option';
 import {ScalingOption} from 'src/app/_models/preferences/scaling-option';
 import {ReaderService} from 'src/app/_services/reader.service';
@@ -78,14 +78,6 @@ export class MangaReaderService {
   isCoverImage(pageNumber: number) {
     if (this.hasPageOffset) return false;
     return pageNumber === 0;
-  }
-
-  togglePageOffset() {
-    this.hasPageOffset = !this.hasPageOffset;
-  }
-
-  getPageOffset() {
-    return this.hasPageOffset;
   }
 
   setPageOffset(toggle: boolean) {

--- a/UI/Web/src/app/pdf-reader/_components/pdf-reader/pdf-reader.component.html
+++ b/UI/Web/src/app/pdf-reader/_components/pdf-reader/pdf-reader.component.html
@@ -24,7 +24,7 @@
         [showOpenFileButton]="false"
         [showPrintButton]="false"
         [showRotateButton]="false"
-        [showDownloadButton]="false"
+        [showDownloadButton]="canDownload()"
         [showPropertiesButton]="false"
         [(zoom)]="zoomSetting"
         [showSecondaryToolbarButton]="true"
@@ -33,7 +33,6 @@
         [backgroundColor]="backgroundColor"
         [customToolbar]="multiToolbar"
         [language]="user.preferences.locale"
-
         [(scrollMode)]="scrollMode"
         [pageViewMode]="pageLayoutMode"
         [spread]="spreadMode"

--- a/UI/Web/src/app/person-detail/_modal/edit-person-modal/edit-person-modal.component.html
+++ b/UI/Web/src/app/person-detail/_modal/edit-person-modal/edit-person-modal.component.html
@@ -45,7 +45,7 @@
 
                   <div class="mb-3 col-md-6 col-xs-12">
                     @if (editForm.get('aniListId'); as formControl) {
-                      <app-setting-item [title]="t('anilist-id-label')" [toggleOnViewClick]="false" [showEdit]="false" [subtitle]="t('anilist-tooltip'+tooltip)">
+                      <app-setting-item [title]="t('anilist-id-label')" [toggleOnViewClick]="false" [showEdit]="false" [subtitle]="t('anilist-tooltip' + tooltip)">
                         <ng-template #view>
                           <input id="anilist-id" class="form-control" formControlName="aniListId" type="number"
                                  [class.is-invalid]="formControl.invalid && !formControl.untouched">

--- a/UI/Web/src/app/person-detail/person-detail.component.html
+++ b/UI/Web/src/app/person-detail/person-detail.component.html
@@ -5,7 +5,7 @@
       <app-side-nav-companion-bar>
         <ng-container title>
           <h2 class="title text-break">
-            <app-card-actionables [entity]="person" [inputActions]="personActions" [labelBy]="person.name" iconClass="fa-ellipsis-v" />
+            <app-card-actionables [entity]="person" [actions]="personActions" [labelBy]="person.name" iconClass="fa-ellipsis-v" />
             <span>{{person.name}}</span>
 
             @for (webLink of (person.webLinks ?? []); track webLink) {

--- a/UI/Web/src/app/profile/_components/profile-overview/profile-overview.component.ts
+++ b/UI/Web/src/app/profile/_components/profile-overview/profile-overview.component.ts
@@ -10,12 +10,36 @@ import {map, Observable} from "rxjs";
 import {AccountService} from "../../../_services/account.service";
 import {translate, TranslocoDirective} from "@jsverse/transloco";
 import {SeriesService} from "../../../_services/series.service";
+import {FilterV2} from "../../../_models/metadata/v2/filter-v2";
+import {FilterCombination} from "../../../_models/metadata/v2/filter-combination";
+import {FilterStatement} from "../../../_models/metadata/v2/filter-statement";
+import {FilterComparison} from "../../../_models/metadata/v2/filter-comparison";
+import {FilterField} from "../../../_models/metadata/v2/filter-field";
+import {SortField} from "../../../_models/metadata/series-filter";
 
 type OverviewStream = {
   title: string;
   api: Observable<any[]>;
   nextPageLoader: NextPageLoader;
 }
+
+const JustFinishedReadingFilter = {
+  limitTo: 20,
+  offset: 0,
+  combination: FilterCombination.And,
+  statements: [
+    {
+      field: FilterField.ReadProgress,
+      comparison: FilterComparison.GreaterThanEqual,
+      value: '100'
+    } as FilterStatement
+  ],
+  name: translate('profile-overview.just-finished-reading'),
+  sortOptions: {
+    sortField: SortField.ReadProgress,
+    isAscending: true
+  }
+} as FilterV2;
 
 @Component({
   selector: 'app-profile-overview',
@@ -56,6 +80,14 @@ export class ProfileOverviewComponent {
           .pipe(map(pr => pr.result)),
         nextPageLoader: (pageNum, pageSize) => this.seriesService
           .getWantToRead(pageNum, pageSize, undefined, memberId),
+      },
+      {
+        title: translate('profile-overview.just-finished-reading'),
+        api: this.seriesService
+          .getAllSeriesV2(0, 20, JustFinishedReadingFilter, memberId)
+          .pipe(map(pr => pr.result)),
+        nextPageLoader: (pageNum, pageSize) => this.seriesService
+          .getAllSeriesV2(pageNum, pageSize, JustFinishedReadingFilter, memberId),
       }
     ];
   });

--- a/UI/Web/src/app/profile/_components/profile/profile.component.html
+++ b/UI/Web/src/app/profile/_components/profile/profile.component.html
@@ -25,7 +25,6 @@
               @if (licenseService.hasValidLicenseSignal()) {
                 <span class="badge kplus-badge">{{t('k+-badge')}}</span>
               }
-
             </div>
           </div>
 

--- a/UI/Web/src/app/reading-list/_components/reading-list-detail/reading-list-detail.component.html
+++ b/UI/Web/src/app/reading-list/_components/reading-list-detail/reading-list-detail.component.html
@@ -75,7 +75,7 @@
 
                 <div class="col-auto ms-2">
                   <div class="card-actions btn-actions" [ngbTooltip]="t('more-alt')">
-                    <app-card-actionables [entity]="rl" [inputActions]="actions" [labelBy]="rl.title" iconClass="fa-ellipsis-h" btnClass="btn" />
+                    <app-card-actionables [entity]="rl" [actions]="actions" [labelBy]="rl.title" iconClass="fa-ellipsis-h" btnClass="btn" />
                   </div>
                 </div>
 

--- a/UI/Web/src/app/reading-list/_components/reading-lists/reading-lists.component.html
+++ b/UI/Web/src/app/reading-list/_components/reading-lists/reading-lists.component.html
@@ -3,7 +3,7 @@
     <app-side-nav-companion-bar>
       <h4 title>
         <span>{{t('title')}}</span>
-        <app-card-actionables [inputActions]="globalActions" (actionHandler)="performGlobalAction($event)" />
+        <app-card-actionables [actions]="globalActions" (actionHandler)="performGlobalAction($event)" />
       </h4>
       @if (pagination) {
         <h5 subtitle class="subtitle-with-actionables">{{t('item-count', {num: pagination.totalItems | number})}}</h5>

--- a/UI/Web/src/app/series-detail/_components/series-detail/series-detail.component.html
+++ b/UI/Web/src/app/series-detail/_components/series-detail/series-detail.component.html
@@ -113,7 +113,7 @@
 
               <div class="col-auto ms-2">
                 <div class="card-actions btn-actions" [ngbTooltip]="t('more-alt')">
-                  <app-card-actionables [entity]="seriesValue" [inputActions]="seriesActions" [labelBy]="seriesValue.name" iconClass="fa-ellipsis-h" btnClass="btn" />
+                  <app-card-actionables [entity]="seriesValue" [actions]="seriesActions" [labelBy]="seriesValue.name" iconClass="fa-ellipsis-h" btnClass="btn" />
                 </div>
               </div>
 

--- a/UI/Web/src/app/shared/_components/list-select-modal/list-select-modal.component.html
+++ b/UI/Web/src/app/shared/_components/list-select-modal/list-select-modal.component.html
@@ -1,4 +1,7 @@
 <ng-container *transloco="let t">
+  @let invalidSelection = !validSelection();
+  @let invalidSelectWarningValue = invalidSelectionWarning();
+  @let selectedItemsValue = selectedItems();
 
   <div class="modal-header">
     <h4 class="modal-title" id="modal-basic-title">{{title()}}</h4>
@@ -6,13 +9,21 @@
   </div>
 
   <div class="modal-body">
+
+    <app-loading [loading]="loading()"></app-loading>
+
     @let itemsValue = items();
     @let filteredItemsValue = filteredItems();
-    @let selectedItemValue = selectedItem();
     @let descriptionValue = description();
 
     @if (descriptionValue) {
       <span class="text-muted"> {{descriptionValue}} </span>
+    }
+    @if (invalidSelection) {
+      <span class="text-danger"> {{invalidSelectWarningValue}} </span>
+    }
+    @if (hideItemsWhenInvalid() && hiddenItems() > 0) {
+      <span class="text-warning" role="alert">{{t(hiddenTranslationKey(), {amount: hiddenItems()})}}</span>
     }
 
     <form [formGroup]="filterForm">
@@ -29,17 +40,18 @@
     </form>
 
     <ul class="list-group mt-4">
-      @for(item of filteredItemsValue; track $index) {
-        <li class="list-group-item clickable" tabindex="0" role="option" (click)="select(item)">
-          <div class="p-2 group-item d-flex justify-content-between align-items-center">
+      @if (!loading()) {
+        @for(item of filteredItemsValue; track $index) {
+          <li class="list-group-item clickable" tabindex="0" role="option" (click)="select(item)" [class.disabled]="!isItemValid(item)">
+            <div class="p-2 group-item d-flex justify-content-between align-items-center">
 
-            <div class="fw-bold">{{item.label | sentenceCase}}</div>
+              <ng-container [ngTemplateOutlet]="finalItemTemplate()"
+                            [ngTemplateOutletContext]="{ $implicit: item, index: $index, first: $first, last: $last, selectedItems: selectedItemsValue }" >
+              </ng-container>
 
-            @if (selectedItemValue && selectedItemValue.label === item.label) {
-              <span class="pill p-1 ms-1">{{t('common.selected')}}</span>
-            }
-          </div>
-        </li>
+            </div>
+          </li>
+        }
       }
     </ul>
 
@@ -48,8 +60,16 @@
   @if (showFooter()) {
     <div class="modal-footer">
       <button type="button" class="btn btn-secondary" (click)="close()">{{t('common.cancel')}}</button>
-      <button type="button" class="btn btn-primary" (click)="confirm()">{{t('common.confirm')}}</button>
+      <button type="button" class="btn btn-primary" (click)="confirm()" [disabled]="invalidSelection">{{t('common.confirm')}}</button>
     </div>
   }
 
 </ng-container>
+
+<ng-template #defaultTemplate let-item let-selectedItems='selectedItems'>
+  <div class="fw-bold">{{item.label | sentenceCase}}</div>
+
+  @if (selectedItems && selectedItems.includes(item)) {
+    <span class="pill p-1 ms-1">{{ selectedText() }}</span>
+  }
+</ng-template>

--- a/UI/Web/src/app/shared/_components/list-select-modal/list-select-modal.component.scss
+++ b/UI/Web/src/app/shared/_components/list-select-modal/list-select-modal.component.scss
@@ -1,5 +1,9 @@
-.clickable:hover, .clickable:focus {
+.clickable:hover:not(.disabled) {
   background-color: var(--list-group-hover-bg-color, var(--primary-color));
+}
+
+.disabled:hover {
+  cursor: not-allowed;
 }
 
 .pill {

--- a/UI/Web/src/app/shared/_components/list-select-modal/list-select-modal.component.ts
+++ b/UI/Web/src/app/shared/_components/list-select-modal/list-select-modal.component.ts
@@ -1,9 +1,21 @@
-import {ChangeDetectionStrategy, Component, computed, inject, model, signal} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  ContentChild, effect,
+  inject, input,
+  model,
+  OnInit,
+  signal,
+  TemplateRef, untracked, viewChild
+} from '@angular/core';
 import {NgbActiveModal} from "@ng-bootstrap/ng-bootstrap";
-import {TranslocoDirective} from "@jsverse/transloco";
+import {translate, TranslocoDirective} from "@jsverse/transloco";
 import {FormControl, FormGroup, ReactiveFormsModule} from "@angular/forms";
 import {toSignal} from "@angular/core/rxjs-interop";
 import {SentenceCasePipe} from "../../../_pipes/sentence-case.pipe";
+import {NgTemplateOutlet} from "@angular/common";
+import {LoadingComponent} from "../../loading/loading.component";
 
 export type ListSelectionItem<T> = {
   label: string,
@@ -16,7 +28,9 @@ export type ListSelectionItem<T> = {
   imports: [
     TranslocoDirective,
     ReactiveFormsModule,
-    SentenceCasePipe
+    SentenceCasePipe,
+    NgTemplateOutlet,
+    LoadingComponent
   ],
   templateUrl: './list-select-modal.component.html',
   styleUrl: './list-select-modal.component.scss',
@@ -26,14 +40,65 @@ export class ListSelectModalComponent<T> {
 
   private readonly modal = inject(NgbActiveModal);
 
+  defaultTemplate = viewChild.required<TemplateRef<any>>('defaultTemplate');
+
   title = model.required<string>();
   description = model<string | null>(null);
-  items = model.required<ListSelectionItem<T>[]>();
+  selectedText = model(translate('common.selected'));
+  invalidSelectionWarning = model<string | null>(null);
+  hiddenTranslationKey = model('list-select-modal.hidden')
+
+  inputItems = model.required<ListSelectionItem<T>[]>();
+  preSelectedItems = model<T[]>([]);
+  isValidItemFunc = model<(item: T, selection: T[]) => boolean>(() => true);
+  isSelectionValidFunc = model<(selection:T[]) => boolean>(() => true);
+  interceptConfirm = model<((selection: T|T[]) => void) | null>(null);
+
   itemsBeforeFilter = model(8);
   requireConfirmation = model(false);
   showFooter = model(true);
+  multiSelect = model(false);
+  hideItemsWhenInvalid = model(false);
 
-  protected selectedItem = signal<ListSelectionItem<T> | null>(null);
+  itemTemplate = input<TemplateRef<any> | null>(null);
+
+  loading = model(false);
+
+  protected validSelection = computed(() => {
+    const fn = this.isSelectionValidFunc();
+    const selection = this.selectedItems().map(item => item.value);
+
+    return fn(selection);
+  })
+
+  protected finalItemTemplate = computed(() => {
+    const defaultTemplate = this.defaultTemplate();
+    const itemTemplate = this.itemTemplate();
+
+    if (itemTemplate) {
+      return itemTemplate;
+    }
+
+    return defaultTemplate;
+  })
+
+  protected selectedItems = signal<ListSelectionItem<T>[]>([]);
+
+  protected items = computed(() => {
+    const items = this.inputItems();
+    const hideOnInvalid = this.hideItemsWhenInvalid();
+
+    if (!hideOnInvalid) return items;
+
+    return items.filter(item => this.isItemValid(item));
+  });
+
+  protected hiddenItems = computed(() => {
+    const allItems = this.inputItems();
+    const items = this.items();
+
+    return allItems.length - items.length;
+  });
 
   protected filteredItems = computed(() => {
     const items = this.items();
@@ -47,12 +112,46 @@ export class ListSelectModalComponent<T> {
   protected filterForm = new FormGroup({
     query: new FormControl('', {nonNullable: true}),
   });
-  protected filterQuery = toSignal(this.filterForm.get('query')!.valueChanges, {initialValue: ''})
+  protected filterQuery = toSignal(this.filterForm.get('query')!.valueChanges, {initialValue: ''});
+
+  constructor() {
+    effect(() => {
+      const items = this.inputItems();
+      const preSelectedItems = this.preSelectedItems();
+      const selectedItems = untracked(this.selectedItems); // Don't trigger effect when selected items changes
+
+      // Never overwrite selected items
+      if (selectedItems.length > 0) return;
+
+      this.selectedItems.set(items.filter(item => preSelectedItems.includes(item.value)));
+    });
+  }
+
+  isItemValid(item: ListSelectionItem<T>) {
+    // Assume selected items are always valid
+    if (this.selectedItems().includes(item)) return true;
+
+
+    return this.isValidItemFunc()(item.value, this.selectedItems().map(item => item.value));
+  }
 
   select(item: ListSelectionItem<T>) {
-    this.selectedItem.set(item);
+    if (!this.isItemValid(item)) return;
 
-    if (!this.requireConfirmation()) {
+    if (this.multiSelect()) {
+      const currentlySelected = this.selectedItems().includes(item);
+      if (currentlySelected) {
+        this.selectedItems.update(x => [...x.filter(i => i !== item)])
+      } else {
+        this.selectedItems.update(x => [...x, item])
+      }
+
+
+    } else {
+      this.selectedItems.set([item]);
+    }
+
+    if (!this.requireConfirmation() && !this.multiSelect()) {
       this.confirm();
       return;
     }
@@ -67,7 +166,15 @@ export class ListSelectModalComponent<T> {
   }
 
   confirm() {
-    this.modal.close(this.selectedItem()?.value);
+    const intercept = this.interceptConfirm();
+    const fn = intercept == null ? this.modal.close : intercept;
+
+
+    if (this.multiSelect()) {
+      fn(this.selectedItems().map(i => i.value))
+    } else {
+      fn(this.selectedItems()[0].value);
+    }
   }
 
 }

--- a/UI/Web/src/app/shared/_services/utility.service.ts
+++ b/UI/Web/src/app/shared/_services/utility.service.ts
@@ -11,6 +11,7 @@ import {debounceTime, ReplaySubject, shareReplay} from "rxjs";
 import {DOCUMENT} from "@angular/common";
 import getComputedStyle from "@popperjs/core/lib/dom-utils/getComputedStyle";
 import {toSignal} from "@angular/core/rxjs-interop";
+import {ActionItem} from "../../_services/action-factory.service";
 
 export enum KEY_CODES {
   RIGHT_ARROW = 'ArrowRight',
@@ -273,5 +274,12 @@ export class UtilityService {
                   || document.documentElement.clientHeight
                   || document.body.clientHeight;
     return [windowWidth, windowHeight];
+  }
+
+  copyActionItem(item: ActionItem<any>): ActionItem<any> {
+    return {
+      ...item,
+      children: item.children.map(child => this.copyActionItem(child))
+    }
   }
 }

--- a/UI/Web/src/app/sidenav/_components/side-nav/side-nav.component.html
+++ b/UI/Web/src/app/sidenav/_components/side-nav/side-nav.component.html
@@ -8,7 +8,7 @@
 
         <app-side-nav-item cdkDrag cdkDragDisabled icon="fa-home" [title]="t('home')" link="/home/">
           <ng-container actions>
-            <app-card-actionables [inputActions]="homeActions" labelBy="home" iconClass="fa-ellipsis-v" (actionHandler)="performHomeAction($event)" />
+            <app-card-actionables [actions]="homeActions" labelBy="home" iconClass="fa-ellipsis-v" (actionHandler)="performHomeAction($event)" />
           </ng-container>
         </app-side-nav-item>
 
@@ -43,7 +43,7 @@
                                    [imageUrl]="getLibraryImage(navStream.library!)" [title]="navStream.library!.name"
                                    [comparisonMethod]="'startsWith'">
                   <ng-container actions>
-                    <app-card-actionables [entity]="navStream.library" [inputActions]="actions" [labelBy]="navStream.name" iconClass="fa-ellipsis-v" />
+                    <app-card-actionables [entity]="navStream.library" [actions]="actions" [labelBy]="navStream.name" iconClass="fa-ellipsis-v" />
                   </ng-container>
                 </app-side-nav-item>
               }

--- a/UI/Web/src/app/statistics/_components/activity-graph/activity-graph.component.ts
+++ b/UI/Web/src/app/statistics/_components/activity-graph/activity-graph.component.ts
@@ -201,14 +201,14 @@ export class ActivityGraphComponent {
 
   getLevelDescription(level: number): string {
     const descriptions = [
-      'activity-graph.no-activity',
-      'activity-graph.low-activity',
-      'activity-graph.moderate-activity',
-      'activity-graph.good-activity',
-      'activity-graph.high-activity'
+      'activity-graph.no-activity-alt',
+      'activity-graph.low-activity-alt',
+      'activity-graph.moderate-activity-alt',
+      'activity-graph.good-activity-alt',
+      'activity-graph.high-activity-alt'
     ];
 
-    return translate(descriptions[level]) || 'activity-graph.no-activity';
+    return translate(descriptions[level]) || 'activity-graph.no-activity-alt';
   }
 
 }

--- a/UI/Web/src/app/user-settings/api-key/api-key.component.ts
+++ b/UI/Web/src/app/user-settings/api-key/api-key.component.ts
@@ -1,6 +1,5 @@
 import {
   ChangeDetectionStrategy,
-  ChangeDetectorRef,
   Component,
   computed,
   ElementRef,
@@ -11,20 +10,21 @@ import {
   ViewChild
 } from '@angular/core';
 import {Clipboard} from '@angular/cdk/clipboard';
-import {TranslocoDirective} from "@jsverse/transloco";
+import {translate, TranslocoDirective} from "@jsverse/transloco";
 import {SettingItemComponent} from "../../settings/_components/setting-item/setting-item.component";
+import {ToastrService} from "ngx-toastr";
 
 @Component({
-    selector: 'app-api-key',
-    templateUrl: './api-key.component.html',
-    styleUrls: ['./api-key.component.scss'],
-    changeDetection: ChangeDetectionStrategy.OnPush,
+  selector: 'app-api-key',
+  templateUrl: './api-key.component.html',
+  styleUrls: ['./api-key.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [TranslocoDirective, SettingItemComponent]
 })
 export class ApiKeyComponent {
 
   private readonly clipboard = inject(Clipboard);
-  private readonly cdRef = inject(ChangeDetectorRef);
+  private readonly toastr = inject(ToastrService);
 
   title = input.required<string>();
   key = input.required<string>();
@@ -44,16 +44,13 @@ export class ApiKeyComponent {
   @ViewChild('apiKey') inputElem!: ElementRef;
 
   async copy() {
-    this.inputElem.nativeElement.select();
-    this.clipboard.copy(this.inputElem.nativeElement.value);
-    this.inputElem.nativeElement.setSelectionRange(0, 0);
-    this.cdRef.markForCheck();
+    this.clipboard.copy(this.key());
+    this.toastr.success(translate('toasts.copied-to-clipboard'));
   }
 
   selectAll() {
     if (this.inputElem) {
       this.inputElem.nativeElement.setSelectionRange(0, this.key().length);
-      this.cdRef.markForCheck();
     }
   }
 

--- a/UI/Web/src/app/user-settings/manage-auth-keys/manage-auth-keys.component.html
+++ b/UI/Web/src/app/user-settings/manage-auth-keys/manage-auth-keys.component.html
@@ -135,7 +135,7 @@
             </div>
 
             <!-- Actions -->
-            <div class="d-flex gap-2">
+            <div class="d-flex gap-2 float-end">
               <button class="btn btn-primary" (click)="rotate(item)" [disabled]="isReadOnly()">
                 <i class="fa-solid fa-rotate" aria-hidden="true"></i>
                 <span class="ms-2">{{t('rotate')}}</span>

--- a/UI/Web/src/app/user-settings/manage-auth-keys/manage-auth-keys.component.html
+++ b/UI/Web/src/app/user-settings/manage-auth-keys/manage-auth-keys.component.html
@@ -35,7 +35,7 @@
         <ngx-datatable
           class="bootstrap"
           [rows]="authKeysValue"
-          [columnMode]="ColumnMode.flex"
+          [columnMode]="'flex'"
           rowHeight="auto"
           [footerHeight]="50"
           [limit]="15"

--- a/UI/Web/src/app/user-settings/manage-auth-keys/manage-auth-keys.component.ts
+++ b/UI/Web/src/app/user-settings/manage-auth-keys/manage-auth-keys.component.ts
@@ -1,10 +1,10 @@
-import {ChangeDetectionStrategy, Component, computed, inject, model, OnInit, signal} from '@angular/core';
+import {ChangeDetectionStrategy, Component, computed, inject, OnInit, signal} from '@angular/core';
 import {ApiKeyComponent} from "../api-key/api-key.component";
 import {translate, TranslocoDirective} from "@jsverse/transloco";
 import {AccountService} from "../../_services/account.service";
 import {SettingsService} from "../../admin/settings.service";
 import {WikiLink} from "../../_models/wiki";
-import {ColumnMode, NgxDatatableModule} from "@siemens/ngx-datatable";
+import {NgxDatatableModule} from "@siemens/ngx-datatable";
 import {AuthKey, AuthKeyProvider} from "../../_models/user/auth-key";
 import {UtcToLocalDatePipe} from "../../_pipes/utc-to-locale-date.pipe";
 import {DefaultDatePipe} from "../../_pipes/default-date.pipe";
@@ -103,7 +103,6 @@ export class ManageAuthKeysComponent implements OnInit {
     this.toastr.success(translate('toasts.copied-to-clipboard'));
   }
 
-  protected readonly ColumnMode = ColumnMode;
   protected readonly AuthKeyProvider = AuthKeyProvider;
   protected readonly Breakpoint = Breakpoint;
 }

--- a/UI/Web/src/app/user-settings/manage-devices/manage-devices.component.html
+++ b/UI/Web/src/app/user-settings/manage-devices/manage-devices.component.html
@@ -12,18 +12,18 @@
 
     <p>{{t('description')}}</p>
 
-    @if (!hasEmailSetup) {
+    @if (!hasEmailSetup()) {
       <div class="alert alert-warning" role="alert">
         <strong>{{t('warning')}}</strong> {{t('email-setup-alert')}}
       </div>
     }
 
-    <app-responsive-table [rows]="devices" [trackByFn]="trackBy">
+    <app-responsive-table [rows]="devices()" [trackByFn]="trackBy">
       <ng-template #tableTemplate>
         <ngx-datatable
           class="bootstrap"
-          [rows]="devices"
-          [columnMode]="ColumnMode.flex"
+          [rows]="devices()"
+          [columnMode]="'flex'"
           rowHeight="auto"
           [footerHeight]="50"
           [limit]="15"

--- a/UI/Web/src/app/user-settings/manage-devices/manage-devices.component.html
+++ b/UI/Web/src/app/user-settings/manage-devices/manage-devices.component.html
@@ -79,12 +79,13 @@
           <div class="card-body">
             <div class="d-flex justify-content-between align-items-start mb-3">
               <h5 class="card-title mb-0">{{item.name}}</h5>
-              <div class="btn-group btn-group-sm" role="group">
-                <button class="btn btn-outline-primary" (click)="editDevice(item)">
+
+              <div>
+                <button class="btn btn-primary btn-sm me-2" (click)="editDevice(item)">
                   <i class="fa fa-pen" aria-hidden="true"></i>
                   <span class="visually-hidden">{{t('edit')}}</span>
                 </button>
-                <button class="btn btn-outline-danger" (click)="deleteDevice(item)">
+                <button class="btn btn-danger btn-sm" (click)="deleteDevice(item)">
                   <i class="fa fa-trash" aria-hidden="true"></i>
                   <span class="visually-hidden">{{t('delete')}}</span>
                 </button>

--- a/UI/Web/src/app/user-settings/manage-devices/manage-devices.component.html
+++ b/UI/Web/src/app/user-settings/manage-devices/manage-devices.component.html
@@ -60,15 +60,17 @@
           <ngx-datatable-column name="actions" [sortable]="false" [draggable]="false" [resizeable]="false" [flexGrow]="1">
             <ng-template let-column="column" ngx-datatable-header-template />
             <ng-template let-item="row" ngx-datatable-cell-template>
-              <button class="btn btn-danger  me-2" (click)="deleteDevice(item)">
-                <i class="fa fa-trash" aria-hidden="true"></i>
-                <span class="visually-hidden">{{t('delete')}}</span>
-              </button>
+              <div class="float-end">
+                <button class="btn btn-danger  me-2" (click)="deleteDevice(item)">
+                  <i class="fa fa-trash" aria-hidden="true"></i>
+                  <span class="visually-hidden">{{t('delete')}}</span>
+                </button>
 
-              <button class="btn btn-primary" (click)="editDevice(item)">
-                <i class="fa fa-pen" aria-hidden="true"></i>
-                <span class="visually-hidden">{{t('edit')}}</span>
-              </button>
+                <button class="btn btn-primary" (click)="editDevice(item)">
+                  <i class="fa fa-pen" aria-hidden="true"></i>
+                  <span class="visually-hidden">{{t('edit')}}</span>
+                </button>
+              </div>
             </ng-template>
           </ngx-datatable-column>
         </ngx-datatable>

--- a/UI/Web/src/app/user-settings/manage-devices/manage-devices.component.html
+++ b/UI/Web/src/app/user-settings/manage-devices/manage-devices.component.html
@@ -1,6 +1,6 @@
 <ng-container *transloco="let t; prefix:'manage-devices'">
 
-  <!-- "Send to" Devices -->
+  <!-- Email Devices -->
   <ng-container>
     <div class="position-relative">
       <button class="btn btn-outline-primary position-absolute custom-position" [disabled]="isReadOnly$ | async" (click)="addDevice()">

--- a/UI/Web/src/app/user-settings/manage-reading-profiles/manage-reading-profiles.component.html
+++ b/UI/Web/src/app/user-settings/manage-reading-profiles/manage-reading-profiles.component.html
@@ -57,6 +57,9 @@
 
                 @if (selectedProfile.id !== 0) {
                   <div class="d-flex justify-content-between">
+                    <button class="btn btn-secondary me-2" (click)="setDevices()" [disabled]="selectedProfile.kind === ReadingProfileKind.Default">
+                      {{t('set-devices')}}
+                    </button>
                     <button type="button" class="btn btn-danger" (click)="delete(selectedProfile!)" [disabled]="selectedProfile.kind === ReadingProfileKind.Default">
                       <i class="fa fa-trash" aria-hidden="true"></i>
                       <span class="visually-hidden">{{t('delete')}}</span>

--- a/UI/Web/src/app/volume-detail/volume-detail.component.html
+++ b/UI/Web/src/app/volume-detail/volume-detail.component.html
@@ -80,7 +80,7 @@
 
               <div class="col-auto ms-2">
                 <div class="card-actions mt-2" [ngbTooltip]="t('more-alt')">
-                  <app-card-actionables [entity]="volume" [inputActions]="volumeActions" [labelBy]="series.name + ' ' + volume.minNumber" iconClass="fa-ellipsis-h" btnClass="btn-actions btn" />
+                  <app-card-actionables [entity]="volume" [actions]="volumeActions" [labelBy]="series.name + ' ' + volume.minNumber" iconClass="fa-ellipsis-h" btnClass="btn-actions btn" />
                 </div>
               </div>
 

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -448,8 +448,6 @@
         "new-password-label": "New Password",
         "confirm-password-label": "Confirm Password",
         "reset": "{{common.reset}}",
-        "edit": "{{common.edit}}",
-        "cancel": "{{common.cancel}}",
         "save": "{{common.save}}",
         "required-field": "{{validation.required-field}}",
         "passwords-must-match": "Passwords must match",
@@ -468,13 +466,9 @@
         "invite-url-label": "Invite Url",
         "invite-url-tooltip": "Copy this and paste in a new tab",
         "has-invalid-email": "It looks like you do not have a valid email set. Change email will require the admin to send you a link to complete this action.",
-
-        "permission-error": "You do not have permission to change your email. Reach out to the admin of the server.",
         "required-field": "{{validation.required-field}}",
         "valid-email": "{{validation.valid-email}}",
         "reset": "{{common.reset}}",
-        "edit": "{{common.edit}}",
-        "cancel": "{{common.cancel}}",
         "save": "{{common.save}}"
     },
 
@@ -482,17 +476,11 @@
         "age-restriction-label": "Age Restriction",
         "unknowns": "Unknowns",
         "reset": "{{common.reset}}",
-        "edit": "{{common.edit}}",
-        "cancel": "{{common.cancel}}",
         "save": "{{common.save}}"
     },
 
     "api-key": {
-        "copy": "Copy",
-        "show": "Show",
-        "hide": "Hide",
-        "regen-warning": "Regenerating your API key will invalidate any existing clients.",
-        "no-key": "ERROR - KEY NOT SET"
+        "copy": "{{book-line-overlay.copy}}"
     },
 
     "scrobbling-providers": {
@@ -546,10 +534,6 @@
     },
 
     "active-user-card": {
-        "overall": "Overall",
-        "this-week": "This Week",
-        "this-month": "This Month",
-        "this-year": "This Year",
         "total-hours": "{{duration}} total",
         "comics-count": "{{count}} comics",
         "books-count": "{{count}} books"
@@ -1034,10 +1018,6 @@
         "not-liked": "Liked by {{amount}} people, you did not like it"
     },
 
-    "annotations-tab": {
-        "title": "{{tabs.annotations-tab}}"
-    },
-
     "view-annotations-drawer": {
         "title": "{{tabs.annotations-tab}}",
         "close": "{{common.close}}",
@@ -1095,27 +1075,11 @@
     },
 
     "book-reader": {
-        "title": "Book Settings",
         "page-label": "Page",
-
-        "pagination-header": "Section",
-        "go-to-first-page": "Go to first page",
-        "go-to-last-page": "Go to last page",
-        "prev-page": "Prev Page",
-        "next-page": "Next Page",
-        "prev-chapter": "Prev Chapter/Volume",
-        "next-chapter": "Next Chapter/Volume",
         "skip-header": "Skip to main content",
-        "virtual-pages": "virtual pages",
-
-        "settings-header": "Settings",
-        "table-of-contents-header": "Table of Contents",
-        "bookmarks-header": "{{side-nav.bookmarks}}",
-        "toc-header": "ToC",
-
         "loading-book": "Loading book…",
         "go-back": "Go Back",
-        "close-reader": "Close Reader",
+        "close-reader-alt": "Close Reader",
         "incognito-mode-alt": "Incognito mode is on. Toggle to turn off.",
         "incognito-mode-label": "Incognito Mode",
         "next": "Next",
@@ -1386,10 +1350,6 @@
 
     "all-annotations": {
         "title": "All Annotations",
-        "filter": {
-            "true": "True",
-            "false": "False"
-        },
         "annotations-count": "{{num}} Annotations",
         "export": "Export"
     },
@@ -1547,7 +1507,6 @@
 
     "card-detail-layout": {
         "total-items": "{{count}} total items",
-        "jumpkey-count": "{{count}} Series",
         "no-data": "{{common.no-data}}"
     },
 
@@ -1637,7 +1596,6 @@
         "clear": "{{common.clear}}",
         "no-data": "No collections created yet",
         "loading": "{{common.loading}}",
-        "create": "{{common.create}}",
         "bound":  "Bound"
     },
 
@@ -2120,7 +2078,6 @@
         "no-data": "There are no items. Try adding a series.",
         "no-data-filtered": "No items match your current filter.",
         "title-alt": "Kavita - {{collectionName}} Collection",
-        "series-header": "Series",
         "sync-progress": "Series Collected: {{title}}",
         "last-sync": "Last Sync: {{date}}",
         "item-count": "{{common.item-count}}"
@@ -2320,10 +2277,6 @@
         "starting-title": "Starting",
         "promote-label": "Promote",
         "promote-tooltip": "Promotion means that the collection can be seen server-wide, not just for you. All series within this collection will still have user-access restrictions placed on them."
-    },
-
-    "browse-themes-modal": {
-        "title": "Browse Themes"
     },
 
     "import-mal-collection-modal": {
@@ -2635,7 +2588,6 @@
         "save": "{{common.save}}",
         "title-label": "Title",
         "sort-order-label": "Sort Order",
-        "sort-order-tooltip": "The reading order in which this chapter is ordered within the volume",
         "isbn-label": "ISBN",
         "release-date-label": "Release",
         "summary-label": "{{edit-series-modal.summary-label}}",
@@ -2751,9 +2703,7 @@
 
     "day-breakdown": {
         "title": "Day Breakdown",
-        "no-data": "No progress, get to reading",
-        "x-axis-label": "Day of Week",
-        "y-axis-label": "Reading Events"
+        "no-data": "No progress, get to reading"
     },
 
     "file-breakdown-stats": {
@@ -2976,7 +2926,6 @@
 
     "avg-time-reading-by-hour": {
         "title": "Average time spent reading by hour",
-        "minutes": "Minutes",
         "most-time-spend-reading": "{{name}} spends most of their time reading between {{startHour}} and {{endHour}} with an average of {{amount}} minutes",
         "data-since": "Only includes reads since {{date}}",
         "no-data": "{{common.no-data}}"
@@ -2997,9 +2946,13 @@
         "pages": "Pages",
         "words": "Words",
         "chapters": "Chapters",
-        "no-activity": "No Activity",
+        "no-activity-alt": "No Activity",
         "no-activity-tooltip": "No reading activity on {{date}}.",
-        "all-time": "{{time-periods.all-time}}"
+        "all-time": "{{time-periods.all-time}}",
+        "low-activity-alt": "Low Activity",
+        "moderate-activity-alt": "Moderate Activity",
+        "good-activity-alt": "Good Activity",
+        "high-activity-alt": "High Activity"
     },
 
     "reading-pace": {
@@ -3141,22 +3094,16 @@
     },
 
     "customize-dashboard-modal": {
-        "title-dashboard": "Customize Dashboard",
-        "title-sidenav": "Customize Side Nav",
-        "title-external-sources": "External Sources",
         "title-smart-filters": "Smart Filters",
-        "close": "{{common.close}}",
         "dashboard": "Dashboard",
         "sidenav": "Side Nav",
         "external-sources": "External Sources",
         "smart-filters": "Smart Filters",
-        "help": "{{common.help}}",
         "description": "You can customize different aspects of Kavita by reordering, toggling visibility, and binding smart filters/external sources to your home page or side nav."
     },
 
     "customize-dashboard-streams": {
         "no-data": "All Smart filters added to Dashboard or none created yet.",
-        "save": "{{common.save}}",
         "add": "{{common.add}}",
         "filter": "{{common.filter}}",
         "clear": "{{common.clear}}",
@@ -3166,7 +3113,6 @@
     "customize-sidenav-streams": {
         "no-data": "All Smart filters added to Side Nav or none created yet.",
         "no-data-external-source": "All External Sources added to Side Nav or none created yet.",
-        "save": "{{common.save}}",
         "add": "{{common.add}}",
         "filter": "{{common.filter}}",
         "clear": "{{common.clear}}",
@@ -3793,7 +3739,6 @@
         "select-all": "Select All",
         "deselect-all": "Deselect All",
         "series-count": "{{num}} Series",
-        "author-count": "{{num}} Authors",
         "item-count": "{{num}} Items",
         "chapter-count": "{{num}} Chapters",
         "issue-count": "{{num}} Issues",
@@ -3808,7 +3753,6 @@
         "book-num-shorthand": "Book {{num}}",
         "issue-num-shorthand": "#{{num}}",
         "volume-num-shorthand": "Vol {{num}}",
-
         "book-nums": "Books",
         "issue-nums": "Issues",
         "chapter-nums": "Chapters",

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -2111,7 +2111,9 @@
         "key-bind-title-page-up": "Page up",
         "key-bind-tooltip-page-up": "Move one page upwards",
         "key-bind-title-page-down": "Page down",
-        "key-bind-tooltip-page-down": "Move one page downwards"
+        "key-bind-tooltip-page-down": "Move one page downwards",
+        "key-bind-title-offset-double-page": "Offset double page",
+        "key-bind-tooltip-offset-double-page": "Manually offset pages for double page spread alignment"
     },
 
     "collection-detail": {
@@ -2217,7 +2219,8 @@
         "bookmark": "Bookmark current page",
         "double-click": "double click",
         "close-reader": "Close reader",
-        "toggle-menu": "Toggle Menu"
+        "toggle-menu": "Toggle Menu",
+        "offset-double-page": "Manually offset pages for spread alignment"
 
     },
 
@@ -2474,7 +2477,8 @@
         "reading-profile-updated": "Reading profile updated",
         "reading-profile-promoted": "Reading profile promoted",
         "emulate-comic-book-label": "{{manage-reading-profiles.emulate-comic-book-label}}",
-        "series-progress": "Series Progress: {{percentage}}"
+        "series-progress": "Series Progress: {{percentage}}",
+        "page-offset-label": "Page Offset"
     },
 
     "metadata-filter": {

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -2113,7 +2113,7 @@
         "key-bind-title-page-down": "Page down",
         "key-bind-tooltip-page-down": "Move one page downwards",
         "key-bind-title-offset-double-page": "Offset double page",
-        "key-bind-tooltip-offset-double-page": "Manually offset pages for double page spread alignment"
+        "key-bind-tooltip-offset-double-page": "Offset pages for double page spread alignment"
     },
 
     "collection-detail": {
@@ -2220,8 +2220,7 @@
         "double-click": "double click",
         "close-reader": "Close reader",
         "toggle-menu": "Toggle Menu",
-        "offset-double-page": "Manually offset pages for spread alignment"
-
+        "offset-double-page": "{{keybind-setting-description-pipe.key-bind-title-offset-double-page}}"
     },
 
     "grouped-typeahead": {
@@ -2892,8 +2891,6 @@
         "stats-tab": "{{tabs.stats-tab}}",
         "reviews-tab": "{{tabs.reviews-tab}}",
         "no-reviews": "No Reviews yet",
-        "user-you": "you",
-        "user-possessive-your": "your",
         "user-possessive": "{{name}}'s",
         "total-reads-badge": "{{reads}} Reads",
         "k+-badge": "K+ Subscriber"

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -18,9 +18,14 @@
 
     "manage-oidc-connect": {
         "save": "{{common.save}}",
+        "reset-label": "Reset ids",
+        "reset-tooltip": "Reset external ids from all users, use this to reset links between users in Kavita and your identity provider",
+        "reset-confirm": "Are you certain you want to reset external ids from all users?",
+        "reset-success": "External ids reset for all users, re-authenticate to link",
         "save-success": "Successfully updated your OIDC settings",
         "notice": "Notice",
         "restart-required": "Changing Provider or advanced settings requires a manual restart of Kavita to take effect.",
+        "auto-save-required": "You've changed critical settings, auto save to persist them",
         "provider-title": "Provider",
         "provider-tooltip": "Provider settings require you to manually click Save. Kavita must be configured as a confidential client and needs a redirect URL. See the <a href='https://wiki.kavitareader.com/guides/admin-settings/open-id-connect/' target='_blank' rel='noreferrer noopener'>wiki</a> for more details.",
         "behavior-title": "Behavior",

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -2865,8 +2865,11 @@
     },
 
     "activity-card": {
-        "pages-count": "{{series-detail.pages-count}}",
-        "words-count": "{{series-detail.words-count}}",
+        "pages-count": "Total Pages",
+        "words-count": "Total Words",
+        "active-pages-label": "{{series-detail.pages-count}}",
+        "active-words-label": "{{series-detail.words-count}}",
+        "total-chapters-label": "Chapters",
         "started-label": "Started",
         "view-label": "View"
     },

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -2860,10 +2860,6 @@
         "no-data": "Nothing to see here"
     },
 
-    "fiction-graph": {
-
-    },
-
     "activity-card": {
         "pages-count": "Total Pages",
         "words-count": "Total Words",
@@ -2980,7 +2976,8 @@
 
     "profile-overview": {
         "currently-reading": "Currently Reading",
-        "want-to-read": "{{side-nav.want-to-read}}"
+        "want-to-read": "{{side-nav.want-to-read}}",
+        "just-finished-reading": "Just Finished Reading"
     },
 
     "activity-graph": {

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -2539,6 +2539,7 @@
         "read-progress": "Last Read",
         "average-rating": "Average Rating",
         "random": "Random",
+        "user-rating": "Own rating",
         "person-name": "Name",
         "person-series-count": "Series Count",
         "person-chapter-count": "Chapter Count",

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -2658,8 +2658,8 @@
 
         "pages-label": "Pages",
         "words-label": "Length",
-        "pages-count": "{{num}} Pages",
-        "words-count": "{{num}} Words",
+        "pages-count": "{{series-detail.pages-count}}",
+        "words-count": "{{series-detail.words-count}}",
 
         "reading-time-label": "Read Time",
         "date-added-label": "Date Added",
@@ -2861,10 +2861,10 @@
     },
 
     "activity-card": {
-        "pages-count": "Total Pages",
-        "words-count": "Total Words",
-        "active-pages-label": "{{series-detail.pages-count}}",
-        "active-words-label": "{{series-detail.words-count}}",
+        "pages-count": "{{series-detail.pages-count}}",
+        "words-count": "{{series-detail.words-count}}",
+        "active-pages-label": "Total Pages",
+        "active-words-label": "Total Words",
         "total-chapters-label": "Chapters",
         "started-label": "Started",
         "view-label": "View"

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -416,11 +416,9 @@
     "edit-device-modal": {
         "title": "Edit Email Device",
         "device-name-label": "{{manage-devices.name-label}}",
-        "platform-label": "{{manage-devices.platform-label}}",
-
+        "device-platform-label": "{{manage-devices.platform-label}}",
         "email-label": "{{common.email}}",
         "email-tooltip": "This email will be used to accept the file via Send To",
-        "device-platform-label": "Device Platform",
         "save": "{{common.save}}",
         "close": "{{common.close}}",
         "cancel": "{{common.cancel}}",
@@ -431,7 +429,7 @@
     "client-device-card": {
         "auth-type-label": "Authentication Type",
         "browser-label": "Browser",
-        "platform-label": "Platform",
+        "platform-label": "{{manage-devices.platform-label}}",
         "screen-label": "Screen",
         "version-label": "App Version",
         "first-seen-label": "First Seen",
@@ -2568,13 +2566,10 @@
         "last-modified-title": "Last Modified",
         "view-files": "View Files",
         "pages-title": "{{edit-chapter-modal.pages-label}}",
-        "words-title": "Words",
         "chapter-title": "Chapter",
         "volume-num": "{{common.volume-num}}",
         "highest-count-tooltip": "Highest Count found across all ComicInfo in the Series",
         "max-issue-tooltip": "Max Issue or Volume field from all ComicInfo in the series",
-        "force-refresh": "Force Refresh",
-        "force-refresh-tooltip": "Force refresh external metadata from Kavita+",
         "loose-leaf-volume": "Loose Leaf Chapters",
         "specials-volume": "Specials",
         "release-year-validation": "{{validation.year-validation}}",
@@ -2648,14 +2643,9 @@
         "words-label": "{{edit-chapter-modal.words-label}}",
         "pages-count": "{{edit-chapter-modal.pages-count}}",
         "words-count": "{{edit-chapter-modal.words-count}}",
-        "reading-time-label": "{{edit-chapter-modal.reading-time-label}}",
         "date-added-label": "{{edit-chapter-modal.date-added-label}}",
         "size-label": "{{edit-chapter-modal.size-label}}",
         "id-label": "{{edit-chapter-modal.id-label}}",
-        "links-label": "{{series-metadata-detail.links-label}}",
-        "last-read-label": "{{edit-chapter-modal.last-read-label}}",
-        "range-hours": "{{value}} {{hourWord}}",
-        "read-time-label": "{{edit-chapter-modal.read-time-label}}",
         "files-label": "{{edit-chapter-modal.files-label}}",
         "cover-image-description": "{{edit-series-modal.cover-image-description}}"
     },
@@ -2665,10 +2655,8 @@
         "general-tab": "{{edit-series-modal.general-tab}}",
         "cover-image-tab": "{{edit-series-modal.cover-image-tab}}",
         "aliases-tab": "Aliases",
-        "loading": "{{common.loading}}",
         "close": "{{common.close}}",
         "name-label": "{{edit-series-modal.name-label}}",
-        "role-label": "Role",
         "mal-id-label": "MAL Id",
         "mal-tooltip": "https://myanimelist.net/people/{MalId}/",
         "mal-tooltip-character": "https://myanimelist.net/character/{MalId}/",
@@ -3431,11 +3419,6 @@
         "hours": "Hours",
         "hour-left": "Hour left",
         "hours-left": "Hours left"
-    },
-
-    "epub-page-calc-method-pipe": {
-        "default": "Default",
-        "calc1": "Calc 1"
     },
 
     "metadata-setting-field-pipe": {

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -2870,10 +2870,8 @@
     },
 
     "activity-card": {
-        "pages-count": "{{series-detail.pages-count}}",
-        "words-count": "{{series-detail.words-count}}",
-        "active-pages-label": "Total Pages",
-        "active-words-label": "Total Words",
+        "total-pages-label": "Total Pages",
+        "total-words-label": "Total Words",
         "total-chapters-label": "Chapters",
         "started-label": "Started",
         "view-label": "View"

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -2999,7 +2999,8 @@
         "words": "Words",
         "chapters": "Chapters",
         "no-activity": "No Activity",
-        "no-activity-tooltip": "No reading activity on {{date}}."
+        "no-activity-tooltip": "No reading activity on {{date}}.",
+        "all-time": "{{time-periods.all-time}}"
     },
 
     "reading-pace": {

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -1765,8 +1765,16 @@
 
         "media-issue-title": "Media Issues",
         "scrobble-issue-title": "Scrobble Issues",
+        "pdf-render-resolution-label": "PDF Render Resolution",
+        "pdf-render-resolution-tooltip": "Resolution at which PDFs will be rendered. Higher resolutions will take longer to render and consume more memory. If you experience issues with PDF rendering, try lowering this.",
         "cover-image-size-label": "Cover Image Size",
         "cover-image-size-tooltip": "How large should cover images generate as. Note: Anything larger than the default will incur longer page load times."
+    },
+
+    "pdf-render-resolution": {
+        "default": "Default (1080x1920)",
+        "high": "High (1920x2560)",
+        "ultra": "Ultra (2160x3840)"
     },
 
     "cover-image-size": {

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -2539,7 +2539,7 @@
         "read-progress": "Last Read",
         "average-rating": "Average Rating",
         "random": "Random",
-        "user-rating": "Own rating",
+        "user-rating": "My rating",
         "person-name": "Name",
         "person-series-count": "Series Count",
         "person-chapter-count": "Chapter Count",

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -1594,7 +1594,9 @@
         "clear": "{{common.clear}}",
         "no-data": "No collections created yet",
         "loading": "{{common.loading}}",
-        "bound":  "Bound"
+        "bound":  "Bound",
+        "warning-duplicate": "Your selection contains overlapping devices, this is not allowed",
+        "hidden": "{{amount}} profile(s) hidden due to invalid state"
     },
 
     "entity-title": {
@@ -3401,8 +3403,8 @@
         "match-success": "Series matched correctly",
         "webtoon-override": "Switching to Webtoon mode due to images representing a webtoon.",
         "scrobble-gen-init": "Enqueued a job to generate scrobble events from past reading history and ratings, syncing them with connected services.",
-        "series-bound-to-reading-profile": "Series bound to Reading Profile {{name}}",
-        "library-bound-to-reading-profile": "Library bound to Reading Profile {{name}}",
+        "series-bound-to-reading-profile": "Series bound to {{amount}} Reading Profiles",
+        "library-bound-to-reading-profile": "Library bound to {{amount}} Reading Profiles",
         "external-match-rate-error": "Kavita ran out of rate looking up {{seriesName}}. Try again in 5 minutes.",
         "confirm-delete-bookmark": "Are you sure you want to delete this Bookmark?",
         "confirm-delete-annotation": "Are you sure you want to delete this Annotation?",
@@ -3565,7 +3567,7 @@
     },
 
     "manage-reading-profiles": {
-        "description": "Not all your series may be read in the same way, set up distinct reading profiles per library or series to make getting back in your series as seamless as possible.",
+        "description": "Not all your series may be read in the same way, set up distinct reading profiles per library/series/device to make getting back in your series as seamless as possible.",
         "extra-tip": "Assign reading profiles via the action menu on series and libraries, or in bulk. When changing settings in a reader, a hidden profile is created that remembers your choices for that series (not for pdfs). This profile is removed when you assign one of your own reading profiles to the series. More information can be found on the",
         "wiki-title": "wiki",
         "profiles-title": "Your reading profiles",
@@ -3576,6 +3578,8 @@
         "no-selected": "No profile selected",
         "confirm": "Are you sure you want to delete the reading profile {{name}}?",
         "selection-tip": "Select a profile from the list, or create a new one at the top right",
+        "set-devices": "Set Devices",
+        "select-devices-for": "Set devices for {{name}}",
 
         "image-reader-settings-title": "Image Reader",
         "reading-direction-label": "Reading Direction",
@@ -3642,6 +3646,10 @@
         "reading-profile-series-settings-title": "Series",
         "reading-profile-library-settings-title": "Library",
         "delete": "{{common.delete}}"
+    },
+
+    "list-select-modal": {
+      "hidden": "{{amount}} items hidden due to invalid state"
     },
 
 
@@ -3726,6 +3734,8 @@
         "chapter-count": "{{num}} Chapters",
         "issue-count": "{{num}} Issues",
         "no-data": "No Data",
+        "confirm": "Confirm",
+        "selected": "Selected",
 
         "book-num": "Book",
         "issue-hash-num": "Issue #",

--- a/UI/Web/src/theme/components/_buttons.scss
+++ b/UI/Web/src/theme/components/_buttons.scss
@@ -201,6 +201,7 @@ button:disabled, .form-control:disabled, .form-control[readonly], .disabled, :di
 
   &:disabled {
     --bs-btn-disabled-bg: transparent;
+    --bs-btn-disabled-border-color: transparent;
   }
 
   &:hover, &:focus, &:focus-visible {

--- a/UI/Web/src/theme/themes/dark.scss
+++ b/UI/Web/src/theme/themes/dark.scss
@@ -480,6 +480,5 @@
   /** Activity Card **/
   --activity-card-client-platform-badge-bg-color: #8b5cf6;
   --activity-card-client-device-badge-bg-color: #3b82f6;
-  --activity-card-client-quantity-badge-bg-color: #cbd5e1;
 
 }

--- a/UI/Web/src/theme/themes/dark.scss
+++ b/UI/Web/src/theme/themes/dark.scss
@@ -477,5 +477,9 @@
   /** Misc **/
   --offwhite-text-color: #8b95a5;
 
+  /** Activity Card **/
+  --activity-card-client-platform-badge-bg-color: #8b5cf6;
+  --activity-card-client-device-badge-bg-color: #3b82f6;
+  --activity-card-client-quantity-badge-bg-color: #cbd5e1;
 
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,7 +30,7 @@ fi
 echo "Starting Kavita"
 echo ls -l "/kavita/config/appsettings.json"
 
-./Kavita
+exec ./Kavita
 
 #if [[ "$PUID" -eq 0 ]]; then
 #    # Run as root


### PR DESCRIPTION
This is it from Amelia and I for the year. This is a large PR with a lot of polish and a few big enhancements, like page offset for double page reader and ability to bind reading profiles to different devices (now that we have devices) and an awesome enhancement to upscale PDF -> Images for Mihon readers. 



# Added
- Added: (Stats) Added a Just Finished stream to the Profile Overview tab
- Added: Added stat collection for total pages/words/time read for users for an planned social badge feature
- Added: Added the ability to change the PDF renderer resolution (Mihon-apps) via a Server Setting. The admin can choose Default (1080x1920), High (1920x2560) or Ultra (2160x3840) (Thanks @StereotypicalCat)
- Added: Added the ability to sort by a user's own rating (Closes FR https://github.com/Kareadita/Kavita/discussions/4210, 1 upvote) (Thanks @ToniKielo)
- Added: Page offset toggle for double page manga reader mode to manually adjust page alignment for proper double-page spreads, including a keybind to toggle it.  (Closes FR https://github.com/Kareadita/Kavita/discussions/2660, 37 upvotes) (Thanks @linkion)
- Added: Reading profiles can now also be bound per device. Profiles with a device get precedence to profiles without. Each series can have at most one profiles for each device, and one without any.  (Closes FR #2929, FR #3901, 34 upvotes)

# Changed
- Changed: Search now searches against aliases for People (Fixes #4297 )
- Changed: (OIDC) Added a warning when auto save is required and a button to reset external Ids 
- Changed: (Stats) Ensure total days is clamped appropriately (develop)
- Change: (Stats) When calculating reading progress, take average of days (per hour) with actual progress instead of all days (develop)
- Changed: Tightened when the reading session close out time is to be closer to the reality (develop)
- Changed: (Performance) Slight memory improvement in creating images from PDFs
- Changed: Implicit profiles will now automatically be bound to the device you're using when they're created


# Fixed
- Fixed: Fixed download action not being surfaced on mobile (develop)
- Fixed: (OIDC) Fixed being logged out when Kavita restarts with Docker 
- Fixed: Don't let users download a PDF within the reader via Ctrl+S without the download role (Fixes #4183)
- Fixed: Fixed the backup service sometimes not copying over the db due to being in use (Fixes #3456) (Thanks @DieselTech)
- Fixed: Fixed docker containers not cleanly stopping, like with docker stop/podman stop (Thanks @ZeroKnight)
- Fixed: Fixed an issue where client device's last seen wasn't updating (develop)
- Fixed: Fixed a bad migration (Fixes #4301, Fixes #4308) (develop) 
- Fixed: Fixed word count logic for a reading session (develop)
- Fixed: Fixed an issue where an empty actionable menu would open when an admin is trying to manipulate a user's client device (develop)
- Fixed: Fixed a bug where a session would start and skip the first pagination event that triggered it. In the case of epub, it will assume the current page (develop)
- Fixed: Fixed the performance issue with images loading by using a better cache strategy (develop)
- Fixed: Fixed copy on opds url not copying the real text (develop)
- Fixed: Fixed Edit Chapter modal not having an Editors field
- Fixed: Fixed NPE when opening the stats page if you had no progress yet (develop)

# Theme
- Added --activity-card-client-platform-badge-bg-color, --activity-card-client-device-badge-bg-color for Activity card badges

# Developer
- Removed a lot of dead localization strings. This process is only a third complete. 
