### PR TITLE
Expose Kavita's Parsing via API

### DIFF
--- a/API/API.csproj
+++ b/API/API.csproj
@@ -205,7 +205,6 @@
     <Content Include="Assets\**">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
-    <Folder Include="DTOs\Misc\" />
     <Folder Include="Extensions\KavitaPlus\" />
     <None Include="I18N\**" />
   </ItemGroup>

--- a/API/Controllers/PluginController.cs
+++ b/API/Controllers/PluginController.cs
@@ -1,11 +1,16 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using API.Data;
 using API.DTOs;
+using API.DTOs.Misc;
 using API.Entities.Enums;
 using API.Middleware;
 using API.Services;
+using API.Services.Tasks.Scanner.Parser;
 using Kavita.Common;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -84,5 +89,86 @@ public class PluginController(IUnitOfWork unitOfWork, ITokenService tokenService
     public async Task<ActionResult<DateTime?>> GetAuthKeyExpiration([Required] string authKey)
     {
         return Ok(await unitOfWork.UserRepository.GetAuthKeyExpiration(authKey, UserId));
+    }
+
+
+    /// <summary>
+    /// Parse a string and return Parsed information from it. Does not support any directory fallback parsing
+    /// </summary>
+    /// <param name="name">String to parse</param>
+    /// <param name="libraryType">Determines the set of pattern matching to use</param>
+    /// <returns></returns>
+    [HttpGet("parse")]
+    public ActionResult<ParseResultDto> Parse([FromQuery] [StringLength(1000)] string name, [FromQuery] LibraryType libraryType)
+    {
+        try
+        {
+            var result = ParseText(name, libraryType);
+
+            return Ok(result);
+        }
+        catch (RegexMatchTimeoutException)
+        {
+            return BadRequest("Input could not be parsed in allowed time");
+        }
+        catch (Exception)
+        {
+            return BadRequest("Failed to parse input");
+        }
+    }
+
+    private static ParseResultDto ParseText(string name, LibraryType libraryType)
+    {
+        var result = new ParseResultDto
+        {
+            SeriesName = Parser.ParseSeries(name, libraryType),
+            SeriesYear = Parser.ParseYear(name)
+        };
+        var chapterRange = Parser.ParseChapter(name, libraryType);
+        result.MinChapterNumber = Parser.MinNumberFromRange(chapterRange);
+        result.MaxChapterNumber = Parser.MaxNumberFromRange(chapterRange);
+        var volumeRange = Parser.ParseVolume(name, libraryType);
+        result.MinVolumeNumber = Parser.MinNumberFromRange(volumeRange);
+        result.MaxVolumeNumber = Parser.MaxNumberFromRange(volumeRange);
+        return result;
+    }
+
+    [HttpPost("parse-bulk")]
+    public ActionResult<ParseBulkResponseDto> ParseBulk(ParseBulkRequestDto dto, CancellationToken cancellationToken)
+    {
+        if (dto.Names.Count > 100)
+        {
+            return BadRequest("Only 100 items can be processed at once");
+        }
+
+        var result = new ParseBulkResponseDto();
+
+        var successfulParses = result.Results;
+        var errorParses = result.Errors;
+        foreach (var name in dto.Names)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (name.Length > 1000)
+            {
+                errorParses.Add(name, "Length > 1000 characters");
+                continue;
+            }
+
+            try
+            {
+                successfulParses.Add(name, ParseText(name, dto.LibraryType));
+            }
+            catch (RegexMatchTimeoutException)
+            {
+                errorParses.Add(name, "Input could not be parsed in allowed time");
+            }
+            catch (Exception)
+            {
+                errorParses.Add(name, "Failed to parse input");
+            }
+        }
+
+        return Ok(result);
     }
 }

--- a/API/DTOs/Misc/ParseBulkRequestDto.cs
+++ b/API/DTOs/Misc/ParseBulkRequestDto.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using API.Entities.Enums;
+
+namespace API.DTOs.Misc;
+
+public sealed record ParseBulkRequestDto
+{
+    public ICollection<string> Names { get; set; }
+    public LibraryType LibraryType { get; set; }
+}

--- a/API/DTOs/Misc/ParseBulkResponseDto.cs
+++ b/API/DTOs/Misc/ParseBulkResponseDto.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+
+namespace API.DTOs.Misc;
+
+public record ParseBulkResponseDto
+{
+    /// <summary>
+    /// The requested name to the parsed result. Does not include errored items
+    /// </summary>
+    public Dictionary<string, ParseResultDto> Results { get; set; } = new();
+    /// <summary>
+    /// The requested name to parse maps to the Error exception
+    /// </summary>
+    public Dictionary<string, string> Errors { get; set; } = new();
+
+    /// <summary>
+    /// Count of errored items
+    /// </summary>
+    public int ErrorCounts => Errors.Count;
+}

--- a/API/DTOs/Misc/ParseResultDto.cs
+++ b/API/DTOs/Misc/ParseResultDto.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace API.DTOs.Misc;
+
+public sealed record ParseResultDto
+{
+    public string SeriesName { get; set; }
+    public string SeriesYear { get; set; }
+    public float MinChapterNumber { get; set; }
+    public  float MaxChapterNumber { get; set; }
+    public float MinVolumeNumber { get; set; }
+    public float MaxVolumeNumber { get; set; }
+
+
+}


### PR DESCRIPTION
These brand new APIs allow for external scripts to leverage Kavita's filename matching logic. 

# Added
- Added: Added the ability for Kavita to expose how it parses information via plugin/parse and plugin/parse-bulk API.
