### PR TITLE
UI Tech Debt Fixes Part 2

### DIFF
--- a/UI/Web/src/app/_services/nav.service.ts
+++ b/UI/Web/src/app/_services/nav.service.ts
@@ -134,8 +134,7 @@ export class NavService {
 
     // To avoid flashing, let's check if we are authenticated before we show
     effect(() => {
-      const user = this.accountService.currentUser();
-      if (user) {
+      if (this.accountService.isLoggedIn()) {
         this.showNavBar();
       }
     })

--- a/UI/Web/src/app/_services/reader.service.ts
+++ b/UI/Web/src/app/_services/reader.service.ts
@@ -1,5 +1,5 @@
 import {HttpClient} from '@angular/common/http';
-import {DestroyRef, effect, inject, Injectable} from '@angular/core';
+import {effect, inject, Injectable} from '@angular/core';
 import {DOCUMENT, Location} from '@angular/common';
 import {Router} from '@angular/router';
 import {environment} from 'src/environments/environment';
@@ -18,7 +18,6 @@ import {PersonalToC} from "../_models/readers/personal-toc";
 import {FilterV2} from "../_models/metadata/v2/filter-v2";
 import NoSleep from 'nosleep.js';
 import {Volume} from "../_models/volume";
-import {UtilityService} from "../shared/_services/utility.service";
 import {translate} from "@jsverse/transloco";
 import {ToastrService} from "ngx-toastr";
 import {FilterField} from "../_models/metadata/v2/filter-field";
@@ -48,8 +47,6 @@ const MS_IN_DAY = 1000 * 60 * 60 * 24;
 })
 export class ReaderService {
 
-  private readonly destroyRef = inject(DestroyRef);
-  private readonly utilityService = inject(UtilityService);
   private readonly router = inject(Router);
   private readonly location = inject(Location);
   private readonly accountService = inject(AccountService);

--- a/UI/Web/src/app/_services/theme.service.ts
+++ b/UI/Web/src/app/_services/theme.service.ts
@@ -235,28 +235,12 @@ export class ThemeService {
             return;
           }
           this.injectStyleNode(theme, content);
-
-          // Check if the theme has --theme-color and apply it to meta tag
-          const themeColor = this.getThemeColor();
-          if (themeColor) {
-            this.document.querySelector('meta[name="theme-color"]')?.setAttribute('content', themeColor);
-            this.document.querySelector('meta[name="apple-mobile-web-app-status-bar-style"]')?.setAttribute('content', themeColor);
-          }
-
-          const tileColor = this.getTileColor();
-          if (tileColor) {
-            this.document.querySelector('meta[name="msapplication-TileColor"]')?.setAttribute('content', themeColor);
-          }
-
-          const colorScheme = this.getColorScheme();
-          if (colorScheme) {
-            this.document.querySelector('body')?.setAttribute('theme', colorScheme);
-          }
-
+          this.updateMetaTags();
           this.currentThemeSource.next(theme);
           this.darkModeSource.next(this.isDarkTheme());
         });
       } else {
+        this.updateMetaTags();
         this.currentThemeSource.next(theme);
         this.darkModeSource.next(this.isDarkTheme());
       }
@@ -265,6 +249,24 @@ export class ThemeService {
       this.getThemes().subscribe(themes => {
         this.setTheme(themeName);
       });
+    }
+  }
+
+  private updateMetaTags() {
+    const themeColor = this.getThemeColor();
+    if (themeColor) {
+      this.document.querySelector('meta[name="theme-color"]')?.setAttribute('content', themeColor);
+      this.document.querySelector('meta[name="apple-mobile-web-app-status-bar-style"]')?.setAttribute('content', themeColor);
+    }
+
+    const tileColor = this.getTileColor();
+    if (tileColor) {
+      this.document.querySelector('meta[name="msapplication-TileColor"]')?.setAttribute('content', tileColor);
+    }
+
+    const colorScheme = this.getColorScheme();
+    if (colorScheme) {
+      this.document.querySelector('body')?.setAttribute('theme', colorScheme);
     }
   }
 

--- a/UI/Web/src/app/_services/theme.service.ts
+++ b/UI/Web/src/app/_services/theme.service.ts
@@ -256,7 +256,7 @@ export class ThemeService {
     const themeColor = this.getThemeColor();
     if (themeColor) {
       this.document.querySelector('meta[name="theme-color"]')?.setAttribute('content', themeColor);
-      this.document.querySelector('meta[name="apple-mobile-web-app-status-bar-style"]')?.setAttribute('content', themeColor);
+      this.document.querySelector('meta[name="apple-mobile-web-app-status-bar-style"]')?.setAttribute('content', this.isDarkTheme() ? 'black' : 'default');
     }
 
     const tileColor = this.getTileColor();

--- a/UI/Web/src/app/book-reader/_components/_drawers/view-edit-annotation-drawer/view-edit-annotation-drawer.component.ts
+++ b/UI/Web/src/app/book-reader/_components/_drawers/view-edit-annotation-drawer/view-edit-annotation-drawer.component.ts
@@ -5,8 +5,8 @@ import {
   DestroyRef,
   effect,
   inject,
+  model,
   OnInit,
-  signal,
   Signal,
   viewChild,
   ViewContainerRef
@@ -21,7 +21,6 @@ import {debounceTime, switchMap} from "rxjs/operators";
 import {of} from "rxjs";
 import {HighlightBarComponent} from "../../_annotations/highlight-bar/highlight-bar.component";
 import {SlotColorPipe} from "../../../../_pipes/slot-color.pipe";
-import {User} from "../../../../_models/user/user";
 import {DomSanitizer, SafeHtml} from "@angular/platform-browser";
 import {DatePipe, DOCUMENT, NgStyle} from "@angular/common";
 import {SafeHtmlPipe} from "../../../../_pipes/safe-html.pipe";
@@ -92,9 +91,8 @@ export class ViewEditAnnotationDrawerComponent implements OnInit {
 
   readonly renderTarget = viewChild.required('renderTarget', { read: ViewContainerRef });
 
-  annotation = signal<Annotation | null>(null);
-  mode = signal<AnnotationMode>(AnnotationMode.View);
-  user = signal<User | null>(null);
+  annotation = model<Annotation | null>(null);
+  mode = model<AnnotationMode>(AnnotationMode.View);
   isEditMode: Signal<boolean>
   isEditOrCreateMode: Signal<boolean>
   titleColor: Signal<string>;

--- a/UI/Web/src/app/carousel/_components/carousel-reel/carousel-reel.component.scss
+++ b/UI/Web/src/app/carousel/_components/carousel-reel/carousel-reel.component.scss
@@ -31,7 +31,7 @@
 
 ::ng-deep swiper-slide {
   width: auto !important;
-  margin: 0 .25rem;
+  margin: 0 .5rem;
 }
 
 ::ng-deep swiper-container {

--- a/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.html
+++ b/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.html
@@ -305,7 +305,7 @@
                 </div>
 
 
-                <div class="col-md-6 col-sm-12">
+                <div class="d-flex flex-column flex-sm-row gap-2">
                   <button class="btn btn-primary"
                           [disabled]="readingProfile.kind !== ReadingProfileKind.Implicit || !parentReadingProfile"
                           (click)="updateParentPref()">

--- a/UI/Web/src/app/series-detail/_components/series-detail/series-detail.component.ts
+++ b/UI/Web/src/app/series-detail/_components/series-detail/series-detail.component.ts
@@ -735,8 +735,8 @@ class SeriesDetailComponent implements OnInit, AfterViewInit {
 
       const seen = new Map<number, PageBookmark>();
       for (const bookmark of bookmarks) {
-        if (!seen.has(bookmark.chapterId)) {
-          seen.set(bookmark.chapterId, bookmark);
+        if (!seen.has(bookmark.seriesId)) {
+          seen.set(bookmark.seriesId, bookmark);
         }
       }
 

--- a/UI/Web/src/app/user-settings/theme-manager/theme-manager.component.ts
+++ b/UI/Web/src/app/user-settings/theme-manager/theme-manager.component.ts
@@ -52,8 +52,8 @@ export class ThemeManagerComponent {
   currentTheme: SiteTheme | undefined;
   user: User | undefined;
   selectedTheme: ThemeContainer | undefined;
-  downloadableThemes: Array<DownloadableSiteTheme> = [];
-  downloadedThemes: Array<SiteTheme> = [];
+  downloadableThemes: DownloadableSiteTheme[] = [];
+  downloadedThemes: SiteTheme[] = [];
 
   canUseThemes = computed(() => !this.accountService.hasReadOnlyRole());
 
@@ -156,20 +156,22 @@ export class ThemeManagerComponent {
 
   public dropped(files: NgxFileDropEntry[]) {
     this.files = files;
-    for (const droppedFile of files) {
-      // Is it a file?
-      if (droppedFile.fileEntry.isFile) {
-        const fileEntry = droppedFile.fileEntry as FileSystemFileEntry;
-        fileEntry.file((file: File) => {
-          this.themeService.uploadTheme(file, droppedFile).subscribe(t => {
-            this.isUploadingTheme = false;
-            this.cdRef.markForCheck();
-          });
-        });
-      }
-    }
     this.isUploadingTheme = true;
     this.cdRef.markForCheck();
+
+    for (const droppedFile of files) {
+      if (!droppedFile.fileEntry.isFile) continue;
+      const fileEntry = droppedFile.fileEntry as FileSystemFileEntry;
+
+      fileEntry.file((file: File) => {
+        this.themeService.uploadTheme(file, droppedFile).subscribe(t => {
+          this.isUploadingTheme = false;
+          this.downloadedThemes.push(t);
+          this.selectTheme(t);
+          this.cdRef.markForCheck();
+        });
+      });
+    }
   }
 
   previewImage(imgUrl: string) {

--- a/UI/Web/src/main.ts
+++ b/UI/Web/src/main.ts
@@ -15,7 +15,7 @@ import {provideHttpClient, withFetch, withInterceptors} from '@angular/common/ht
 import {provideTransloco, TranslocoConfig, TranslocoService} from "@jsverse/transloco";
 import {environment} from "./environments/environment";
 import {AccountService} from "./app/_services/account.service";
-import {catchError, firstValueFrom, of, switchMap, tap} from "rxjs";
+import {firstValueFrom, of, switchMap} from "rxjs";
 import {provideTranslocoLocale} from "@jsverse/transloco-locale";
 import {LazyLoadImageModule} from "ng-lazyload-image";
 import {getSaver, SAVER} from "./app/_providers/saver.provider";
@@ -130,13 +130,18 @@ function bootstrapUser() {
   const accountService = inject(AccountService);
   const transloco = inject(TranslocoService);
 
+  // Load user from localStorage so refreshAccount() and locale loading can proceed
+  const localUser = accountService.getUserFromLocalStorage();
+  if (localUser) {
+    accountService.setCurrentUser(localUser, false);
+  }
+
   return firstValueFrom(accountService.isOidcAuthenticated().pipe(
-    switchMap((isOidc)=> isOidc ? accountService.getAccount() : of(null)),
-    catchError(() => of(null)),
-    tap(user => {
-      if (!user) {
-        accountService.setCurrentUser(accountService.getUserFromLocalStorage());
+    switchMap(isOidc => {
+      if (!isOidc) {
+        return accountService.refreshAccount();
       }
+      return of(null); // Changed from EMPTY so loadUserLocale fires for OIDC users too
     }),
     switchMap(() => loadUserLocale(transloco, accountService)),
   ));

--- a/UI/Web/src/main.ts
+++ b/UI/Web/src/main.ts
@@ -15,7 +15,7 @@ import {provideHttpClient, withFetch, withInterceptors} from '@angular/common/ht
 import {provideTransloco, TranslocoConfig, TranslocoService} from "@jsverse/transloco";
 import {environment} from "./environments/environment";
 import {AccountService} from "./app/_services/account.service";
-import {firstValueFrom, of, switchMap} from "rxjs";
+import {catchError, firstValueFrom, of, switchMap} from "rxjs";
 import {provideTranslocoLocale} from "@jsverse/transloco-locale";
 import {LazyLoadImageModule} from "ng-lazyload-image";
 import {getSaver, SAVER} from "./app/_providers/saver.provider";
@@ -138,11 +138,12 @@ function bootstrapUser() {
 
   return firstValueFrom(accountService.isOidcAuthenticated().pipe(
     switchMap(isOidc => {
-      if (!isOidc) {
-        return accountService.refreshAccount();
+      if (isOidc) {
+        return accountService.getAccount();
       }
-      return of(null); // Changed from EMPTY so loadUserLocale fires for OIDC users too
+      return accountService.refreshAccount();
     }),
+    catchError(() => of(null)),
     switchMap(() => loadUserLocale(transloco, accountService)),
   ));
 }


### PR DESCRIPTION
# Changed
- Changed: Slightly widened the gap on carousels to align with spacing of the card grid

# Fixed
- Fixed: Fixed many issues around refreshing account state on load/reload (develop)
- Fixed: Fixed nav bar appearing while reading (Fixes #4478) (develop)
- Fixed: Fixed duplicate bookmarks on series detail page (develop)
- Fixed: Annotation drawer was broken (develop)
- Fixed: Fixed a bug where after adding a custom theme, the page was left in a half-broken state. 
- Fixed: Some theme settings were not applying to meta values (Fixes #4479 )
- Fixed: Fixed an issue with apple-mobile-web-app-status-bar-style on iOS where we were passing incorrect values. Now we send black or default based on if the theme is dark or not.
- Fixed: Fixed the spacing on the buttons on small screen in manga reader (Fixes #4358)

Part of https://github.com/Kareadita/Kavita/issues/4472