### PR TITLE
UI Tech Debt Fixes Part 1 (Re-release)

### DIFF
--- a/UI/Web/src/app/_services/drawer.service.ts
+++ b/UI/Web/src/app/_services/drawer.service.ts
@@ -1,0 +1,36 @@
+import {ComponentRef, inject, Injectable, Type} from '@angular/core';
+import {NgbOffcanvas, NgbOffcanvasOptions, NgbOffcanvasRef} from "@ng-bootstrap/ng-bootstrap";
+
+export interface TypedOffcanvasRef<C> extends NgbOffcanvasRef {
+  setInput<K extends string>(key: K, value: unknown): void;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class DrawerService {
+
+  private readonly offcanvas = inject(NgbOffcanvas);
+
+  /** * TODO: This is a hack to get the ComponentRef because NgbOffcanvasRef does not expose it.
+   * See https://github.com/ng-bootstrap/ng-bootstrap/issues/4688 */
+  open<C>(content: Type<C>, options?: NgbOffcanvasOptions): TypedOffcanvasRef<C> {
+    const ref = this.offcanvas.open(content, options) as TypedOffcanvasRef<C>;
+
+    ref.setInput = (key: string, value: unknown) => {
+      const componentRef: ComponentRef<C> = (ref as any)['_contentRef'].componentRef;
+      componentRef.setInput(key, value);
+    };
+
+    return ref;
+  }
+
+  hasOpenOffcanvas() {
+    return this.offcanvas.hasOpenOffcanvas();
+  }
+
+  dismiss() {
+    this.offcanvas.dismiss();
+  }
+
+}

--- a/UI/Web/src/app/_services/entity-title.service.ts
+++ b/UI/Web/src/app/_services/entity-title.service.ts
@@ -1,0 +1,181 @@
+import {inject, Injectable} from '@angular/core';
+import {TranslocoService} from '@jsverse/transloco';
+import {UtilityService} from '../shared/_services/utility.service';
+import {Chapter, LooseLeafOrDefaultNumber} from '../_models/chapter';
+import {LibraryType} from '../_models/library/library';
+import {Volume} from '../_models/volume';
+
+const LooseLeafOrSpecial = LooseLeafOrDefaultNumber + '';
+
+@Injectable({ providedIn: 'root' })
+export class EntityTitleService {
+  private readonly translocoService = inject(TranslocoService);
+  private readonly utilityService = inject(UtilityService);
+
+  computeTitle(
+    entity: Volume | Chapter,
+    libraryType: LibraryType | number,
+    options?: {
+      prioritizeTitleName?: boolean;
+      fallbackToVolume?: boolean;
+      includeChapter?: boolean;
+      includeVolume?: boolean;
+    }
+  ): string {
+    const prioritizeTitleName = options?.prioritizeTitleName ?? true;
+    const fallbackToVolume = options?.fallbackToVolume ?? true;
+    const includeChapter = options?.includeChapter ?? false;
+    const includeVolume = options?.includeVolume ?? false;
+
+    const isChapter = this.utilityService.isChapter(entity);
+
+    // Special chapters always display their title directly
+    if (isChapter && (entity as Chapter).isSpecial) {
+      const chapter = entity as Chapter;
+      return chapter.title || chapter.range || '';
+    }
+
+    // Compute titleName
+    let titleName = '';
+    if (isChapter) {
+      titleName = (entity as Chapter).titleName || '';
+    } else {
+      const volume = entity as Volume;
+      let title = volume.name || '';
+      if (volume.chapters.length > 0 && volume.chapters[0].titleName) {
+        title += ' - ' + volume.chapters[0].titleName;
+      }
+      titleName = title;
+    }
+
+    // Compute number (range for chapter, name for volume)
+    const number = isChapter ? (entity as Chapter).range || '' : (entity as Volume).name || '';
+
+    // Compute volumeTitle
+    const volumeTitle = isChapter
+      ? (entity as Chapter).volumeTitle || ''
+      : (entity as Volume).name || '';
+
+    switch (libraryType) {
+      case LibraryType.Manga:
+        return this.calculateMangaRenderText(titleName, prioritizeTitleName, fallbackToVolume, isChapter, number, volumeTitle, includeChapter, includeVolume);
+      case LibraryType.Comic:
+      case LibraryType.ComicVine:
+        return this.calculateComicRenderText(titleName, prioritizeTitleName, fallbackToVolume, isChapter, number, volumeTitle, includeChapter, includeVolume);
+      case LibraryType.Book:
+        return this.calculateBookRenderText(titleName, prioritizeTitleName, fallbackToVolume, isChapter, number, volumeTitle);
+      case LibraryType.Images:
+        return this.calculateImageRenderText(isChapter, number, volumeTitle, fallbackToVolume);
+      case LibraryType.LightNovel:
+        return this.calculateLightNovelRenderText(titleName, prioritizeTitleName, fallbackToVolume, isChapter, number, volumeTitle);
+      default:
+        return '';
+    }
+  }
+
+  private calculateBookRenderText(titleName: string, prioritizeTitleName: boolean, fallbackToVolume: boolean, isChapter: boolean, number: string, volumeTitle: string): string {
+    let renderText = '';
+    if (titleName !== '' && prioritizeTitleName) {
+      renderText = titleName;
+    } else if (fallbackToVolume && isChapter) {
+      renderText = this.translocoService.translate('entity-title.single-volume');
+    } else if (number === LooseLeafOrSpecial) {
+      renderText = '';
+    } else {
+      renderText = this.translocoService.translate('entity-title.book-num', {num: volumeTitle});
+    }
+    return renderText;
+  }
+
+  private calculateLightNovelRenderText(titleName: string, prioritizeTitleName: boolean, fallbackToVolume: boolean, isChapter: boolean, number: string, volumeTitle: string): string {
+    let renderText = '';
+    if (titleName !== '' && prioritizeTitleName) {
+      renderText = titleName;
+    } else if (fallbackToVolume && isChapter) {
+      renderText = this.translocoService.translate('entity-title.single-volume');
+    } else if (number === LooseLeafOrSpecial) {
+      renderText = '';
+    } else {
+      const bookNum = isChapter ? number : volumeTitle;
+      renderText = this.translocoService.translate('entity-title.book-num', {num: bookNum});
+    }
+    return renderText;
+  }
+
+  private calculateMangaRenderText(titleName: string, prioritizeTitleName: boolean, fallbackToVolume: boolean, isChapter: boolean, number: string, volumeTitle: string, includeChapter: boolean, includeVolume: boolean): string {
+    let renderText = '';
+
+    if (titleName !== '' && prioritizeTitleName) {
+      if (isChapter && includeChapter) {
+        if (number === LooseLeafOrSpecial) {
+          renderText = this.translocoService.translate('entity-title.chapter') + ' - ';
+        } else {
+          renderText = this.translocoService.translate('entity-title.chapter') + ' ' + number + ' - ';
+        }
+      }
+      renderText += titleName;
+    } else {
+      if (includeVolume && volumeTitle !== '') {
+        if (number !== LooseLeafOrSpecial && isChapter && includeVolume) {
+          renderText = volumeTitle;
+        }
+      }
+
+      if (number !== LooseLeafOrSpecial) {
+        if (isChapter) {
+          renderText = this.translocoService.translate('entity-title.chapter') + ' ' + number;
+        } else {
+          renderText = volumeTitle;
+        }
+      } else if (fallbackToVolume && isChapter && volumeTitle) {
+        renderText = this.translocoService.translate('entity-title.vol-num', {num: volumeTitle});
+      } else if (fallbackToVolume && isChapter) {
+        renderText = this.translocoService.translate('entity-title.single-volume');
+      } else {
+        renderText = this.translocoService.translate('entity-title.special');
+      }
+    }
+
+    return renderText;
+  }
+
+  private calculateImageRenderText(isChapter: boolean, number: string, volumeTitle: string, fallbackToVolume: boolean): string {
+    let renderText = '';
+
+    if (number !== LooseLeafOrSpecial) {
+      if (isChapter) {
+        renderText = this.translocoService.translate('entity-title.chapter') + ' ' + number;
+      } else {
+        renderText = volumeTitle;
+      }
+    } else {
+      renderText = this.translocoService.translate('entity-title.special');
+    }
+
+    return renderText;
+  }
+
+  private calculateComicRenderText(titleName: string, prioritizeTitleName: boolean, fallbackToVolume: boolean,
+                                   isChapter: boolean, number: string, volumeTitle: string, includeChapter: boolean,
+                                   includeVolume: boolean): string {
+    let renderText = '';
+
+    if (titleName && prioritizeTitleName) {
+      if (isChapter && includeChapter) {
+        renderText = this.translocoService.translate('entity-title.issue-num') + ' ' + number + ' - ';
+      }
+      renderText += titleName;
+    } else {
+      if (includeVolume && volumeTitle) {
+        if (number !== LooseLeafOrSpecial) {
+          renderText = isChapter ? volumeTitle : '';
+        }
+      }
+      renderText += number !== LooseLeafOrSpecial
+        ? (isChapter ? this.translocoService.translate('entity-title.issue-num') + ' ' + number : volumeTitle)
+        : this.translocoService.translate('entity-title.special');
+    }
+
+    return renderText;
+  }
+}


### PR DESCRIPTION
This is the preliminary pass from users. Keep the testing coming please. 

# Changed
- Changed: Tweaked the card layout to try and squeeze more spacing out

# Fixed
- Fixed: Fixed library detail not loading jumbar on startup (develop)
- Fixed: Fixed broken match series modal due to missing setInput (develop)
- Fixed: [Ensure that when an entity doesn't have a read func, we don't render the read button. (develop)
- Fixed: No profile image on nav header  (develop)
- Fixed: Fixed missing known for section on person detail  (develop)
- Fixed: Fixed delete selected on scrobble table not reflecting due to improperly updating state. (develop)
- Fixed: Incorrect chapter card titles (develop)
- Fixed: Fixed recommended external card drawers failing to open (develop)
- Fixed: Fixed reread modal being too wide (develop)

Part of https://github.com/Kareadita/Kavita/issues/4472