### PR TITLE
Almost there

### DIFF
--- a/API.Tests/Helpers/KoreaderHelperTests.cs
+++ b/API.Tests/Helpers/KoreaderHelperTests.cs
@@ -55,9 +55,15 @@ public class KoreaderHelperTests
         Assert.Equal(expected.PageNum, actual.PageNum);
     }
 
+    /// <summary>
+    /// KOReader is 1-indexed
+    /// </summary>
+    /// <param name="scrollId"></param>
+    /// <param name="page"></param>
+    /// <param name="koreaderPosition"></param>
     [Theory]
-    [InlineData("//body/p[20]", 5, "/body/DocFragment[5]/body/p[20]")]
-    [InlineData(null, 10, "/body/DocFragment[10]/body/p[1]")] // I've not seen a null/just an "A" from Koreader in testing
+    [InlineData("//body/p[20]", 4, "/body/DocFragment[5]/body/p[20]")]
+    [InlineData(null, 9, "/body/DocFragment[10]/body/p[1]")] // I've not seen a null/just an "A" from Koreader in testing
     public void GetKoreaderPosition(string? scrollId, int page, string koreaderPosition)
     {
         var given = EmptyProgressDto();

--- a/API.Tests/Helpers/KoreaderHelperTests.cs
+++ b/API.Tests/Helpers/KoreaderHelperTests.cs
@@ -7,78 +7,179 @@ namespace API.Tests.Helpers;
 
 public class KoreaderHelperTests
 {
+    #region UpdateProgressDto Tests
 
     [Theory]
-    [InlineData("/body/DocFragment[11]/body/div/a", 10, null)]
-    [InlineData("/body/DocFragment[1]/body/div/p[40]", 0, 40)]
-    public void GetEpubPositionDto(string koreaderPosition, int page, int? pNumber)
+    [InlineData("/body/DocFragment[11]/body/div/a", 10, null)] // Anchor tags return null BookScrollId
+    [InlineData("/body/DocFragment[1]/body/div/p[40]", 0, "//body/div/p[40]")]
+    [InlineData("/body/DocFragment[5]/body/section/div[2]", 4, "//body/section/div[2]")]
+    public void UpdateProgressDto_StandardXPath(string koreaderPosition, int expectedPage, string? expectedScrollId)
     {
-        var expected = EmptyProgressDto();
-        expected.BookScrollId = pNumber.HasValue ? $"//BODY/DIV/P[{pNumber}]" : null;
-        expected.PageNum = page;
         var actual = EmptyProgressDto();
 
         KoreaderHelper.UpdateProgressDto(actual, koreaderPosition);
-        Assert.Equal(expected.BookScrollId?.ToLowerInvariant(), actual.BookScrollId);
-        Assert.Equal(expected.PageNum, actual.PageNum);
+
+        Assert.Equal(expectedPage, actual.PageNum);
+        Assert.Equal(expectedScrollId, actual.BookScrollId);
     }
 
     [Theory]
-    [InlineData("/body/DocFragment[8]/body/div/p[28]/text().264", 7, 28)]
-    public void GetEpubPositionDtoWithExtraXpath(string koreaderPosition, int page, int? pNumber)
-    {
-        var expected = EmptyProgressDto();
-        expected.BookScrollId = pNumber.HasValue ? $"//BODY/DIV/P[{pNumber}]" : null;
-        expected.PageNum = page;
-        var actual = EmptyProgressDto();
-
-        KoreaderHelper.UpdateProgressDto(actual, koreaderPosition);
-        Assert.Equal(expected.BookScrollId?.ToLowerInvariant(), actual.BookScrollId);
-        Assert.Equal(expected.PageNum, actual.PageNum);
-    }
-
-    [Theory]
+    [InlineData("/body/DocFragment[8]/body/div/p[28]/text().264", 7, "//body/div/p[28]")]
     [InlineData("/body/DocFragment[3]/body/h1/text().0", 2, "//body/h1")]
-    [InlineData("/body/DocFragment[10].0", 9, null)]
     [InlineData("/body/DocFragment[9]/body/p[52]/text().248", 8, "//body/p[52]")]
-    public void GetEpubPositionDto_UserSubmitted(string koreaderPosition, int page, string? convertedXpath)
+    [InlineData("/body/DocFragment[6]/body/div/span.0", 5, "//body/div/span")] // Trailing .0 stripped
+    public void UpdateProgressDto_WithTextOffsets(string koreaderPosition, int expectedPage, string? expectedScrollId)
     {
-        var expected = EmptyProgressDto();
-        expected.PageNum = page;
         var actual = EmptyProgressDto();
 
         KoreaderHelper.UpdateProgressDto(actual, koreaderPosition);
-        if (!string.IsNullOrEmpty(convertedXpath))
-        {
-            Assert.Equal(convertedXpath, actual.BookScrollId);
-        }
-        Assert.Equal(expected.PageNum, actual.PageNum);
+
+        Assert.Equal(expectedPage, actual.PageNum);
+        Assert.Equal(expectedScrollId, actual.BookScrollId);
     }
 
-    /// <summary>
-    /// KOReader is 1-indexed
-    /// </summary>
-    /// <param name="scrollId"></param>
-    /// <param name="page"></param>
-    /// <param name="koreaderPosition"></param>
     [Theory]
-    [InlineData("//body/p[20]", 4, "/body/DocFragment[5]/body/p[20]")]
-    [InlineData(null, 9, "/body/DocFragment[10]/body/p[1]")] // I've not seen a null/just an "A" from Koreader in testing
-    public void GetKoreaderPosition(string? scrollId, int page, string koreaderPosition)
+    [InlineData("/body/DocFragment[10].0", 9, null)] // Short path - no scroll ID determinable
+    [InlineData("/body/DocFragment[5]", 4, null)]
+    [InlineData("/body/DocFragment[1]/body", 0, null)] // Too short for full path extraction
+    public void UpdateProgressDto_ShortPaths(string koreaderPosition, int expectedPage, string? expectedScrollId)
+    {
+        var actual = EmptyProgressDto();
+
+        KoreaderHelper.UpdateProgressDto(actual, koreaderPosition);
+
+        Assert.Equal(expectedPage, actual.PageNum);
+        Assert.Equal(expectedScrollId, actual.BookScrollId);
+    }
+
+    [Theory]
+    [InlineData("#_doc_fragment_10", 9, null)]
+    [InlineData("#_doc_fragment_1", 0, null)]
+    [InlineData("#_doc_fragment_10_ some_anchor", 9, null)] // With trailing anchor
+    [InlineData("#_doc_fragment10", 9, null)] // Legacy format without underscore
+    [InlineData("#_doc_fragment1", 0, null)]
+    public void UpdateProgressDto_HashFragmentFormat(string koreaderPosition, int expectedPage, string? expectedScrollId)
+    {
+        var actual = EmptyProgressDto();
+
+        KoreaderHelper.UpdateProgressDto(actual, koreaderPosition);
+
+        Assert.Equal(expectedPage, actual.PageNum);
+        Assert.Equal(expectedScrollId, actual.BookScrollId);
+    }
+
+    [Theory]
+    [InlineData("5", 4)] // Archive/PDF page number (1-indexed from KOReader)
+    [InlineData("1", 0)]
+    [InlineData("100", 99)]
+    public void UpdateProgressDto_NumericOnly(string koreaderPosition, int expectedPage)
+    {
+        var actual = EmptyProgressDto();
+
+        KoreaderHelper.UpdateProgressDto(actual, koreaderPosition);
+
+        Assert.Equal(expectedPage, actual.PageNum);
+    }
+
+    [Theory]
+    [InlineData("/body/DocFragment[11]/body/id(\"chapter1\")", 10, null)] // id() selectors not supported
+    [InlineData("/body/DocFragment[5]/body/div/id(\"section2\")/p[1]", 4, null)]
+    public void UpdateProgressDto_IdSelectors(string koreaderPosition, int expectedPage, string? expectedScrollId)
+    {
+        var actual = EmptyProgressDto();
+
+        KoreaderHelper.UpdateProgressDto(actual, koreaderPosition);
+
+        Assert.Equal(expectedPage, actual.PageNum);
+        Assert.Equal(expectedScrollId, actual.BookScrollId);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void UpdateProgressDto_EmptyOrNull_NoChanges(string? koreaderPosition)
+    {
+        var actual = EmptyProgressDto();
+        actual.PageNum = 5;
+        actual.BookScrollId = "//body/p[1]";
+
+        KoreaderHelper.UpdateProgressDto(actual, koreaderPosition!);
+
+        // Should remain unchanged
+        Assert.Equal(5, actual.PageNum);
+        Assert.Equal("//body/p[1]", actual.BookScrollId);
+    }
+
+    #endregion
+
+    #region GetKoreaderPosition Tests
+
+    [Theory]
+    [InlineData("//body/p[20]", 4, "/body/DocFragment[5]/body/p[20].0")]
+    [InlineData("//body/div/section[3]", 0, "/body/DocFragment[1]/body/div/section[3].0")]
+    [InlineData("//body/h1", 9, "/body/DocFragment[10]/body/h1.0")]
+    public void GetKoreaderPosition_WithScrollId(string? scrollId, int page, string expectedPosition)
     {
         var given = EmptyProgressDto();
         given.BookScrollId = scrollId;
         given.PageNum = page;
 
-        Assert.Equal(koreaderPosition.ToUpperInvariant(), KoreaderHelper.GetKoreaderPosition(given).ToUpperInvariant());
+        var result = KoreaderHelper.GetKoreaderPosition(given);
+
+        Assert.Equal(expectedPosition, result, ignoreCase: true);
     }
 
     [Theory]
-    [InlineData("./Data/AesopsFables.epub", "8795ACA4BF264B57C1EEDF06A0CEE688")]
-    public void GetKoreaderHash(string filePath, string hash)
+    [InlineData(null, 9, "/body/DocFragment[10].0")]
+    [InlineData("", 0, "/body/DocFragment[1].0")]
+    [InlineData(null, 4, "/body/DocFragment[5].0")]
+    public void GetKoreaderPosition_NoScrollId_ReturnsFragmentOnly(string? scrollId, int page, string expectedPosition)
     {
-        Assert.Equal(KoreaderHelper.HashContents(filePath), hash);
+        var given = EmptyProgressDto();
+        given.BookScrollId = scrollId;
+        given.PageNum = page;
+
+        var result = KoreaderHelper.GetKoreaderPosition(given);
+
+        Assert.Equal(expectedPosition, result, ignoreCase: true);
     }
+
+    [Theory]
+    [InlineData("id(\"chapter1\")", 5, "/body/DocFragment[6].0")]
+    [InlineData("id(\"h2\")", 10, "/body/DocFragment[11].0")]
+    public void GetKoreaderPosition_IdSelector_ReturnsFragmentOnly(string scrollId, int page, string expectedPosition)
+    {
+        var given = EmptyProgressDto();
+        given.BookScrollId = scrollId;
+        given.PageNum = page;
+
+        var result = KoreaderHelper.GetKoreaderPosition(given);
+
+        Assert.Equal(expectedPosition, result, ignoreCase: true);
+    }
+
+    #endregion
+
+    #region HashContents Tests
+
+    [Theory]
+    [InlineData("./Data/AesopsFables.epub", "8795ACA4BF264B57C1EEDF06A0CEE688")]
+    public void HashContents_ValidFile_ReturnsExpectedHash(string filePath, string expectedHash)
+    {
+        Assert.Equal(expectedHash, KoreaderHelper.HashContents(filePath));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("./Data/NonExistent.epub")]
+    public void HashContents_InvalidFile_ReturnsNull(string? filePath)
+    {
+        Assert.Null(KoreaderHelper.HashContents(filePath!));
+    }
+
+    #endregion
 
     private static ProgressDto EmptyProgressDto()
     {

--- a/API.Tests/Services/ReadingHistoryServiceTests.cs
+++ b/API.Tests/Services/ReadingHistoryServiceTests.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using API.Data;
+using API.DTOs.Progress;
+using API.Entities;
+using API.Entities.Enums;
+using API.Entities.Progress;
+using API.Helpers.Builders;
+using API.Services.Reading;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace API.Tests.Services;
+
+public class ReadingHistoryServiceTests(ITestOutputHelper testOutputHelper) : AbstractDbTest(testOutputHelper)
+{
+    private ReadingHistoryService Setup(DataContext context)
+    {
+        return new ReadingHistoryService(context, Substitute.For<ILogger<ReadingHistoryService>>());
+    }
+
+    [Fact]
+    public async Task ActiveSession_DoNotCreateHistoryItems()
+    {
+        var (_, dataContext, _) = await CreateDatabase();
+        var service = Setup(dataContext);
+
+        // Setup data
+        var lib = await dataContext.Library.FirstAsync();
+        lib.Series.Add(new SeriesBuilder("Test")
+            .WithVolume(new VolumeBuilder("1").WithChapter(new ChapterBuilder("1").WithPages(2).Build()).Build())
+            .Build());
+
+        await dataContext.AppUser.AddAsync(new AppUser() { UserName = "Test" });
+
+        await  dataContext.SaveChangesAsync();
+
+        // Create an active session dated for yesterday
+        var yesterday= DateTime.Now.Date.AddDays(-1);
+        var yesterdayUtc = DateTime.UtcNow.Date.AddDays(-1);
+        await dataContext.AppUserReadingSession.AddAsync(new AppUserReadingSession()
+        {
+            ActivityData =
+            [
+                new AppUserReadingSessionActivityData(new ProgressDto()
+                {
+                    ChapterId = 1, VolumeId = 1, LibraryId = 1, PageNum = 1, SeriesId = 1
+                }, 1, MangaFormat.Archive)
+            ],
+            AppUserId = 1,
+            StartTime = yesterday,
+            StartTimeUtc = yesterdayUtc,
+            IsActive = true,
+        });
+
+        // Run the service
+        await service.AggregateYesterdaysActivity();
+
+        // Check that there are no history items
+        Assert.False(await dataContext.AppUserReadingHistory.AnyAsync());
+    }
+
+
+    [Fact]
+    public async Task CreatesForYesterdaySessions()
+    {
+        var (_, dataContext, _) = await CreateDatabase();
+        var service = Setup(dataContext);
+
+        // Setup data
+        var lib = await dataContext.Library.FirstAsync();
+        lib.Series.Add(new SeriesBuilder("Test")
+            .WithVolume(new VolumeBuilder("1").WithChapter(new ChapterBuilder("1").WithPages(2).Build()).Build())
+            .Build());
+
+        await dataContext.AppUser.AddAsync(new AppUser() { UserName = "Test" });
+
+        await  dataContext.SaveChangesAsync();
+
+        // Create an active session dated for yesterday
+        var yesterday= DateTime.Now.Date.AddDays(-1);
+        var yesterdayUtc = DateTime.UtcNow.Date.AddDays(-1);
+        var activityData = new AppUserReadingSessionActivityData(new ProgressDto()
+        {
+            ChapterId = 1, VolumeId = 1, LibraryId = 1, PageNum = 1, SeriesId = 1
+        }, 1, MangaFormat.Archive);
+
+        activityData.StartTime = yesterday;
+        activityData.StartTimeUtc = yesterdayUtc;
+
+        await dataContext.AppUserReadingSession.AddAsync(new AppUserReadingSession()
+        {
+            ActivityData =
+            [
+                activityData
+            ],
+            AppUserId = 1,
+            StartTime = yesterday,
+            StartTimeUtc = yesterdayUtc,
+            EndTime = yesterday.AddHours(1),
+            EndTimeUtc = yesterdayUtc.AddHours(1),
+            IsActive = false,
+        });
+
+        await  dataContext.SaveChangesAsync();
+
+        // Run the service
+        await service.AggregateYesterdaysActivity();
+
+        // Check that there are no history items
+        var historyItems = await dataContext.AppUserReadingHistory.ToListAsync();
+        Assert.Single(historyItems);
+        Assert.Single(historyItems[0].Data.Activities);
+    }
+}
+

--- a/API/DTOs/Progress/DailyReadingDataDto.cs
+++ b/API/DTOs/Progress/DailyReadingDataDto.cs
@@ -1,6 +1,10 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using API.Entities.Enums;
+using API.Services;
 
 namespace API.DTOs.Progress;
+#nullable enable
 
 public class DailyReadingDataDto
 {
@@ -8,6 +12,38 @@ public class DailyReadingDataDto
     public int TotalPagesRead { get; set; }
     public int TotalWordsRead { get; set; }
     public int LongestSessionMinutes { get; set; }
-    public IList<int> SeriesIds { get; set; }
-    public IList<int> ChapterIds { get; set; }
+
+    public List<ReadingActivitySnapshotDto> Activities { get; set; } = [];
+
+    // Data may be deleted
+    public IList<int?> SeriesIds { get; set; }
+    public IList<int?> ChapterIds { get; set; }
+}
+
+public class ReadingActivitySnapshotDto
+{
+    // Nullable FKs - null means entity was deleted
+    public int? SeriesId { get; set; }
+    public int? ChapterId { get; set; }
+    public int? VolumeId { get; set; }
+    public int? LibraryId { get; set; }
+
+    // Denormalized metadata captured at read time
+    public string SeriesName { get; set; } = string.Empty;
+    /// <summary>
+    /// This will be the transformed name from <see cref="EntityNamingService"/>
+    /// </summary>
+    public string? ChapterTitle { get; set; }
+    public string? LibraryName { get; set; }
+    public MangaFormat Format { get; set; }
+
+    // Reading metrics for this specific activity
+    public int PagesRead { get; set; }
+    public int WordsRead { get; set; }
+    public int MinutesRead { get; set; }
+    public int TotalPages { get; set; }
+    public long TotalWords { get; set; }
+
+    public DateTime StartTimeUtc { get; set; }
+    public DateTime EndTimeUtc { get; set; }
 }

--- a/API/DTOs/Progress/DailyReadingDataDto.cs
+++ b/API/DTOs/Progress/DailyReadingDataDto.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using API.Entities;
 using API.Entities.Enums;
 using API.Services;
 
@@ -13,9 +14,12 @@ public class DailyReadingDataDto
     public int TotalWordsRead { get; set; }
     public int LongestSessionMinutes { get; set; }
 
+    /// <summary>
+    /// Detailed breakdown by series/chapter read that day
+    /// </summary>
     public List<ReadingActivitySnapshotDto> Activities { get; set; } = [];
 
-    // Data may be deleted
+    // Data may be deleted, these are legacy identifiers
     public IList<int?> SeriesIds { get; set; }
     public IList<int?> ChapterIds { get; set; }
 }
@@ -29,20 +33,25 @@ public class ReadingActivitySnapshotDto
     public int? LibraryId { get; set; }
 
     // Denormalized metadata captured at read time
-    public string SeriesName { get; set; } = string.Empty;
+    public string SeriesName { get; set; }
+    public string? LocalizedSeriesName { get; set; }
+    public string LibraryName { get; set; }
     /// <summary>
-    /// This will be the transformed name from <see cref="EntityNamingService"/>
+    /// Maps to <see cref="Chapter.Range"/>
     /// </summary>
-    public string? ChapterTitle { get; set; }
-    public string? LibraryName { get; set; }
+    public string ChapterRange { get; set; }
+    /// <summary>
+    /// Maps to <see cref="Volume.MinNumber"/>
+    /// </summary>
+    public float VolumeNumber { get; set; }
+
     public MangaFormat Format { get; set; }
+    public LibraryType LibraryType { get; set; }
 
     // Reading metrics for this specific activity
     public int PagesRead { get; set; }
     public int WordsRead { get; set; }
     public int MinutesRead { get; set; }
-    public int TotalPages { get; set; }
-    public long TotalWords { get; set; }
 
     public DateTime StartTimeUtc { get; set; }
     public DateTime EndTimeUtc { get; set; }

--- a/API/Data/ManualMigrations/v0.8.9/MigrateBadKoreaderProgress.cs
+++ b/API/Data/ManualMigrations/v0.8.9/MigrateBadKoreaderProgress.cs
@@ -26,8 +26,7 @@ public class MigrateBadKoreaderProgress : ManualMigration
 
         if (badProgressWithLibrary.Count == 0) return;
 
-        logger.LogInformation("[MigrateBadKoreaderProgress] Found {Count} progress records with LibraryId = 0, fixing...",
-            badProgressWithLibrary.Count);
+        logger.LogInformation("Found {Count} progress records with LibraryId = 0", badProgressWithLibrary.Count);
 
         foreach (var item in badProgressWithLibrary)
         {
@@ -36,7 +35,6 @@ public class MigrateBadKoreaderProgress : ManualMigration
 
         await context.SaveChangesAsync();
 
-        logger.LogInformation("[MigrateBadKoreaderProgress] Successfully fixed {Count} progress records",
-            badProgressWithLibrary.Count);
+        logger.LogInformation("Successfully fixed {Count} progress records", badProgressWithLibrary.Count);
     }
 }

--- a/API/Data/Migrations/20260112165908_ReadingHistoryChanges.Designer.cs
+++ b/API/Data/Migrations/20260112165908_ReadingHistoryChanges.Designer.cs
@@ -6,6 +6,7 @@ using API.Entities.MetadataMatching;
 using API.Entities.Progress;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -13,9 +14,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace API.Data.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20260112165908_ReadingHistoryChanges")]
+    partial class ReadingHistoryChanges
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.1");

--- a/API/Data/Migrations/20260112165908_ReadingHistoryChanges.cs
+++ b/API/Data/Migrations/20260112165908_ReadingHistoryChanges.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace API.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class ReadingHistoryChanges : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CreatedUtc",
+                table: "AppUserReadingHistory");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Data",
+                table: "AppUserReadingHistory",
+                type: "TEXT",
+                nullable: true,
+                defaultValue: "{\"TotalMinutesRead\":0,\"TotalPagesRead\":0,\"TotalWordsRead\":0,\"LongestSessionMinutes\":0,\"Activities\":[],\"SeriesIds\":null,\"ChapterIds\":null}",
+                oldClrType: typeof(string),
+                oldType: "TEXT",
+                oldNullable: true,
+                oldDefaultValue: "{\"TotalMinutesRead\":0,\"TotalPagesRead\":0,\"TotalWordsRead\":0,\"LongestSessionMinutes\":0,\"SeriesIds\":null,\"ChapterIds\":null}");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Data",
+                table: "AppUserReadingHistory",
+                type: "TEXT",
+                nullable: true,
+                defaultValue: "{\"TotalMinutesRead\":0,\"TotalPagesRead\":0,\"TotalWordsRead\":0,\"LongestSessionMinutes\":0,\"SeriesIds\":null,\"ChapterIds\":null}",
+                oldClrType: typeof(string),
+                oldType: "TEXT",
+                oldNullable: true,
+                oldDefaultValue: "{\"TotalMinutesRead\":0,\"TotalPagesRead\":0,\"TotalWordsRead\":0,\"LongestSessionMinutes\":0,\"Activities\":[],\"SeriesIds\":null,\"ChapterIds\":null}");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "CreatedUtc",
+                table: "AppUserReadingHistory",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+        }
+    }
+}

--- a/API/Entities/Progress/AppUserReadingHistory.cs
+++ b/API/Entities/Progress/AppUserReadingHistory.cs
@@ -18,6 +18,7 @@ public class AppUserReadingHistory
     /// JSON Column
     /// </summary>
     public DailyReadingDataDto Data { get; set; }
+
     /// <summary>
     /// JSON Column
     /// </summary>

--- a/API/Entities/Progress/AppUserReadingHistory.cs
+++ b/API/Entities/Progress/AppUserReadingHistory.cs
@@ -13,7 +13,6 @@ public class AppUserReadingHistory
 {
     public int Id { get; set; }
     public DateTime DateUtc { get; set; }
-    public DateTime CreatedUtc { get; set; }
     /// <summary>
     /// JSON Column
     /// </summary>

--- a/API/Entities/Progress/AppUserReadingSessionActivityData.cs
+++ b/API/Entities/Progress/AppUserReadingSessionActivityData.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using API.DTOs.Progress;
 using API.Entities.Enums;
 using Microsoft.EntityFrameworkCore;
 
@@ -54,4 +55,29 @@ public class AppUserReadingSessionActivityData
     /// </summary>
     /// <remarks>JSON Column</remarks>
     public List<int> DeviceIds { get; set; } = [];
+
+    public AppUserReadingSessionActivityData()
+    {
+    }
+
+    public AppUserReadingSessionActivityData(ProgressDto dto, int startPage, MangaFormat format)
+    {
+        ChapterId = dto.ChapterId;
+        VolumeId = dto.VolumeId;
+        SeriesId = dto.SeriesId;
+        LibraryId = dto.LibraryId;
+        StartPage = startPage;
+        StartBookScrollId = dto.BookScrollId;
+        EndPage = dto.PageNum;
+        StartTime = DateTime.Now;
+        StartTimeUtc = DateTime.UtcNow;
+        EndTime = null;
+        EndTimeUtc = null;
+        PagesRead = 0;
+        WordsRead = 0;
+        ClientInfo = null;
+        DeviceIds = [];
+        Format = format;
+
+    }
 }

--- a/API/Entities/Volume.cs
+++ b/API/Entities/Volume.cs
@@ -18,7 +18,7 @@ public class Volume : IEntityDate, IHasReadTimeEstimate, IHasCoverImage
     /// </summary>
     public string LookupName { get; set; }
     /// <summary>
-    /// The minimum number in the Name field in Int form
+    /// The minimum number in the Name field in Int form. NOTE: For books, this is always 0 which will break logic. Do not use.
     /// </summary>
     /// <remarks>Removed in v0.7.13.8, this was an int and we need the ability to have 0.5 volumes render on the UI</remarks>
     [Obsolete("Use MinNumber and MaxNumber instead")]

--- a/API/Extensions/QueryExtensions/ChapterQueryExtensions.cs
+++ b/API/Extensions/QueryExtensions/ChapterQueryExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using API.Entities;
 using API.Services.Tasks.Scanner.Parser;
+using Microsoft.EntityFrameworkCore;
 
 namespace API.Extensions.QueryExtensions;
 
@@ -9,16 +10,17 @@ public static class ChapterQueryExtensions
     public static IOrderedQueryable<Chapter> ApplyDefaultChapterOrdering(this IQueryable<Chapter> query)
     {
         return query
+            .Include(c => c.Volume)
             .OrderBy(c =>
-                // Priority 1: Regular volumes (not loose leaf, not special)
-                c.Volume.Number == Parser.LooseLeafVolumeNumber ||
-                c.Volume.Number == Parser.SpecialVolumeNumber ? 1 : 0)
+                // Priority 1: Regular volumes (not loose-leaf, not special)
+                c.Volume.MinNumber == Parser.LooseLeafVolumeNumber ||
+                c.Volume.MinNumber == Parser.SpecialVolumeNumber ? 1 : 0)
             .ThenBy(c =>
                 // Priority 2: Loose leaf over specials
-                c.Volume.Number == Parser.SpecialVolumeNumber ? 1 : 0)
+                c.Volume.MinNumber == Parser.SpecialVolumeNumber ? 1 : 0)
             // Priority 3: Non-special chapters
             .ThenBy(c => c.IsSpecial ? 1 : 0)
-            .ThenBy(c => c.Volume.Number)
+            .ThenBy(c => c.Volume.MinNumber)
             .ThenBy(c => c.SortOrder);
     }
 }

--- a/API/Middleware/AuthKeyAuthenticationHandler.cs
+++ b/API/Middleware/AuthKeyAuthenticationHandler.cs
@@ -103,6 +103,10 @@ private readonly IUnitOfWork _unitOfWork;
 
             return AuthenticateResult.Success(ticket);
         }
+        catch (OperationCanceledException)
+        {
+            return AuthenticateResult.Fail("Auth Key authentication failed");
+        }
         catch (Exception ex)
         {
             Logger.LogError(ex, "Auth Key authentication failed");

--- a/API/Middleware/DeviceTrackingMiddleware.cs
+++ b/API/Middleware/DeviceTrackingMiddleware.cs
@@ -51,6 +51,10 @@ public class DeviceTrackingMiddleware(RequestDelegate next, ILogger<DeviceTracki
                 logger.LogTrace("Device {DeviceId} tracked for user {UserId}", deviceId, userId);
             }
         }
+        catch (OperationCanceledException)
+        {
+            /* Ignore */
+        }
         catch (Exception ex)
         {
             logger.LogError(ex, "Failed to track device activity");

--- a/API/Services/Reading/ReadingHistoryService.cs
+++ b/API/Services/Reading/ReadingHistoryService.cs
@@ -4,8 +4,8 @@ using System.Linq;
 using System.Threading.Tasks;
 using API.Data;
 using API.DTOs.Progress;
+using API.Entities.Enums;
 using API.Entities.Progress;
-using Hangfire;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
@@ -22,6 +22,9 @@ public class ReadingHistoryService : IReadingHistoryService
     private readonly DataContext _context;
     private readonly ILogger<ReadingHistoryService> _logger;
 
+    private sealed record ChapterMetadata(int Id, string? Range, float VolumeNumber, string SeriesName, string? LocalizedSeriesName, string LibraryName, LibraryType LibraryType);
+    private sealed record SeriesMetadata(int Id, string Name, string? LocalizedName, string LibraryName, LibraryType LibraryType);
+
     public ReadingHistoryService(DataContext context, ILogger<ReadingHistoryService> logger)
     {
         _context = context;
@@ -30,117 +33,183 @@ public class ReadingHistoryService : IReadingHistoryService
 
     public async Task AggregateYesterdaysActivity()
     {
-        var yesterday = DateTime.Today.AddDays(-1);
         var yesterdayUtc = DateTime.UtcNow.Date.AddDays(-1);
+        var startUtc = yesterdayUtc;
+        var endUtc = yesterdayUtc.AddDays(1).AddTicks(-1);
 
-        // Define precise boundaries for yesterday
-        var yesterdayStart = yesterday; // 2025-10-22 00:00:00.000
-        var yesterdayEnd = yesterday.AddDays(1).AddTicks(-1); // 2025-10-22 23:59:59.9999999
+        var usersToProcess = await GetUsersPendingAggregation(startUtc, endUtc, yesterdayUtc);
 
-        // First - Validate that all sessions are closed, if not, reschedule ourselves for 10 mins in future
-        if (await _context.AppUserReadingSession.AnyAsync(s => s.IsActive || s.EndTime == null))
+        foreach (var userId in usersToProcess)
         {
-            _logger.LogWarning("Not all reading sessions are closed, rescheduling for 10 minutes");
-            BackgroundJob.Schedule(() => AggregateYesterdaysActivity(), TimeSpan.FromMinutes(10));
-        }
-
-        // Second - Validate we haven't already created a ReadingHistory for yesterday
-        var existingHistoryUserIds = await _context.AppUserReadingHistory
-            .Where(h => h.DateUtc == yesterdayUtc)
-            .Select(h => h.AppUserId)
-            .ToListAsync();
-
-        if (existingHistoryUserIds.Count != 0)
-        {
-            _logger.LogInformation("Reading history already exists for {Count} users on {Date}",
-                existingHistoryUserIds.Count, yesterday);
-            return;
-        }
-
-        // Third - Get all closed sessions from yesterday using precise boundaries
-        var yesterdaySessions = await _context.AppUserReadingSession
-            .Where(s => !s.IsActive && s.EndTime.HasValue)
-            .Where(s => s.StartTime >= yesterdayStart && s.StartTime <= yesterdayEnd)
-            .Include(s => s.ActivityData)
-            .ToListAsync();
-
-        if (yesterdaySessions.Count == 0)
-        {
-            _logger.LogInformation("No reading sessions found for {Date}", yesterday);
-            return;
-        }
-
-        // Fourth - Group by user and aggregate
-        var userGroups = yesterdaySessions.GroupBy(s => s.AppUserId);
-        var userCount = 0;
-
-        foreach (var userGroup in userGroups)
-        {
-            var userId = userGroup.Key;
-            var sessions = userGroup.ToList();
-
-            // Calculate aggregates
-            var totalMinutes = 0;
-            var totalPages = 0;
-            var totalWords = 0;
-            var longestSessionMinutes = 0;
-            var seriesIds = new List<int>();
-            var chapterIds = new List<int>();
-
-            var devicesUsed = sessions
-                .SelectMany(s => s.ActivityData)
-                .Select(a => a.ClientInfo)
-                .Where(c => c != null)
-                .DistinctBy(c => new { c.UserAgent, c.IpAddress, c.ClientType, c.Platform, c.DeviceType })
-                .ToList();
-
-            foreach (var session in sessions)
-            {
-                if (session.EndTime.HasValue)
-                {
-                    var sessionMinutes = (int)(session.EndTime.Value - session.StartTime).TotalMinutes;
-                    totalMinutes += sessionMinutes;
-                    longestSessionMinutes = Math.Max(longestSessionMinutes, sessionMinutes);
-                }
-
-                // Parse ActivityData JSON
-                foreach (var activity in session.ActivityData)
-                {
-                    totalPages += activity.PagesRead;
-                    totalWords += activity.WordsRead;
-                    seriesIds.Add(activity.SeriesId);
-                    chapterIds.Add(activity.ChapterId);
-                }
-            }
-
-            var dailyData = new DailyReadingDataDto
-            {
-                TotalMinutesRead = totalMinutes,
-                TotalPagesRead = totalPages,
-                TotalWordsRead = totalWords,
-                LongestSessionMinutes = longestSessionMinutes,
-                SeriesIds = seriesIds.Distinct().ToList(),
-                ChapterIds = chapterIds.Distinct().ToList()
-            };
-
-            // Create ReadingHistory record
-            var history = new AppUserReadingHistory
-            {
-                AppUserId = userId,
-                DateUtc = yesterdayUtc,
-                Data = dailyData,
-                CreatedUtc = DateTime.UtcNow,
-                ClientInfoUsed = devicesUsed
-            };
-
-            _context.AppUserReadingHistory.Add(history);
-            userCount++;
+            await AggregateUserActivity(userId, startUtc, endUtc, yesterdayUtc);
         }
 
         await _context.SaveChangesAsync();
+    }
 
-        _logger.LogInformation("Aggregated reading history for {UserCount} users on {Date}",
-            userCount, yesterday);
+    private async Task<List<int>> GetUsersPendingAggregation(DateTime start, DateTime end, DateTime reportDate)
+    {
+        var activeUserIds = await _context.AppUserReadingSession
+            .Where(s => s.StartTime >= start && s.StartTime <= end)
+            .Where(s => !s.IsActive && s.EndTime != null)
+            .Select(s => s.AppUserId)
+            .Distinct()
+            .ToListAsync();
 
+        var existingHistoryUserIds = await _context.AppUserReadingHistory
+            .Where(h => h.DateUtc == reportDate)
+            .Select(h => h.AppUserId)
+            .ToListAsync();
+
+        return activeUserIds.Except(existingHistoryUserIds).ToList();
+    }
+
+    private async Task AggregateUserActivity(int userId, DateTime start, DateTime end, DateTime reportDate)
+    {
+        var sessions = await _context.AppUserReadingSession
+            .Include(s => s.ActivityData)
+            .Where(s => s.AppUserId == userId &&
+                        s.StartTime >= start && s.StartTime <= end &&
+                        !s.IsActive && s.EndTime != null)
+            .ToListAsync();
+
+        if (sessions.Count == 0) return;
+
+        var chapterMeta = await GetChapterMetadata(sessions);
+        var seriesMeta = await GetSeriesMetadata(sessions);
+
+        var dailyData = CalculateDailyData(sessions, chapterMeta, seriesMeta);
+
+        _context.AppUserReadingHistory.Add(new AppUserReadingHistory
+        {
+            AppUserId = userId,
+            DateUtc = reportDate,
+            ClientInfoUsed = ExtractClientInfo(sessions),
+            Data = dailyData
+        });
+    }
+
+    private async Task<Dictionary<int, ChapterMetadata>> GetChapterMetadata(List<AppUserReadingSession> sessions)
+    {
+        var ids = sessions.SelectMany(s => s.ActivityData.Select(ad => ad.ChapterId)).Distinct().ToList();
+        return await _context.Chapter
+            .Where(c => ids.Contains(c.Id))
+            .Select(c => new ChapterMetadata(
+                c.Id, c.Range, c.Volume.MinNumber, c.Volume.Series.Name,
+                c.Volume.Series.LocalizedName, c.Volume.Series.Library.Name,
+                c.Volume.Series.Library.Type))
+            .ToDictionaryAsync(c => c.Id);
+    }
+
+    private async Task<Dictionary<int, SeriesMetadata>> GetSeriesMetadata(List<AppUserReadingSession> sessions)
+    {
+        var ids = sessions.SelectMany(s => s.ActivityData.Select(ad => ad.SeriesId)).Distinct().ToList();
+        return await _context.Series
+            .Where(s => ids.Contains(s.Id))
+            .Select(s => new SeriesMetadata(s.Id, s.Name, s.LocalizedName, s.Library.Name, s.Library.Type))
+            .ToDictionaryAsync(s => s.Id);
+    }
+
+    private static DailyReadingDataDto CalculateDailyData(List<AppUserReadingSession> sessions,
+        Dictionary<int, ChapterMetadata> chapterMeta, Dictionary<int, SeriesMetadata> seriesMeta)
+    {
+        var totalMinutes = 0;
+        var totalPages = 0;
+        var totalWords = 0;
+        var longestSession = 0;
+        var seriesIds = new HashSet<int>();
+        var chapterIds = new HashSet<int>();
+        var activities = new List<ReadingActivitySnapshotDto>();
+
+        foreach (var session in sessions)
+        {
+            var duration = (int)(session.EndTime!.Value - session.StartTime).TotalMinutes;
+            totalMinutes += duration;
+            longestSession = Math.Max(longestSession, duration);
+
+            foreach (var activity in session.ActivityData)
+            {
+                totalPages += activity.PagesRead;
+                totalWords += activity.WordsRead;
+                chapterIds.Add(activity.ChapterId);
+                seriesIds.Add(activity.SeriesId);
+
+                activities.Add(MapToSnapshot(activity, chapterMeta, seriesMeta));
+            }
+        }
+
+        return new DailyReadingDataDto
+        {
+            TotalMinutesRead = totalMinutes,
+            TotalPagesRead = totalPages,
+            TotalWordsRead = totalWords,
+            LongestSessionMinutes = longestSession,
+            SeriesIds = seriesIds.Cast<int?>().ToList(),
+            ChapterIds = chapterIds.Cast<int?>().ToList(),
+            Activities = activities
+        };
+    }
+
+    private static ReadingActivitySnapshotDto MapToSnapshot( AppUserReadingSessionActivityData activity,
+        Dictionary<int, ChapterMetadata> chapterLookup, Dictionary<int, SeriesMetadata> seriesLookup)
+    {
+        var minutesRead = activity.EndTimeUtc.HasValue
+            ? (int)(activity.EndTimeUtc.Value - activity.StartTimeUtc).TotalMinutes
+            : 0;
+
+        var snapshot = new ReadingActivitySnapshotDto
+        {
+            ChapterId = activity.ChapterId,
+            VolumeId = activity.VolumeId,
+            SeriesId = activity.SeriesId,
+            LibraryId = activity.LibraryId,
+            Format = activity.Format,
+            PagesRead = activity.PagesRead,
+            WordsRead = activity.WordsRead,
+            MinutesRead = minutesRead,
+            StartTimeUtc = activity.StartTimeUtc,
+            EndTimeUtc = activity.EndTimeUtc ?? activity.StartTimeUtc,
+
+            // Set defaults for required strings
+            SeriesName = string.Empty,
+            LibraryName = string.Empty,
+            ChapterRange = string.Empty
+        };
+
+        if (chapterLookup.TryGetValue(activity.ChapterId, out var c))
+        {
+            snapshot.SeriesName = c.SeriesName;
+            snapshot.LocalizedSeriesName = c.LocalizedSeriesName;
+            snapshot.ChapterRange = c.Range ?? string.Empty;
+            snapshot.VolumeNumber = c.VolumeNumber;
+            snapshot.LibraryName = c.LibraryName;
+            snapshot.LibraryType = c.LibraryType;
+        }
+        else if (seriesLookup.TryGetValue(activity.SeriesId, out var s))
+        {
+            snapshot.SeriesName = s.Name;
+            snapshot.LocalizedSeriesName = s.LocalizedName;
+            snapshot.LibraryName = s.LibraryName;
+            snapshot.LibraryType = s.LibraryType;
+            snapshot.ChapterRange = "[Deleted]";
+        }
+        else
+        {
+            snapshot.SeriesName = "[Deleted Data]";
+            snapshot.ChapterRange = "[Deleted]";
+        }
+
+        return snapshot;
+    }
+
+    private static List<ClientInfoData> ExtractClientInfo(List<AppUserReadingSession> sessions)
+    {
+        return sessions
+            .SelectMany(s => s.ActivityData)
+            .Select(a => a.ClientInfo)
+            .Where(c => c != null)
+            .Select(c => c!)
+            .DistinctBy(c => new { c.UserAgent, c.IpAddress, c.Platform })
+            .ToList();
     }
 }

--- a/API/Services/Reading/ReadingHistoryService.cs
+++ b/API/Services/Reading/ReadingHistoryService.cs
@@ -49,19 +49,19 @@ public class ReadingHistoryService : IReadingHistoryService
 
     private async Task<List<int>> GetUsersPendingAggregation(DateTime start, DateTime end, DateTime reportDate)
     {
-        var activeUserIds = await _context.AppUserReadingSession
+        var needAggregationUserIds = await _context.AppUserReadingSession
             .Where(s => s.StartTime >= start && s.StartTime <= end)
             .Where(s => !s.IsActive && s.EndTime != null)
             .Select(s => s.AppUserId)
             .Distinct()
             .ToListAsync();
 
-        var existingHistoryUserIds = await _context.AppUserReadingHistory
+        var alreadyHasHistoryUserIds = await _context.AppUserReadingHistory
             .Where(h => h.DateUtc == reportDate)
             .Select(h => h.AppUserId)
             .ToListAsync();
 
-        return activeUserIds.Except(existingHistoryUserIds).ToList();
+        return needAggregationUserIds.Except(alreadyHasHistoryUserIds).ToList();
     }
 
     private async Task AggregateUserActivity(int userId, DateTime start, DateTime end, DateTime reportDate)

--- a/API/Services/Reading/ReadingSessionService.cs
+++ b/API/Services/Reading/ReadingSessionService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -32,6 +33,7 @@ public sealed class ReadingSessionService : IReadingSessionService, IDisposable,
     private readonly TimeSpan _pollInterval;
     private readonly Timer _cleanupTimer;
     private readonly SemaphoreSlim _cleanupLock = new(1, 1);
+    private static readonly ConcurrentDictionary<int, SemaphoreSlim> UserLocks = new();
     private bool _disposed;
 
     private static readonly HybridCacheEntryOptions ChapterFormatCacheOptions = new()
@@ -63,22 +65,35 @@ public sealed class ReadingSessionService : IReadingSessionService, IDisposable,
 
     public async Task UpdateProgress(int userId, ProgressDto progressDto, ClientInfoData? clientInfo, int? deviceId)
     {
-        _logger.LogDebug("Updating Reading Session for {UserId} on {ChapterId}", userId, progressDto.ChapterId);
+        // We need to lock per-user as progress events can come fast and duplicate, as we are using new DataContext per Background Task
+        var userLock = UserLocks.GetOrAdd(userId, _ => new SemaphoreSlim(1, 1));
 
-        using var scope = _serviceScopeFactory.CreateScope();
-        var context = scope.ServiceProvider.GetRequiredService<DataContext>();
-        var eventHub = scope.ServiceProvider.GetRequiredService<IEventHub>();
+        await userLock.WaitAsync();
 
-        var session = await GetOrCreateSessionAsync(userId, progressDto, context);
+        try
+        {
+            _logger.LogDebug("Updating Reading Session for {UserId} on {ChapterId}", userId, progressDto.ChapterId);
 
-        await UpdateActivityDataAsync(session, progressDto, clientInfo, deviceId, scope, context);
+            using var scope = _serviceScopeFactory.CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<DataContext>();
+            var eventHub = scope.ServiceProvider.GetRequiredService<IEventHub>();
 
-        session.LastModified = DateTime.Now;
-        session.LastModifiedUtc = DateTime.UtcNow;
+            var session = await GetOrCreateSessionAsync(userId, progressDto, context);
 
-        await context.SaveChangesAsync();
+            await UpdateActivityDataAsync(session, progressDto, clientInfo, deviceId, scope, context);
 
-        await eventHub.SendMessageAsync(MessageFactory.ReadingSessionUpdate, MessageFactory.ReadingSessionUpdateEvent(userId, session.Id));
+            session.LastModified = DateTime.Now;
+            session.LastModifiedUtc = DateTime.UtcNow;
+
+            await context.SaveChangesAsync();
+
+            await eventHub.SendMessageAsync(MessageFactory.ReadingSessionUpdate,
+                MessageFactory.ReadingSessionUpdateEvent(userId, session.Id));
+        }
+        finally
+        {
+            userLock.Release();
+        }
     }
 
     private async Task<AppUserReadingSession> GetOrCreateSessionAsync(int userId, ProgressDto dto, DataContext context)
@@ -94,8 +109,10 @@ public sealed class ReadingSessionService : IReadingSessionService, IDisposable,
 
         if (existingSession != null)
         {
+            _logger.LogDebug("Found existing session {SessionId} for user {UserId} for Chapter {ChapterId}", existingSession.Id, userId, dto.ChapterId);
             return existingSession;
         }
+
 
         var chapterFormat = await GetChapterFormatAsync(dto.ChapterId, context);
         var newSession = new AppUserReadingSession
@@ -112,6 +129,7 @@ public sealed class ReadingSessionService : IReadingSessionService, IDisposable,
         context.AppUserReadingSession.Add(newSession);
         await context.SaveChangesAsync();
 
+        _logger.LogDebug("Created new session {SessionId} for user {UserId} for Chapter {ChapterId}", newSession.Id, userId, dto.ChapterId);
         return newSession;
     }
 
@@ -128,10 +146,12 @@ public sealed class ReadingSessionService : IReadingSessionService, IDisposable,
 
         if (existingActivity != null)
         {
+            _logger.LogDebug("Updating Session {SessionId} with an existing Activity {ActivityId}", session.Id,  existingActivity.Id);
             await UpdateExistingActivityAsync(existingActivity, progressDto, clientInfo, deviceId, chapterFormat, scope);
         }
         else
         {
+            _logger.LogDebug("Updating Session {SessionId} with a new Activity", session.Id);
             var newActivity = NewActivityData(progressDto, chapterFormat);
             if (clientInfo != null)
             {
@@ -258,6 +278,7 @@ public sealed class ReadingSessionService : IReadingSessionService, IDisposable,
 
             foreach (var session in expiredSessions)
             {
+                _logger.LogDebug("Closing session {SessionId} for user {UserId}", session.Id, session.AppUserId);
                 var completedIds = CloseSession(session);
                 allCompletedChapterIds.AddRange(completedIds);
             }
@@ -351,25 +372,7 @@ public sealed class ReadingSessionService : IReadingSessionService, IDisposable,
     {
         var startPage = format == MangaFormat.Epub ? dto.PageNum : Math.Max(dto.PageNum - 1, 0);
 
-        return new AppUserReadingSessionActivityData
-        {
-            ChapterId = dto.ChapterId,
-            VolumeId = dto.VolumeId,
-            SeriesId = dto.SeriesId,
-            LibraryId = dto.LibraryId,
-            StartPage = startPage,
-            StartBookScrollId = dto.BookScrollId,
-            EndPage = dto.PageNum,
-            StartTime = DateTime.Now,
-            StartTimeUtc = DateTime.UtcNow,
-            EndTime = null,
-            EndTimeUtc = null,
-            PagesRead = 0,
-            WordsRead = 0,
-            ClientInfo = null,
-            DeviceIds = [],
-            Format = format,
-        };
+        return new AppUserReadingSessionActivityData(dto, startPage, format);
     }
 
     public void Dispose()
@@ -378,6 +381,13 @@ public sealed class ReadingSessionService : IReadingSessionService, IDisposable,
 
         _cleanupTimer.Dispose();
         _cleanupLock.Dispose();
+
+        foreach (var kvp in UserLocks)
+        {
+            kvp.Value.Dispose();
+        }
+        UserLocks.Clear();
+
         _disposed = true;
     }
 
@@ -387,6 +397,13 @@ public sealed class ReadingSessionService : IReadingSessionService, IDisposable,
 
         await _cleanupTimer.DisposeAsync();
         _cleanupLock.Dispose();
+
+        foreach (var kvp in UserLocks)
+        {
+            kvp.Value.Dispose();
+        }
+        UserLocks.Clear();
+
         _disposed = true;
     }
 }

--- a/API/Services/Reading/ReadingSessionService.cs
+++ b/API/Services/Reading/ReadingSessionService.cs
@@ -382,12 +382,6 @@ public sealed class ReadingSessionService : IReadingSessionService, IDisposable,
         _cleanupTimer.Dispose();
         _cleanupLock.Dispose();
 
-        foreach (var kvp in UserLocks)
-        {
-            kvp.Value.Dispose();
-        }
-        UserLocks.Clear();
-
         _disposed = true;
     }
 
@@ -397,12 +391,6 @@ public sealed class ReadingSessionService : IReadingSessionService, IDisposable,
 
         await _cleanupTimer.DisposeAsync();
         _cleanupLock.Dispose();
-
-        foreach (var kvp in UserLocks)
-        {
-            kvp.Value.Dispose();
-        }
-        UserLocks.Clear();
 
         _disposed = true;
     }

--- a/API/Services/Tasks/Scanner/Parser/Parser.cs
+++ b/API/Services/Tasks/Scanner/Parser/Parser.cs
@@ -12,7 +12,7 @@ namespace API.Services.Tasks.Scanner.Parser;
 public static partial class Parser
 {
     // NOTE: If you change this, don't forget to change in the UI (see Series Detail)
-    public const string DefaultChapter = "-100000"; // -2147483648
+    public const string DefaultChapter = "-100000";
     public const string LooseLeafVolume = "-100000";
     public const int DefaultChapterNumber = -100_000;
     public const int LooseLeafVolumeNumber = -100_000;

--- a/API/Startup.cs
+++ b/API/Startup.cs
@@ -481,6 +481,7 @@ public class Startup
                     #endregion
 
                     #region v0.8.9
+                    await new MigrateBadKoreaderProgress().RunAsync(dataContext, logger);
                     await new MigrateProgressToReadingSessions().RunAsync(dataContext, logger);
                     await new MigrateMissingCreatedUtcDate().RunAsync(dataContext, logger);
                     await new MigrateTotalReads().RunAsync(dataContext, logger);
@@ -488,7 +489,6 @@ public class Startup
                     await new MigrateMissingAppUserRatingDateColumns().RunAsync(dataContext, logger);
                     await new MigrateFormatToActivityDataV2().RunAsync(dataContext, logger);
                     await new MigrateIncorrectUtcTimes().RunAsync(dataContext, logger);
-                    await new MigrateBadKoreaderProgress().RunAsync(dataContext, logger);
                     #endregion
 
                     #endregion

--- a/UI/Web/package-lock.json
+++ b/UI/Web/package-lock.json
@@ -451,6 +451,7 @@
       "integrity": "sha512-PYVgNbjNtuD5/QOuS6cHR8A7bRqsVqxtUUXGqdv76FYMAajQcAvyfR0QxOkqf3NmYxgNgO3hlUHWq0ILjVbcow==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@angular-eslint/bundled-angular-compiler": "21.1.0",
         "eslint-scope": "^9.0.0"
@@ -496,6 +497,7 @@
       "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-21.0.7.tgz",
       "integrity": "sha512-TfGE+emi67LAIUYmyiHfnL8BVqk26ZZVNEz7hDfbFztbZ5qhtHeKoG+97bAKtJDTTkxgs1JvB8escZExe1JkdA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -611,6 +613,7 @@
       "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-21.0.5.tgz",
       "integrity": "sha512-yO/IRYEZ5wJkpwg3GT3b6RST4pqNFTAhuyPdEdLcE81cs283K3aKOsCYh2xUR3bR4WxBh2kBPSJ31AFZyJXbSA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "parse5": "^8.0.0",
         "tslib": "^2.3.0"
@@ -627,6 +630,7 @@
       "integrity": "sha512-UYFQqn9Ow1wFVSwdB/xfjmZo4Yb7CUNxilbeYDFIybesfxXSdjMJBbXLtV0+icIhjmqfSUm2gTls6WIrG8qv9A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@angular-devkit/architect": "0.2100.5",
         "@angular-devkit/core": "21.0.5",
@@ -662,6 +666,7 @@
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-21.0.7.tgz",
       "integrity": "sha512-KNstFFCv6//x33F+YBPEIztDSNBVyLH99C8yFPmb7vawxGbR9liKSHC1WnEk+GR5KgV3I5lFOJyWL7Elfm0K5A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -678,6 +683,7 @@
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-21.0.7.tgz",
       "integrity": "sha512-Qsjx0OrOquyx10fMynkHilRRoZy9qJcstHdML7NGKg887xqHW4YvgNKREIXmKYjnV6sUBBUxJUD1L5ouarb/YA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -690,6 +696,7 @@
       "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-21.0.7.tgz",
       "integrity": "sha512-M4ePAA7AwjTsbUq6Qpremgo7qIP9GIgWqV5FoJPUEthtFGPNEiKGYjpOtXJ/OLB1J2Tn0ygrqe0PAYE0YxeEUA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "7.28.4",
         "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -722,6 +729,7 @@
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-21.0.7.tgz",
       "integrity": "sha512-MvgRRse2PaEleQFp+35rj7ew5gBmBh3wp5yNDYPTiPaVp1I3fJ08VYSpldodaXmdkdWRB+OU4WJhnFkagyRx7A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -747,6 +755,7 @@
       "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-21.0.7.tgz",
       "integrity": "sha512-HUfUaO6+cxam9wug3Upc83ueBIDSgJwxzYIuPCP4AjL5DhT6Fbqv/Zq+nLbLF7rklbKdqzYsMjse97pxmxJGLQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "tslib": "^2.3.0"
@@ -766,6 +775,7 @@
       "resolved": "https://registry.npmjs.org/@angular/localize/-/localize-21.0.7.tgz",
       "integrity": "sha512-H1BdOOe0prtQa/EjWyzyZ9Ls4dPHcPNK/oN4fAYkpaZzyyqhvmPU64TYHa/3DNxFQrbSYjVMcpRXIJFThLeOZQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "7.28.4",
         "@types/babel__core": "7.20.5",
@@ -790,6 +800,7 @@
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-21.0.7.tgz",
       "integrity": "sha512-mhsN2hn5qG0Oelqpko3uLmYdqadruzG2rY3CJ7duRdOrzs5g5F8QhzphoI/ljgLyxrrgZT6Nykyyf6RNhowf2A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -871,6 +882,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -2162,6 +2174,7 @@
       "integrity": "sha512-X7/+dG9SLpSzRkwgG5/xiIzW0oMrV3C0HOa7YHG1WnrLK+vCQHfte4k/T80059YBdei29RBC3s+pSMvPJDU9/A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^4.3.0",
         "@inquirer/confirm": "^5.1.19",
@@ -2402,6 +2415,7 @@
       "resolved": "https://registry.npmjs.org/@jsverse/transloco/-/transloco-8.2.0.tgz",
       "integrity": "sha512-5SU9mjmKHlTraW/GKSUsWEjt7ATBLzKcKd6w+mTbRrnU38ZyYdCJoR2W/ii8lWiRwhfgbXTFCsTUueW5Ak61WA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jsverse/transloco-utils": "^8.2.0",
         "@jsverse/utils": "1.0.0-beta.5",
@@ -2484,7 +2498,8 @@
       "version": "1.0.0-beta.5",
       "resolved": "https://registry.npmjs.org/@jsverse/utils/-/utils-1.0.0-beta.5.tgz",
       "integrity": "sha512-z7IdlV6BdSeF3Veii8Yyk64KuyTjNIQnFaW5PAhmDx0wN29lB2BFp8WO6+tJPLPjtlz2yKeNrjkp1XqnMPaeHA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@listr2/prompt-adapter-inquirer": {
       "version": "3.0.5",
@@ -3763,6 +3778,7 @@
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -4563,7 +4579,8 @@
       "version": "25.0.0",
       "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-25.0.0.tgz",
       "integrity": "sha512-XKLA6syeBUaPzx4j3qwMqzzq+V4uo72BnlbOjmuljLrRqdsd3qnzvZZoxvMHZ23ndsRS4aufU6JOZYpCbU6T1A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
@@ -4958,6 +4975,7 @@
       "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -5003,6 +5021,7 @@
       "integrity": "sha512-iIACsx8pxRnguSYhHiMn2PvhvfpopO9FXHyn1mG5txZIsAaB6F0KwbFnUQN3KCiG3Jcuad/Cao2FAs1Wp7vAyg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.52.0",
         "@typescript-eslint/types": "8.52.0",
@@ -5110,6 +5129,7 @@
       "integrity": "sha512-LWQV1V4q9V4cT4H5JCIx3481iIFxH1UkVk+ZkGGAV1ZGcjGI9IoFOfg3O6ywz8QqCDEp7Inlg6kovMofsNRaGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -5152,6 +5172,7 @@
       "integrity": "sha512-wYndVMWkweqHpEpwPhwqE2lnD2DxC6WVLupU/DOt/0/v+/+iQbbzO3jOHjmBMnhu0DgLULvOaU4h4pwHYi2oRQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
         "@typescript-eslint/scope-manager": "8.52.0",
@@ -5263,6 +5284,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5577,6 +5599,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6267,29 +6290,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
-      }
-    },
-    "node_modules/encoding/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/entities": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
@@ -6452,6 +6452,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6758,6 +6759,7 @@
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -7898,6 +7900,7 @@
       "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cli-truncate": "^5.0.0",
         "colorette": "^2.0.20",
@@ -9563,6 +9566,7 @@
       "resolved": "https://registry.npmjs.org/quill/-/quill-2.0.3.tgz",
       "integrity": "sha512-xEYQBqfYx/sfb33VJiKnSJp8ehloavImQ2A6564GAbqG55PGw1dAWUn1MUbQB62t0azawUS2CZZhWCjO8gRvTw==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "eventemitter3": "^5.0.1",
         "lodash-es": "^4.17.21",
@@ -9812,6 +9816,7 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -9829,6 +9834,7 @@
       "integrity": "sha512-t+YPtOQHpGW1QWsh1CHQ5cPIr9lbbGZLZnbihP/D/qZj/yuV68m8qarcV17nvkOX81BCrvzAlq2klCQFZghyTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -10506,7 +10512,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tuf-js": {
       "version": "4.1.0",
@@ -10557,6 +10564,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10721,6 +10729,7 @@
       "integrity": "sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -11575,6 +11584,7 @@
       "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -11593,7 +11603,8 @@
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.16.0.tgz",
       "integrity": "sha512-LqLPpIQANebrlxY6jKcYKdgN5DTXyyHAKnnWWjE5pPfEQ4n7j5zn7mOEEpwNZVKGqx3kKKmvplEmoBrvpgROTA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/zrender": {
       "version": "6.0.0",

--- a/UI/Web/src/app/_guards/profile.guard.ts
+++ b/UI/Web/src/app/_guards/profile.guard.ts
@@ -1,16 +1,18 @@
-import {CanActivateFn} from '@angular/router';
+import {CanActivateFn, RedirectCommand, Router} from '@angular/router';
 import {AccountService} from "../_services/account.service";
 import {inject} from "@angular/core";
 import {MemberService} from "../_services/member.service";
 import {ToastrService} from "ngx-toastr";
 import {translate} from "@jsverse/transloco";
 import {tap} from "rxjs";
+import {map} from "rxjs/operators";
 
 export const profileGuard: CanActivateFn = (route, state) => {
   const userId = parseInt(route.params['userId'] || route.parent?.params['userId'], 10);
 
   const accountService = inject(AccountService);
   const memberService = inject(MemberService);
+  const router = inject(Router);
   const toastr = inject(ToastrService);
 
   // If this is my profile, allow
@@ -21,10 +23,17 @@ export const profileGuard: CanActivateFn = (route, state) => {
   // Otherwise check if that user has their account shared
   return memberService.hasProfileShared(userId).pipe(
     tap(hasAccess => {
-      console.log('hasAccess', hasAccess);
       if (!hasAccess) {
         toastr.info(translate('toasts.profile-unauthorized'));
       }
+    }),
+    map(hasAccess => {
+      if (hasAccess) {
+        return true;
+      }
+
+      const dashboard = router.parseUrl('/home');
+      return new RedirectCommand(dashboard);
     })
   );
 };

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -3024,17 +3024,6 @@
         "saturday-short": "Sat"
     },
 
-    "ordinal-date-pipe": {
-        "ordinalFormat": "{{month}} {{day}}",
-        "ordinal": {
-            "st": "st",
-            "nd": "nd",
-            "rd": "rd",
-            "th": "th"
-        }
-    },
-
-
     "errors": {
         "series-doesnt-exist": "This series no longer exists",
         "collection-invalid-access": "You don't have access to any libraries this tag belongs to or this collection is invalid",


### PR DESCRIPTION
We are almost there, keep testing and letting us know. 

# Changed
- Changed: Don't log cancelled exceptions (develop)
- Changed: Tweaked how historical data is summarized and saved. This is not in use by Kavita, but will store daily summaries per user of what was read and stores some copies of data to help restore data in case of chapter deletion (develop)
- Changed: Greatly enhanced the KOReader Progress translation layer to account for more formats. (develop)


# Fixed
- Fixed: Fixed not redirecting to home when accessing a non-shared profile (develop)
- Fixed: Fixed a bad migration to reading session by moving the bad Koreader progress event migration higher in the stack (Fixes #4301 )
- Fixed: Fixed a bug with light novel libraries sometimes choosing the wrong starting location
- Fixed: Fixed duplicate sessions being created when faced with quick progress events (develop)