### PR TITLE
Add easing to manga reader menu open/close animation

### DIFF
--- a/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.html
+++ b/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.html
@@ -9,44 +9,42 @@
         }
       </div>
     }
-    @if (menuOpen) {
-      <div class="fixed-top overlay" [@slideFromTop]="menuOpen">
-        <div style="display: flex; margin-top: 5px;">
-          <button class="btn btn-icon" style="height: 100%" [title]="t('back')" (click)="closeReader()">
-            <i class="fa fa-arrow-left" aria-hidden="true"></i>
-            <span class="visually-hidden">{{t('back')}}</span>
-          </button>
+    <div class="fixed-top overlay slide-from-top" [class.visible]="menuOpen">
+      <div style="display: flex; margin-top: 5px;">
+        <button class="btn btn-icon" style="height: 100%" [title]="t('back')" (click)="closeReader()">
+          <i class="fa fa-arrow-left" aria-hidden="true"></i>
+          <span class="visually-hidden">{{t('back')}}</span>
+        </button>
 
-          <div>
-            <div style="font-weight: bold;">{{title}}
-              @if (incognitoMode) {
-                <span class="clickable" (click)="turnOffIncognito()" role="button" [attr.aria-label]="t('incognito-alt')">(<i class="fa fa-glasses"  aria-hidden="true"></i><span class="visually-hidden">{{t('incognito-title')}}</span>)</span>
-              }
-            </div>
-            <div class="subtitle">
-              {{chapterTitleLabel()}}
-              @if (totalSeriesPages > 0) {
-                <span class="ms-2">{{t('series-progress', {percentage: (Math.min(1, ((totalSeriesPagesRead + pageNum) / totalSeriesPages)) | percent)}) }}</span>
-              }
-            </div>
+        <div>
+          <div style="font-weight: bold;">{{title}}
+            @if (incognitoMode) {
+              <span class="clickable" (click)="turnOffIncognito()" role="button" [attr.aria-label]="t('incognito-alt')">(<i class="fa fa-glasses"  aria-hidden="true"></i><span class="visually-hidden">{{t('incognito-title')}}</span>)</span>
+            }
           </div>
-
-          <div style="margin-left: auto; padding-right: 3%;">
-            <button class="btn btn-icon" [title]="t('shortcuts-menu-alt')" (click)="openShortcutModal()">
-              <i class="fa-regular fa-rectangle-list" aria-hidden="true"></i>
-              <span class="visually-hidden">{{t('shortcuts-menu-alt')}}</span>
-            </button>
-            @if (!bookmarkMode() && hasBookmarkRights) {
-              <button class="btn btn-icon" role="checkbox" [attr.aria-checked]="CurrentPageBookmarked"
-                      title="{{t(CurrentPageBookmarked ? 'unbookmark-page-tooltip' : 'bookmark-page-tooltip')}}" (click)="bookmarkPage()">
-                <i class="{{CurrentPageBookmarked ? 'fa' : 'far'}} fa-bookmark" aria-hidden="true"></i>
-                <span class="visually-hidden">{{t(CurrentPageBookmarked ? 'unbookmark-page-tooltip' : 'bookmark-page-tooltip')}}</span>
-              </button>
+          <div class="subtitle">
+            {{chapterTitleLabel()}}
+            @if (totalSeriesPages > 0) {
+              <span class="ms-2">{{t('series-progress', {percentage: (Math.min(1, ((totalSeriesPagesRead + pageNum) / totalSeriesPages)) | percent)}) }}</span>
             }
           </div>
         </div>
+
+        <div style="margin-left: auto; padding-right: 3%;">
+          <button class="btn btn-icon" [title]="t('shortcuts-menu-alt')" (click)="openShortcutModal()">
+            <i class="fa-regular fa-rectangle-list" aria-hidden="true"></i>
+            <span class="visually-hidden">{{t('shortcuts-menu-alt')}}</span>
+          </button>
+          @if (!bookmarkMode() && hasBookmarkRights) {
+            <button class="btn btn-icon" role="checkbox" [attr.aria-checked]="CurrentPageBookmarked"
+                    title="{{t(CurrentPageBookmarked ? 'unbookmark-page-tooltip' : 'bookmark-page-tooltip')}}" (click)="bookmarkPage()">
+              <i class="{{CurrentPageBookmarked ? 'fa' : 'far'}} fa-bookmark" aria-hidden="true"></i>
+              <span class="visually-hidden">{{t(CurrentPageBookmarked ? 'unbookmark-page-tooltip' : 'bookmark-page-tooltip')}}</span>
+            </button>
+          }
+        </div>
       </div>
-    }
+    </div>
 
 
     <app-loading [loading]="isLoading || (!(currentImage$ | async)?.complete && this.readerMode !== ReaderMode.Webtoon)" [absolute]="true" />
@@ -135,196 +133,192 @@
       }
     </div>
 
-    @if (menuOpen) {
-      <div class="fixed-bottom overlay"  [@slideFromBottom]="menuOpen">
-        @if (pageOptions !== undefined && pageOptions.ceil !== undefined) {
-          <div class="mb-3">
-            <span class="visually-hidden" id="slider-info"></span>
-            <div class="row g-0">
-              <button class="btn btn-icon col-1" [disabled]="prevChapterDisabled" (click)="loadPrevChapter();resetMenuCloseTimer();" [title]="t('prev-chapter-tooltip')"><i class="fa fa-fast-backward" aria-hidden="true"></i></button>
-              <button class="btn btn-icon col-2" [disabled]="prevPageDisabled || pageNum === 0" (click)="goToPage(0);resetMenuCloseTimer();" [title]="t('first-page-tooltip')"><i class="fa fa-step-backward" aria-hidden="true"></i></button>
-              @if (pageOptions.ceil > 0) {
-                <div class="col custom-slider">
-                  <ngx-slider [options]="pageOptions" [value]="pageNum" aria-describedby="slider-info" [manualRefresh]="refreshSlider" (userChangeEnd)="sliderPageUpdate($event);startMenuCloseTimer()" (userChange)="sliderDragUpdate($event)" (userChangeStart)="cancelMenuCloseTimer();" />
-                </div>
-              } @else {
-                <div class="col custom-slider">
-                  <ngx-slider [options]="pageOptions" [value]="pageNum" aria-describedby="slider-info" (userChangeEnd)="startMenuCloseTimer()" (userChangeStart)="cancelMenuCloseTimer();" />
-                </div>
-              }
-              <button class="btn btn-icon col-2" [disabled]="nextPageDisabled || pageNum >= maxPages - 1" (click)="goToPage(this.maxPages);resetMenuCloseTimer();" [title]="t('last-page-tooltip')"><i class="fa fa-step-forward" aria-hidden="true"></i></button>
-              <button class="btn btn-icon col-1" [disabled]="nextChapterDisabled" (click)="loadNextChapter();resetMenuCloseTimer();" [title]="t('next-chapter-tooltip')"><i class="fa fa-fast-forward" aria-hidden="true"></i></button>
-            </div>
-          </div>
-        }
-        <div class="row pt-4 ms-2 me-2 mb-2">
-          <div class="col">
-            <button class="btn btn-icon" (click)="setReadingDirection();resetMenuCloseTimer();" [disabled]="readerMode === ReaderMode.Webtoon || readerMode === ReaderMode.UpDown" aria-describedby="reading-direction" [title]="t('reading-direction-tooltip') + readingDirection === ReadingDirection.LeftToRight ? t('left-to-right-alt') : t('right-to-left-alt')">
-              <i class="fa fa-angle-double-{{readingDirection === ReadingDirection.LeftToRight ? 'right' : 'left'}}" aria-hidden="true"></i>
-              <span id="reading-direction" class="visually-hidden">{{readingDirection === ReadingDirection.LeftToRight ? t('left-to-right-alt') : t('right-to-left-alt')}}</span>
-            </button>
-          </div>
-          <div class="col">
-            <button class="btn btn-icon" [title]="t('reading-mode-tooltip')" (click)="toggleReaderMode();resetMenuCloseTimer();">
-              <i class="fa {{readerMode | readerModeIcon}}" aria-hidden="true"></i>
-              <span class="visually-hidden">{{t('reading-mode-tooltip')}}</span>
-            </button>
-          </div>
-          <div class="col">
-            <button class="btn btn-icon" title="{{isFullscreen ? t('collapse') : t('fullscreen')}}" (click)="toggleFullscreen();resetMenuCloseTimer();">
-              <i class="fa {{isFullscreen | fullscreenIcon}}" aria-hidden="true"></i>
-              <span class="visually-hidden">{{isFullscreen ? t('collapse') : t('fullscreen')}}</span>
-            </button>
-          </div>
-          <div class="col">
-            <button class="btn btn-icon" [title]="t('settings-tooltip')" (click)="settingsOpen = !settingsOpen;resetMenuCloseTimer();">
-              <i class="fa fa-sliders-h" aria-hidden="true"></i>
-              <span class="visually-hidden">{{t('settings-tooltip')}}</span>
-            </button>
+    <div class="fixed-bottom overlay slide-from-bottom" [class.visible]="menuOpen">
+      @if (pageOptions !== undefined && pageOptions.ceil !== undefined) {
+        <div class="mb-3">
+          <span class="visually-hidden" id="slider-info"></span>
+          <div class="row g-0">
+            <button class="btn btn-icon col-1" [disabled]="prevChapterDisabled" (click)="loadPrevChapter();resetMenuCloseTimer();" [title]="t('prev-chapter-tooltip')"><i class="fa fa-fast-backward" aria-hidden="true"></i></button>
+            <button class="btn btn-icon col-2" [disabled]="prevPageDisabled || pageNum === 0" (click)="goToPage(0);resetMenuCloseTimer();" [title]="t('first-page-tooltip')"><i class="fa fa-step-backward" aria-hidden="true"></i></button>
+            @if (pageOptions.ceil > 0) {
+              <div class="col custom-slider">
+                <ngx-slider [options]="pageOptions" [value]="pageNum" aria-describedby="slider-info" [manualRefresh]="refreshSlider" (userChangeEnd)="sliderPageUpdate($event);startMenuCloseTimer()" (userChange)="sliderDragUpdate($event)" (userChangeStart)="cancelMenuCloseTimer();" />
+              </div>
+            } @else {
+              <div class="col custom-slider">
+                <ngx-slider [options]="pageOptions" [value]="pageNum" aria-describedby="slider-info" (userChangeEnd)="startMenuCloseTimer()" (userChangeStart)="cancelMenuCloseTimer();" />
+              </div>
+            }
+            <button class="btn btn-icon col-2" [disabled]="nextPageDisabled || pageNum >= maxPages - 1" (click)="goToPage(this.maxPages);resetMenuCloseTimer();" [title]="t('last-page-tooltip')"><i class="fa fa-step-forward" aria-hidden="true"></i></button>
+            <button class="btn btn-icon col-1" [disabled]="nextChapterDisabled" (click)="loadNextChapter();resetMenuCloseTimer();" [title]="t('next-chapter-tooltip')"><i class="fa fa-fast-forward" aria-hidden="true"></i></button>
           </div>
         </div>
-        @if (settingsOpen && generalSettingsForm) {
-          <div class="bottom-menu">
-            <form [formGroup]="generalSettingsForm">
-              <div class="row mb-2">
-                <div class="col-md-6 col-sm-12">
-                  <label for="page-splitting" class="form-label">{{t('image-splitting-label')}}</label>&nbsp;
-                  <div class="split fa fa-image">
-                    <div class="{{SplitIconClass}}"></div>
-                  </div>
-                  <select class="form-control" id="page-splitting" formControlName="pageSplitOption">
-                    @for (opt of pageSplitOptionsTranslated; track opt.value) {
-                      <option [value]="opt.value">{{opt.text}}</option>
-                    }
-                  </select>
+      }
+      <div class="row pt-4 ms-2 me-2 mb-2">
+        <div class="col">
+          <button class="btn btn-icon" (click)="setReadingDirection();resetMenuCloseTimer();" [disabled]="readerMode === ReaderMode.Webtoon || readerMode === ReaderMode.UpDown" aria-describedby="reading-direction" [title]="t('reading-direction-tooltip') + readingDirection === ReadingDirection.LeftToRight ? t('left-to-right-alt') : t('right-to-left-alt')">
+            <i class="fa fa-angle-double-{{readingDirection === ReadingDirection.LeftToRight ? 'right' : 'left'}}" aria-hidden="true"></i>
+            <span id="reading-direction" class="visually-hidden">{{readingDirection === ReadingDirection.LeftToRight ? t('left-to-right-alt') : t('right-to-left-alt')}}</span>
+          </button>
+        </div>
+        <div class="col">
+          <button class="btn btn-icon" [title]="t('reading-mode-tooltip')" (click)="toggleReaderMode();resetMenuCloseTimer();">
+            <i class="fa {{readerMode | readerModeIcon}}" aria-hidden="true"></i>
+            <span class="visually-hidden">{{t('reading-mode-tooltip')}}</span>
+          </button>
+        </div>
+        <div class="col">
+          <button class="btn btn-icon" title="{{isFullscreen ? t('collapse') : t('fullscreen')}}" (click)="toggleFullscreen();resetMenuCloseTimer();">
+            <i class="fa {{isFullscreen | fullscreenIcon}}" aria-hidden="true"></i>
+            <span class="visually-hidden">{{isFullscreen ? t('collapse') : t('fullscreen')}}</span>
+          </button>
+        </div>
+        <div class="col">
+          <button class="btn btn-icon" [title]="t('settings-tooltip')" (click)="settingsOpen = !settingsOpen;resetMenuCloseTimer();">
+            <i class="fa fa-sliders-h" aria-hidden="true"></i>
+            <span class="visually-hidden">{{t('settings-tooltip')}}</span>
+          </button>
+        </div>
+      </div>
+      @if (settingsOpen && generalSettingsForm) {
+        <div class="bottom-menu">
+          <form [formGroup]="generalSettingsForm">
+            <div class="row mb-2">
+              <div class="col-md-6 col-sm-12">
+                <label for="page-splitting" class="form-label">{{t('image-splitting-label')}}</label>&nbsp;
+                <div class="split fa fa-image">
+                  <div class="{{SplitIconClass}}"></div>
                 </div>
-
-                <div class="col-md-6 col-sm-12">
-                  <label for="page-fitting" class="form-label">{{t('image-scaling-label')}}</label>&nbsp;<i class="{{FittingOption | fittingIcon}}" aria-hidden="true"></i>
-                  <select class="form-control" id="page-fitting" formControlName="fittingOption">
-                    <option value="full-height">{{t('height')}}</option>
-                    <option value="full-width">{{t('width')}}</option>
-                    <option value="original">{{t('original')}}</option>
-                  </select>
-                </div>
+                <select class="form-control" id="page-splitting" formControlName="pageSplitOption">
+                  @for (opt of pageSplitOptionsTranslated; track opt.value) {
+                    <option [value]="opt.value">{{opt.text}}</option>
+                  }
+                </select>
               </div>
 
-              <div class="row mb-2">
-                <div class="col-md-6 col-sm-12">
-                  <label for="layout-mode" class="form-label">Layout Mode</label>&nbsp;
-                  @switch (layoutMode) {
-                    @case (LayoutMode.Single) {
-                      <div class="split-double">
-                        <span class="fa-stack fa-1x">
-                            <i class="fa-regular fa-square-full fa-stack-2x"></i>
-                            <i class="fa fa-image fa-stack-1x"></i>
-                        </span>
-                      </div>
-                    }
-                    @case (LayoutMode.Double) {
-                      <div class="split-double">
-                        <span class="fa-stack fa-1x">
-                            <i class="fa-regular fa-square-full fa-stack-2x"></i>
-                            <i class="fab fa-1 fa-stack-1x"></i>
-                        </span>
-                        <span class="fa-stack fa right">
+              <div class="col-md-6 col-sm-12">
+                <label for="page-fitting" class="form-label">{{t('image-scaling-label')}}</label>&nbsp;<i class="{{FittingOption | fittingIcon}}" aria-hidden="true"></i>
+                <select class="form-control" id="page-fitting" formControlName="fittingOption">
+                  <option value="full-height">{{t('height')}}</option>
+                  <option value="full-width">{{t('width')}}</option>
+                  <option value="original">{{t('original')}}</option>
+                </select>
+              </div>
+            </div>
+
+            <div class="row mb-2">
+              <div class="col-md-6 col-sm-12">
+                <label for="layout-mode" class="form-label">Layout Mode</label>&nbsp;
+                @switch (layoutMode) {
+                  @case (LayoutMode.Single) {
+                    <div class="split-double">
+                      <span class="fa-stack fa-1x">
                           <i class="fa-regular fa-square-full fa-stack-2x"></i>
-                          <i class="fab fa-2 fa-stack-1x"></i>
-                        </span>
-                      </div>
-                    }
-                    @case (LayoutMode.DoubleReversed) {
-                      <div class="split-double">
-                        <span class="fa-stack fa-1x">
-                            <i class="fa-regular fa-square-full fa-stack-2x"></i>
-                            <i class="fab fa-2 fa-stack-1x"></i>
-                        </span>
-                        <span class="fa-stack fa right">
+                          <i class="fa fa-image fa-stack-1x"></i>
+                      </span>
+                    </div>
+                  }
+                  @case (LayoutMode.Double) {
+                    <div class="split-double">
+                      <span class="fa-stack fa-1x">
                           <i class="fa-regular fa-square-full fa-stack-2x"></i>
                           <i class="fab fa-1 fa-stack-1x"></i>
-                        </span>
-                      </div>
-                    }
+                      </span>
+                      <span class="fa-stack fa right">
+                        <i class="fa-regular fa-square-full fa-stack-2x"></i>
+                        <i class="fab fa-2 fa-stack-1x"></i>
+                      </span>
+                    </div>
                   }
+                  @case (LayoutMode.DoubleReversed) {
+                    <div class="split-double">
+                      <span class="fa-stack fa-1x">
+                          <i class="fa-regular fa-square-full fa-stack-2x"></i>
+                          <i class="fab fa-2 fa-stack-1x"></i>
+                      </span>
+                      <span class="fa-stack fa right">
+                        <i class="fa-regular fa-square-full fa-stack-2x"></i>
+                        <i class="fab fa-1 fa-stack-1x"></i>
+                      </span>
+                    </div>
+                  }
+                }
 
-                  <select class="form-control" id="layout-mode" formControlName="layoutMode">
-                    @for (opt of layoutModesTranslated; track opt.value) {
-                      <option [value]="opt.value">{{opt.text}}</option>
-                    }
-                  </select>
+                <select class="form-control" id="layout-mode" formControlName="layoutMode">
+                  @for (opt of layoutModesTranslated; track opt.value) {
+                    <option [value]="opt.value">{{opt.text}}</option>
+                  }
+                </select>
+              </div>
+              <div class="col-md-3 col-sm-12">
+                <div class="mb-3">
+                  <div class="form-check form-switch">
+                    <input type="checkbox" id="auto-close" formControlName="autoCloseMenu" class="form-check-input" switch>
+                    <label class="form-check-label" for="auto-close">{{t('auto-close-menu-label')}}</label>
+                  </div>
                 </div>
-                <div class="col-md-3 col-sm-12">
-                  <div class="mb-3">
-                    <div class="form-check form-switch">
-                      <input type="checkbox" id="auto-close" formControlName="autoCloseMenu" class="form-check-input" switch>
-                      <label class="form-check-label" for="auto-close">{{t('auto-close-menu-label')}}</label>
-                    </div>
-                  </div>
 
-                  <div class="mb-3">
-                    <div class="form-check form-switch">
-                      <input type="checkbox" id="swipe-to-paginate" formControlName="swipeToPaginate" class="form-check-input" switch>
-                      <label class="form-check-label" for="swipe-to-paginate">{{t('swipe-enabled-label')}}</label>
-                    </div>
-                  </div>
-                </div>
-                <div class="col-md-3 col-sm-12">
-                  <div class="mb-3">
-                    <div class="form-check form-switch">
-                      <input type="checkbox" id="emulate-book" formControlName="emulateBook" class="form-check-input" switch>
-                      <label class="form-check-label" for="emulate-book">{{t('emulate-comic-book-label')}}</label>
-                    </div>
-                  </div>
-
-                  <div class="mb-3">
-                    <div class="form-check form-switch" [title]="generalSettingsForm.get('pageOffset')?.disabled ? t('offset-only-double') : ''">
-                      <input type="checkbox" id="page-offset" formControlName="pageOffset" class="form-check-input" switch>
-                      <label class="form-check-label" for="page-offset">{{t('page-offset-label')}}</label>
-                    </div>
+                <div class="mb-3">
+                  <div class="form-check form-switch">
+                    <input type="checkbox" id="swipe-to-paginate" formControlName="swipeToPaginate" class="form-check-input" switch>
+                    <label class="form-check-label" for="swipe-to-paginate">{{t('swipe-enabled-label')}}</label>
                   </div>
                 </div>
               </div>
-              <div class="row mb-2">
-                <div class="col-md-6 col-sm-12">
-                  <label for="darkness" class="form-label range-label">{{t('brightness-label')}}</label>
-                  <span class="ms-1 range-text">{{generalSettingsForm.get('darkness')?.value + '%'}}</span>
-                  <input type="range" class="form-range" id="darkness"
-                         min="10" max="100" step="1" formControlName="darkness">
+              <div class="col-md-3 col-sm-12">
+                <div class="mb-3">
+                  <div class="form-check form-switch">
+                    <input type="checkbox" id="emulate-book" formControlName="emulateBook" class="form-check-input" switch>
+                    <label class="form-check-label" for="emulate-book">{{t('emulate-comic-book-label')}}</label>
+                  </div>
                 </div>
 
-                <div class="col-md-6 col-sm-12">
-                  <label for="width-override-slider" class="form-label">{{t('width-override-label')}}:
-                    @if (widthOverrideLabel$ | async; as widthOverrideLabel) {
-                      {{ widthOverrideLabel ? widthOverrideLabel : t('off') }}
-                    }
-                    @else {
-                      {{t('off')}}
-                    }
-                  </label>
-                  <input id="width-override-slider" type="range" min="0" max="100" class="form-range" formControlName="widthSlider">
-                </div>
-
-
-                <div class="col-md-6 col-sm-12">
-                  <button class="btn btn-primary"
-                          [disabled]="readingProfile.kind !== ReadingProfileKind.Implicit || !parentReadingProfile"
-                          (click)="updateParentPref()">
-                    {{ t('update-parent', {name: parentReadingProfile?.name || t('loading')}) }}
-                  </button>
-                  <button class="btn btn-primary ms-sm-2"
-                          [ngbTooltip]="t('create-new-tooltip')"
-                          [disabled]="readingProfile.kind !== ReadingProfileKind.Implicit"
-                          (click)="createNewProfileFromImplicit()">
-                    {{ t('create-new') }}
-                  </button>
+                <div class="mb-3">
+                  <div class="form-check form-switch" [title]="generalSettingsForm.get('pageOffset')?.disabled ? t('offset-only-double') : ''">
+                    <input type="checkbox" id="page-offset" formControlName="pageOffset" class="form-check-input" switch>
+                    <label class="form-check-label" for="page-offset">{{t('page-offset-label')}}</label>
+                  </div>
                 </div>
               </div>
-            </form>
-          </div>
-        }
-      </div>
-    }
+            </div>
+            <div class="row mb-2">
+              <div class="col-md-6 col-sm-12">
+                <label for="darkness" class="form-label range-label">{{t('brightness-label')}}</label>
+                <span class="ms-1 range-text">{{generalSettingsForm.get('darkness')?.value + '%'}}</span>
+                <input type="range" class="form-range" id="darkness"
+                        min="10" max="100" step="1" formControlName="darkness">
+              </div>
 
+              <div class="col-md-6 col-sm-12">
+                <label for="width-override-slider" class="form-label">{{t('width-override-label')}}:
+                  @if (widthOverrideLabel$ | async; as widthOverrideLabel) {
+                    {{ widthOverrideLabel ? widthOverrideLabel : t('off') }}
+                  }
+                  @else {
+                    {{t('off')}}
+                  }
+                </label>
+                <input id="width-override-slider" type="range" min="0" max="100" class="form-range" formControlName="widthSlider">
+              </div>
+
+
+              <div class="col-md-6 col-sm-12">
+                <button class="btn btn-primary"
+                        [disabled]="readingProfile.kind !== ReadingProfileKind.Implicit || !parentReadingProfile"
+                        (click)="updateParentPref()">
+                  {{ t('update-parent', {name: parentReadingProfile?.name || t('loading')}) }}
+                </button>
+                <button class="btn btn-primary ms-sm-2"
+                        [ngbTooltip]="t('create-new-tooltip')"
+                        [disabled]="readingProfile.kind !== ReadingProfileKind.Implicit"
+                        (click)="createNewProfileFromImplicit()">
+                  {{ t('create-new') }}
+                </button>
+              </div>
+            </div>
+          </form>
+        </div>
+      }
+    </div>
   </div>
-
 </ng-container>

--- a/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.scss
+++ b/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.scss
@@ -64,6 +64,24 @@ $pointer-offset: 5px;
   background-color: var(--manga-reader-overlay-bg-color);
   backdrop-filter: var(--manga-reader-overlay-filter); // BUG: This doesn't work on Firefox
   color: var(--manga-reader-overlay-text-color);
+
+  &.slide-from-top {
+    transform: translateY(-100%);
+    transition: transform 200ms cubic-bezier(.4,0,.2,1);
+
+    &.visible {
+      transform: translateY(0);
+    }
+  }
+
+  &.slide-from-bottom {
+    transform: translateY(100%);
+    transition: transform 200ms cubic-bezier(.4,0,.2,1);
+
+    &.visible {
+      transform: translateY(0);
+    }
+  }
 }
 
 @media(min-width: 600px) {

--- a/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.ts
+++ b/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.ts
@@ -33,7 +33,6 @@ import {
   tap
 } from 'rxjs';
 import {ChangeContext, LabelType, NgxSliderModule, Options} from '@angular-slider/ngx-slider';
-import {animate, state, style, transition, trigger} from '@angular/animations';
 import {FormBuilder, FormControl, FormGroup, ReactiveFormsModule} from '@angular/forms';
 import {NgbModal, NgbModalRef, NgbTooltip} from '@ng-bootstrap/ng-bootstrap';
 import {ToastrService} from 'ngx-toastr';
@@ -91,7 +90,6 @@ const PREFETCH_PAGES = 10;
 const CHAPTER_ID_NOT_FETCHED = -2;
 const CHAPTER_ID_DOESNT_EXIST = -1;
 
-const ANIMATION_SPEED = 200;
 const OVERLAY_AUTO_CLOSE_TIME = 3000;
 const CLICK_OVERLAY_TIMEOUT = 3000;
 
@@ -114,28 +112,6 @@ enum KeyDirection {
     styleUrls: ['./manga-reader.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush,
     providers: [MangaReaderService],
-    animations: [
-        trigger('slideFromTop', [
-            state('in', style({ transform: 'translateY(0)' })),
-            transition('void => *', [
-                style({ transform: 'translateY(-100%)' }),
-                animate(ANIMATION_SPEED)
-            ]),
-            transition('* => void', [
-                animate(ANIMATION_SPEED, style({ transform: 'translateY(-100%)' })),
-            ])
-        ]),
-        trigger('slideFromBottom', [
-            state('in', style({ transform: 'translateY(0)' })),
-            transition('void => *', [
-                style({ transform: 'translateY(100%)' }),
-                animate(ANIMATION_SPEED)
-            ]),
-            transition('* => void', [
-                animate(ANIMATION_SPEED, style({ transform: 'translateY(100%)' })),
-            ])
-        ])
-    ],
   imports: [NgStyle, LoadingComponent, SwipeDirective, CanvasRendererComponent, SingleRendererComponent,
     DoubleRendererComponent, DoubleReverseRendererComponent, DoubleNoCoverRendererComponent, InfiniteScrollerComponent,
     NgxSliderModule, ReactiveFormsModule, FittingIconPipe, ReaderModeIconPipe,
@@ -1227,7 +1203,6 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       this.toggleMenu();
     }, OVERLAY_AUTO_CLOSE_TIME);
   }
-
 
   toggleMenu() {
     this.menuOpen = !this.menuOpen;


### PR DESCRIPTION
Opening on behalf of OP due to a bad target merge. 

# Changed
- Changed: Manga reader menu now uses a cubic-bezier easing for its animation
