### PR TITLE
Fix: Enable Double Page layout and Fit to Width on foldable devices

### DIFF
--- a/UI/Web/src/_manga-reader-common.scss
+++ b/UI/Web/src/_manga-reader-common.scss
@@ -9,7 +9,7 @@ img {
   align-items: center;
 
   &.full-width {
-    height: 100dvh;
+    min-height: 100dvh;
     display: grid;
   }
 
@@ -21,7 +21,7 @@ img {
   }
 
   &.original {
-    height: calc(100dvh);
+    min-height: calc(100dvh);
     display: grid;
   }
 

--- a/UI/Web/src/app/manga-reader/_components/double-renderer-no-cover/double-no-cover-renderer.component.html
+++ b/UI/Web/src/app/manga-reader/_components/double-renderer-no-cover/double-no-cover-renderer.component.html
@@ -1,5 +1,5 @@
 @if (isValid()) {
-  <div class="image-container {{imageFitClass$ | async}} {{layoutClass$ | async}} {{emulateBookClass$ | async}}"
+  <div class="image-container {{layoutClass$ | async}} {{emulateBookClass$ | async}}"
     [style.filter]="(darkness$ | async)  ?? '' | safeStyle"
     [ngClass]="{'center-double': (shouldRenderDouble$ | async)}">
     @if (currentImage) {
@@ -7,12 +7,15 @@
         #image [src]="currentImage.src"
         id="image-1"
         class="{{imageFitClass$ | async}} {{readerModeClass$ | async}} {{showClickOverlayClass$ | async}}"
+        [class.double]="shouldRenderDouble$ | async"
         >
       }
       @if (shouldRenderDouble$ | async) {
         <img alt=" " [src]="currentImage2.src"
           id="image-2"
-          class="image-2 {{imageFitClass$ | async}} {{readerModeClass$ | async}} {{showClickOverlayClass$ | async}}">
+          class="image-2 {{imageFitClass$ | async}} {{readerModeClass$ | async}} {{showClickOverlayClass$ | async}}"
+          [class.double]="shouldRenderDouble$ | async"
+          >
         }
       </div>
     }

--- a/UI/Web/src/app/manga-reader/_components/double-renderer-no-cover/double-no-cover-renderer.component.scss
+++ b/UI/Web/src/app/manga-reader/_components/double-renderer-no-cover/double-no-cover-renderer.component.scss
@@ -1,7 +1,11 @@
 @use '../../../../manga-reader-common';
 
 .image-container {
-    height: calc(100vh); // override as on single, we -34px for the potential scrollbar
+    min-height: calc(100dvh);
+    display: flex;
+    align-content: center;
+    justify-content: center;
+    align-items: center;
     
     #image-1 {
         &.double {
@@ -18,19 +22,22 @@
     width: 100%;
     margin: 0 auto;
     vertical-align: top;
-    max-width: fit-content;
+    max-width: 50%;
 
     &.double {
         width: 50%;
 
         &.cover {
             width: 100%;
+            max-width: 100%;
         }
     }
 }
 
 .center-double {
     display: flex;
+    justify-content: center;
+    align-items: center;
     overflow: unset;
 }
 
@@ -49,4 +56,3 @@
     left: 50%;
     max-width: 100%;
 }
-

--- a/UI/Web/src/app/manga-reader/_components/double-renderer/double-renderer.component.html
+++ b/UI/Web/src/app/manga-reader/_components/double-renderer/double-renderer.component.html
@@ -1,5 +1,5 @@
 @if (isValid()) {
-  <div class="image-container {{imageFitClass$ | async}} {{layoutClass$ | async}} {{emulateBookClass$ | async}}"
+  <div class="image-container {{layoutClass$ | async}} {{emulateBookClass$ | async}}"
     [style.filter]="(darkness$ | async)  ?? '' | safeStyle"
     [ngClass]="{'center-double': (shouldRenderDouble$ | async)}">
     @if (currentImage) {
@@ -7,12 +7,15 @@
         #image [src]="currentImage.src"
         id="image-1"
         class="{{imageFitClass$ | async}} {{readerModeClass$ | async}} {{showClickOverlayClass$ | async}}"
+        [class.double]="shouldRenderDouble$ | async"
         >
       }
       @if (shouldRenderDouble$ | async) {
         <img alt=" " [src]="currentImage2.src"
           id="image-2"
-          class="image-2 {{imageFitClass$ | async}} {{readerModeClass$ | async}} {{showClickOverlayClass$ | async}}">
+          class="image-2 {{imageFitClass$ | async}} {{readerModeClass$ | async}} {{showClickOverlayClass$ | async}}"
+          [class.double]="shouldRenderDouble$ | async"
+          >
         }
       </div>
     }

--- a/UI/Web/src/app/manga-reader/_components/double-renderer/double-renderer.component.scss
+++ b/UI/Web/src/app/manga-reader/_components/double-renderer/double-renderer.component.scss
@@ -1,6 +1,12 @@
 @use '../../../../manga-reader-common';
 
 .image-container {
+    min-height: calc(100dvh);
+    display: flex;
+    align-content: center;
+    justify-content: center;
+    align-items: center;
+    
     #image-1 {
         &.double {
         }
@@ -23,19 +29,22 @@
 .full-width {
     width: 100%;
     vertical-align: top;
-    max-width: fit-content;
+    max-width: 50%;
 
     &.double {
         width: 50%;
 
         &.cover {
             width: 100%;
+            max-width: 100%;
         }
     }
 }
 
 .center-double {
     display: flex;
+    justify-content: center;
+    align-items: center;
     overflow: unset;
 }
 
@@ -54,4 +63,3 @@
     left: 50%;
     max-width: 100%;
 }
-

--- a/UI/Web/src/app/manga-reader/_components/double-reverse-renderer/double-reverse-renderer.component.html
+++ b/UI/Web/src/app/manga-reader/_components/double-reverse-renderer/double-reverse-renderer.component.html
@@ -7,13 +7,15 @@
       <img alt=" "
            #image [src]="leftImage.src"
            id="image-1"
-           class="{{imageFitClass$ | async}} {{readerModeClass$ | async}} {{showClickOverlayClass$ | async}}">
+           class="{{imageFitClass$ | async}} {{readerModeClass$ | async}} {{showClickOverlayClass$ | async}}"
+           [class.double]="shouldRenderDouble$ | async">
     }
 
     @if (shouldRenderDouble$ | async) {
       <img alt=" " [src]="rightImage.src"
            id="image-2"
-           class="image-2 {{imageFitClass$ | async}} {{readerModeClass$ | async}} {{showClickOverlayClass$ | async}}">  <!--reverse-->
+           class="image-2 {{imageFitClass$ | async}} {{readerModeClass$ | async}} {{showClickOverlayClass$ | async}}"
+           [class.double]="shouldRenderDouble$ | async">  <!--reverse-->
     }
   </div>
 }

--- a/UI/Web/src/app/manga-reader/_components/double-reverse-renderer/double-reverse-renderer.component.scss
+++ b/UI/Web/src/app/manga-reader/_components/double-reverse-renderer/double-reverse-renderer.component.scss
@@ -2,13 +2,18 @@
 
 // Overrides for reverse
 .image-container {
-    height: calc(100dvh); // override as on single, we -34px for the potential scrollbar
+    min-height: calc(100dvh); // override as on single, we -34px for the potential scrollbar
+    display: flex;
+    align-content: center;
+    justify-content: center;
+    align-items: center;
     
     &.reverse {
         overflow: unset;
         display: flex;
         align-content: center;
         justify-content: center;
+        align-items: center;
         flex-direction: row-reverse;
 
         img {
@@ -30,11 +35,6 @@
 }
 
 .image-container {
-    display: flex;
-    align-content: center;
-    justify-content: center;
-
-
     .full-height {
         margin: unset;
         object-fit: contain;
@@ -45,13 +45,14 @@
     width: 100%;
     margin: 0 auto;
     vertical-align: top;
-    max-width: fit-content;
+    max-width: 50%;
 
     &.double {
         width: 50%;
 
         &.cover {
             width: 100%;
+            max-width: 100%;
         }
     }
 }

--- a/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.ts
+++ b/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.ts
@@ -801,8 +801,10 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
         this.generalSettingsForm.get('pageSplitOption')?.setValue(PageSplitOption.NoSplit);
         this.generalSettingsForm.get('pageSplitOption')?.disable();
         this.generalSettingsForm.get('widthSlider')?.disable();
-        this.generalSettingsForm.get('fittingOption')?.setValue(this.mangaReaderService.translateScalingOption(ScalingOption.FitToHeight));
-        this.generalSettingsForm.get('fittingOption')?.disable();
+        if (window.innerWidth < Breakpoint.Mobile) {
+          this.generalSettingsForm.get('fittingOption')?.setValue(this.mangaReaderService.translateScalingOption(ScalingOption.FitToHeight));
+          this.generalSettingsForm.get('fittingOption')?.disable();
+        }
         this.generalSettingsForm.get('emulateBook')?.enable();
         this.generalSettingsForm.get('pageOffset')?.enable();
       }
@@ -938,7 +940,7 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   disableDoubleRendererIfScreenTooSmall() {
-    if (window.innerWidth > window.innerHeight) {
+    if (window.innerWidth > window.innerHeight || window.innerWidth >= Breakpoint.Mobile) {
       if (this.generalSettingsForm.get('layoutMode')?.disabled) {
         this.generalSettingsForm.get('layoutMode')?.enable();
       }
@@ -1835,7 +1837,9 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
 
       if (this.layoutMode !== LayoutMode.Single) {
         this.generalSettingsForm.get('pageSplitOption')?.disable();
-        this.generalSettingsForm.get('fittingOption')?.disable();
+        if (window.innerWidth < Breakpoint.Mobile) {
+          this.generalSettingsForm.get('fittingOption')?.disable();
+        }
         this.generalSettingsForm.get('pageOffset')?.enable();
       } else {
         this.generalSettingsForm.get('pageOffset')?.disable();


### PR DESCRIPTION
# Changed
- Changed: If display width is greater than 768px (eg. foldables and tablets in portrait) then does not disable double page mode toggles.
- Changed: Changes height to min-height in common styles to allow vertical scrolling in 'Fit to Width' mode.

# Fixed
- Fixed: Cropped pages on inner displays of foldable devices (Fixes #4244)
- Fixed: Mismatch in behaviour between Double (Manga) and Double Page that resulted in pages not being vertically aligned.