### PR TITLE
Fixed Locale Position for Volume/Chapter/Book numbers

### DIFF
--- a/API.Tests/Services/EntityNamingServiceTests.cs
+++ b/API.Tests/Services/EntityNamingServiceTests.cs
@@ -1316,5 +1316,71 @@ public class EntityNamingServiceTests
 
     #endregion
 
+    #region Label Validation Tests
+
+    [Fact]
+    public void FormatChapterTitle_ChapterLabelWithoutPlaceholder_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            _sut.FormatChapterTitle(LibraryType.Manga, isSpecial: false, "1", null, chapterLabel: "Chapter"));
+    }
+
+    [Fact]
+    public void FormatChapterTitle_IssueLabelWithoutPlaceholder_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            _sut.FormatChapterTitle(LibraryType.Comic, isSpecial: false, "1", null, issueLabel: "Issue"));
+    }
+
+    [Fact]
+    public void FormatChapterTitle_BookLabelWithoutPlaceholder_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            _sut.FormatChapterTitle(LibraryType.Book, isSpecial: false, "1", "Title", bookLabel: "Book"));
+    }
+
+    [Fact]
+    public void FormatVolumeName_VolumeLabelWithoutPlaceholder_ThrowsArgumentException()
+    {
+        var volume = new VolumeDto
+        {
+            Number = 1,
+            Name = "1",
+            MinNumber = 1,
+            MaxNumber = 1,
+            Chapters = [],
+        };
+
+        Assert.Throws<ArgumentException>(() =>
+            _sut.FormatVolumeName(LibraryType.Manga, volume, volumeLabel: "Band"));
+    }
+
+    [Fact]
+    public void BuildChapterTitle_VolumeLabelWithoutPlaceholder_ThrowsArgumentException()
+    {
+        var chapter = new ChapterDto { Number = "1", Range = "1", MinNumber = 1, MaxNumber = 1 };
+        var volume = new VolumeDto
+        {
+            Number = 1,
+            Name = "1",
+            MinNumber = 1,
+            MaxNumber = 1,
+            Chapters = [chapter],
+        };
+
+        Assert.Throws<ArgumentException>(() =>
+            _sut.BuildChapterTitle(LibraryType.Manga, volume, chapter, volumeLabel: "Band"));
+    }
+
+    [Fact]
+    public void FormatReadingListItemTitle_VolumeLabelWithoutPlaceholder_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            _sut.FormatReadingListItemTitle(LibraryType.Manga, MangaFormat.Archive, "1", "1", null, false,
+                volumeLabel: "Band"));
+    }
+
+    #endregion
+
 
 }

--- a/API.Tests/Services/EntityNamingServiceTests.cs
+++ b/API.Tests/Services/EntityNamingServiceTests.cs
@@ -109,7 +109,7 @@ public class EntityNamingServiceTests
             isSpecial: false,
             range: "5",
             title: null,
-            chapterLabel: "Kapitel");
+            chapterLabel: "Kapitel {0}");
 
         Assert.Equal("Kapitel 5", result);
     }
@@ -190,7 +190,7 @@ public class EntityNamingServiceTests
     {
         var volume = CreateVolumeDto(name: "1", minNumber: 1);
 
-        var result = _sut.FormatVolumeName(LibraryType.Manga, volume, volumeLabel: "Band");
+        var result = _sut.FormatVolumeName(LibraryType.Manga, volume, volumeLabel: "Band {0}");
 
         Assert.Equal("Band 1", result);
     }
@@ -359,7 +359,7 @@ public class EntityNamingServiceTests
             series,
             volume: null,
             chapter,
-            chapterLabel: "Kapitel");
+            chapterLabel: "Kapitel {0}");
 
         Assert.Equal("Manga Series - Kapitel 5", result);
     }
@@ -631,8 +631,8 @@ public class EntityNamingServiceTests
 
         var result = _sut.BuildChapterTitle(
             LibraryType.Manga, volume, chapter1,
-            volumeLabel: "Band",
-            chapterLabel: "Kapitel");
+            volumeLabel: "Band {0}",
+            chapterLabel: "Kapitel {0}");
 
         Assert.Equal("Band 2 - Kapitel 5", result);
     }
@@ -866,7 +866,7 @@ public class EntityNamingServiceTests
             volumeNumber: "1",
             chapterTitleName: null,
             isSpecial: false,
-            chapterLabel: "Kapitel");
+            chapterLabel: "Kapitel {0}");
 
         Assert.Equal("Kapitel 5", result);
     }
@@ -881,7 +881,7 @@ public class EntityNamingServiceTests
             volumeNumber: "3",
             chapterTitleName: null,
             isSpecial: false,
-            volumeLabel: "Band");
+            volumeLabel: "Band {0}");
 
         Assert.Equal("Band 3", result);
     }
@@ -1080,6 +1080,109 @@ public class EntityNamingServiceTests
         Assert.NotNull(result);
         Assert.DoesNotContain(" - ", result.Replace("Chapter ", ""));
     }
+
+    #region Korean Locale Tests
+
+    // Korean locale format strings:
+    //   "volume-num":  "{0} 권"
+    //   "chapter-num": "{0} 화"
+    //   "issue-num":   "{0}{1} 이슈"
+    //   "book-num":    "{0} 권"
+    private const string KoVolumeLabel  = "{0} 권";
+    private const string KoChapterLabel = "{0} 화";
+    private const string KoIssueLabel   = "{0}{1} 이슈";
+    private const string KoBookLabel    = "{0} 권";
+
+    [Fact]
+    public void FormatVolumeName_Korean_ReturnsSuffixFormat()
+    {
+        var volume = CreateVolumeDto(name: "1", minNumber: 1);
+
+        var result = _sut.FormatVolumeName(LibraryType.Manga, volume, volumeLabel: KoVolumeLabel);
+
+        Assert.Equal("1 권", result);
+    }
+
+    [Fact]
+    public void FormatChapterTitle_Korean_Manga_ReturnsSuffixFormat()
+    {
+        var result = _sut.FormatChapterTitle(
+            LibraryType.Manga, isSpecial: false, range: "5", title: null,
+            chapterLabel: KoChapterLabel);
+
+        Assert.Equal("5 화", result);
+    }
+
+    [Fact]
+    public void FormatChapterTitle_Korean_Comic_ReturnsSuffixFormat()
+    {
+        var result = _sut.FormatChapterTitle(
+            LibraryType.Comic, isSpecial: false, range: "3", title: null,
+            issueLabel: KoIssueLabel);
+
+        Assert.Equal("#3 이슈", result);
+    }
+
+    [Fact]
+    public void FormatChapterTitle_Korean_LightNovel_ReturnsSuffixFormat()
+    {
+        // LightNovel uses range with bookLabel, so "{0} 권" with range="2" -> "2 권"
+        var result = _sut.FormatChapterTitle(
+            LibraryType.LightNovel, isSpecial: false, range: "2", title: null,
+            bookLabel: KoBookLabel);
+
+        Assert.Equal("2 권", result);
+    }
+
+    [Fact]
+    public void FormatReadingListItemTitle_Korean_VolumeOnly_ReturnsSuffixFormat()
+    {
+        var result = _sut.FormatReadingListItemTitle(
+            LibraryType.Manga,
+            MangaFormat.Archive,
+            chapterNumber: Parser.DefaultChapter,
+            volumeNumber: "2",
+            chapterTitleName: null,
+            isSpecial: false,
+            volumeLabel: KoVolumeLabel);
+
+        Assert.Equal("2 권", result);
+    }
+
+    [Fact]
+    public void FormatReadingListItemTitle_Korean_Chapter_ReturnsSuffixFormat()
+    {
+        var result = _sut.FormatReadingListItemTitle(
+            LibraryType.Manga,
+            MangaFormat.Archive,
+            chapterNumber: "10",
+            volumeNumber: "1",
+            chapterTitleName: null,
+            isSpecial: false,
+            chapterLabel: KoChapterLabel);
+
+        Assert.Equal("10 화", result);
+    }
+
+    [Fact]
+    public void BuildFullTitle_Korean_MultipleChapterVolume_ReturnsSuffixFormat()
+    {
+        var series = CreateSeriesDto("My Series");
+        var chapter1 = CreateChapterDto(range: "5");
+        var chapter2 = CreateChapterDto(range: "6");
+        var volume = CreateVolumeDto(name: "1", minNumber: 1, chapters: [chapter1, chapter2]);
+
+        var result = _sut.BuildFullTitle(
+            LibraryType.Manga, series, volume, chapter1,
+            volumeLabel: KoVolumeLabel,
+            chapterLabel: KoChapterLabel,
+            issueLabel: KoIssueLabel,
+            bookLabel: KoBookLabel);
+
+        Assert.Equal("My Series - 1 권 - 5 화", result);
+    }
+
+    #endregion
 
     #region Extra Tests
 

--- a/API.Tests/Services/EntityNamingServiceTests.cs
+++ b/API.Tests/Services/EntityNamingServiceTests.cs
@@ -195,6 +195,18 @@ public class EntityNamingServiceTests
         Assert.Equal("Band 1", result);
     }
 
+    [Theory]
+    [InlineData("Band 1", "Band {0}")]
+    [InlineData("1 권", "{0} 권")]
+    public void FormatVolumeName_WithLocalizedLabelAlreadyPresent_DoesNotDuplicate(string volumeName, string volumeLabel)
+    {
+        var volume = CreateVolumeDto(name: volumeName, minNumber: 1);
+
+        var result = _sut.FormatVolumeName(LibraryType.Manga, volume, volumeLabel: volumeLabel);
+
+        Assert.Equal(volumeName, result);
+    }
+
     [Fact]
     public void FormatVolumeName_BookLibrary_WithTitleName_ReturnsTitleName()
     {

--- a/API/Helpers/Formatting/LocalizedNamingContext.cs
+++ b/API/Helpers/Formatting/LocalizedNamingContext.cs
@@ -43,10 +43,11 @@ public sealed class LocalizedNamingContext
         int userId,
         LibraryType libraryType)
     {
-        var volumeTask = localizationService.Translate(userId, "volume-num", string.Empty);
-        var chapterTask = localizationService.Translate(userId, "chapter-num", string.Empty);
-        var issueTask = localizationService.Translate(userId, "issue-num", string.Empty, string.Empty);
-        var bookTask = localizationService.Translate(userId, "book-num", string.Empty);
+        var volumeTask = localizationService.Translate(userId, "volume-num");
+        var chapterTask = localizationService.Translate(userId, "chapter-num");
+        var issueTask = localizationService.Translate(userId, "issue-num");
+        var bookTask = localizationService.Translate(userId, "book-num");
+
 
         await Task.WhenAll(volumeTask, chapterTask, issueTask, bookTask);
 

--- a/API/Services/EntityNamingService.cs
+++ b/API/Services/EntityNamingService.cs
@@ -358,7 +358,7 @@ public partial class EntityNamingService : IEntityNamingService
         }
 
         // Already has the label - return as-is
-        if (HasVolumePrefix(volumeName))
+        if (HasVolumePrefix(volumeName, volumeLabel))
         {
             return volumeName;
         }
@@ -368,9 +368,8 @@ public partial class EntityNamingService : IEntityNamingService
 
     /// <summary>
     /// Checks if the volume name already starts with a volume-like prefix.
-    /// Handles common English label variations.
     /// </summary>
-    private static bool HasVolumePrefix(string volumeName)
+    private static bool HasVolumePrefix(string volumeName, string? volumeLabel = null)
     {
         if (string.IsNullOrEmpty(volumeName))
         {
@@ -384,6 +383,25 @@ public partial class EntityNamingService : IEntityNamingService
             {
                 return true;
             }
+        }
+
+        if (string.IsNullOrEmpty(volumeLabel)) return false;
+
+        const int placeholderLength = 3; // "{0}".Length
+        var placeholderIndex = volumeLabel.IndexOf("{0}", StringComparison.Ordinal);
+        if (placeholderIndex < 0) return false;
+
+        var labelPrefix = volumeLabel[..placeholderIndex].Trim();
+        var labelSuffix = volumeLabel[(placeholderIndex + placeholderLength)..].Trim();
+
+        if (!string.IsNullOrEmpty(labelPrefix) && volumeName.StartsWith(labelPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (!string.IsNullOrEmpty(labelSuffix) && volumeName.EndsWith(labelSuffix, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
         }
 
         return false;

--- a/API/Services/EntityNamingService.cs
+++ b/API/Services/EntityNamingService.cs
@@ -63,6 +63,22 @@ public partial class EntityNamingService : IEntityNamingService
     [GeneratedRegex(@"^\d+(\.\d+)?$", RegexOptions.Compiled)]
     private static partial Regex JustNumbersRegex();
 
+    [GeneratedRegex(@"\{\d+\}")]
+    private static partial Regex FormatPlaceholderRegex();
+
+    /// <summary>
+    /// Validates that a label string contains at least one format placeholder (e.g., {0}).
+    /// Throws <see cref="ArgumentException"/> if the placeholder is missing.
+    /// This prevents silent data loss when callers pass plain strings to format-string parameters.
+    /// </summary>
+    private static void ValidateFormatLabel(string label, string paramName)
+    {
+        if (!FormatPlaceholderRegex().IsMatch(label))
+        {
+            throw new ArgumentException($"Label must contain at least one format placeholder (e.g., {{0}}).", paramName);
+        }
+    }
+
     public string FormatChapterTitle(LibraryType libraryType, ChapterDto chapter,
         string? chapterLabel = null, string? issueLabel = null, string? bookLabel = null)
     {
@@ -81,6 +97,10 @@ public partial class EntityNamingService : IEntityNamingService
         chapterLabel ??= DefaultChapterLabel;
         issueLabel ??= DefaultIssueLabel;
         bookLabel ??= DefaultBookLabel;
+        ValidateFormatLabel(chapterLabel, nameof(chapterLabel));
+        ValidateFormatLabel(issueLabel, nameof(issueLabel));
+        ValidateFormatLabel(bookLabel, nameof(bookLabel));
+
         var hashMark = withHash ? DefaultHashMark : string.Empty;
 
         var baseTitle = libraryType switch
@@ -109,6 +129,7 @@ public partial class EntityNamingService : IEntityNamingService
         }
 
         volumeLabel ??= DefaultVolumeLabel;
+        ValidateFormatLabel(volumeLabel, nameof(volumeLabel));
 
         if (libraryType is LibraryType.Book or LibraryType.LightNovel)
         {
@@ -123,6 +144,7 @@ public partial class EntityNamingService : IEntityNamingService
     {
         var seriesName = series.Name!;
         volumeLabel ??= DefaultVolumeLabel;
+        ValidateFormatLabel(volumeLabel, nameof(volumeLabel));
 
         // No volume context
         if (volume == null)
@@ -142,6 +164,7 @@ public partial class EntityNamingService : IEntityNamingService
         string? chapterLabel = null, string? issueLabel = null, string? bookLabel = null)
     {
         volumeLabel ??= DefaultVolumeLabel;
+        ValidateFormatLabel(volumeLabel, nameof(volumeLabel));
 
         // Special volume - just use chapter title
         if (volume.IsSpecial())
@@ -200,6 +223,10 @@ public partial class EntityNamingService : IEntityNamingService
         chapterLabel ??= DefaultChapterLabel;
         issueLabel ??= DefaultIssueLabel;
         bookLabel ??= DefaultBookLabel;
+        ValidateFormatLabel(volumeLabel, nameof(volumeLabel));
+        ValidateFormatLabel(chapterLabel, nameof(chapterLabel));
+        ValidateFormatLabel(issueLabel, nameof(issueLabel));
+        ValidateFormatLabel(bookLabel, nameof(bookLabel));
 
         // Handle epub format with special logic
         if (format == MangaFormat.Epub)

--- a/API/Services/EntityNamingService.cs
+++ b/API/Services/EntityNamingService.cs
@@ -54,10 +54,10 @@ public interface IEntityNamingService
 
 public partial class EntityNamingService : IEntityNamingService
 {
-    private const string DefaultVolumeLabel = "Volume";
-    private const string DefaultChapterLabel = "Chapter";
-    private const string DefaultIssueLabel = "Issue";
-    private const string DefaultBookLabel = "Book";
+    private const string DefaultVolumeLabel = "Volume {0}";
+    private const string DefaultChapterLabel = "Chapter {0}";
+    private const string DefaultIssueLabel = "Issue {0}{1}";
+    private const string DefaultBookLabel = "Book {0}";
     private const string DefaultHashMark = "#";
 
     [GeneratedRegex(@"^\d+(\.\d+)?$", RegexOptions.Compiled)]
@@ -85,11 +85,11 @@ public partial class EntityNamingService : IEntityNamingService
 
         var baseTitle = libraryType switch
         {
-            LibraryType.Book => $"{bookLabel} {title}".Trim(),
-            LibraryType.LightNovel => $"{bookLabel} {range}".Trim(),
-            LibraryType.Comic or LibraryType.ComicVine => $"{issueLabel} {hashMark}{range}".Trim(),
-            LibraryType.Manga or LibraryType.Image => $"{chapterLabel} {range}".Trim(),
-            _ => $"{chapterLabel} {range}".Trim()
+            LibraryType.Book => string.Format(bookLabel, title).Trim(),
+            LibraryType.LightNovel => string.Format(bookLabel, range).Trim(),
+            LibraryType.Comic or LibraryType.ComicVine => string.Format(issueLabel, hashMark, range).Trim(),
+            LibraryType.Manga or LibraryType.Image => string.Format(chapterLabel, range).Trim(),
+            _ => string.Format(chapterLabel, range).Trim()
         };
 
         // Append title only if it adds new information
@@ -192,17 +192,9 @@ public partial class EntityNamingService : IEntityNamingService
             bookLabel);
     }
 
-    public string FormatReadingListItemTitle(
-        LibraryType libraryType,
-        MangaFormat format,
-        string? chapterNumber,
-        string? volumeNumber,
-        string? chapterTitleName,
-        bool isSpecial,
-        string? volumeLabel = null,
-        string? chapterLabel = null,
-        string? issueLabel = null,
-        string? bookLabel = null)
+    public string FormatReadingListItemTitle( LibraryType libraryType, MangaFormat format, string? chapterNumber,
+        string? volumeNumber, string? chapterTitleName, bool isSpecial, string? volumeLabel = null,
+        string? chapterLabel = null, string? issueLabel = null, string? bookLabel = null)
     {
         volumeLabel ??= DefaultVolumeLabel;
         chapterLabel ??= DefaultChapterLabel;
@@ -218,7 +210,7 @@ public partial class EntityNamingService : IEntityNamingService
         // Try volume-only title first (when chapter is default but volume is real)
         if (Parser.IsDefaultChapter(chapterNumber) && !Parser.IsLooseLeafVolume(volumeNumber))
         {
-            return $"{volumeLabel} {volumeNumber}";
+            return string.Format(volumeLabel, volumeNumber);
         }
 
         // Clean chapter number for display
@@ -239,8 +231,14 @@ public partial class EntityNamingService : IEntityNamingService
         }
 
         // Standard chapter formatting based on library type
-        var chapterPrefix = GetChapterPrefix(libraryType, chapterLabel, issueLabel, bookLabel);
-        return $"{chapterPrefix}{displayChapterNumber}";
+        return libraryType switch
+        {
+            LibraryType.Comic or LibraryType.ComicVine =>
+                string.Format(issueLabel, DefaultHashMark, displayChapterNumber),
+            LibraryType.Book or LibraryType.LightNovel =>
+                string.Format(bookLabel, displayChapterNumber),
+            _ => string.Format(chapterLabel, displayChapterNumber)
+        };
     }
 
     #region Reading List Helpers
@@ -267,7 +265,7 @@ public partial class EntityNamingService : IEntityNamingService
 
             // Fall back to volume
             var cleanedVolume = Parser.CleanSpecialTitle(volumeNumber);
-            return $"{volumeLabel} {cleanedVolume}";
+            return string.Format(volumeLabel, cleanedVolume);
         }
 
         // Special volume marker - just use cleaned chapter
@@ -277,7 +275,7 @@ public partial class EntityNamingService : IEntityNamingService
         }
 
         // Regular epub with chapter number
-        return $"{volumeLabel} {cleanedChapterNumber}";
+        return string.Format(volumeLabel, cleanedChapterNumber);
     }
 
     /// <summary>
@@ -298,24 +296,6 @@ public partial class EntityNamingService : IEntityNamingService
 
         // Otherwise clean special title formatting
         return Parser.CleanSpecialTitle(chapterNumber);
-    }
-
-    /// <summary>
-    /// Gets the chapter prefix string based on library type.
-    /// Maps to ReaderService.FormatChapterName logic.
-    /// </summary>
-    private static string GetChapterPrefix(
-        LibraryType libraryType,
-        string chapterLabel,
-        string issueLabel,
-        string bookLabel)
-    {
-        return libraryType switch
-        {
-            LibraryType.Comic or LibraryType.ComicVine => $"{issueLabel} #",
-            LibraryType.Book or LibraryType.LightNovel => $"{bookLabel} ",
-            _ => $"{chapterLabel} "
-        };
     }
 
     #endregion
@@ -378,32 +358,25 @@ public partial class EntityNamingService : IEntityNamingService
         }
 
         // Already has the label - return as-is
-        if (HasVolumePrefix(volumeName, volumeLabel))
+        if (HasVolumePrefix(volumeName))
         {
             return volumeName;
         }
 
-        return $"{volumeLabel} {volumeName}".Trim();
+        return string.Format(volumeLabel, volumeName).Trim();
     }
 
     /// <summary>
     /// Checks if the volume name already starts with a volume-like prefix.
-    /// Handles localized labels and common variations.
+    /// Handles common English label variations.
     /// </summary>
-    private static bool HasVolumePrefix(string volumeName, string volumeLabel)
+    private static bool HasVolumePrefix(string volumeName)
     {
         if (string.IsNullOrEmpty(volumeName))
         {
             return false;
         }
 
-        // Check for the provided label
-        if (volumeName.StartsWith(volumeLabel, StringComparison.OrdinalIgnoreCase))
-        {
-            return true;
-        }
-
-        // Check for common variations that might exist in data
         var commonPrefixes = new[] { "Volume", "Vol.", "Vol ", "V." };
         foreach (var prefix in commonPrefixes)
         {


### PR DESCRIPTION
# Fixed
- Fixed: Fixed a localization bug where locale number positioning for chapter/book/volume numbers weren't taking into effect. For example Korean Volume was showing as 권 1 when locale specified 1 권
