### PR TITLE
Ability to Download Reading Lists and Collections plus some bugfixes

### DIFF
--- a/Kavita.API/Repositories/IChapterRepository.cs
+++ b/Kavita.API/Repositories/IChapterRepository.cs
@@ -42,8 +42,8 @@ public interface IChapterRepository
     Task<IList<Chapter>> GetChaptersAsync(int volumeId, ChapterIncludes includes = ChapterIncludes.None, CancellationToken ct = default);
     Task<IList<ChapterDto>> GetChapterDtosAsync(int volumeId, int userId, CancellationToken ct = default);
     Task<IList<MangaFile>> GetFilesForChaptersAsync(IReadOnlyList<int> chapterIds, CancellationToken ct = default);
-    Task<long> GetFilesizeForChapterAsync(int chapterId, CancellationToken ct = default);
-    Task<Dictionary<int, long>> GetFilesizeForChaptersAsync(IList<int> chapterIds, CancellationToken ct = default);
+    Task<long> GetFilesizeAsync(int chapterId, CancellationToken ct = default);
+    Task<Dictionary<int, long>> GetFilesizesAsync(IList<int> chapterIds, CancellationToken ct = default);
     Task<string?> GetChapterCoverImageAsync(int chapterId, CancellationToken ct = default);
     Task<IList<string>> GetAllCoverImagesAsync(CancellationToken ct = default);
     Task<IList<Chapter>> GetAllChaptersWithCoversInDifferentEncoding(EncodeFormat format, CancellationToken ct = default);

--- a/Kavita.API/Repositories/IReadingListRepository.cs
+++ b/Kavita.API/Repositories/IReadingListRepository.cs
@@ -52,4 +52,6 @@ public interface IReadingListRepository
     Task<bool> AnyUserReadingProgressAsync(int readingListId, int userId, CancellationToken ct = default);
     Task<ReadingListItemDto?> GetContinueReadingPoint(int readingListId, int userId, CancellationToken ct = default);
     Task<int> GetReadingListItemCountAsync(int readingListId, int userId, CancellationToken ct = default);
+    Task<long> GetFilesizeAsync(int readingListId, int userId, CancellationToken ct = default);
+    Task<Dictionary<int, long>> GetFilesizesAsync(IList<int> readingListIds, int userId, CancellationToken ct = default);
 }

--- a/Kavita.API/Repositories/ISeriesRepository.cs
+++ b/Kavita.API/Repositories/ISeriesRepository.cs
@@ -92,8 +92,8 @@ public interface ISeriesRepository
     Task<IList<Series>> GetSeriesByIdsAsync(IList<int> seriesIds, bool fullSeries = true, CancellationToken ct = default);
     Task<int[]> GetChapterIdsForSeriesAsync(IList<int> seriesIds, CancellationToken ct = default);
     Task<IDictionary<int, IList<int>>> GetChapterIdWithSeriesIdForSeriesAsync(int[] seriesIds, CancellationToken ct = default);
-    Task<long> GetFilesizeForSeriesAsync(int seriesId, CancellationToken ct = default);
-    Task<Dictionary<int, long>> GetFilesizeForMultipleSeriesAsync(IList<int> seriesIds, CancellationToken ct = default);
+    Task<long> GetFilesizeAsync(int seriesId, CancellationToken ct = default);
+    Task<Dictionary<int, long>> GetFilesizesAsync(IList<int> seriesIds, CancellationToken ct = default);
     Task<string?> GetSeriesCoverImageAsync(int seriesId, CancellationToken ct = default);
     Task<PagedList<SeriesDto>> GetOnDeck(int userId, int libraryId, UserParams userParams, FilterDto? filter, CancellationToken ct = default);
     Task<PagedList<SeriesDto>> GetRecentlyAdded(int libraryId, int userId, UserParams userParams, FilterDto filter, CancellationToken ct = default);

--- a/Kavita.API/Repositories/IVolumeRepository.cs
+++ b/Kavita.API/Repositories/IVolumeRepository.cs
@@ -38,6 +38,6 @@ public interface IVolumeRepository
     Task<IList<Volume>> GetVolumesById(IList<int> volumeIds, VolumeIncludes includes = VolumeIncludes.None, CancellationToken ct = default);
     Task<IList<Volume>> GetAllWithCoversInDifferentEncoding(EncodeFormat encodeFormat, CancellationToken ct = default);
     Task<IEnumerable<string>> GetCoverImagesForLockedVolumesAsync(CancellationToken ct = default);
-    Task<long> GetFilesizeForVolumeAsync(int volumeId, CancellationToken ct = default);
-    Task<Dictionary<int, long>> GetFilesizeForVolumesAsync(IList<int> volumeIds, CancellationToken ct = default);
+    Task<long> GetFilesizeAsync(int volumeId, CancellationToken ct = default);
+    Task<Dictionary<int, long>> GetFilesizesAsync(IList<int> volumeIds, CancellationToken ct = default);
 }

--- a/Kavita.Database/Extensions/QueryableExtensions.cs
+++ b/Kavita.Database/Extensions/QueryableExtensions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Threading;
 using System.Threading.Tasks;
 using Kavita.API.Repositories;
 using Kavita.Models.DTOs.Annotations;
@@ -20,7 +21,7 @@ public static class QueryableExtensions
 {
     private const float DefaultTolerance = 0.001f;
 
-    public static Task<AgeRestriction> GetUserAgeRestriction(this DbSet<AppUser> queryable, int userId)
+    public static Task<AgeRestriction> GetUserAgeRestriction(this DbSet<AppUser> queryable, int userId, CancellationToken ct = default)
     {
         if (userId < 1)
         {
@@ -38,7 +39,7 @@ public static class QueryableExtensions
                     AgeRating = u.AgeRestriction,
                     IncludeUnknowns = u.AgeRestrictionIncludeUnknowns
                 })
-            .SingleAsync();
+            .SingleAsync(ct);
     }
 
 

--- a/Kavita.Database/Repositories/ChapterRepository.cs
+++ b/Kavita.Database/Repositories/ChapterRepository.cs
@@ -268,14 +268,14 @@ public class ChapterRepository(DataContext context, IMapper mapper) : IChapterRe
             .ToListAsync(ct);
     }
 
-    public async Task<long> GetFilesizeForChapterAsync(int chapterId, CancellationToken ct = default)
+    public async Task<long> GetFilesizeAsync(int chapterId, CancellationToken ct = default)
     {
         return await context.MangaFile
             .Where(c => c.ChapterId == chapterId)
             .SumAsync(c => c.Bytes, cancellationToken: ct);
     }
 
-    public async Task<Dictionary<int, long>> GetFilesizeForChaptersAsync(IList<int> chapterIds, CancellationToken ct = default)
+    public async Task<Dictionary<int, long>> GetFilesizesAsync(IList<int> chapterIds, CancellationToken ct = default)
     {
         return await chapterIds.BatchToDictionaryAsync(50, batch =>
             context.MangaFile

--- a/Kavita.Database/Repositories/ReadingListRepository.cs
+++ b/Kavita.Database/Repositories/ReadingListRepository.cs
@@ -294,11 +294,11 @@ public class ReadingListRepository(DataContext context, IMapper mapper) : IReadi
     public async Task<IEnumerable<ReadingListDto>> GetReadingListDtosForChapterAndUserAsync(int userId, int chapterId,
         bool includePromoted, CancellationToken ct = default)
     {
-        var user = await context.AppUser.FirstAsync(u => u.Id == userId, ct);
+        var ageRestriction = await context.AppUser.GetUserAgeRestriction(userId, ct: ct);
 
         var query = context.ReadingList
             .Where(l => l.AppUserId == userId || (includePromoted && l.Promoted ))
-            .RestrictAgainstAgeRestriction(user.GetAgeRestriction())
+            .RestrictAgainstAgeRestriction(ageRestriction)
             .Where(l => l.Items.Any(i => i.ChapterId == chapterId))
             .AsSplitQuery()
             .OrderBy(l => l.Title)
@@ -329,7 +329,6 @@ public class ReadingListRepository(DataContext context, IMapper mapper) : IReadi
 
         return await context.AppUserProgresses
             .Where(p => chapterIdsQuery.Contains(p.ChapterId) && p.AppUserId == userId)
-            .AsNoTracking()
             .AnyAsync(ct);
     }
 
@@ -438,6 +437,39 @@ public class ReadingListRepository(DataContext context, IMapper mapper) : IReadi
     public Task<int> GetReadingListItemCountAsync(int readingListId, int userId, CancellationToken ct = default)
     {
         return context.ReadingListItem.Where(rli => rli.ReadingListId == readingListId).CountAsync(ct);
+    }
+
+    public async Task<long> GetFilesizeAsync(int readingListId, int userId, CancellationToken ct = default)
+    {
+        var ageRestriction = await context.AppUser.GetUserAgeRestriction(userId, ct: ct);
+
+        return await context.ReadingList
+            .Where(l => l.Id == readingListId && (l.AppUserId == userId || l.Promoted))
+            .RestrictAgainstAgeRestriction(ageRestriction)
+            .SelectMany(l => l.Items)
+            .SelectMany(i => i.Chapter.Files)
+            .SumAsync(f => f.Bytes, ct);
+    }
+
+    public async Task<Dictionary<int, long>> GetFilesizesAsync(IList<int> readingListIds, int userId, CancellationToken ct = default)
+    {
+        var ageRestriction = await context.AppUser.GetUserAgeRestriction(userId, ct: ct);
+
+        return await readingListIds.BatchToDictionaryAsync(50, batch =>
+            context.ReadingList
+                .Where(l => batch.Contains(l.Id) && (l.AppUserId == userId || l.Promoted))
+                .RestrictAgainstAgeRestriction(ageRestriction)
+                .Select(l => new
+                {
+                    l.Id,
+                    Bytes = l.Items
+                        .SelectMany(i => i.Chapter.Files)
+                        .Sum(f => f.Bytes)
+                })
+                .ToDictionaryAsync(
+                    x => x.Id,
+                    x => x.Bytes,
+                    cancellationToken: ct));
     }
 
 

--- a/Kavita.Database/Repositories/ReadingListRepository.cs
+++ b/Kavita.Database/Repositories/ReadingListRepository.cs
@@ -329,6 +329,7 @@ public class ReadingListRepository(DataContext context, IMapper mapper) : IReadi
 
         return await context.AppUserProgresses
             .Where(p => chapterIdsQuery.Contains(p.ChapterId) && p.AppUserId == userId)
+            .AsNoTracking()
             .AnyAsync(ct);
     }
 

--- a/Kavita.Database/Repositories/SeriesRepository.cs
+++ b/Kavita.Database/Repositories/SeriesRepository.cs
@@ -541,14 +541,14 @@ public class SeriesRepository(DataContext context, IMapper mapper) : ISeriesRepo
         return seriesChapters;
     }
 
-    public async Task<long> GetFilesizeForSeriesAsync(int seriesId, CancellationToken ct = default)
+    public async Task<long> GetFilesizeAsync(int seriesId, CancellationToken ct = default)
     {
         return await context.Volume
             .Where(v => v.SeriesId == seriesId)
             .SumAsync(v => v.Chapters.Sum(c => c.Files.Sum(f => f.Bytes)), cancellationToken: ct);
     }
 
-    public async Task<Dictionary<int, long>> GetFilesizeForMultipleSeriesAsync(IList<int> seriesIds, CancellationToken ct = default)
+    public async Task<Dictionary<int, long>> GetFilesizesAsync(IList<int> seriesIds, CancellationToken ct = default)
     {
         return await seriesIds.BatchToDictionaryAsync(50, batch =>
             context.Volume

--- a/Kavita.Database/Repositories/VolumeRepository.cs
+++ b/Kavita.Database/Repositories/VolumeRepository.cs
@@ -215,7 +215,7 @@ public class VolumeRepository(DataContext context, IMapper mapper) : IVolumeRepo
             .ToListAsync(ct))!;
     }
 
-    public async Task<long> GetFilesizeForVolumeAsync(int volumeId, CancellationToken ct = default)
+    public async Task<long> GetFilesizeAsync(int volumeId, CancellationToken ct = default)
     {
         return await context.Chapter
             .Where(c => volumeId == c.VolumeId)
@@ -224,7 +224,7 @@ public class VolumeRepository(DataContext context, IMapper mapper) : IVolumeRepo
             .SumAsync(f => f.Bytes, cancellationToken: ct);
     }
 
-    public async Task<Dictionary<int, long>> GetFilesizeForVolumesAsync(IList<int> volumeIds, CancellationToken ct = default)
+    public async Task<Dictionary<int, long>> GetFilesizesAsync(IList<int> volumeIds, CancellationToken ct = default)
     {
         return await volumeIds.BatchToDictionaryAsync(50, batch =>
             context.Chapter

--- a/Kavita.Models/DTOs/Downloads/BulkSizeRequests.cs
+++ b/Kavita.Models/DTOs/Downloads/BulkSizeRequests.cs
@@ -1,0 +1,8 @@
+﻿using System.Collections.Generic;
+
+namespace Kavita.Models.DTOs.Downloads;
+
+public record BulkChapterSizeRequest(List<int> ChapterIds);
+public record BulkVolumeSizeRequest(List<int> VolumeIds);
+public record BulkSeriesSizeRequest(List<int> SeriesIds);
+public record BulkReadingListSizeRequest(List<int> ReadingListIds);

--- a/Kavita.Models/Entities/ReadingList.cs
+++ b/Kavita.Models/Entities/ReadingList.cs
@@ -19,9 +19,8 @@ public class ReadingList : IEntityDate, IHasCoverImage
     /// A normalized string used to check if the reading list already exists in the DB
     /// </summary>
     public required string NormalizedTitle { get; set; }
-    public string? Summary { get; set; }
     /// <summary>
-    /// Reading lists that are promoted are only done by admins
+    /// Promotion allows non-owners to view the list
     /// </summary>
     public bool Promoted { get; set; }
     public string? CoverImage { get; set; }
@@ -29,17 +28,19 @@ public class ReadingList : IEntityDate, IHasCoverImage
     public string? SecondaryColor { get; set; }
     public bool CoverImageLocked { get; set; }
 
-    /// <summary>
-    /// The highest age rating from all Series within the reading list
-    /// </summary>
-    /// <remarks>Introduced in v0.6</remarks>
-    public required AgeRating AgeRating { get; set; } = AgeRating.Unknown;
 
     public ICollection<ReadingListItem> Items { get; set; } = null!;
     public DateTime Created { get; set; }
     public DateTime LastModified { get; set; }
     public DateTime CreatedUtc { get; set; }
     public DateTime LastModifiedUtc { get; set; }
+
+    #region Metadata
+    public string? Summary { get; set; }
+    /// <summary>
+    /// The highest age rating from all Series within the reading list
+    /// </summary>
+    public required AgeRating AgeRating { get; set; } = AgeRating.Unknown;
     /// <summary>
     /// Minimum Year the Reading List starts
     /// </summary>
@@ -56,6 +57,7 @@ public class ReadingList : IEntityDate, IHasCoverImage
     /// Maximum Month the Reading List starts
     /// </summary>
     public int EndingMonth { get; set; }
+    #endregion
 
     // Relationships
     public int AppUserId { get; set; }

--- a/Kavita.Models/Entities/ReadingListItem.cs
+++ b/Kavita.Models/Entities/ReadingListItem.cs
@@ -11,6 +11,7 @@ public class ReadingListItem
     /// </summary>
     public int Order { get; set; }
 
+
     // Relationship
     public ReadingList ReadingList { get; set; } = null!;
     public int ReadingListId { get; set; }

--- a/Kavita.Server/Controllers/DownloadController.cs
+++ b/Kavita.Server/Controllers/DownloadController.cs
@@ -20,6 +20,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Kavita.Server.Controllers;
 
+
 /// <summary>
 /// All APIs related to downloading entities from the system. Requires Download Role or Admin Role.
 /// </summary>
@@ -51,12 +52,12 @@ public class DownloadController(
     /// <summary>
     /// For a set of volumes, return the size in bytes
     /// </summary>
-    /// <param name="volumeIds"></param>
+    /// <param name="request"></param>
     /// <returns></returns>
     [HttpPost("bulk-volume-size")]
-    public async Task<ActionResult<Dictionary<int, long>>> GetBulkVolumeSize([FromBody] IList<int> volumeIds)
+    public async Task<ActionResult<Dictionary<int, long>>> GetBulkVolumeSize(BulkVolumeSizeRequest request)
     {
-        return Ok(await unitOfWork.VolumeRepository.GetFilesizesAsync(volumeIds));
+        return Ok(await unitOfWork.VolumeRepository.GetFilesizesAsync(request.VolumeIds));
     }
 
     /// <summary>
@@ -71,16 +72,16 @@ public class DownloadController(
         return Ok(await unitOfWork.ChapterRepository.GetFilesizeAsync(chapterId));
     }
 
+
     /// <summary>
     /// For a set of chapters, return the size in bytes
     /// </summary>
-    /// <param name="chapterIds"></param>
+    /// <param name="request"></param>
     /// <returns></returns>
     [HttpPost("bulk-chapter-size")]
-    public async Task<ActionResult<Dictionary<int, long>>> GetChapterSizeInBulk([FromBody] IList<int> chapterIds)
+    public async Task<ActionResult<Dictionary<int, long>>> GetChapterSizeInBulk(BulkChapterSizeRequest request)
     {
-        // If there are more than 50 chapterIds, we need to break up into multiple calls
-        return Ok(await unitOfWork.ChapterRepository.GetFilesizesAsync(chapterIds));
+        return Ok(await unitOfWork.ChapterRepository.GetFilesizesAsync(request.ChapterIds));
     }
 
     /// <summary>
@@ -110,24 +111,24 @@ public class DownloadController(
     /// <summary>
     /// Returns the mapping of readinglist -> size
     /// </summary>
-    /// <param name="readingListIds"></param>
+    /// <param name="request"></param>
     /// <returns></returns>
     [ReadingListAccess]
     [HttpGet("bulk-readinglist-size")]
-    public async Task<ActionResult<Dictionary<int, long>>> GetBulkReadingListSize([FromBody] IList<int> readingListIds)
+    public async Task<ActionResult<Dictionary<int, long>>> GetBulkReadingListSize(BulkReadingListSizeRequest request)
     {
-        return Ok(await unitOfWork.ReadingListRepository.GetFilesizesAsync(readingListIds, UserId));
+        return Ok(await unitOfWork.ReadingListRepository.GetFilesizesAsync(request.ReadingListIds, UserId));
     }
 
     /// <summary>
     /// For a set of series, return the size in bytes
     /// </summary>
-    /// <param name="seriesIds"></param>
+    /// <param name="request"></param>
     /// <returns></returns>
     [HttpPost("bulk-series-size")]
-    public async Task<ActionResult<Dictionary<int, long>>> GetBulkSeriesSize([FromBody] IList<int> seriesIds)
+    public async Task<ActionResult<Dictionary<int, long>>> GetBulkSeriesSize(BulkSeriesSizeRequest request)
     {
-        return Ok(await unitOfWork.SeriesRepository.GetFilesizesAsync(seriesIds));
+        return Ok(await unitOfWork.SeriesRepository.GetFilesizesAsync(request.SeriesIds));
     }
 
 
@@ -191,6 +192,7 @@ public class DownloadController(
             return BadRequest(ex.Message);
         }
     }
+
 
     private async Task<ActionResult> DownloadFiles(ICollection<MangaFile> files, string tempFolder, string downloadName, string? correlationId = null)
     {

--- a/Kavita.Server/Controllers/DownloadController.cs
+++ b/Kavita.Server/Controllers/DownloadController.cs
@@ -45,7 +45,7 @@ public class DownloadController(
     [HttpGet("volume-size")]
     public async Task<ActionResult<long>> GetVolumeSize(int volumeId)
     {
-        return Ok(await unitOfWork.VolumeRepository.GetFilesizeForVolumeAsync(volumeId));
+        return Ok(await unitOfWork.VolumeRepository.GetFilesizeAsync(volumeId));
     }
 
     /// <summary>
@@ -56,7 +56,7 @@ public class DownloadController(
     [HttpPost("bulk-volume-size")]
     public async Task<ActionResult<Dictionary<int, long>>> GetBulkVolumeSize([FromBody] IList<int> volumeIds)
     {
-        return Ok(await unitOfWork.VolumeRepository.GetFilesizeForVolumesAsync(volumeIds));
+        return Ok(await unitOfWork.VolumeRepository.GetFilesizesAsync(volumeIds));
     }
 
     /// <summary>
@@ -68,7 +68,7 @@ public class DownloadController(
     [HttpGet("chapter-size")]
     public async Task<ActionResult<long>> GetChapterSize(int chapterId)
     {
-        return Ok(await unitOfWork.ChapterRepository.GetFilesizeForChapterAsync(chapterId));
+        return Ok(await unitOfWork.ChapterRepository.GetFilesizeAsync(chapterId));
     }
 
     /// <summary>
@@ -80,7 +80,7 @@ public class DownloadController(
     public async Task<ActionResult<Dictionary<int, long>>> GetChapterSizeInBulk([FromBody] IList<int> chapterIds)
     {
         // If there are more than 50 chapterIds, we need to break up into multiple calls
-        return Ok(await unitOfWork.ChapterRepository.GetFilesizeForChaptersAsync(chapterIds));
+        return Ok(await unitOfWork.ChapterRepository.GetFilesizesAsync(chapterIds));
     }
 
     /// <summary>
@@ -92,7 +92,31 @@ public class DownloadController(
     [HttpGet("series-size")]
     public async Task<ActionResult<long>> GetSeriesSize(int seriesId)
     {
-        return Ok(await unitOfWork.SeriesRepository.GetFilesizeForSeriesAsync(seriesId));
+        return Ok(await unitOfWork.SeriesRepository.GetFilesizeAsync(seriesId));
+    }
+
+    /// <summary>
+    /// Returns the filesize for all items of a reading list that the requesting user has access to
+    /// </summary>
+    /// <param name="readingListId"></param>
+    /// <returns></returns>
+    [ReadingListAccess]
+    [HttpGet("readinglist-size")]
+    public async Task<ActionResult<long>> GetReadingListSize(int readingListId)
+    {
+        return Ok(await unitOfWork.ReadingListRepository.GetFilesizeAsync(readingListId, UserId));
+    }
+
+    /// <summary>
+    /// Returns the mapping of readinglist -> size
+    /// </summary>
+    /// <param name="readingListIds"></param>
+    /// <returns></returns>
+    [ReadingListAccess]
+    [HttpGet("bulk-readinglist-size")]
+    public async Task<ActionResult<Dictionary<int, long>>> GetBulkReadingListSize([FromBody] IList<int> readingListIds)
+    {
+        return Ok(await unitOfWork.ReadingListRepository.GetFilesizesAsync(readingListIds, UserId));
     }
 
     /// <summary>
@@ -103,7 +127,7 @@ public class DownloadController(
     [HttpPost("bulk-series-size")]
     public async Task<ActionResult<Dictionary<int, long>>> GetBulkSeriesSize([FromBody] IList<int> seriesIds)
     {
-        return Ok(await unitOfWork.SeriesRepository.GetFilesizeForMultipleSeriesAsync(seriesIds));
+        return Ok(await unitOfWork.SeriesRepository.GetFilesizesAsync(seriesIds));
     }
 
 

--- a/Kavita.Server/Controllers/DownloadController.cs
+++ b/Kavita.Server/Controllers/DownloadController.cs
@@ -113,8 +113,7 @@ public class DownloadController(
     /// </summary>
     /// <param name="request"></param>
     /// <returns></returns>
-    [ReadingListAccess]
-    [HttpGet("bulk-readinglist-size")]
+    [HttpPost("bulk-readinglist-size")]
     public async Task<ActionResult<Dictionary<int, long>>> GetBulkReadingListSize(BulkReadingListSizeRequest request)
     {
         return Ok(await unitOfWork.ReadingListRepository.GetFilesizesAsync(request.ReadingListIds, UserId));
@@ -136,6 +135,7 @@ public class DownloadController(
     /// Downloads all chapters within a volume. If the chapters are multiple zips, they will all be zipped up.
     /// </summary>
     /// <param name="volumeId"></param>
+    /// <param name="correlationId">Only for UI</param>
     /// <returns></returns>
     [VolumeAccess]
     [HttpGet("volume")]

--- a/Kavita.Server/Controllers/LibraryController.cs
+++ b/Kavita.Server/Controllers/LibraryController.cs
@@ -198,12 +198,10 @@ public class LibraryController(
     /// <summary>
     /// Return a specific library
     /// </summary>
-    /// <remarks>If the user is not an admin, only id, type, and name will be returned</remarks>
+    /// <remarks>If the user is not an admin, only id, type, and name will be returned (<see cref="LiteLibraryDto"/></remarks>
     /// <returns></returns>
     [HttpGet]
     [LibraryAccess]
-    [ProducesResponseType<LibraryDto>(StatusCodes.Status200OK)]
-    [ProducesResponseType<LiteLibraryDto>(StatusCodes.Status200OK)]
     public async Task<ActionResult<LibraryDto?>> GetLibrary(int libraryId)
     {
         if (User.IsInRole(PolicyConstants.AdminRole))

--- a/Kavita.Server/Controllers/LibraryController.cs
+++ b/Kavita.Server/Controllers/LibraryController.cs
@@ -198,7 +198,7 @@ public class LibraryController(
     /// <summary>
     /// Return a specific library
     /// </summary>
-    /// <remarks>If the user is not an admin, only id, type, and name will be returned (<see cref="LiteLibraryDto"/></remarks>
+    /// <remarks>If the user is not an admin, only id, type, and name will be returned (<see cref="LiteLibraryDto"/>)</remarks>
     /// <returns></returns>
     [HttpGet]
     [LibraryAccess]

--- a/Kavita.Server/Controllers/LicenseController.cs
+++ b/Kavita.Server/Controllers/LicenseController.cs
@@ -96,6 +96,11 @@ public class LicenseController(
     }
 
 
+    /// <summary>
+    /// Break the registration between Kavita+ and this instance
+    /// </summary>
+    /// <param name="dto"></param>
+    /// <returns></returns>
     [HttpPost("reset")]
     [Authorize(PolicyGroups.AdminPolicy)]
     public async Task<ActionResult> ResetLicense(UpdateLicenseDto dto)

--- a/Kavita.Server/Controllers/PanelsController.cs
+++ b/Kavita.Server/Controllers/PanelsController.cs
@@ -2,7 +2,6 @@
 using Kavita.API.Database;
 using Kavita.API.Services.Reading;
 using Kavita.Models.DTOs.Progress;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Kavita.Server.Controllers;

--- a/Kavita.Server/Controllers/PersonController.cs
+++ b/Kavita.Server/Controllers/PersonController.cs
@@ -221,19 +221,6 @@ public class PersonController(
         return Ok(await unitOfWork.PersonRepository.GetSeriesKnownFor(personId, UserId));
     }
 
-    /// <summary>
-    /// Return external Series the person is an artist/author of. Requires Admin due to age rating restrictions.
-    /// </summary>
-    /// <param name="personId"></param>
-    /// <returns></returns>
-    [PersonAccess]
-    [KPlus]
-    [Authorize(PolicyGroups.AdminPolicy)]
-    [HttpGet("external-series")]
-    public async Task<ActionResult<IEnumerable<ExternalSeriesDto>>> GetExternalSeries(int personId)
-    {
-        return Ok(await unitOfWork.ExternalSeriesMetadataRepository.GetExternalSeriesForPerson(personId, UserId));
-    }
 
     /// <summary>
     /// Returns all individual chapters by role. Limited to 20 results.

--- a/Kavita.Server/Controllers/PersonController.cs
+++ b/Kavita.Server/Controllers/PersonController.cs
@@ -14,6 +14,7 @@ using Kavita.Models.DTOs;
 using Kavita.Models.DTOs.Metadata.Browse;
 using Kavita.Models.DTOs.Metadata.Browse.Requests;
 using Kavita.Models.DTOs.Person;
+using Kavita.Models.DTOs.Recommendation;
 using Kavita.Models.DTOs.SignalR;
 using Kavita.Models.Entities.Enums;
 using Kavita.Server.Attributes;
@@ -218,6 +219,20 @@ public class PersonController(
     public async Task<ActionResult<IEnumerable<SeriesDto>>> GetKnownSeries(int personId)
     {
         return Ok(await unitOfWork.PersonRepository.GetSeriesKnownFor(personId, UserId));
+    }
+
+    /// <summary>
+    /// Return external Series the person is an artist/author of. Requires Admin due to age rating restrictions.
+    /// </summary>
+    /// <param name="personId"></param>
+    /// <returns></returns>
+    [PersonAccess]
+    [KPlus]
+    [Authorize(PolicyGroups.AdminPolicy)]
+    [HttpGet("external-series")]
+    public async Task<ActionResult<IEnumerable<ExternalSeriesDto>>> GetExternalSeries(int personId)
+    {
+        return Ok(await unitOfWork.ExternalSeriesMetadataRepository.GetExternalSeriesForPerson(personId, UserId));
     }
 
     /// <summary>

--- a/Kavita.Server/Controllers/SeriesController.cs
+++ b/Kavita.Server/Controllers/SeriesController.cs
@@ -556,6 +556,9 @@ public class SeriesController(
     /// </summary>
     /// <param name="match"></param>
     /// <param name="seriesId"></param>
+    /// <param name="aniListId"></param>
+    /// <param name="malId"></param>
+    /// <param name="cbrId"></param>
     /// <returns></returns>
     [HttpPost("update-match")]
     [Authorize(Policy = PolicyGroups.AdminPolicy)]

--- a/Kavita.Services/EntityNamingService.cs
+++ b/Kavita.Services/EntityNamingService.cs
@@ -41,7 +41,8 @@ public partial class EntityNamingService : IEntityNamingService
     public string FormatChapterTitle(LibraryType libraryType, ChapterDto chapter,
         string? chapterLabel = null, string? issueLabel = null, string? bookLabel = null)
     {
-        return FormatChapterTitle(libraryType, chapter.IsSpecial, chapter.Range, chapter.Title,
+        var title = string.IsNullOrEmpty(chapter.TitleName) ? Parser.CleanSpecialTitle(chapter.Title) : chapter.TitleName;
+        return FormatChapterTitle(libraryType, chapter.IsSpecial, chapter.Range, title,
             chapterLabel, issueLabel, bookLabel);
     }
 
@@ -50,7 +51,7 @@ public partial class EntityNamingService : IEntityNamingService
     {
         if (isSpecial)
         {
-            return Parser.CleanSpecialTitle(title!);
+            return title!;
         }
 
         chapterLabel ??= DefaultChapterLabel;

--- a/Kavita.Services/Extensions/MarkdownExtensions.cs
+++ b/Kavita.Services/Extensions/MarkdownExtensions.cs
@@ -1,0 +1,14 @@
+using Markdig;
+
+namespace Kavita.Services.Extensions;
+
+public static class MarkdownExtensions
+{
+    public static MarkdownPipelineBuilder UseGithub(this MarkdownPipelineBuilder pipeline)
+    {
+        return pipeline.UsePipeTables()
+            .UseFootnotes()
+            .UseMathematics()
+            .UseGenericAttributes(); // Always last!
+    }
+}

--- a/Kavita.Services/Kavita.Services.csproj
+++ b/Kavita.Services/Kavita.Services.csproj
@@ -15,6 +15,7 @@
   <ItemGroup>
     <PackageReference Include="CsvHelper" Version="33.1.0" />
     <PackageReference Include="MailKit" Version="4.15.1" />
+    <PackageReference Include="Markdig" Version="1.1.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -29,7 +30,6 @@
     <PackageReference Include="Hangfire.InMemory" Version="1.0.0" />
     <PackageReference Include="Hangfire.MaximumConcurrentExecutions" Version="1.1.0" />
     <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
-    <PackageReference Include="MarkdownDeep.NET.Core" Version="1.5.0.4" />
     <PackageReference Include="Hangfire.AspNetCore" Version="1.8.23" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.3" />

--- a/Kavita.Services/Plus/ExternalMetadataService.cs
+++ b/Kavita.Services/Plus/ExternalMetadataService.cs
@@ -266,7 +266,7 @@ public class ExternalMetadataService : IExternalMetadataService
         // Get from Kavita+ API the Full Series metadata with rec/rev and cache to ExternalMetadata tables
         try
         {
-            return await FetchExternalMetadataForSeries(seriesId, libraryType, data, ct);
+            return await FetchExternalMetadataForSeries(seriesId, libraryType, data, false, ct);
         }
         catch (KavitaException ex)
         {
@@ -297,7 +297,7 @@ public class ExternalMetadataService : IExternalMetadataService
                     CbrId = cbrId,
                     MediaFormat = series.Library.Type.ConvertToPlusMediaFormat(series.Format),
                     SeriesName = series.Name // Required field, not used since AniList/Mal Id are passed
-                }, ct);
+                }, true, ct);
 
             if (metadata.Series == null)
             {
@@ -362,8 +362,9 @@ public class ExternalMetadataService : IExternalMetadataService
     /// <param name="seriesId"></param>
     /// <param name="libraryType"></param>
     /// <param name="data"></param>
+    /// <param name="ct"></param>
     /// <returns></returns>
-    private async Task<SeriesDetailPlusDto> FetchExternalMetadataForSeries(int seriesId, LibraryType libraryType, PlusSeriesRequestDto data, CancellationToken ct = default)
+    private async Task<SeriesDetailPlusDto> FetchExternalMetadataForSeries(int seriesId, LibraryType libraryType, PlusSeriesRequestDto data, bool fromMatchFlow = false, CancellationToken ct = default)
     {
 
         var series = await _unitOfWork.SeriesRepository.GetSeriesByIdAsync(seriesId, SeriesIncludes.Library, ct);
@@ -453,7 +454,7 @@ public class ExternalMetadataService : IExternalMetadataService
 
             // If there is metadata and the user has metadata download turned on
             var madeMetadataModification = false;
-            if (result.Series != null && series.Library.AllowMetadataMatching)
+            if (result.Series != null && (series.Library.AllowMetadataMatching || fromMatchFlow))
             {
                 externalSeriesMetadata.Series = await _unitOfWork.SeriesRepository.GetSeriesByIdAsync(seriesId, ct: ct);
 

--- a/Kavita.Services/Plus/LicenseService.cs
+++ b/Kavita.Services/Plus/LicenseService.cs
@@ -199,7 +199,14 @@ public class LicenseService(
     }
 
 
-
+    /// <summary>
+    /// Removes this installId from Kavita+, essentially allowing the user to re-register an instance
+    /// </summary>
+    /// <param name="license"></param>
+    /// <param name="email"></param>
+    /// <param name="ct"></param>
+    /// <returns></returns>
+    /// <exception cref="KavitaException"></exception>
     public async Task<bool> ResetLicense(string license, string email, CancellationToken ct = default)
     {
         try

--- a/Kavita.Services/SiteThemeService.cs
+++ b/Kavita.Services/SiteThemeService.cs
@@ -17,12 +17,14 @@ using Kavita.Models.DTOs.SignalR;
 using Kavita.Models.DTOs.Theme;
 using Kavita.Models.Entities;
 using Kavita.Models.Entities.Enums.Theme;
+using Kavita.Services.Extensions;
 using Kavita.Services.Scanner;
-using MarkdownDeep;
+using Markdig;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using Microsoft.Net.Http.Headers;
 using Newtonsoft.Json;
+using Markdown = Markdig.Markdown;
 
 namespace Kavita.Services;
 
@@ -64,7 +66,7 @@ public class ThemeService(
     IMemoryCache cache)
     : IThemeService
 {
-    private readonly Markdown _markdown = new();
+    private readonly MarkdownPipeline _markdownPipeline = new MarkdownPipelineBuilder().UseGithub().Build();
 
     private readonly MemoryCacheEntryOptions _cacheOptions = new MemoryCacheEntryOptions()
         .SetSize(1)
@@ -198,7 +200,7 @@ public class ThemeService(
         var tempDownloadFile = await GithubReadme.DownloadFileAsync(directoryService.TempDirectory);
 
         // Read file into Markdown
-        var htmlContent  = _markdown.Transform(await directoryService.FileSystem.File.ReadAllTextAsync(tempDownloadFile));
+        var htmlContent  = Markdown.ToHtml(await directoryService.FileSystem.File.ReadAllTextAsync(tempDownloadFile), _markdownPipeline);
         var htmlDoc = new HtmlDocument();
         htmlDoc.LoadHtml(htmlContent);
 

--- a/Kavita.Services/VersionUpdaterService.cs
+++ b/Kavita.Services/VersionUpdaterService.cs
@@ -15,9 +15,11 @@ using Kavita.Common.Extensions;
 using Kavita.Common.Helpers;
 using Kavita.Models.DTOs.SignalR;
 using Kavita.Models.DTOs.Update;
-using MarkdownDeep;
+using Kavita.Services.Extensions;
+using Markdig;
 using Microsoft.Extensions.Logging;
 using Microsoft.Net.Http.Headers;
+using Markdown = Markdig.Markdown;
 
 namespace Kavita.Services;
 
@@ -54,7 +56,8 @@ public partial class VersionUpdaterService : IVersionUpdaterService
 {
     private readonly ILogger<VersionUpdaterService> _logger;
     private readonly IEventHub _eventHub;
-    private readonly Markdown _markdown = new MarkdownDeep.Markdown();
+    private readonly MarkdownPipeline _markdownPipeline = new MarkdownPipelineBuilder().UseGithub().Build();
+
 #pragma warning disable S1075
     private const string GithubLatestReleasesUrl = "https://api.github.com/repos/Kareadita/Kavita/releases/latest";
     private const string GithubAllReleasesUrl = "https://api.github.com/repos/Kareadita/Kavita/releases";
@@ -160,11 +163,11 @@ public partial class VersionUpdaterService : IVersionUpdaterService
                     Removed = sections.TryGetValue("Removed", out var removed) ? removed : [],
                     Theme = sections.TryGetValue("Theme", out var theme) ? theme : [],
                     Developer = sections.TryGetValue("Developer", out var developer) ? developer : [],
-                    KnownIssues = sections.TryGetValue("KnownIssues", out var knownIssues) ? knownIssues : [],
+                    KnownIssues = sections.TryGetValue("Known Issues", out var knownIssues) ? knownIssues : [],
                     Api = sections.TryGetValue("Api", out var api) ? api : [],
                     FeatureRequests = sections.TryGetValue("Feature Requests", out var frs) ? frs : [],
-                    BlogPart = _markdown.Transform(blogPart.Trim()),
-                    UpdateBody = _markdown.Transform(prInfo.Body.Trim())
+                    BlogPart = Markdown.Parse(blogPart.Trim(), _markdownPipeline).ToHtml(),
+                    UpdateBody = Markdown.Parse(prInfo.Body.Trim(), _markdownPipeline).ToHtml()
                 };
 
                 nightlyDtos.Add(nightlyDto);
@@ -523,9 +526,10 @@ public partial class VersionUpdaterService : IVersionUpdaterService
         var updateVersion = new Version(update.Tag_Name.Replace("v", string.Empty));
         var currentVersion = BuildInfo.Version.ToString(4);
 
-        var bodyHtml = _markdown.Transform(update.Body.Trim());
+
+        var bodyHtml = Markdown.Parse(update.Body.Trim(), _markdownPipeline).ToHtml();
         var parsedSections = ParseReleaseBody(update.Body);
-        var blogPart = _markdown.Transform(ExtractBlogPart(update.Body).Trim());
+        var blogPart = Markdown.Parse(ExtractBlogPart(update.Body).Trim(), _markdownPipeline).ToHtml();
 
         return new UpdateNotificationDto()
         {

--- a/Kavita.Services/VersionUpdaterService.cs
+++ b/Kavita.Services/VersionUpdaterService.cs
@@ -166,8 +166,8 @@ public partial class VersionUpdaterService : IVersionUpdaterService
                     KnownIssues = sections.TryGetValue("Known Issues", out var knownIssues) ? knownIssues : [],
                     Api = sections.TryGetValue("Api", out var api) ? api : [],
                     FeatureRequests = sections.TryGetValue("Feature Requests", out var frs) ? frs : [],
-                    BlogPart = Markdown.Parse(blogPart.Trim(), _markdownPipeline).ToHtml(),
-                    UpdateBody = Markdown.Parse(prInfo.Body.Trim(), _markdownPipeline).ToHtml()
+                    BlogPart = Markdown.ToHtml(blogPart.Trim(), _markdownPipeline),
+                    UpdateBody = Markdown.ToHtml(prInfo.Body.Trim(), _markdownPipeline)
                 };
 
                 nightlyDtos.Add(nightlyDto);
@@ -527,9 +527,9 @@ public partial class VersionUpdaterService : IVersionUpdaterService
         var currentVersion = BuildInfo.Version.ToString(4);
 
 
-        var bodyHtml = Markdown.Parse(update.Body.Trim(), _markdownPipeline).ToHtml();
+        var bodyHtml = Markdown.ToHtml(update.Body.Trim(), _markdownPipeline);
         var parsedSections = ParseReleaseBody(update.Body);
-        var blogPart = Markdown.Parse(ExtractBlogPart(update.Body).Trim(), _markdownPipeline).ToHtml();
+        var blogPart = Markdown.ToHtml(ExtractBlogPart(update.Body).Trim(), _markdownPipeline);
 
         return new UpdateNotificationDto()
         {

--- a/UI/Web/src/app/_models/chapter.ts
+++ b/UI/Web/src/app/_models/chapter.ts
@@ -108,6 +108,4 @@ export interface Chapter extends IHasCast, IHasReadingTime, IHasCover, IHasProgr
   titleNameLocked: boolean;
   sortOrderLocked: boolean;
   releaseDateLocked: boolean;
-
-  readonly _type: 'Chapter';
 }

--- a/UI/Web/src/app/_models/chapter.ts
+++ b/UI/Web/src/app/_models/chapter.ts
@@ -108,4 +108,6 @@ export interface Chapter extends IHasCast, IHasReadingTime, IHasCover, IHasProgr
   titleNameLocked: boolean;
   sortOrderLocked: boolean;
   releaseDateLocked: boolean;
+
+  readonly _type: 'Chapter';
 }

--- a/UI/Web/src/app/_models/collection-tag.ts
+++ b/UI/Web/src/app/_models/collection-tag.ts
@@ -22,4 +22,6 @@ export interface UserCollection {
   missingSeriesFromSource: string | null;
   ageRating: AgeRating;
   itemCount: number;
+
+  readonly _type: 'UserCollection';
 }

--- a/UI/Web/src/app/_models/collection-tag.ts
+++ b/UI/Web/src/app/_models/collection-tag.ts
@@ -22,6 +22,4 @@ export interface UserCollection {
   missingSeriesFromSource: string | null;
   ageRating: AgeRating;
   itemCount: number;
-
-  readonly _type: 'UserCollection';
 }

--- a/UI/Web/src/app/_models/reading-list.ts
+++ b/UI/Web/src/app/_models/reading-list.ts
@@ -44,8 +44,6 @@ export interface ReadingList extends IHasCover {
   endingMonth: number;
   itemCount: number;
   ageRating: AgeRating;
-
-  readonly _type: 'ReadingList';
 }
 
 export interface ReadingListInfo extends IHasReadingTime, IHasReadingTime {

--- a/UI/Web/src/app/_models/reading-list.ts
+++ b/UI/Web/src/app/_models/reading-list.ts
@@ -44,6 +44,8 @@ export interface ReadingList extends IHasCover {
   endingMonth: number;
   itemCount: number;
   ageRating: AgeRating;
+
+  readonly _type: 'ReadingList';
 }
 
 export interface ReadingListInfo extends IHasReadingTime, IHasReadingTime {

--- a/UI/Web/src/app/_models/series.ts
+++ b/UI/Web/src/app/_models/series.ts
@@ -88,5 +88,4 @@ export interface Series extends IHasCover, IHasReadingTime, IHasProgress {
    * Min number of reads across all chapters
    */
   totalReads: number;
-  readonly _type: 'Series';
 }

--- a/UI/Web/src/app/_models/series.ts
+++ b/UI/Web/src/app/_models/series.ts
@@ -88,5 +88,5 @@ export interface Series extends IHasCover, IHasReadingTime, IHasProgress {
    * Min number of reads across all chapters
    */
   totalReads: number;
-
+  readonly _type: 'Series';
 }

--- a/UI/Web/src/app/_models/volume.ts
+++ b/UI/Web/src/app/_models/volume.ts
@@ -27,5 +27,4 @@ export interface Volume extends IHasCover, IHasReadingTime, IHasProgress {
   coverImageLocked: boolean;
   primaryColor: string;
   secondaryColor: string;
-  readonly _type: 'Volume';
 }

--- a/UI/Web/src/app/_models/volume.ts
+++ b/UI/Web/src/app/_models/volume.ts
@@ -1,30 +1,31 @@
-import { Chapter } from './chapter';
-import { HourEstimateRange } from './series-detail/hour-estimate-range';
+import {Chapter} from './chapter';
+import {HourEstimateRange} from './series-detail/hour-estimate-range';
 import {IHasCover} from "./common/i-has-cover";
 import {IHasReadingTime} from "./common/i-has-reading-time";
 import {IHasProgress} from "./common/i-has-progress";
 
 export interface Volume extends IHasCover, IHasReadingTime, IHasProgress {
-    id: number;
-    minNumber: number;
-    maxNumber: number;
-    name: string;
-    createdUtc: string;
-    lastModifiedUtc: string;
-    pages: number;
-    pagesRead: number;
-    wordCount: number;
-    chapters: Array<Chapter>;
-    /**
-     * This is only available on the object when fetched for SeriesDetail
-     */
-    timeEstimate?: HourEstimateRange;
-    minHoursToRead: number;
-    maxHoursToRead: number;
-    avgHoursToRead: number;
+  id: number;
+  minNumber: number;
+  maxNumber: number;
+  name: string;
+  createdUtc: string;
+  lastModifiedUtc: string;
+  pages: number;
+  pagesRead: number;
+  wordCount: number;
+  chapters: Array<Chapter>;
+  /**
+   * This is only available on the object when fetched for SeriesDetail
+   */
+  timeEstimate?: HourEstimateRange;
+  minHoursToRead: number;
+  maxHoursToRead: number;
+  avgHoursToRead: number;
 
-    coverImage?: string;
-    coverImageLocked: boolean;
-    primaryColor: string;
-    secondaryColor: string;
+  coverImage?: string;
+  coverImageLocked: boolean;
+  primaryColor: string;
+  secondaryColor: string;
+  readonly _type: 'Volume';
 }

--- a/UI/Web/src/app/_services/account.service.ts
+++ b/UI/Web/src/app/_services/account.service.ts
@@ -272,15 +272,14 @@ export class AccountService {
 
     this.stopRefreshTokenTimer();
 
-    if (user) {
-      if (!isSameUser) {
-        this.messageHub.stopHubConnection();
-        this.messageHub.createHubConnection(user);
-        this.licenseService.checkForValidLicense().subscribe();
-      }
-      if (user.token) {
-        this.startRefreshTokenTimer();
-      }
+    if (user && !isSameUser) {
+      this.messageHub.stopHubConnection();
+      this.messageHub.createHubConnection(user);
+      this.licenseService.checkForValidLicense().subscribe();
+    }
+
+    if (user?.token) {
+      this.startRefreshTokenTimer();
     }
   }
 
@@ -447,7 +446,10 @@ export class AccountService {
   refreshAccount(): Observable<null | User> {
     if (!this._currentUser()) return of(null);
     return this.httpClient.get<User>(this.baseUrl + 'account/refresh-account').pipe(map((user: User) => {
-      if (user) this.setCurrentUser({ ...user });
+      if (user) {
+        this.setCurrentUser({...user});
+        this.licenseService.checkForValidLicense().subscribe();
+      }
       return user;
     }));
   }

--- a/UI/Web/src/app/_services/account.service.ts
+++ b/UI/Web/src/app/_services/account.service.ts
@@ -276,7 +276,7 @@ export class AccountService {
       if (!isSameUser) {
         this.messageHub.stopHubConnection();
         this.messageHub.createHubConnection(user);
-        this.licenseService.hasValidLicense().subscribe();
+        this.licenseService.checkForValidLicense().subscribe();
       }
       if (user.token) {
         this.startRefreshTokenTimer();

--- a/UI/Web/src/app/_services/account.service.ts
+++ b/UI/Web/src/app/_services/account.service.ts
@@ -401,11 +401,14 @@ export class AccountService {
     return this.httpClient.post<Preferences>(this.baseUrl + 'users/update-preferences', userPreferences).pipe(map(settings => {
       const current = this._currentUser();
       if (current) {
+        const localeChange = current.preferences.locale != settings.locale;
         this.setCurrentUser({ ...current, preferences: settings }, false);
 
-        // Update the locale on disk (for logout and compact-number pipe)
-        localStorage.setItem(AccountService.localeKey, settings.locale);
-        this.localizationService.refreshTranslations(settings.locale);
+        if (localeChange) {
+          // Update the locale on disk (for logout and compact-number pipe)
+          localStorage.setItem(AccountService.localeKey, settings.locale);
+          this.localizationService.refreshTranslations(settings.locale);
+        }
       }
       return settings;
     }), takeUntilDestroyed(this.destroyRef));

--- a/UI/Web/src/app/_services/action-factory.service.ts
+++ b/UI/Web/src/app/_services/action-factory.service.ts
@@ -925,6 +925,17 @@ export class ActionFactoryService {
         children: [],
       },
       {
+        action: Action.Download,
+        title: 'download',
+        description: 'download-tooltip',
+
+        callback: this.dummyCallback,
+        shouldRender: this.dummyShouldRender,
+
+        requiredRoles: [Role.Download],
+        children: [],
+      },
+      {
         action: Action.Delete,
         title: 'delete',
         description: 'delete-tooltip',

--- a/UI/Web/src/app/_services/action-factory.service.ts
+++ b/UI/Web/src/app/_services/action-factory.service.ts
@@ -374,6 +374,17 @@ export class ActionFactoryService {
         children: [],
       },
       {
+        action: Action.Download,
+        title: 'download',
+        description: 'download-tooltip',
+
+        callback: this.dummyCallback,
+        shouldRender: this.dummyShouldRender,
+
+        requiredRoles: [Role.Download],
+        children: [],
+      },
+      {
         action: Action.Delete,
         title: 'delete',
         description: 'delete-tooltip',

--- a/UI/Web/src/app/_services/action.service.ts
+++ b/UI/Web/src/app/_services/action.service.ts
@@ -650,6 +650,10 @@ export class ActionService {
           map(() => this.fromAction(action, readingList, 'remove'))
         );
 
+      case Action.Download:
+        this.downloadService.download('readinglist', readingList, 0, 0);
+        return of(this.fromAction(action, readingList, 'none'));
+
       case Action.Edit:
         const ref = this.modalService.open(EditReadingListModalComponent, editModal());
         ref.componentInstance.readingList = readingList;
@@ -1227,6 +1231,10 @@ export class ActionService {
           tap(() => this.toastr.success(translate('toasts.reading-lists-deleted'))),
           map(() => this.fromAction(action, readingLists, 'remove'))
         );
+
+      case Action.Download:
+        for (const rl of readingLists) { this.downloadService.download('readinglist', rl, 0, 0); }
+        return of(this.fromAction(action, readingLists, 'none'));
 
       default:
         return of(this.fromAction(action, readingLists, 'none'));

--- a/UI/Web/src/app/_services/action.service.ts
+++ b/UI/Web/src/app/_services/action.service.ts
@@ -704,6 +704,9 @@ export class ActionService {
           tap(() => this.toastr.success(translate('toasts.collections-unpromoted'))),
           map(() => this.fromAction(action, {...collection, promoted: false}, 'update'))
         );
+      case Action.Download:
+        this.downloadService.download('collection', collection, 0, 0);
+        return of(this.fromAction(action, collection, 'none'));
 
       default:
         return of(this.fromAction(action, collection, 'none'));
@@ -1204,6 +1207,10 @@ export class ActionService {
           tap(() => this.toastr.success(translate('toasts.collections-deleted'))),
           map(() => this.fromAction(action, collections, 'remove'))
         );
+
+      case Action.Download:
+        for (let c of collections) this.downloadService.download('collection', c, 0, 0);
+        return of(this.fromAction(action, collections, 'none'));
 
       default:
         return of(this.fromAction(action, collections, 'none'));

--- a/UI/Web/src/app/_services/action.service.ts
+++ b/UI/Web/src/app/_services/action.service.ts
@@ -651,7 +651,7 @@ export class ActionService {
         );
 
       case Action.Download:
-        this.downloadService.download('readinglist', readingList, 0, 0);
+        this.downloadService.download('readingList', readingList, 0, 0);
         return of(this.fromAction(action, readingList, 'none'));
 
       case Action.Edit:
@@ -1240,7 +1240,7 @@ export class ActionService {
         );
 
       case Action.Download:
-        for (const rl of readingLists) { this.downloadService.download('readinglist', rl, 0, 0); }
+        for (const rl of readingLists) { this.downloadService.download('readingList', rl, 0, 0); }
         return of(this.fromAction(action, readingLists, 'none'));
 
       default:

--- a/UI/Web/src/app/_services/card-config-factory.service.ts
+++ b/UI/Web/src/app/_services/card-config-factory.service.ts
@@ -343,6 +343,7 @@ export class CardConfigFactory {
       actionableFunc: (c) => this.actionFactory.getCollectionTagActions(params?.shouldRenderAction),
       readFunc: null,
       clickFunc: (c) => this.router.navigate(['collections', c.id]),
+      downloadItemFunc: (c) => this.downloadService.getItemForEntity(c, true),
     };
 
     return this.mergeConfig(defaults, params?.overrides);
@@ -375,6 +376,7 @@ export class CardConfigFactory {
       actionableFunc: (r) => this.actionFactory.getReadingListActions(params?.shouldRenderAction),
       readFunc: null,
       clickFunc: (r) => this.router.navigate(['lists', r.id]),
+      downloadItemFunc: (r) => this.downloadService.getItemForEntity(r, true),
     };
 
     return this.mergeConfig(defaults, params?.overrides);

--- a/UI/Web/src/app/_services/entity-title.service.ts
+++ b/UI/Web/src/app/_services/entity-title.service.ts
@@ -110,7 +110,7 @@ export class EntityTitleService {
         if (number === LooseLeafOrSpecial) {
           renderText = this.translocoService.translate('entity-title.chapter') + ' - ';
         } else {
-          renderText = this.translocoService.translate('entity-title.chapter') + ' ' + number + ' - ';
+          renderText = this.translocoService.translate('entity-title.chapter', {num: number}) + ' - ';
         }
       }
       renderText += titleName;

--- a/UI/Web/src/app/_services/entity-title.service.ts
+++ b/UI/Web/src/app/_services/entity-title.service.ts
@@ -123,7 +123,7 @@ export class EntityTitleService {
 
       if (number !== LooseLeafOrSpecial) {
         if (isChapter) {
-          renderText = this.translocoService.translate('entity-title.chapter') + ' ' + number;
+          renderText = this.translocoService.translate('entity-title.chapter', {num: number});
         } else {
           renderText = volumeTitle;
         }
@@ -144,7 +144,7 @@ export class EntityTitleService {
 
     if (number !== LooseLeafOrSpecial) {
       if (isChapter) {
-        renderText = this.translocoService.translate('entity-title.chapter') + ' ' + number;
+        renderText = this.translocoService.translate('entity-title.chapter', {num: number});
       } else {
         renderText = volumeTitle;
       }
@@ -162,7 +162,7 @@ export class EntityTitleService {
 
     if (titleName && prioritizeTitleName) {
       if (isChapter && includeChapter) {
-        renderText = this.translocoService.translate('entity-title.issue-num') + ' ' + number + ' - ';
+        renderText = this.translocoService.translate('entity-title.issue-num', {num: number}) + ' - ';
       }
       renderText += titleName;
     } else {
@@ -172,7 +172,7 @@ export class EntityTitleService {
         }
       }
       renderText += number !== LooseLeafOrSpecial
-        ? (isChapter ? this.translocoService.translate('entity-title.issue-num') + ' ' + number : volumeTitle)
+        ? (isChapter ? this.translocoService.translate('entity-title.issue-num', {num: number}) : volumeTitle)
         : this.translocoService.translate('entity-title.special');
     }
 

--- a/UI/Web/src/app/_services/license.service.ts
+++ b/UI/Web/src/app/_services/license.service.ts
@@ -1,10 +1,9 @@
-import {inject, Injectable} from '@angular/core';
+import {inject, Injectable, signal} from '@angular/core';
 import {HttpClient} from "@angular/common/http";
-import {catchError, map, ReplaySubject, tap, throwError} from "rxjs";
+import {catchError, map, tap, throwError} from "rxjs";
 import {environment} from "../../environments/environment";
 import {TextResonse} from '../_types/text-response';
 import {LicenseInfo} from "../_models/kavitaplus/license-info";
-import {toSignal} from "@angular/core/rxjs-interop";
 
 @Injectable({
   providedIn: 'root'
@@ -12,14 +11,11 @@ import {toSignal} from "@angular/core/rxjs-interop";
 export class LicenseService {
   private readonly httpClient = inject(HttpClient);
 
-  baseUrl = environment.apiUrl;
+  private readonly baseUrl = environment.apiUrl;
 
-  private readonly hasValidLicenseSource = new ReplaySubject<boolean>(1);
-  /**
-   * Does the user have an active license
-   */
-  public readonly hasValidLicense$ = this.hasValidLicenseSource.asObservable();
-  public readonly hasValidLicenseSignal = toSignal(this.hasValidLicense$, {initialValue: false});
+  private readonly _hasValidLicense = signal<boolean>(false);
+  /** Does the user have an active license */
+  public readonly hasValidLicense = this._hasValidLicense.asReadonly();
 
 
   /**
@@ -29,15 +25,16 @@ export class LicenseService {
     return this.httpClient.delete<string>(this.baseUrl + 'license', TextResonse).pipe(
       map(res => res === "true"),
       tap(_ => {
-        this.hasValidLicenseSource.next(false)
+        this._hasValidLicense.set(false);
       }),
       catchError(error => {
-        this.hasValidLicenseSource.next(false);
+        this._hasValidLicense.set(false);
         return throwError(error); // Rethrow the error to propagate it further
       })
     );
   }
 
+  /** Break the registration between Kavita+ and this instance */
   resetLicense(license: string, email: string) {
     return this.httpClient.post<string>(this.baseUrl + 'license/reset', {license, email}, TextResonse);
   }
@@ -52,29 +49,30 @@ export class LicenseService {
   licenseInfo(forceCheck: boolean = false) {
     return this.httpClient.get<LicenseInfo | null>(this.baseUrl + `license/info?forceCheck=${forceCheck}`).pipe(
       tap(res => {
-        this.hasValidLicenseSource.next(res?.isActive || false)
+        this._hasValidLicense.set(res?.isActive || false);
       }),
       catchError(error => {
-        this.hasValidLicenseSource.next(false);
         return throwError(error); // Rethrow the error to propagate it further
       })
     );
   }
 
-  hasValidLicense(forceCheck: boolean = false) {
+  /** Checks with the Server if the user has an active license. Force check will passthru to K+ */
+  checkForValidLicense(forceCheck: boolean = false) {
     return this.httpClient.get<string>(this.baseUrl + 'license/valid-license?forceCheck=' + forceCheck, TextResonse)
       .pipe(
         map(res => res === "true"),
-        tap(res => {
-          this.hasValidLicenseSource.next(res)
+        tap(value => {
+          this._hasValidLicense.set(value);
         }),
         catchError(error => {
-          this.hasValidLicenseSource.next(false);
+          this._hasValidLicense.set(false);
           return throwError(error); // Rethrow the error to propagate it further
         })
       );
   }
 
+  /** Has any license registered with the instance. Does not validate against Kavita+ API */
   hasAnyLicense() {
     return this.httpClient.get<string>(this.baseUrl + 'license/has-license', TextResonse)
       .pipe(

--- a/UI/Web/src/app/_services/license.service.ts
+++ b/UI/Web/src/app/_services/license.service.ts
@@ -52,6 +52,8 @@ export class LicenseService {
         this._hasValidLicense.set(res?.isActive || false);
       }),
       catchError(error => {
+        console.error(error);
+        this._hasValidLicense.set(false);
         return throwError(error); // Rethrow the error to propagate it further
       })
     );

--- a/UI/Web/src/app/_services/localization.service.ts
+++ b/UI/Web/src/app/_services/localization.service.ts
@@ -1,7 +1,7 @@
 import {inject, Injectable} from '@angular/core';
 import {environment} from "../../environments/environment";
-import { HttpClient } from "@angular/common/http";
-import {KavitaLocale, Language} from "../_models/metadata/language";
+import {HttpClient} from "@angular/common/http";
+import {KavitaLocale} from "../_models/metadata/language";
 import {ReplaySubject, tap} from "rxjs";
 import {TranslocoService} from "@jsverse/transloco";
 
@@ -25,12 +25,13 @@ export class LocalizationService {
     }));
   }
 
-  refreshTranslations(lang: string) {
+  refreshTranslations(newLang: string) {
 
     // Clear the cached translation
-    localStorage.removeItem(`@@TRANSLOCO_PERSIST_TRANSLATIONS/${lang}`);
+    localStorage.removeItem(`@transloco/translations`);
+    localStorage.removeItem(`@transloco/translations/timestamp`);
 
     // Reload the translation
-    return this.translocoService.load(lang);
+    return this.translocoService.load(newLang);
   }
 }

--- a/UI/Web/src/app/_services/localization.service.ts
+++ b/UI/Web/src/app/_services/localization.service.ts
@@ -32,6 +32,7 @@ export class LocalizationService {
     localStorage.removeItem(`@transloco/translations/timestamp`);
 
     // Reload the translation
+    this.translocoService.setActiveLang(newLang);
     return this.translocoService.load(newLang);
   }
 }

--- a/UI/Web/src/app/_single-module/profile-icon/profile-icon.component.ts
+++ b/UI/Web/src/app/_single-module/profile-icon/profile-icon.component.ts
@@ -1,4 +1,14 @@
-import {ChangeDetectionStrategy, Component, computed, DestroyRef, inject, input, signal} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  DestroyRef,
+  inject,
+  input,
+  OnInit,
+  Signal,
+  signal
+} from '@angular/core';
 import {ImageService} from "../../_services/image.service";
 import {ImageComponent} from "../../shared/image/image.component";
 import {EVENTS, MessageHubService} from "../../_services/message-hub.service";
@@ -14,7 +24,7 @@ import {takeUntilDestroyed} from "@angular/core/rxjs-interop";
   styleUrl: './profile-icon.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class ProfileIconComponent {
+export class ProfileIconComponent implements OnInit {
   protected readonly imageService = inject(ImageService);
   protected readonly hubService = inject(MessageHubService);
   protected readonly destroyRef = inject(DestroyRef);
@@ -30,14 +40,16 @@ export class ProfileIconComponent {
   private readonly randomSeed = signal<number>(0);
   noImage = signal<boolean>(false);
 
-  currentImageUrl = computed(() => {
-    const userId = this.userId();
-    const seed = this.randomSeed();
-    const url = this.imageService.getUserCoverImage(userId);
-    return seed > 0 ? `${url}&random=${seed}` : url;
-  });
+  currentImageUrl!: Signal<string>;
 
-  constructor() {
+  ngOnInit() {
+    this.currentImageUrl = computed(() => {
+      const userId = this.userId();
+      const seed = this.randomSeed();
+      const url = this.imageService.getUserCoverImage(userId);
+      return seed > 0 ? `${url}&random=${seed}` : url;
+    });
+
     this.hubService.messages$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(res => {
       if (!this.processEvents()) return;
       const imageUrl = this.currentImageUrl();

--- a/UI/Web/src/app/admin/import-mappings/import-mappings.component.ts
+++ b/UI/Web/src/app/admin/import-mappings/import-mappings.component.ts
@@ -40,7 +40,7 @@ import {NgTemplateOutlet} from "@angular/common";
 import {Router} from "@angular/router";
 import {LicenseService} from "../../_services/license.service";
 import {SettingsTabId} from "../../sidenav/preference-nav/preference-nav.component";
-import {toObservable, toSignal} from "@angular/core/rxjs-interop";
+import {toSignal} from "@angular/core/rxjs-interop";
 
 enum Step {
   Import = 0,
@@ -195,7 +195,7 @@ export class ImportMappingsComponent implements OnInit {
 
     this.settingsService.updateMetadataSettings(newSettings).subscribe({
       next: () => {
-        const fragment = this.licenseService.hasValidLicenseSignal()
+        const fragment = this.licenseService.hasValidLicense()
           ? SettingsTabId.Metadata : SettingsTabId.ManageMetadata;
 
         this.router.navigate(['settings'], { fragment: fragment });

--- a/UI/Web/src/app/admin/manage-matched-metadata/manage-matched-metadata.component.html
+++ b/UI/Web/src/app/admin/manage-matched-metadata/manage-matched-metadata.component.html
@@ -35,7 +35,7 @@
         class="bootstrap"
         [rows]="data()"
         [loadingIndicator]="isLoading()"
-        [columnMode]="ColumnMode.flex"
+        [columnMode]="'flex'"
         rowHeight="auto"
         [footerHeight]="50"
         [externalPaging]="true"

--- a/UI/Web/src/app/admin/manage-matched-metadata/manage-matched-metadata.component.ts
+++ b/UI/Web/src/app/admin/manage-matched-metadata/manage-matched-metadata.component.ts
@@ -1,6 +1,4 @@
-import {ChangeDetectionStrategy, Component, computed, effect, inject, OnInit, signal} from '@angular/core';
-import {LicenseService} from "../../_services/license.service";
-import {Router} from "@angular/router";
+import {ChangeDetectionStrategy, Component, inject, OnInit, signal} from '@angular/core';
 import {translate, TranslocoDirective} from "@jsverse/transloco";
 import {ImageComponent} from "../../shared/image/image.component";
 import {ImageService} from "../../_services/image.service";
@@ -16,7 +14,7 @@ import {MatchStateOptionPipe} from "../../_pipes/match-state.pipe";
 import {UtcToLocalTimePipe} from "../../_pipes/utc-to-local-time.pipe";
 import {debounceTime, distinctUntilChanged, switchMap, tap} from "rxjs";
 import {DefaultValuePipe} from "../../_pipes/default-value.pipe";
-import {ColumnMode, NgxDatatableModule} from "@siemens/ngx-datatable";
+import {NgxDatatableModule} from "@siemens/ngx-datatable";
 import {LibraryNamePipe} from "../../_pipes/library-name.pipe";
 import {APP_BASE_HREF, AsyncPipe} from "@angular/common";
 import {EVENTS, MessageHubService} from "../../_services/message-hub.service";
@@ -49,14 +47,11 @@ import {Pagination} from "../../_models/pagination";
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ManageMatchedMetadataComponent implements OnInit {
-  protected readonly ColumnMode = ColumnMode;
   protected readonly MatchStateOption = MatchStateOption;
   protected readonly allMatchStates = allMatchStates.filter(m => m !== MatchStateOption.Matched); // Matched will have too many
   protected readonly allLibraryTypes = allKavitaPlusMetadataApplicableTypes;
 
-  private readonly licenseService = inject(LicenseService);
   private readonly actionService = inject(ActionService);
-  private readonly router = inject(Router);
   private readonly manageService = inject(ManageService);
   private readonly messageHub = inject(MessageHubService);
   private readonly toastr = inject(ToastrService);
@@ -79,41 +74,33 @@ export class ManageMatchedMetadataComponent implements OnInit {
   trackBy = (idx: number, item: ManageMatchSeries) => `${item.isMatched}_${item.series.name}_${idx}`;
 
   ngOnInit() {
-    this.licenseService.hasValidLicense$.subscribe(license => {
-      if (!license) {
-        // Navigate home
-        this.router.navigate(['/']);
-        return;
+    this.messageHub.messages$.subscribe(message => {
+      if (message.event == EVENTS.ScanSeries) {
+        const evt = message.payload as ScanSeriesEvent;
+        if (this.data().filter(d => d.series.id === evt.seriesId).length > 0) {
+          this.loadData();
+        }
       }
 
-      this.messageHub.messages$.subscribe(message => {
-        if (message.event == EVENTS.ScanSeries) {
-          const evt = message.payload as ScanSeriesEvent;
-          if (this.data().filter(d => d.series.id === evt.seriesId).length > 0) {
-            this.loadData();
-          }
-        }
-
-        if (message.event == EVENTS.ExternalMatchRateLimitError) {
-          const evt = message.payload as ExternalMatchRateLimitErrorEvent;
-          this.toastr.error(translate('toasts.external-match-rate-error', {seriesName: evt.seriesName}))
-        }
-      });
-
-      this.filterGroup.valueChanges.pipe(
-        debounceTime(300),
-        distinctUntilChanged(),
-        tap(_ => {
-          this.isLoading.set(true);
-        }),
-        switchMap(_ => this.loadData()),
-        tap(_ => {
-          this.isLoading.set(false);
-        }),
-      ).subscribe();
-
-      this.loadData().subscribe();
+      if (message.event == EVENTS.ExternalMatchRateLimitError) {
+        const evt = message.payload as ExternalMatchRateLimitErrorEvent;
+        this.toastr.error(translate('toasts.external-match-rate-error', {seriesName: evt.seriesName}))
+      }
     });
+
+    this.filterGroup.valueChanges.pipe(
+      debounceTime(300),
+      distinctUntilChanged(),
+      tap(_ => {
+        this.isLoading.set(true);
+      }),
+      switchMap(_ => this.loadData()),
+      tap(_ => {
+        this.isLoading.set(false);
+      }),
+    ).subscribe();
+
+    this.loadData().subscribe();
   }
 
   onPageChange(page: number) {

--- a/UI/Web/src/app/admin/manage-matched-metadata/manage-matched-metadata.component.ts
+++ b/UI/Web/src/app/admin/manage-matched-metadata/manage-matched-metadata.component.ts
@@ -1,4 +1,4 @@
-import {ChangeDetectionStrategy, Component, inject, OnInit, signal} from '@angular/core';
+import {ChangeDetectionStrategy, Component, DestroyRef, inject, OnInit, signal} from '@angular/core';
 import {translate, TranslocoDirective} from "@jsverse/transloco";
 import {ImageComponent} from "../../shared/image/image.component";
 import {ImageService} from "../../_services/image.service";
@@ -25,6 +25,7 @@ import {ExternalMatchRateLimitErrorEvent} from "../../_models/events/external-ma
 import {ToastrService} from "ngx-toastr";
 import {ResponsiveTableComponent} from "../../shared/_components/responsive-table/responsive-table.component";
 import {Pagination} from "../../_models/pagination";
+import {takeUntilDestroyed} from "@angular/core/rxjs-interop";
 
 @Component({
   selector: 'app-manage-matched-metadata',
@@ -57,6 +58,7 @@ export class ManageMatchedMetadataComponent implements OnInit {
   private readonly toastr = inject(ToastrService);
   protected readonly imageService = inject(ImageService);
   protected readonly baseUrl = inject(APP_BASE_HREF);
+  protected readonly destroyRef = inject(DestroyRef);
 
   isLoading = signal(true);
   data = signal<ManageMatchSeries[]>([]);
@@ -74,7 +76,7 @@ export class ManageMatchedMetadataComponent implements OnInit {
   trackBy = (idx: number, item: ManageMatchSeries) => `${item.isMatched}_${item.series.name}_${idx}`;
 
   ngOnInit() {
-    this.messageHub.messages$.subscribe(message => {
+    this.messageHub.messages$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(message => {
       if (message.event == EVENTS.ScanSeries) {
         const evt = message.payload as ScanSeriesEvent;
         if (this.data().filter(d => d.series.id === evt.seriesId).length > 0) {
@@ -98,6 +100,7 @@ export class ManageMatchedMetadataComponent implements OnInit {
       tap(_ => {
         this.isLoading.set(false);
       }),
+      takeUntilDestroyed(this.destroyRef)
     ).subscribe();
 
     this.loadData().subscribe();

--- a/UI/Web/src/app/admin/manage-public-metadata-settings/manage-public-metadata-settings.component.html
+++ b/UI/Web/src/app/admin/manage-public-metadata-settings/manage-public-metadata-settings.component.html
@@ -1,6 +1,6 @@
 <ng-container *transloco="let t; prefix: 'manage-metadata-settings'">
 
-  @if (licenseService.hasValidLicenseSignal()) {
+  @if (licenseService.hasValidLicense()) {
     <p class="alert alert-warning" role="alert">{{t('k+-warning')}}</p>
   }
 

--- a/UI/Web/src/app/app.component.html
+++ b/UI/Web/src/app/app.component.html
@@ -1,4 +1,4 @@
-<div [ngClass]="{'no-transitions' : transitionState()}">
+<div [class.no-animations]="transitionState()" [class.no-transitions]="transitionState()" [class.animate-disabled]="transitionState()">
   @let currentUser = accountService.currentUser();
     @if (currentUser && (navService.navbarVisible$ | async) === true) {
       <div class="fullpage-background">

--- a/UI/Web/src/app/app.component.ts
+++ b/UI/Web/src/app/app.component.ts
@@ -1,10 +1,19 @@
-import {ChangeDetectionStrategy, Component, computed, DestroyRef, HostListener, inject, OnInit} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  DestroyRef,
+  effect,
+  HostListener,
+  inject,
+  OnInit
+} from '@angular/core';
 import {NavigationStart, Router, RouterOutlet} from '@angular/router';
 import {shareReplay, take} from 'rxjs/operators';
 import {AccountService} from './_services/account.service';
 import {LibraryService} from './_services/library.service';
 import {NavService} from './_services/nav.service';
-import {NgbModal, NgbOffcanvas} from '@ng-bootstrap/ng-bootstrap';
+import {NgbModal, NgbOffcanvas, NgbOffcanvasConfig} from '@ng-bootstrap/ng-bootstrap';
 import {AsyncPipe, DOCUMENT, NgClass} from '@angular/common';
 import {filter} from 'rxjs';
 import {ThemeService} from "./_services/theme.service";
@@ -44,10 +53,21 @@ export class AppComponent implements OnInit {
   private readonly breakpointService = inject(BreakpointService); // Needs to be injected to run background job
   private readonly licenseService = inject(LicenseService);
   private readonly localizationService = inject(LocalizationService);
+  private readonly ngbCanvasConfig = inject(NgbOffcanvasConfig);
   transitionState = computed(() => this.accountService.userPreferences()?.noTransitions ?? false);
 
 
   constructor() {
+
+    effect(() => {
+      const animationsDisabled = this.transitionState();
+      if (animationsDisabled) {
+        console.log('User has animations off, disabling ngbBootstrap')
+        this.ngbCanvasConfig.animation = false;
+        document.documentElement.classList.add('no-animations', 'animate-disabled');
+      }
+    })
+
     // Close any open modals when a route change occurs
     this.router.events
       .pipe(

--- a/UI/Web/src/app/app.component.ts
+++ b/UI/Web/src/app/app.component.ts
@@ -58,17 +58,15 @@ export class AppComponent implements OnInit {
 
 
   constructor() {
+    const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
 
     effect(() => {
-      const animationsDisabled = this.transitionState();
-      if (animationsDisabled) {
-        console.log('User has animations off, disabling ngbBootstrap')
-        this.ngbCanvasConfig.animation = false;
-        document.documentElement.classList.add('no-animations', 'animate-disabled');
-      } else {
-        // TODO: Let's move this logic into theme service/function because when we undo, we need to respect motion preferences  
-      }
-    })
+      this.applyAnimationState(this.transitionState(), reducedMotion.matches);
+    });
+
+    reducedMotion.addEventListener('change', () => {
+      this.applyAnimationState(this.transitionState(), reducedMotion.matches);
+    });
 
     // Close any open modals when a route change occurs
     this.router.events
@@ -111,6 +109,17 @@ export class AppComponent implements OnInit {
     this.themeService.setColorScape('');
   }
 
+
+  private applyAnimationState(userDisabled: boolean, reducedMotion: boolean) {
+    const shouldDisable = userDisabled || reducedMotion;
+    this.ngbCanvasConfig.animation = !shouldDisable;
+
+    if (shouldDisable) {
+      document.documentElement.classList.add('no-animations', 'animate-disabled');
+    } else {
+      document.documentElement.classList.remove('no-animations', 'animate-disabled');
+    }
+  }
 
   setCurrentUser() {
     const user = this.accountService.currentUser();

--- a/UI/Web/src/app/app.component.ts
+++ b/UI/Web/src/app/app.component.ts
@@ -65,6 +65,8 @@ export class AppComponent implements OnInit {
         console.log('User has animations off, disabling ngbBootstrap')
         this.ngbCanvasConfig.animation = false;
         document.documentElement.classList.add('no-animations', 'animate-disabled');
+      } else {
+        // TODO: Let's move this logic into theme service/function because when we undo, we need to respect motion preferences  
       }
     })
 

--- a/UI/Web/src/app/app.component.ts
+++ b/UI/Web/src/app/app.component.ts
@@ -115,9 +115,9 @@ export class AppComponent implements OnInit {
     this.ngbCanvasConfig.animation = !shouldDisable;
 
     if (shouldDisable) {
-      document.documentElement.classList.add('no-animations', 'animate-disabled');
+      document.documentElement.classList.add('animate-disabled');
     } else {
-      document.documentElement.classList.remove('no-animations', 'animate-disabled');
+      document.documentElement.classList.remove('animate-disabled');
     }
   }
 

--- a/UI/Web/src/app/cards/bulk-selection.service.ts
+++ b/UI/Web/src/app/cards/bulk-selection.service.ts
@@ -215,7 +215,7 @@ export class BulkSelectionService {
     }
 
     if (this.hasDataSource('collection')) {
-      const actions = this.applyFilterToList(this.actionFactory.getCollectionTagActions(shouldRender), [Action.Promote, Action.UnPromote, Action.Delete]);
+      const actions = this.applyFilterToList(this.actionFactory.getCollectionTagActions(shouldRender), [Action.Promote, Action.UnPromote, Action.Delete, Action.Download]);
       return this.wireBulkCallback(actions, (action) => {
         const collections = this.resolveEntities<UserCollection>('collection');
         return this.actionService.handleBulkCollectionAction(action, collections);

--- a/UI/Web/src/app/cards/bulk-selection.service.ts
+++ b/UI/Web/src/app/cards/bulk-selection.service.ts
@@ -61,7 +61,6 @@ export class BulkSelectionService {
   public isShiftDown: boolean = false;
 
   private actionsSource = new ReplaySubject<ActionItem<any>[]>(1);
-  public actions$ = this.actionsSource.asObservable();
   public actionsSignal = toSignal(this.actionsSource);
 
   private selectionsSource = new ReplaySubject<number>(1);
@@ -224,7 +223,7 @@ export class BulkSelectionService {
     }
 
     if (this.hasDataSource('readingList')) {
-      const actions = this.applyFilterToList(this.actionFactory.getReadingListActions(shouldRender), [Action.Promote, Action.UnPromote, Action.Delete]);
+      const actions = this.applyFilterToList(this.actionFactory.getReadingListActions(shouldRender), [Action.Promote, Action.UnPromote, Action.Delete, Action.Download]);
       return this.wireBulkCallback(actions, (action) => {
         const readingLists = this.resolveEntities<ReadingList>('readingList');
         return this.actionService.handleBulkReadingListAction(action, readingLists);

--- a/UI/Web/src/app/cards/entity-card/entity-card.component.ts
+++ b/UI/Web/src/app/cards/entity-card/entity-card.component.ts
@@ -380,12 +380,10 @@ export class EntityCardComponent<T> implements OnInit {
     const result = event as ActionResult<any>;
     switch (result.effect) {
       case 'update':
-        console.log('handle actionable result - update')
         this.dataChanged.emit(result.entity);
         break;
       case 'remove':
       case 'reload':
-        console.log('handle actionable result - reload')
         this.reload.emit(result.entity?.id ?? 0);
         break;
       case 'none':

--- a/UI/Web/src/app/collections/_components/collection-detail/collection-detail.component.ts
+++ b/UI/Web/src/app/collections/_components/collection-detail/collection-detail.component.ts
@@ -97,13 +97,12 @@ export class CollectionDetailComponent implements AfterContentChecked {
   protected readonly ScrobbleProvider = ScrobbleProvider;
 
   scrollingBlock = viewChild<ElementRef<HTMLDivElement>>('scrollingBlock');
-  companionBar = viewChild<ElementRef<HTMLDivElement>>('companionBar');
 
   collectionId = input(0, {transform: numberAttribute});
   collectionTag = getWritableResolvedData(this.route, 'collection');
   summary = computed(() => (this.collectionTag()?.summary ?? '').replace(/\n/g, '<br>'));
 
-  user = this.accountService.currentUser;
+  readonly user = this.accountService.currentUser;
 
   isLoading = signal(true);
   series = signal<Array<Series>>([]);

--- a/UI/Web/src/app/dashboard/_components/dashboard.component.ts
+++ b/UI/Web/src/app/dashboard/_components/dashboard.component.ts
@@ -134,7 +134,7 @@ export class DashboardComponent {
       }
     });
 
-    this.licenseService.checkForValidLicense()
+    this.licenseService.hasAnyLicense()
       .pipe(
         filter((hasLic: boolean) => hasLic),
         switchMap(_ => this.scrobblingService.hasTokenExpired(ScrobbleProvider.AniList)),

--- a/UI/Web/src/app/dashboard/_components/dashboard.component.ts
+++ b/UI/Web/src/app/dashboard/_components/dashboard.component.ts
@@ -134,7 +134,7 @@ export class DashboardComponent {
       }
     });
 
-    this.licenseService.hasValidLicense()
+    this.licenseService.checkForValidLicense()
       .pipe(
         filter((hasLic: boolean) => hasLic),
         switchMap(_ => this.scrobblingService.hasTokenExpired(ScrobbleProvider.AniList)),
@@ -142,7 +142,6 @@ export class DashboardComponent {
       if (hasExpired) {
         this.toastr.error(translate('toasts.anilist-token-expired'));
       }
-      this.cdRef.markForCheck();
     });
   }
 

--- a/UI/Web/src/app/nav/_components/download-queue-item/download-queue-item.component.ts
+++ b/UI/Web/src/app/nav/_components/download-queue-item/download-queue-item.component.ts
@@ -29,9 +29,11 @@ export class DownloadQueueItemComponent {
   readonly imageUrl = computed(() => {
     const item = this.item();
 
-    return item.entityType === 'volume'
-      ? this.imageService.getVolumeCoverImage(item.entityId)
-      : this.imageService.getChapterCoverImage(item.entityId)
+    switch (item.entityType) {
+      case 'volume': return this.imageService.getVolumeCoverImage(item.entityId);
+      case 'chapter': return this.imageService.getChapterCoverImage(item.entityId);
+      case 'readinglist-item': return this.imageService.getChapterCoverImage(item.chapterId!);
+    }
   });
 
   readonly statusBadgeColor = computed<TagBadgeColor>(() => {

--- a/UI/Web/src/app/nav/_components/events-widget/events-widget.component.html
+++ b/UI/Web/src/app/nav/_components/events-widget/events-widget.component.html
@@ -8,13 +8,12 @@
           [autoClose]="'outside'">
 
     @if (readingSessionCount > 1) {
-      <span class="me-2" [ngClass]="{'colored': activeEvents() > 0 || updateAvailable() || readingSessionCount > 0}">
+      <span class="me-2" [class.colored]="activeEvents() > 0 || updateAvailable() || readingSessionCount > 0">
         {{readingSessionCount}}
       </span>
     }
 
-    <i aria-hidden="true" class="fa fa-wave-square nav"
-       [ngClass]="{'colored': activeEvents() > 0 || updateAvailable()}"></i>
+    <i aria-hidden="true" class="fa fa-wave-square nav" [class.colored]="activeEvents() > 0 || updateAvailable()"></i>
 
     @if (errors().length > 0) {
       <i aria-hidden="true" class="fa fa-circle-exclamation nav widget-button--indicator error"></i>
@@ -22,6 +21,8 @@
       <i aria-hidden="true" class="fa fa-circle-info nav widget-button--indicator info"></i>
     } @else if (updateAvailable()) {
       <i aria-hidden="true" class="fa fa-circle-arrow-up nav widget-button--indicator update"></i>
+    } @else if (activeEvents() > 0) {
+      <div class="nav widget-button--indicator spinner-border spinner-border-sm"></div>
     }
   </button>
 

--- a/UI/Web/src/app/nav/_components/events-widget/events-widget.component.ts
+++ b/UI/Web/src/app/nav/_components/events-widget/events-widget.component.ts
@@ -11,7 +11,7 @@ import {User} from 'src/app/_models/user/user';
 import {AccountService} from 'src/app/_services/account.service';
 import {EVENTS, Message, MessageHubService} from 'src/app/_services/message-hub.service';
 import {takeUntilDestroyed} from "@angular/core/rxjs-interop";
-import {NgClass, NgStyle} from '@angular/common';
+import {NgStyle} from '@angular/common';
 import {TranslocoDirective} from "@jsverse/transloco";
 import {RouterLink} from "@angular/router";
 import {ReadingSessionUpdateEvent} from "../../../_models/events/reading-session-close-event";
@@ -22,7 +22,7 @@ import {VersionService} from "../../../_services/version.service";
   templateUrl: './events-widget.component.html',
   styleUrls: ['./events-widget.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [NgClass, NgbPopover, NgStyle, TranslocoDirective, RouterLink]
+  imports: [NgbPopover, NgStyle, TranslocoDirective, RouterLink]
 })
 export class EventsWidgetComponent implements OnInit {
   public readonly downloadService = inject(DownloadService);

--- a/UI/Web/src/app/person-detail/person-detail.component.html
+++ b/UI/Web/src/app/person-detail/person-detail.component.html
@@ -111,7 +111,7 @@
     </div>
 
     <!-- External Series including Author -->
-    @if (licenseService.hasValidLicense$ | async) {
+    @if (licenseService.hasValidLicense()) {
       <div class="row mt-2">
 
       </div>

--- a/UI/Web/src/app/person-detail/person-detail.component.ts
+++ b/UI/Web/src/app/person-detail/person-detail.component.ts
@@ -25,7 +25,6 @@ import {ActionFactoryService} from "../_services/action-factory.service";
 import {translate, TranslocoDirective} from "@jsverse/transloco";
 import {ChapterCardComponent} from "../cards/chapter-card/chapter-card.component";
 import {ThemeService} from "../_services/theme.service";
-import {ToastrService} from "ngx-toastr";
 import {LicenseService} from "../_services/license.service";
 import {SafeUrlPipe} from "../_pipes/safe-url.pipe";
 import {EVENTS, MessageHubService} from "../_services/message-hub.service";
@@ -74,7 +73,6 @@ export class PersonDetailComponent {
   protected readonly accountService = inject(AccountService);
   protected readonly licenseService = inject(LicenseService);
   private readonly themeService = inject(ThemeService);
-  private readonly toastr = inject(ToastrService);
   private readonly messageHubService = inject(MessageHubService)
   private readonly metadataService = inject(MetadataService)
 
@@ -120,9 +118,7 @@ export class PersonDetailComponent {
     }
 
     // Fetch series known for this person
-    this.personService.getSeriesMostKnownFor(person.id).pipe(
-      takeUntilDestroyed(this.destroyRef)
-    ).subscribe(series => this.works.set(series));
+    this.personService.getSeriesMostKnownFor(person.id).subscribe(series => this.works.set(series));
   }
 
   createFilter(roles: PersonRole[]) {

--- a/UI/Web/src/app/profile/_components/profile/profile.component.html
+++ b/UI/Web/src/app/profile/_components/profile/profile.component.html
@@ -22,7 +22,7 @@
                 </app-loading>
               </span>
 
-              @if (licenseService.hasValidLicenseSignal()) {
+              @if (licenseService.hasValidLicense()) {
                 <span class="badge kplus-badge">{{t('k+-badge')}}</span>
               }
             </div>

--- a/UI/Web/src/app/reading-list/_components/reading-lists/reading-lists.component.ts
+++ b/UI/Web/src/app/reading-list/_components/reading-lists/reading-lists.component.ts
@@ -9,7 +9,6 @@ import {
   TemplateRef,
   viewChild
 } from '@angular/core';
-import {ToastrService} from 'ngx-toastr';
 import {JumpKey} from 'src/app/_models/jumpbar/jump-key';
 import {PaginatedResult, Pagination} from 'src/app/_models/pagination';
 import {ReadingList} from 'src/app/_models/reading-list';
@@ -47,7 +46,6 @@ import {PromotedIconComponent} from "../../../shared/_components/promoted-icon/p
 export class ReadingListsComponent implements OnInit {
   private readingListService = inject(ReadingListService);
   private readonly accountService = inject(AccountService);
-  private readonly toastr = inject(ToastrService);
   private readonly jumpbarService = inject(JumpbarService);
   private readonly cdRef = inject(ChangeDetectorRef);
   private readonly cardConfigFactory = inject(CardConfigFactory);

--- a/UI/Web/src/app/series-detail/_components/series-detail/series-detail.component.ts
+++ b/UI/Web/src/app/series-detail/_components/series-detail/series-detail.component.ts
@@ -248,7 +248,7 @@ class SeriesDetailComponent implements OnInit, AfterViewInit {
 
   libraryAllowsScrobbling  = signal<boolean>(false);
   isScrobbling = signal<boolean>(true);
-  showScrobbleControls = computed(() => this.licenseService.hasValidLicenseSignal() && this.libraryAllowsScrobbling());
+  showScrobbleControls = computed(() => this.licenseService.hasValidLicense() && this.libraryAllowsScrobbling());
 
   currentlyReadingChapter = signal<Chapter | null>(null);
   continueReadingTitle = computed(() => {
@@ -324,7 +324,7 @@ class SeriesDetailComponent implements OnInit, AfterViewInit {
   unreadCount = signal(0);
   totalCount = signal(0);
   seriesActions = computed(() => {
-    const hasLicense = this.licenseService.hasValidLicenseSignal();
+    const hasLicense = this.licenseService.hasValidLicense();
     let actions = this.actionFactoryService.getSeriesActions()
       .filter(action => action.action !== Action.Edit);
     if (!hasLicense) {
@@ -409,7 +409,7 @@ class SeriesDetailComponent implements OnInit, AfterViewInit {
   });
 
   trackStoryLineIdentity = (index: number, item: StoryLineItem) => item.isChapter ? `${item.chapter!.data.id}_ch_storyline` : `${item.volume!.data.id}_vol_storyline`;
-  
+
   /**
    * Related Series. Sorted by backend
    */

--- a/UI/Web/src/app/series-detail/_components/series-detail/series-detail.component.ts
+++ b/UI/Web/src/app/series-detail/_components/series-detail/series-detail.component.ts
@@ -239,7 +239,6 @@ class SeriesDetailComponent implements OnInit, AfterViewInit {
   });
 
   activeTabId = TabID.Storyline;
-  downloadInProgress: boolean = false;
   mobileSeriesImgBackground = this.themeService.getCssVariable('--mobile-series-img-background');
 
   isLoading = signal<boolean>(true);
@@ -561,14 +560,9 @@ class SeriesDetailComponent implements OnInit, AfterViewInit {
         this.router.navigate(['library', this.libraryId()]);
         break;
       case 'reload':
-        this.loadSeries(this.seriesId(), true);
+        this.loadPageSource.next(true);
         break;
       case 'none':
-        if (result.action === Action.Download) {
-          if (this.downloadInProgress) return;
-          this.downloadInProgress = true;
-          this.cdRef.markForCheck();
-        }
         break;
     }
   }
@@ -896,10 +890,12 @@ class SeriesDetailComponent implements OnInit, AfterViewInit {
     patchEntitySignal(this.chapters, c);
     patchEntitySignal(this.specials, c);
     patchEntitySignal(this.storylineChapters, c);
+    this.setContinuePoint();
   }
 
   updateVolume(c: Volume) {
     patchEntitySignal(this.volumes, c);
+    this.setContinuePoint();
   }
 
   protected readonly LibraryType = LibraryType;

--- a/UI/Web/src/app/series-detail/_components/series-detail/series-detail.component.ts
+++ b/UI/Web/src/app/series-detail/_components/series-detail/series-detail.component.ts
@@ -752,10 +752,11 @@ class SeriesDetailComponent implements OnInit, AfterViewInit {
     } else {
       if (libType == LibraryType.Comic || libType == LibraryType.ComicVine) {
         if (this.chapters().length === 0) {
-          if (this.specials().length > 0) {
-            this.activeTabId = TabID.Specials;
-          } else {
+
+          if (this.volumes().length > 0) {
             this.activeTabId = TabID.Volumes;
+          } else if (this.specials().length > 0) {
+            this.activeTabId = TabID.Specials;
           }
         } else {
           this.activeTabId = TabID.Chapters;

--- a/UI/Web/src/app/settings/_components/settings/settings.component.html
+++ b/UI/Web/src/app/settings/_components/settings/settings.component.html
@@ -163,7 +163,7 @@
           }
 
           @case (SettingsTabId.MatchedMetadata) {
-            @if (accountService.hasAdminRole()) {
+            @if (accountService.hasAdminRole() && licenseService.hasValidLicense()) {
               @defer (prefetch on idle) {
                 <div class="scale col-md-12">
                   <app-manage-matched-metadata />

--- a/UI/Web/src/app/settings/_components/settings/settings.component.ts
+++ b/UI/Web/src/app/settings/_components/settings/settings.component.ts
@@ -115,11 +115,11 @@ export class SettingsComponent {
   private readonly cdRef = inject(ChangeDetectorRef);
   private readonly destroyRef = inject(DestroyRef);
   private readonly router = inject(Router);
-  private readonly licenseService = inject(LicenseService);
+  protected readonly licenseService = inject(LicenseService);
   protected readonly accountService = inject(AccountService);
 
   fragment: SettingsTabId = SettingsTabId.Account;
-  hasActiveLicense = computed(() => this.licenseService.hasValidLicenseSignal());
+  hasActiveLicense = computed(() => this.licenseService.hasValidLicense());
 
   constructor() {
     this.route.fragment.pipe(tap(frag => {

--- a/UI/Web/src/app/shared/_models/download-queue-item.ts
+++ b/UI/Web/src/app/shared/_models/download-queue-item.ts
@@ -39,4 +39,6 @@ export interface DownloadQueueItem {
   completedAt?: string | number;
   /** The reading list id if invoked from a reading list */
   readingListId?: number;
+  /** The collection id if invoked from a collection */
+  collectionId?: number;
 }

--- a/UI/Web/src/app/shared/_models/download-queue-item.ts
+++ b/UI/Web/src/app/shared/_models/download-queue-item.ts
@@ -1,12 +1,13 @@
 import {Volume} from "../../_models/volume";
 import {Chapter} from "../../_models/chapter";
+import {ReadingListItem} from "../../_models/reading-list";
 
 export type DownloadQueueStatus = 'queued' | 'preparing' | 'downloading' | 'completed' | 'failed' | 'cancelled';
 
 export interface DownloadQueueItem {
   id: number;
   /** Atomic unit of download, series/reading-list/collection always decompose to these */
-  entityType: 'volume' | 'chapter';
+  entityType: 'volume' | 'chapter' | 'readinglist-item';
   entityId: number;
   libraryId: number;
   seriesId: number;
@@ -25,7 +26,9 @@ export interface DownloadQueueItem {
   /** UTC ISO string when the item was queued */
   queuedAt: string | number;
   /** Present only for in-memory items; stripped before IndexedDB persistence and absent on restored items. */
-  entity?: Volume | Chapter;
+  entity?: Volume | Chapter | ReadingListItem;
+  /** For readinglist-item: the chapter ID to use for the download endpoint. Persisted to IDB. */
+  chapterId?: number;
   /** Predicted backend filename used to match SignalR progress events */
   downloadName: string;
   /** Smoothed bytes/sec, in-memory only */
@@ -34,4 +37,6 @@ export interface DownloadQueueItem {
   etaSeconds?: number;
   /** UTC ISO string when completed or failed */
   completedAt?: string | number;
+  /** The reading list id if invoked from a reading list */
+  readingListId?: number;
 }

--- a/UI/Web/src/app/shared/_services/download.service.ts
+++ b/UI/Web/src/app/shared/_services/download.service.ts
@@ -25,6 +25,10 @@ import {DownloadStorageService} from './download-storage.service';
 import {normalizeTimestamp} from "../../../libs/download-timestamp";
 import {ReadingList, ReadingListItem} from "../../_models/reading-list";
 import {ReadingListService} from "../../_services/reading-list.service";
+import {UserCollection} from "../../_models/collection-tag";
+import {FilterField} from "../../_models/metadata/v2/filter-field";
+import {FilterComparison} from "../../_models/metadata/v2/filter-comparison";
+import {FilterCombination} from "../../_models/metadata/v2/filter-combination";
 
 export const DEBOUNCE_TIME = 100;
 
@@ -33,11 +37,11 @@ const bytesPipe = new BytesPipe();
 /**
  * Valid entity types for downloading
  */
-export type DownloadEntityType = 'volume' | 'chapter' | 'series' | 'bookmark' | 'logs' | 'readinglist' | 'readinglist-item';
+export type DownloadEntityType = 'volume' | 'chapter' | 'series' | 'bookmark' | 'logs' | 'readinglist' | 'readinglist-item' | 'collection';
 /**
  * Valid entities for downloading. Undefined exclusively for logs.
  */
-export type DownloadEntity = Series | Volume | Chapter | PageBookmark[] | ReadingList | ReadingListItem | undefined;
+export type DownloadEntity = Series | Volume | Chapter | PageBookmark[] | ReadingList | ReadingListItem | UserCollection | undefined;
 
 @Injectable({
   providedIn: 'root'
@@ -70,7 +74,7 @@ export class DownloadService {
   private IOS_SIZE_WARNING = 209_715_200;
 
   /** Set to true to enable verbose download queue logging in the browser console. */
-  private readonly debug = false;
+  private readonly debug = true;
 
   private debugLog(...args: any[]) {
     if (this.debug) console.log('[DownloadService]', ...args);
@@ -184,7 +188,7 @@ export class DownloadService {
    */
   restoreQueue() {
     this.storage.open().then(items => {
-      const startOfDayIso = DateTime.utc().startOf('day').toISO()!;
+      const startOfDayIso = this.getStartOfDay();
 
       // Mark interrupted items as failed
       const processed = items.map(i =>
@@ -267,6 +271,9 @@ export class DownloadService {
       case 'readinglist':
         this.downloadReadingList(entity as ReadingList);
         break;
+      case 'collection':
+        this.downloadCollection(entity as UserCollection);
+        break;
     }
   }
 
@@ -307,9 +314,12 @@ export class DownloadService {
   }
 
   clearCompleted() {
-    const ids = this.completedToday().map(i => i.id);
+    const items = this.completedToday();
     this.completedToday.set([]);
-    ids.forEach(id => this.storage.delete(id));
+    for (const item of items) {
+      this._completedEntityIds.delete(this._indexKey(item.entityType, item.entityId));
+      this.storage.delete(item.id);
+    }
   }
 
   clearCompletedByIds(ids: number[]) {
@@ -326,21 +336,30 @@ export class DownloadService {
   loadOlderCompleted() {
     if (this._olderLoaded) return;
     this._olderLoaded = true;
-    const startOfDayIso = DateTime.utc().startOf('day').toISO()!;
+    const startOfDayIso = this.getStartOfDay();
     this.storage.getCompletedBefore(startOfDayIso).then(items => {
       this._olderItems.set(items.sort((a, b) => normalizeTimestamp(b.completedAt).localeCompare(normalizeTimestamp(a.completedAt))));
     });
   }
 
   clearOlderCompleted() {
-    const items = this._olderItems();
+    // Clear in-memory state (this may not be loaded as it's lazy-loaded)
+    const loadedItems = this._olderItems();
     this._olderItems.set([]);
     this._olderCompletedCount.set(0);
     this._olderLoaded = false;
-    for (const item of items) {
-      this.storage.delete(item.id);
+    for (const item of loadedItems) {
       this._completedEntityIds.delete(this._indexKey(item.entityType, item.entityId));
     }
+
+    // Delete from storage directly in case _olderItems wasn't loaded yet
+    const startOfDayIso = this.getStartOfDay();
+    this.storage.getCompletedBefore(startOfDayIso).then(items => {
+      for (const item of items) {
+        this.storage.delete(item.id);
+        this._completedEntityIds.delete(this._indexKey(item.entityType, item.entityId));
+      }
+    });
   }
 
   retryDownload(itemId: number) {
@@ -424,6 +443,17 @@ export class DownloadService {
 
       if (includeCompleted) {
         items.push(...ct.filter(i => i.readingListId === rlId));
+      }
+      return this._aggregateSeriesItems(items);
+    }
+
+    if (this.utilityService.isUserCollection(entity)) {
+      const cId = (entity as UserCollection).id;
+
+      const items = aq.filter(i => ['queued', 'preparing', 'downloading'].includes(i.status) && i.collectionId === cId);
+
+      if (includeCompleted) {
+        items.push(...ct.filter(i => i.collectionId === cId));
       }
       return this._aggregateSeriesItems(items);
     }
@@ -535,6 +565,39 @@ export class DownloadService {
     }
   }
 
+  private downloadCollection(collection: UserCollection) {
+    this.debugLog('downloadCollection()', collection.title);
+
+    const userPrefs = this.accountService.userPreferences();
+
+    // A collection is just a set of series, so we can just call down
+    this.seriesService.getAllSeriesV2(0, 0, {
+      statements: [{field: FilterField.CollectionTags, value: collection.id + '', comparison: FilterComparison.Equal}],
+      combination: FilterCombination.And,
+      limitTo: 0
+    }).subscribe(collectionSeries => {
+
+
+      if (userPrefs?.promptForDownloadSize && collectionSeries.result.length > 0) {
+        const seriesIds = collectionSeries.result.map(s => s.id);
+        this.getBulkEntityDownloadSize('series', seriesIds).pipe(
+          map(r => Object.values(r).reduce((acc, curr) => acc + curr, 0)),
+          switchMap(async size => this.confirmSize(size, 'series')),
+          filter(confirmed => confirmed),
+          takeUntilDestroyed(this.destroyRef)
+        ).subscribe(() => {
+
+          collectionSeries.result.forEach(s => {
+            this.downloadSeries(s, collection.id);
+          });
+        });
+      } else {
+        collectionSeries.result.forEach(s => {
+          this.downloadSeries(s, collection.id);
+        });
+      }
+    });
+  }
   private downloadReadingList(readingList: ReadingList) {
     this.debugLog('downloadReadingList()', readingList.title);
 
@@ -549,7 +612,7 @@ export class DownloadService {
     });
   }
 
-  private downloadSeries(series: Series) {
+  private downloadSeries(series: Series, collectionId = 0) {
     this.debugLog('downloadSeries()', series.name);
     this.seriesService.getSeriesDetail(series.id).pipe(
       takeUntilDestroyed(this.destroyRef)
@@ -568,14 +631,14 @@ export class DownloadService {
           switchMap(async size => this.confirmSize(size, 'series')),
           filter(confirmed => confirmed),
           takeUntilDestroyed(this.destroyRef)
-        ).subscribe(() => this.enqueueItems(items, series.name, series.libraryId, series.id));
+        ).subscribe(() => this.enqueueItems(items, series.name, series.libraryId, series.id, 0, collectionId));
       } else {
-        this.enqueueItems(items, series.name, series.libraryId, series.id);
+        this.enqueueItems(items, series.name, series.libraryId, series.id, 0, collectionId);
       }
     });
   }
 
-  private enqueueItems(items: Array<{ entity: Volume | Chapter | ReadingListItem; entityType: 'volume' | 'chapter' | 'readinglist-item' }>, seriesName: string, libraryId: number, seriesId = 0, readingListId = 0) {
+  private enqueueItems(items: Array<{ entity: Volume | Chapter | ReadingListItem; entityType: 'volume' | 'chapter' | 'readinglist-item' }>, seriesName: string, libraryId: number, seriesId = 0, readingListId = 0, collectionId = 0) {
     this.debugLog(`enqueueItems() adding ${items.length} items for series "${seriesName}"`);
 
     const volumeItems = items.filter(i => i.entityType === 'volume');
@@ -598,20 +661,26 @@ export class DownloadService {
     ).subscribe(async ([volMap, chMap, rlMap]) => {
       for (const item of items) {
         let size: number;
-        if (item.entityType === 'volume') {
-          size = volMap[item.entity.id] ?? 0;
-        } else if (item.entityType === 'readinglist-item') {
-          size = rlMap[(item.entity as ReadingListItem).chapterId] ?? 0;
-        } else {
-          size = chMap[item.entity.id] ?? 0;
+
+        switch (item.entityType) {
+          case "volume":
+            size = volMap[item.entity.id] ?? 0;
+            break;
+          case "chapter":
+            size = chMap[item.entity.id] ?? 0;
+            break;
+          case "readinglist-item":
+            size = rlMap[(item.entity as ReadingListItem).chapterId] ?? 0;
+            break;
         }
-        await this.addToQueue(item.entity, item.entityType, seriesName, libraryId, size, seriesId, readingListId, true);
+
+        await this.addToQueue(item.entity, item.entityType, seriesName, libraryId, size, seriesId, readingListId, collectionId, true);
       }
       this.processQueue();
     });
   }
 
-  private enqueueSingle(entity: Volume | Chapter, entityType: 'volume' | 'chapter', seriesName: string, libraryId: number, seriesId = 0, readingListId = 0) {
+  private enqueueSingle(entity: Volume | Chapter, entityType: 'volume' | 'chapter', seriesName: string, libraryId: number, seriesId = 0, readingListId = 0, collectionId = 0) {
     const user = this.accountService.currentUser();
     const sizeCall$ = entityType === 'volume'
       ? this.downloadBulkVolumeSizes([entity.id]).pipe(map(m => m[entity.id] ?? 0))
@@ -627,7 +696,7 @@ export class DownloadService {
       filter(result => result.confirmed),
       takeUntilDestroyed(this.destroyRef)
     ).subscribe(async ({ size }) => {
-      await this.addToQueue(entity, entityType, seriesName, libraryId, size, seriesId, readingListId);
+      await this.addToQueue(entity, entityType, seriesName, libraryId, size, seriesId, readingListId, collectionId);
       this.processQueue();
     });
   }
@@ -656,7 +725,7 @@ export class DownloadService {
     }
   }
 
-  private async addToQueue(entity: Volume | Chapter | ReadingListItem, entityType: 'volume' | 'chapter' | 'readinglist-item', seriesName: string, libraryId: number, estimatedSize = 0, seriesId = 0, readingListId = 0, skipRedownloadPrompt = false) {
+  private async addToQueue(entity: Volume | Chapter | ReadingListItem, entityType: 'volume' | 'chapter' | 'readinglist-item', seriesName: string, libraryId: number, estimatedSize = 0, seriesId = 0, readingListId = 0, collectionId = 0, skipRedownloadPrompt = false) {
     seriesName = await this.resolveSeriesName(seriesName, seriesId);
     const entityId = entity.id;
     const key = this._indexKey(entityType, entityId);
@@ -736,6 +805,7 @@ export class DownloadService {
       entity,
       downloadName,
       readingListId,
+      collectionId,
       ...(chapterId !== undefined ? { chapterId } : {}),
     };
 
@@ -1009,5 +1079,9 @@ export class DownloadService {
       await this.confirmService.confirm(translate('toasts.confirm-download-size',
         { entityType: translate('entity-type.' + entityType), size: bytesPipe.transform(size) })
         + (!showIosWarning ? '' : '<br/><br/>' + translate('toasts.confirm-download-size-ios'))));
+  }
+
+  private getStartOfDay() {
+    return DateTime.utc().startOf('day').toISO()!;
   }
 }

--- a/UI/Web/src/app/shared/_services/download.service.ts
+++ b/UI/Web/src/app/shared/_services/download.service.ts
@@ -249,7 +249,7 @@ export class DownloadService {
         this.downloadSeries(entity as Series);
         break;
       case 'volume':
-        this.enqueueSingle(entity as Volume, 'volume', '', libraryId, seriesId);
+        this.downloadVolume(entity as Volume, libraryId, seriesId);
         break;
       case 'chapter':
         this.enqueueSingle(entity as Chapter, 'chapter', '', libraryId, seriesId);
@@ -487,6 +487,41 @@ export class DownloadService {
 
   private downloadBulkSeriesSize(seriesIds: number[]) {
     return this.httpClient.post<Record<number, number>>(this.baseUrl + 'download/bulk-series-size', seriesIds);
+  }
+
+  private downloadVolumeSize(volumeId: number) {
+    return this.httpClient.get<number>(this.baseUrl + 'download/volume-size?volumeId=' + volumeId);
+  }
+
+  private downloadChapterSize(chapterId: number) {
+    return this.httpClient.get<number>(this.baseUrl + 'download/chapter-size?chapterId=' + chapterId);
+  }
+
+  private downloadVolume(volume: Volume, libraryId: number, seriesId: number) {
+    this.debugLog('downloadVolume()', volume.minNumber);
+
+    // Volumes can be either a bunch of chapters or just 1
+    if (volume.chapters.length === 1) {
+      this.enqueueSingle(volume, 'volume', '', libraryId, seriesId);
+      return;
+    }
+    this.debugLog(`downloadVolume() decomposed into ${volume.chapters.length} items`);
+
+    const items = volume.chapters.map(c => ({ entity: c as Chapter, entityType: 'chapter' as const }));
+
+    const userPrefs = this.accountService.userPreferences();
+    if (userPrefs?.promptForDownloadSize && items.length > 0) {
+      // Single size call for the whole series, single confirm dialog
+      this.downloadVolumeSize(volume.id).pipe(
+        switchMap(async size => this.confirmSize(size, 'volume')),
+        filter(confirmed => confirmed),
+        takeUntilDestroyed(this.destroyRef)
+      ).subscribe(() => this.enqueueItems(items, '', libraryId, seriesId));
+    } else {
+      this.enqueueItems(items, '', libraryId, seriesId);
+    }
+
+
   }
 
   private downloadSeries(series: Series) {

--- a/UI/Web/src/app/shared/_services/download.service.ts
+++ b/UI/Web/src/app/shared/_services/download.service.ts
@@ -33,11 +33,11 @@ const bytesPipe = new BytesPipe();
 /**
  * Valid entity types for downloading
  */
-export type DownloadEntityType = 'volume' | 'chapter' | 'series' | 'bookmark' | 'logs' | 'readinglist';
+export type DownloadEntityType = 'volume' | 'chapter' | 'series' | 'bookmark' | 'logs' | 'readinglist' | 'readinglist-item';
 /**
  * Valid entities for downloading. Undefined exclusively for logs.
  */
-export type DownloadEntity = Series | Volume | Chapter | PageBookmark[] | ReadingList | undefined;
+export type DownloadEntity = Series | Volume | Chapter | PageBookmark[] | ReadingList | ReadingListItem | undefined;
 
 @Injectable({
   providedIn: 'root'
@@ -236,6 +236,7 @@ export class DownloadService {
       case 'chapter':  return (downloadEntity as Chapter).minNumber + '';
       case 'bookmark': return '';
       case 'logs':     return '';
+      case 'readinglist-item': return (downloadEntity as ReadingListItem).title;
     }
     return '';
   }
@@ -396,7 +397,9 @@ export class DownloadService {
    * Returns the active queue item for the given entity, or null if none.
    * Use this for card download indicators.
    */
-  getItemForEntity(entity: Series | Volume | Chapter | PageBookmark[], includeCompleted = false): DownloadQueueItem | null {
+  getItemForEntity(entity: DownloadEntity, includeCompleted = false): DownloadQueueItem | null {
+    if (entity === undefined) return null;
+
     // Read both signals up front so Angular computed/effect tracks them as dependencies,
     // even for code paths that use the plain Map/Set for O(1) lookup.
     const aq = this.activeQueue();
@@ -409,6 +412,18 @@ export class DownloadService {
 
       if (includeCompleted) {
         items.push(...ct.filter(i => i.seriesId === sId));
+      }
+      return this._aggregateSeriesItems(items);
+    }
+
+    // ReadingList: aggregate across all active + completed items together so progress doesn't drop
+    if (this.utilityService.isReadingList(entity)) {
+      const rlId = (entity as ReadingList).id;
+
+      const items = aq.filter(i => ['queued', 'preparing', 'downloading'].includes(i.status) && i.readingListId === rlId);
+
+      if (includeCompleted) {
+        items.push(...ct.filter(i => i.readingListId === rlId));
       }
       return this._aggregateSeriesItems(items);
     }
@@ -529,9 +544,8 @@ export class DownloadService {
       this.readingListService.getListItems(readingList.id);
 
     items$.subscribe((items: ReadingListItem[]) => {
-      // Now we have items, but we actually either need the chapter OR we need a backend ability to download an item (proxy to chapter)
-      const chapterItems = items.map(item => ({ entity: {id: item.chapterId, minNumber: parseFloat(item.chapterNumber) || 0} as Chapter, entityType: 'chapter' as const }))
-      this.enqueueItems(chapterItems, readingList.title, 0, 0);
+      const rliItems = items.map(item => ({ entity: item as ReadingListItem, entityType: 'readinglist-item' as const }));
+      this.enqueueItems(rliItems, readingList.title, 0, 0, readingList.id);
     });
   }
 
@@ -561,11 +575,12 @@ export class DownloadService {
     });
   }
 
-  private enqueueItems(items: Array<{ entity: Volume | Chapter; entityType: 'volume' | 'chapter' }>, seriesName: string, libraryId: number, seriesId = 0) {
+  private enqueueItems(items: Array<{ entity: Volume | Chapter | ReadingListItem; entityType: 'volume' | 'chapter' | 'readinglist-item' }>, seriesName: string, libraryId: number, seriesId = 0, readingListId = 0) {
     this.debugLog(`enqueueItems() adding ${items.length} items for series "${seriesName}"`);
 
     const volumeItems = items.filter(i => i.entityType === 'volume');
     const chapterItems = items.filter(i => i.entityType === 'chapter');
+    const rliItems = items.filter(i => i.entityType === 'readinglist-item');
 
     const volSizes$ = volumeItems.length > 0
       ? this.getBulkEntityDownloadSize('volume', volumeItems.map(i => i.entity.id))
@@ -573,21 +588,30 @@ export class DownloadService {
     const chSizes$ = chapterItems.length > 0
       ? this.getBulkEntityDownloadSize('chapter', chapterItems.map(i => i.entity.id))
       : of({} as Record<number, number>);
+    // ReadingListItems download via the chapter endpoint, so fetch chapter sizes using chapterId
+    const rliSizes$ = rliItems.length > 0
+      ? this.getBulkEntityDownloadSize('chapter', rliItems.map(i => (i.entity as ReadingListItem).chapterId))
+      : of({} as Record<number, number>);
 
-    forkJoin([volSizes$, chSizes$]).pipe(
+    forkJoin([volSizes$, chSizes$, rliSizes$]).pipe(
       takeUntilDestroyed(this.destroyRef)
-    ).subscribe(async ([volMap, chMap]) => {
+    ).subscribe(async ([volMap, chMap, rlMap]) => {
       for (const item of items) {
-        const size = item.entityType === 'volume'
-          ? (volMap[item.entity.id] ?? 0)
-          : (chMap[item.entity.id] ?? 0);
-        await this.addToQueue(item.entity, item.entityType, seriesName, libraryId, size, seriesId, true);
+        let size: number;
+        if (item.entityType === 'volume') {
+          size = volMap[item.entity.id] ?? 0;
+        } else if (item.entityType === 'readinglist-item') {
+          size = rlMap[(item.entity as ReadingListItem).chapterId] ?? 0;
+        } else {
+          size = chMap[item.entity.id] ?? 0;
+        }
+        await this.addToQueue(item.entity, item.entityType, seriesName, libraryId, size, seriesId, readingListId, true);
       }
       this.processQueue();
     });
   }
 
-  private enqueueSingle(entity: Volume | Chapter, entityType: 'volume' | 'chapter', seriesName: string, libraryId: number, seriesId = 0) {
+  private enqueueSingle(entity: Volume | Chapter, entityType: 'volume' | 'chapter', seriesName: string, libraryId: number, seriesId = 0, readingListId = 0) {
     const user = this.accountService.currentUser();
     const sizeCall$ = entityType === 'volume'
       ? this.downloadBulkVolumeSizes([entity.id]).pipe(map(m => m[entity.id] ?? 0))
@@ -603,7 +627,7 @@ export class DownloadService {
       filter(result => result.confirmed),
       takeUntilDestroyed(this.destroyRef)
     ).subscribe(async ({ size }) => {
-      await this.addToQueue(entity, entityType, seriesName, libraryId, size, seriesId);
+      await this.addToQueue(entity, entityType, seriesName, libraryId, size, seriesId, readingListId);
       this.processQueue();
     });
   }
@@ -632,7 +656,7 @@ export class DownloadService {
     }
   }
 
-  private async addToQueue(entity: Volume | Chapter, entityType: 'volume' | 'chapter', seriesName: string, libraryId: number, estimatedSize = 0, seriesId = 0, skipRedownloadPrompt = false) {
+  private async addToQueue(entity: Volume | Chapter | ReadingListItem, entityType: 'volume' | 'chapter' | 'readinglist-item', seriesName: string, libraryId: number, estimatedSize = 0, seriesId = 0, readingListId = 0, skipRedownloadPrompt = false) {
     seriesName = await this.resolveSeriesName(seriesName, seriesId);
     const entityId = entity.id;
     const key = this._indexKey(entityType, entityId);
@@ -673,11 +697,19 @@ export class DownloadService {
 
     let subLabel: string;
     let downloadName: string;
+    let chapterId: number | undefined;
 
     if (entityType === 'volume') {
       const vol = entity as Volume;
       subLabel = vol.minNumber + '';
       downloadName = seriesName ? `${seriesName} - Volume ${vol.name}` : `Volume ${vol.name}`;
+    } else if (entityType === 'readinglist-item') {
+      const rli = entity as ReadingListItem;
+      subLabel = rli.title;
+      downloadName = seriesName ? `${seriesName} - ${rli.title}` : rli.title;
+      chapterId = rli.chapterId;
+      libraryId = rli.libraryId;
+      seriesId = rli.seriesId;
     } else {
       const ch = entity as Chapter;
       subLabel = ch.minNumber + '';
@@ -703,6 +735,8 @@ export class DownloadService {
       queuedAt: DateTime.utc().toISO()!,
       entity,
       downloadName,
+      readingListId,
+      ...(chapterId !== undefined ? { chapterId } : {}),
     };
 
     this.activeQueue.update(q => [...q, item]);
@@ -744,9 +778,12 @@ export class DownloadService {
       return;
     }
 
-    const idKey = item.entityType === 'volume' ? 'volumeId' : 'chapterId';
-    const url = `${this.baseUrl}download/${item.entityType}` +
-                `?${idKey}=${item.entityId}` +
+    // readinglistitem downloads via the chapter endpoint using chapterId
+    const endpoint = item.entityType === 'readinglist-item' ? 'chapter' : item.entityType;
+    const idKey = endpoint === 'volume' ? 'volumeId' : 'chapterId';
+    const idValue = item.entityType === 'readinglist-item' ? item.chapterId! : item.entityId;
+    const url = `${this.baseUrl}download/${endpoint}` +
+                `?${idKey}=${idValue}` +
                 `&correlationId=${item.id}` +
                 `&_t=${Date.now()}` +
                 `&apiKey=${encodeURIComponent(apiKey)}`;

--- a/UI/Web/src/app/shared/_services/download.service.ts
+++ b/UI/Web/src/app/shared/_services/download.service.ts
@@ -492,10 +492,19 @@ export class DownloadService {
       ?? items.find(i => i.status === 'queued')
       ?? items[0];
 
+    // When between sequential downloads (some completed, rest queued), use 'preparing'
+    // instead of 'queued' to prevent the indicator from flashing between active/queued states
+    let aggregateStatus = representative.status;
+    if (allCompleted) {
+      aggregateStatus = 'completed';
+    } else if (representative.status === 'queued' && items.some(i => i.status === 'completed')) {
+      aggregateStatus = 'preparing';
+    }
+
     return {
       ...representative,
       progress: Math.round(totalProgress / items.length),
-      status: allCompleted ? 'completed' : representative.status,
+      status: aggregateStatus,
     };
   }
 

--- a/UI/Web/src/app/shared/_services/download.service.ts
+++ b/UI/Web/src/app/shared/_services/download.service.ts
@@ -5,7 +5,7 @@ import {environment} from 'src/environments/environment';
 import {ConfirmService} from '../confirm.service';
 import {Chapter} from 'src/app/_models/chapter';
 import {Volume} from 'src/app/_models/volume';
-import {asyncScheduler, filter, firstValueFrom, forkJoin, Observable, of, tap} from 'rxjs';
+import {asyncScheduler, filter, firstValueFrom, forkJoin, of, tap} from 'rxjs';
 import {download} from '../_models/download';
 import {PageBookmark} from 'src/app/_models/readers/page-bookmark';
 import {map, switchMap, throttleTime} from 'rxjs/operators';
@@ -23,6 +23,8 @@ import {SeriesService} from "../../_services/series.service";
 import {DownloadQueueItem, DownloadQueueStatus} from '../_models/download-queue-item';
 import {DownloadStorageService} from './download-storage.service';
 import {normalizeTimestamp} from "../../../libs/download-timestamp";
+import {ReadingList, ReadingListItem} from "../../_models/reading-list";
+import {ReadingListService} from "../../_services/reading-list.service";
 
 export const DEBOUNCE_TIME = 100;
 
@@ -31,11 +33,11 @@ const bytesPipe = new BytesPipe();
 /**
  * Valid entity types for downloading
  */
-export type DownloadEntityType = 'volume' | 'chapter' | 'series' | 'bookmark' | 'logs';
+export type DownloadEntityType = 'volume' | 'chapter' | 'series' | 'bookmark' | 'logs' | 'readinglist';
 /**
  * Valid entities for downloading. Undefined exclusively for logs.
  */
-export type DownloadEntity = Series | Volume | Chapter | PageBookmark[] | undefined;
+export type DownloadEntity = Series | Volume | Chapter | PageBookmark[] | ReadingList | undefined;
 
 @Injectable({
   providedIn: 'root'
@@ -49,6 +51,7 @@ export class DownloadService {
   private readonly utilityService = inject(UtilityService);
   private readonly messageHub = inject(MessageHubService);
   private readonly seriesService = inject(SeriesService);
+  private readonly readingListService = inject(ReadingListService);
   private readonly storage = inject(DownloadStorageService);
   private readonly translocoService = inject(TranslocoService);
   private readonly save = inject(SAVER);
@@ -259,6 +262,9 @@ export class DownloadService {
         break;
       case 'logs':
         this.downloadLogsBlob();
+        break;
+      case 'readinglist':
+        this.downloadReadingList(entity as ReadingList);
         break;
     }
   }
@@ -512,8 +518,21 @@ export class DownloadService {
     } else {
       this.enqueueItems(items, '', libraryId, seriesId);
     }
+  }
 
+  private downloadReadingList(readingList: ReadingList) {
+    this.debugLog('downloadReadingList()', readingList.title);
 
+    // We need to check if this instance has items or not
+    let items$ = readingList.hasOwnProperty('items') ?
+      of(readingList.items ?? []) :
+      this.readingListService.getListItems(readingList.id);
+
+    items$.subscribe((items: ReadingListItem[]) => {
+      // Now we have items, but we actually either need the chapter OR we need a backend ability to download an item (proxy to chapter)
+      const chapterItems = items.map(item => ({ entity: {id: item.chapterId, minNumber: parseFloat(item.chapterNumber) || 0} as Chapter, entityType: 'chapter' as const }))
+      this.enqueueItems(chapterItems, readingList.title, 0, 0);
+    });
   }
 
   private downloadSeries(series: Series) {
@@ -549,10 +568,10 @@ export class DownloadService {
     const chapterItems = items.filter(i => i.entityType === 'chapter');
 
     const volSizes$ = volumeItems.length > 0
-      ? this.downloadBulkVolumeSizes(volumeItems.map(i => i.entity.id))
+      ? this.getBulkEntityDownloadSize('volume', volumeItems.map(i => i.entity.id))
       : of({} as Record<number, number>);
     const chSizes$ = chapterItems.length > 0
-      ? this.downloadBulkChapterSizes(chapterItems.map(i => i.entity.id))
+      ? this.getBulkEntityDownloadSize('chapter', chapterItems.map(i => i.entity.id))
       : of({} as Record<number, number>);
 
     forkJoin([volSizes$, chSizes$]).pipe(

--- a/UI/Web/src/app/shared/_services/download.service.ts
+++ b/UI/Web/src/app/shared/_services/download.service.ts
@@ -449,17 +449,6 @@ export class DownloadService {
   }
 
   /**
-   * Returns an observable of the queue item for the given entity, or null if none.
-   * Emits on every queue change. Use this for card download indicators.
-   */
-  getEntityDownload$(entity: Series | Volume | Chapter | PageBookmark[]): Observable<DownloadQueueItem | null> {
-    if (!entity.hasOwnProperty('id')) return of(null);
-    return this.activeQueue$.pipe(
-      map(() => this.getItemForEntity(entity))
-    );
-  }
-
-  /**
    * Download the given data as a JSON file
    */
   downloadObjectAsJson(data: any, title: string) {
@@ -473,29 +462,32 @@ export class DownloadService {
     URL.revokeObjectURL(url);
   }
 
+  private getEntityDownloadSize(entityType: 'series' | 'volume' | 'chapter' | 'readinglist', id: number) {
+    return this.httpClient.get<number>(this.baseUrl + `download/${entityType}-size?${entityType}Id=${id}`);
+  }
+
+  private getBulkEntityDownloadSize(entityType: 'series' | 'volume' | 'chapter' | 'readinglist', ids: number[]) {
+    const data = {} as any;
+    data[entityType + 'Ids'] = ids;
+    return this.httpClient.post<Record<number, number>>(this.baseUrl + `download/bulk-${entityType}-size`, data);
+  }
+
   private downloadSeriesSize(seriesId: number) {
-    return this.httpClient.get<number>(this.baseUrl + 'download/series-size?seriesId=' + seriesId);
+    return this.getEntityDownloadSize('series', seriesId);
   }
 
   private downloadBulkVolumeSizes(volumeIds: number[]) {
-    return this.httpClient.post<Record<number, number>>(this.baseUrl + 'download/bulk-volume-size', volumeIds);
+    return this.getBulkEntityDownloadSize('volume', volumeIds);
   }
 
   private downloadBulkChapterSizes(chapterIds: number[]) {
-    return this.httpClient.post<Record<number, number>>(this.baseUrl + 'download/bulk-chapter-size', chapterIds);
-  }
-
-  private downloadBulkSeriesSize(seriesIds: number[]) {
-    return this.httpClient.post<Record<number, number>>(this.baseUrl + 'download/bulk-series-size', seriesIds);
+    return this.getBulkEntityDownloadSize('chapter', chapterIds);
   }
 
   private downloadVolumeSize(volumeId: number) {
-    return this.httpClient.get<number>(this.baseUrl + 'download/volume-size?volumeId=' + volumeId);
+    return this.getEntityDownloadSize('volume', volumeId);
   }
 
-  private downloadChapterSize(chapterId: number) {
-    return this.httpClient.get<number>(this.baseUrl + 'download/chapter-size?chapterId=' + chapterId);
-  }
 
   private downloadVolume(volume: Volume, libraryId: number, seriesId: number) {
     this.debugLog('downloadVolume()', volume.minNumber);
@@ -609,7 +601,7 @@ export class DownloadService {
     }
     try {
       const series = await firstValueFrom(this.seriesService.getSeries(seriesId));
-      // Evict oldest if at capacity
+      // Evict oldest, if at capacity
       if (this._seriesNameCache.size >= this.SERIES_NAME_CACHE_MAX) {
         const oldest = this._seriesNameCache.keys().next().value!;
         this._seriesNameCache.delete(oldest);

--- a/UI/Web/src/app/shared/_services/download.service.ts
+++ b/UI/Web/src/app/shared/_services/download.service.ts
@@ -634,7 +634,7 @@ export class DownloadService {
       this.debugLog(`downloadSeries() decomposed into ${items.length} items (${detail.volumes.length} vols, ${detail.chapters.length + detail.specials.length} chapters)`);
 
       const userPrefs = this.accountService.userPreferences();
-      if (skipSizePrompt || (userPrefs?.promptForDownloadSize && items.length > 0)) {
+      if (!skipSizePrompt && userPrefs?.promptForDownloadSize && items.length > 0) {
         // Single size call for the whole series, single confirm dialog
         this.downloadSeriesSize(series.id).pipe(
           switchMap(async size => this.confirmSize(size, 'series')),

--- a/UI/Web/src/app/shared/_services/download.service.ts
+++ b/UI/Web/src/app/shared/_services/download.service.ts
@@ -597,7 +597,7 @@ export class DownloadService {
         ).subscribe(() => {
 
           collectionSeries.result.forEach(s => {
-            this.downloadSeries(s, collection.id);
+            this.downloadSeries(s, collection.id, true);
           });
         });
       } else {
@@ -621,7 +621,7 @@ export class DownloadService {
     });
   }
 
-  private downloadSeries(series: Series, collectionId = 0) {
+  private downloadSeries(series: Series, collectionId = 0, skipSizePrompt = false) {
     this.debugLog('downloadSeries()', series.name);
     this.seriesService.getSeriesDetail(series.id).pipe(
       takeUntilDestroyed(this.destroyRef)
@@ -634,7 +634,7 @@ export class DownloadService {
       this.debugLog(`downloadSeries() decomposed into ${items.length} items (${detail.volumes.length} vols, ${detail.chapters.length + detail.specials.length} chapters)`);
 
       const userPrefs = this.accountService.userPreferences();
-      if (userPrefs?.promptForDownloadSize && items.length > 0) {
+      if (skipSizePrompt || (userPrefs?.promptForDownloadSize && items.length > 0)) {
         // Single size call for the whole series, single confirm dialog
         this.downloadSeriesSize(series.id).pipe(
           switchMap(async size => this.confirmSize(size, 'series')),

--- a/UI/Web/src/app/shared/_services/download.service.ts
+++ b/UI/Web/src/app/shared/_services/download.service.ts
@@ -37,7 +37,7 @@ const bytesPipe = new BytesPipe();
 /**
  * Valid entity types for downloading
  */
-export type DownloadEntityType = 'volume' | 'chapter' | 'series' | 'bookmark' | 'logs' | 'readinglist' | 'readinglist-item' | 'collection';
+export type DownloadEntityType = 'volume' | 'chapter' | 'series' | 'bookmark' | 'logs' | 'readingList' | 'readingListItem' | 'collection';
 /**
  * Valid entities for downloading. Undefined exclusively for logs.
  */
@@ -240,7 +240,7 @@ export class DownloadService {
       case 'chapter':  return (downloadEntity as Chapter).minNumber + '';
       case 'bookmark': return '';
       case 'logs':     return '';
-      case 'readinglist-item': return (downloadEntity as ReadingListItem).title;
+      case 'readingListItem': return (downloadEntity as ReadingListItem).title;
     }
     return '';
   }
@@ -268,7 +268,7 @@ export class DownloadService {
       case 'logs':
         this.downloadLogsBlob();
         break;
-      case 'readinglist':
+      case 'readingList':
         this.downloadReadingList(entity as ReadingList);
         break;
       case 'collection':

--- a/UI/Web/src/app/shared/_services/download.service.ts
+++ b/UI/Web/src/app/shared/_services/download.service.ts
@@ -74,7 +74,7 @@ export class DownloadService {
   private IOS_SIZE_WARNING = 209_715_200;
 
   /** Set to true to enable verbose download queue logging in the browser console. */
-  private readonly debug = true;
+  private readonly debug = false;
 
   private debugLog(...args: any[]) {
     if (this.debug) console.log('[DownloadService]', ...args);

--- a/UI/Web/src/app/shared/_services/utility.service.ts
+++ b/UI/Web/src/app/shared/_services/utility.service.ts
@@ -101,6 +101,10 @@ export class UtilityService {
     return d != null && d.hasOwnProperty('originalName');
   }
 
+  isReadingList(d: any) {
+     return d != null && d.hasOwnProperty('title') && d.hasOwnProperty('itemCount');
+  }
+
   asVolume(d: any) {
     return <Volume>d;
   }

--- a/UI/Web/src/app/shared/_services/utility.service.ts
+++ b/UI/Web/src/app/shared/_services/utility.service.ts
@@ -101,8 +101,13 @@ export class UtilityService {
     return d != null && d.hasOwnProperty('originalName');
   }
 
+  // TODO: We need a better way
   isReadingList(d: any) {
-     return d != null && d.hasOwnProperty('title') && d.hasOwnProperty('itemCount');
+     return d != null && d.hasOwnProperty('title') && d.hasOwnProperty('startingYear');
+  }
+
+  isUserCollection(d: any) {
+     return d != null && d.hasOwnProperty('title') && d.hasOwnProperty('itemCount') && !d.hasOwnProperty('startingYear');
   }
 
   asVolume(d: any) {

--- a/UI/Web/src/app/shared/_services/utility.service.ts
+++ b/UI/Web/src/app/shared/_services/utility.service.ts
@@ -89,39 +89,24 @@ export class UtilityService {
     return input.toUpperCase().replace(reg, '') === filter.toUpperCase().replace(reg, '');
   }
 
-  isVolume(d: any) {
-    return d != null
-      && typeof d === 'object'
-      && ('_type' in d && d._type === 'Volume'
-        || 'chapters' in d);
+  isVolume(d: unknown) {
+    return d != null && d.hasOwnProperty('chapters');
   }
 
-  isChapter(d: any) {
-    return d != null
-      && typeof d === 'object'
-      && ('_type' in d && d._type === 'Chapter'
-        || 'volumeId' in d);
+  isChapter(d: unknown) {
+    return d != null && d.hasOwnProperty('volumeId');
   }
 
-  isSeries(d: any) {
-    return d != null
-      && typeof d === 'object'
-      && ('_type' in d && d._type === 'Series'
-        || 'originalName' in d);
+  isSeries(d: unknown) {
+    return d != null && d.hasOwnProperty('originalName');
   }
 
-  isReadingList(d: any) {
-    return d != null
-      && typeof d === 'object'
-      && '_type' in d
-      && d._type === 'ReadingList';
+  isReadingList(d: unknown) {
+    return d != null && d.hasOwnProperty('title') && d.hasOwnProperty('startingYear');
   }
 
   isUserCollection(d: unknown) {
-    return d != null
-      && typeof d === 'object'
-      && '_type' in d
-      && d._type === 'UserCollection';
+    return d != null && d.hasOwnProperty('title') && d.hasOwnProperty('itemCount') && !d.hasOwnProperty('startingYear');
   }
 
   asVolume(d: any) {

--- a/UI/Web/src/app/shared/_services/utility.service.ts
+++ b/UI/Web/src/app/shared/_services/utility.service.ts
@@ -90,24 +90,38 @@ export class UtilityService {
   }
 
   isVolume(d: any) {
-    return d != null && d.hasOwnProperty('chapters');
+    return d != null
+      && typeof d === 'object'
+      && ('_type' in d && d._type === 'Volume'
+        || 'chapters' in d);
   }
 
   isChapter(d: any) {
-    return d != null && d.hasOwnProperty('volumeId');
+    return d != null
+      && typeof d === 'object'
+      && ('_type' in d && d._type === 'Chapter'
+        || 'volumeId' in d);
   }
 
   isSeries(d: any) {
-    return d != null && d.hasOwnProperty('originalName');
+    return d != null
+      && typeof d === 'object'
+      && ('_type' in d && d._type === 'Series'
+        || 'originalName' in d);
   }
 
-  // TODO: We need a better way
   isReadingList(d: any) {
-     return d != null && d.hasOwnProperty('title') && d.hasOwnProperty('startingYear');
+    return d != null
+      && typeof d === 'object'
+      && '_type' in d
+      && d._type === 'ReadingList';
   }
 
-  isUserCollection(d: any) {
-     return d != null && d.hasOwnProperty('title') && d.hasOwnProperty('itemCount') && !d.hasOwnProperty('startingYear');
+  isUserCollection(d: unknown) {
+    return d != null
+      && typeof d === 'object'
+      && '_type' in d
+      && d._type === 'UserCollection';
   }
 
   asVolume(d: any) {

--- a/UI/Web/src/app/sidenav/_components/side-nav/side-nav.component.html
+++ b/UI/Web/src/app/sidenav/_components/side-nav/side-nav.component.html
@@ -4,9 +4,10 @@
   @let sideNavCollapsed = navService.sideNavCollapsedSignal();
 
   @if (accountService.currentUser()) {
-    <div class="side-nav-container" [ngClass]="{'closed' : sideNavCollapsed,
-    'hidden': !sideNavVisible,
-    'no-donate': (licenseService.hasValidLicense$ | async) === true}">
+    <div class="side-nav-container"
+         [class.no-donate]="licenseService.hasValidLicense()"
+         [class.closed]="sideNavCollapsed"
+         [class.hidden]="!sideNavVisible">
       <div class="side-nav" cdkDropList (cdkDropListDropped)="reorderDrop($event)" [cdkDropListDisabled]="accountService.hasReadOnlyRole()">
 
 
@@ -107,13 +108,12 @@
   }
 
   @if (breakpointService.isTabletOrBelow()) {
-    <div class="side-nav-overlay" (click)="toggleNavBar()" [ngClass]="{'closed' : sideNavCollapsed}"></div>
+    <div class="side-nav-overlay" (click)="toggleNavBar()" [class.closed]="sideNavCollapsed"></div>
   }
 
-  <div class="sidenav-bottom" [ngClass]="{'closed' : sideNavCollapsed,
-      'hidden': !sideNavVisible || (licenseService.hasValidLicense$ | async) === true}">
-    @if ((licenseService.hasValidLicense$ | async) === false) {
-      <app-side-nav-item [ngClass]="'donate'" icon="fa-heart"
+  <div class="sidenav-bottom" [class.closed]="sideNavCollapsed" [class.hidden]="!sideNavVisible || licenseService.hasValidLicense()">
+    @if (!licenseService.hasValidLicense()) {
+      <app-side-nav-item class="donate" icon="fa-heart"
                         [ngbTooltip]="t('donate-tooltip')"
                         [link]="WikiLink.Donation"
                         [external]="true" />

--- a/UI/Web/src/app/sidenav/_components/side-nav/side-nav.component.ts
+++ b/UI/Web/src/app/sidenav/_components/side-nav/side-nav.component.ts
@@ -9,9 +9,9 @@ import {Library, LibraryType} from '../../../_models/library/library';
 import {AccountService} from '../../../_services/account.service';
 import {ActionFactoryService} from '../../../_services/action-factory.service';
 import {NavService} from '../../../_services/nav.service';
-import {takeUntilDestroyed} from "@angular/core/rxjs-interop";
+import {takeUntilDestroyed, toObservable} from "@angular/core/rxjs-interop";
 import {BehaviorSubject, merge, Observable, of, ReplaySubject, startWith, switchMap} from "rxjs";
-import {AsyncPipe, NgClass} from "@angular/common";
+import {AsyncPipe} from "@angular/common";
 import {SideNavItemComponent} from "../side-nav-item/side-nav-item.component";
 import {FilterPipe} from "../../../_pipes/filter.pipe";
 import {FormsModule} from "@angular/forms";
@@ -34,7 +34,7 @@ import {ActionResult} from "../../../_models/actionables/action-result";
 @Component({
   selector: 'app-side-nav',
   imports: [SideNavItemComponent, CardActionablesComponent, FilterPipe, FormsModule, TranslocoDirective, NgbTooltip,
-    NgClass, AsyncPipe, CdkDropList, CdkDrag],
+    AsyncPipe, CdkDropList, CdkDrag],
   templateUrl: './side-nav.component.html',
   styleUrls: ['./side-nav.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush
@@ -67,6 +67,8 @@ export class SideNavComponent {
   editMode: boolean = false;
   totalSize = 0;
   isReadOnly = this.accountService.hasReadOnlyRole;
+
+  readonly hasValidLicense$ = toObservable(this.licenseService.hasValidLicense);
 
   private showAllSubject = new BehaviorSubject<boolean>(false);
   showAll$ = this.showAllSubject.asObservable();
@@ -151,7 +153,7 @@ export class SideNavComponent {
       this.destroyRef,
       (e) => this.router.navigate(['/settings'], { fragment: SettingsTabId.Scrobbling}),
       [KeyBindTarget.NavigateToScrobbling],
-      {condition$: this.licenseService.hasValidLicense$},
+      {condition$: this.hasValidLicense$},
     );
 
     effect(() => {

--- a/UI/Web/src/app/sidenav/preference-nav/preference-nav.component.html
+++ b/UI/Web/src/app/sidenav/preference-nav/preference-nav.component.html
@@ -5,7 +5,7 @@
       <div class="preference side-nav-container"  [ngClass]="{
       'closed' : navService.sideNavCollapsedSignal(),
       'hidden': !navService.sideNavVisibilitySignal(),
-      'no-donate': licenseService.hasValidLicenseSignal()
+      'no-donate': licenseService.hasValidLicense()
       }">
         <div class="side-nav">
 

--- a/UI/Web/src/app/sidenav/preference-nav/preference-nav.component.ts
+++ b/UI/Web/src/app/sidenav/preference-nav/preference-nav.component.ts
@@ -145,6 +145,8 @@ export class PreferenceNavComponent implements AfterViewInit {
   private readonly keyBindService = inject(KeyBindService);
   protected readonly breakpointService = inject(BreakpointService);
 
+  readonly hasValidLicense$ = toObservable(this.licenseService.hasValidLicense);
+
   private readonly navEnd = toSignal(
     this.router.events.pipe(
       filter((event): event is NavigationEnd => event instanceof NavigationEnd)
@@ -160,7 +162,7 @@ export class PreferenceNavComponent implements AfterViewInit {
   private readonly matchedMetadataBadgeCount = toSignal(
     toObservable(this.accountService.hasAdminRole).pipe(
       take(1),
-      filter(_ => this.licenseService.hasValidLicenseSignal()),
+      filter(_ => this.licenseService.hasValidLicense()),
       switchMap(isAdmin => {
         if (!isAdmin) return of(-1);
         return this.manageService.getAllKavitaPlusSeries({
@@ -295,7 +297,7 @@ export class PreferenceNavComponent implements AfterViewInit {
 
     // Refresh visibility if license changes
     effect(() => {
-      this.licenseService.hasValidLicenseSignal();
+      this.licenseService.hasValidLicense();
       this.cdRef.markForCheck();
     });
 
@@ -304,7 +306,7 @@ export class PreferenceNavComponent implements AfterViewInit {
       () => this.router.navigate(['/settings'], { fragment: SettingsTabId.Scrobbling})
         .then(() => this.scrollToActiveItem()),
       [KeyBindTarget.NavigateToScrobbling],
-      {condition$: this.licenseService.hasValidLicense$},
+      {condition$: this.hasValidLicense$},
     );
   }
 
@@ -327,7 +329,7 @@ export class PreferenceNavComponent implements AfterViewInit {
   }
 
   isItemVisible(user: User, item: SideNavItem) {
-    return this.accountService.hasAnyRole(user, item.roles, item.restrictRoles) && (!item.kPlusOnly || this.licenseService.hasValidLicenseSignal())
+    return this.accountService.hasAnyRole(user, item.roles, item.restrictRoles) && (!item.kPlusOnly || this.licenseService.hasValidLicense())
   }
 
   collapse() {

--- a/UI/Web/src/app/statistics/_components/active-user-card/active-user-card.component.html
+++ b/UI/Web/src/app/statistics/_components/active-user-card/active-user-card.component.html
@@ -1,29 +1,30 @@
 <ng-container *transloco="let t; prefix:'active-user-card'">
+  @let activeUser = user();
   <div class="card active-user-card">
     <div class="card-body">
       <!-- Header row: avatar, name, hours in period -->
       <div class="d-flex align-items-center gap-3 mb-3">
         <div class="user-avatar rounded-circle d-flex align-items-center justify-content-center" role="img">
-          <app-profile-icon [userId]="user().userId" [size]="48" />
+          <app-profile-icon [userId]="activeUser.userId" [size]="48" />
         </div>
 
         <h6 class="mb-0 flex-grow-1 text-truncate username">
-          <a [routerLink]="['/profile', user().userId]">{{user().username}}</a>
+          <a [routerLink]="['/profile', activeUser.userId]">{{activeUser.username}}</a>
         </h6>
 
         <div class="hours-period text-end">
-          <span class="hours-value">{{ user().timePeriodHours | timeDuration }}</span>
+          <span class="hours-value">{{ activeUser.timePeriodHours | timeDuration }}</span>
           <span class="hours-label">{{ timeFrameLabel() }}</span>
         </div>
       </div>
 
       <!-- Top series covers -->
-      @if (user().topSeries.length > 0) {
+      @if (activeUser.topSeries.length > 0) {
         <div
           class="series-covers d-flex gap-2 mb-3"
           role="list"
-          [attr.aria-label]="'Top series read by ' + user().username">
-          @for (series of user().topSeries; track series.id) {
+          [attr.aria-label]="'Top series read by ' + activeUser.username">
+          @for (series of activeUser.topSeries; track series.id) {
             <div
               class="series-cover-wrapper"
               role="listitem"
@@ -44,20 +45,20 @@
 
       <div class="stats-row">
         <span class="stat-item">
-          {{ t('total-hours', {duration: user().totalHours | timeDuration}) }}
+          {{ t('total-hours', {duration: activeUser.totalHours | timeDuration}) }}
         </span>
 
-        @if (user().totalComics > 0) {
+        @if (activeUser.totalComics > 0) {
           <span class="stat-divider" aria-hidden="true">|</span>
           <span class="stat-item">
-            {{ t('comics-count', {count: user().totalComics}) }}
+            {{ t('comics-count', {count: activeUser.totalComics}) }}
           </span>
         }
 
-        @if (user().totalBooks > 0) {
+        @if (activeUser.totalBooks > 0) {
           <span class="stat-divider" aria-hidden="true">|</span>
           <span class="stat-item">
-            {{ t('books-count', {count: user().totalBooks}) }}
+            {{ t('books-count', {count: activeUser.totalBooks}) }}
           </span>
         }
       </div>

--- a/UI/Web/src/app/user-settings/custom-key-binds/manage-custom-key-binds.component.ts
+++ b/UI/Web/src/app/user-settings/custom-key-binds/manage-custom-key-binds.component.ts
@@ -67,7 +67,7 @@ export class ManageCustomKeyBindsComponent implements OnInit {
   protected duplicatedKeyBinds = signal<Partial<Record<KeyBindTarget, number[]>>>({});
   protected filteredKeyBindGroups = computed(() => {
     const roles = this.accountService.currentUser()!.roles;
-    const hasKPlus = this.licenseService.hasValidLicenseSignal();
+    const hasKPlus = this.licenseService.hasValidLicense();
 
     return KeyBindGroups.map(g => {
       g.elements = g.elements.filter(e => {

--- a/UI/Web/src/app/user-settings/manage-scrobbling-providers/manage-scrobbling-providers.component.html
+++ b/UI/Web/src/app/user-settings/manage-scrobbling-providers/manage-scrobbling-providers.component.html
@@ -1,14 +1,14 @@
 <ng-container *transloco="let t; prefix:'scrobbling-providers'">
 
-  <app-setting-title [title]="t('title')" [canEdit]="hasValidLicense" [isEditMode]="!isViewMode" (isEditModeChange)="updateEditMode($event)" />
+  <app-setting-title [title]="t('title')" [canEdit]="hasValidLicense()" [isEditMode]="!isViewMode" (isEditModeChange)="updateEditMode($event)" />
 
-  @if (loaded) {
-    @if(!hasValidLicense) {
+  @if (isLoaded()) {
+    @if(!hasValidLicense()) {
       {{t('requires', {product: 'Kavita+'})}}
     } @else {
       <form [formGroup]="formGroup">
         <div class="row">
-          <app-scrobble-provider-item [token]="aniListToken" [provider]="ScrobbleProvider.AniList" [isEditMode]="!isViewMode">
+          <app-scrobble-provider-item [token]="aniListToken" [provider]="ScrobbleProvider.AniList" [isEditMode]="!isViewMode()">
             <ng-template #edit>
               <p>{{t('instructions', {service: ScrobbleProvider.AniList | scrobbleProviderName})}}</p>
               <p class="text-muted">{{t('anilist-used-for')}}</p>
@@ -28,7 +28,7 @@
           </app-scrobble-provider-item>
         </div>
         <div class="row mt-2">
-          <app-scrobble-provider-item [token]="malToken" [provider]="ScrobbleProvider.Mal" [isEditMode]="!isViewMode">
+          <app-scrobble-provider-item [token]="malToken" [provider]="ScrobbleProvider.Mal" [isEditMode]="!isViewMode()">
             <ng-template #edit>
                 <span class="md-4">
                   <p>{{t('mal-instructions', {service: ScrobbleProvider.Mal | scrobbleProviderName})}}</p>
@@ -52,6 +52,6 @@
       </form>
     }
   } @else {
-    <app-loading [loading]="!loaded" [message]="t('loading')" />
+    <app-loading [loading]="!isLoaded()" [message]="t('loading')" />
   }
 </ng-container>

--- a/UI/Web/src/app/user-settings/manage-scrobbling-providers/manage-scrobbling-providers.component.html
+++ b/UI/Web/src/app/user-settings/manage-scrobbling-providers/manage-scrobbling-providers.component.html
@@ -1,6 +1,6 @@
 <ng-container *transloco="let t; prefix:'scrobbling-providers'">
 
-  <app-setting-title [title]="t('title')" [canEdit]="hasValidLicense()" [isEditMode]="!isViewMode" (isEditModeChange)="updateEditMode($event)" />
+  <app-setting-title [title]="t('title')" [canEdit]="hasValidLicense()" [isEditMode]="!isViewMode()" (isEditModeChange)="updateEditMode($event)" />
 
   @if (isLoaded()) {
     @if(!hasValidLicense()) {

--- a/UI/Web/src/app/user-settings/manage-scrobbling-providers/manage-scrobbling-providers.component.ts
+++ b/UI/Web/src/app/user-settings/manage-scrobbling-providers/manage-scrobbling-providers.component.ts
@@ -1,11 +1,10 @@
-import {ChangeDetectorRef, Component, DestroyRef, inject, OnInit} from '@angular/core';
+import {ChangeDetectorRef, Component, inject, OnInit, signal} from '@angular/core';
 import {FormControl, FormGroup, ReactiveFormsModule, Validators} from "@angular/forms";
 import {translate, TranslocoDirective} from "@jsverse/transloco";
 import {AccountService} from "../../_services/account.service";
 import {ScrobbleProvider, ScrobblingService} from "../../_services/scrobbling.service";
 import {ToastrService} from "ngx-toastr";
 import {LoadingComponent} from "../../shared/loading/loading.component";
-import {takeUntilDestroyed} from "@angular/core/rxjs-interop";
 import {ScrobbleProviderItemComponent} from "../scrobble-provider-item/scrobble-provider-item.component";
 import {ScrobbleProviderNamePipe} from "../../_pipes/scrobble-provider-name.pipe";
 import {SettingTitleComponent} from "../../settings/_components/setting-title/setting-title.component";
@@ -30,13 +29,12 @@ export class ManageScrobblingProvidersComponent implements OnInit {
   private readonly scrobblingService = inject(ScrobblingService);
   private readonly toastr = inject(ToastrService);
   private readonly cdRef = inject(ChangeDetectorRef);
-  private readonly destroyRef = inject(DestroyRef);
   private readonly licenseService = inject(LicenseService);
   private readonly confirmService = inject(ConfirmService);
 
   protected readonly ScrobbleProvider = ScrobbleProvider;
 
-  hasValidLicense: boolean = false;
+  hasValidLicense = this.licenseService.hasValidLicense;
 
   formGroup: FormGroup = new FormGroup({});
   aniListToken: string = '';
@@ -44,35 +42,29 @@ export class ManageScrobblingProvidersComponent implements OnInit {
   malUsername: string = '';
 
 
-  isViewMode: boolean = true;
-  loaded: boolean = false;
-
-  constructor() {
-    this.licenseService.hasValidLicense$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(res => {
-      this.hasValidLicense = res;
-      this.cdRef.markForCheck();
-      if (this.hasValidLicense) {
-        this.scrobblingService.getAniListToken().subscribe(token => {
-          this.aniListToken = token;
-          this.formGroup.get('aniListToken')?.setValue(token);
-          this.loaded = true;
-          this.cdRef.markForCheck();
-        });
-        this.scrobblingService.getMalToken().subscribe(dto => {
-          this.malToken = dto.accessToken;
-          this.malUsername = dto.username;
-          this.formGroup.get('malToken')?.setValue(this.malToken);
-          this.formGroup.get('malUsername')?.setValue(this.malUsername);
-          this.cdRef.markForCheck();
-        });
-      } else {
-        this.loaded = true;
-        this.cdRef.markForCheck();
-      }
-    });
-  }
+  isViewMode = signal<boolean>(true);
+  isLoaded = signal<boolean>(false);
 
   ngOnInit(): void {
+
+    if (!this.hasValidLicense()) {
+      this.isLoaded.set(true);
+    }
+
+    this.scrobblingService.getAniListToken().subscribe(token => {
+      this.aniListToken = token;
+      this.formGroup.get('aniListToken')?.setValue(token);
+      this.isLoaded.set(true);
+      this.cdRef.markForCheck();
+    });
+    this.scrobblingService.getMalToken().subscribe(dto => {
+      this.malToken = dto.accessToken;
+      this.malUsername = dto.username;
+      this.formGroup.get('malToken')?.setValue(this.malToken);
+      this.formGroup.get('malUsername')?.setValue(this.malUsername);
+      this.cdRef.markForCheck();
+    });
+
     this.formGroup.addControl('aniListToken', new FormControl('', [Validators.required]));
     this.formGroup.addControl('malClientId', new FormControl('', [Validators.required]));
     this.formGroup.addControl('malUsername', new FormControl('', [Validators.required]));
@@ -130,7 +122,7 @@ export class ManageScrobblingProvidersComponent implements OnInit {
   }
 
   updateEditMode(mode: boolean) {
-    this.isViewMode = !mode;
+    this.isViewMode.set(!mode);
     this.resetForm();
     this.cdRef.markForCheck();
   }

--- a/UI/Web/src/app/user-settings/manage-scrobbling-providers/manage-scrobbling-providers.component.ts
+++ b/UI/Web/src/app/user-settings/manage-scrobbling-providers/manage-scrobbling-providers.component.ts
@@ -49,6 +49,7 @@ export class ManageScrobblingProvidersComponent implements OnInit {
 
     if (!this.hasValidLicense()) {
       this.isLoaded.set(true);
+      return;
     }
 
     this.scrobblingService.getAniListToken().subscribe(token => {

--- a/UI/Web/src/app/user-settings/manga-user-preferences/manage-user-preferences.component.html
+++ b/UI/Web/src/app/user-settings/manga-user-preferences/manage-user-preferences.component.html
@@ -256,7 +256,7 @@
         </div>
       </ng-container>
 
-      @if (licenseService.hasValidLicense$ | async) {
+      @if (licenseService.hasValidLicense()) {
         <div class="setting-section-break"></div>
         <h4 id="kavitaplus-heading" class="mt-4">{{t('kavitaplus-settings-title')}}</h4>
 

--- a/UI/Web/src/main.ts
+++ b/UI/Web/src/main.ts
@@ -43,7 +43,7 @@ import {LibraryService} from "./app/_services/library.service";
 
 const disableAnimations = !('animate' in document.documentElement);
 if (disableAnimations) {
-  document.documentElement.classList.add('no-animations');
+  document.documentElement.classList.add('no-animations', 'animate-disabled');
 }
 
 


### PR DESCRIPTION
# Added
- Added: Added the ability to download Reading Lists and Collections from Kavita

# Changed
- Changed: Allow Kavita+ to match against a series during a manual match always regardless if the library has automatic metadata matching off. (Fixes #4418)

# Fixed
- Fixed: Fixed Volume downloads with multiple sub-chapters not deconstructing into chapters for downloading (develop) 
- Fixed: Fixed Known Issue parsing from Github using wrong header
- Fixed: Fixed Markdown parsing not working on sub-nested lists
- Fixed: Fixed an issue where specials weren't prioritizing title comicinfo (Fixes #3781)
- Fixed: Fixed the No Transitions setting not properly applying to all animations in the site (Fixes #4361)
- Fixed: Fixed profile icon throwing an error on page load (develop)
- Fixed: Fixed continue from title not updating after progress updates (develop)
- Fixed: Event widget was missing the spinner when active (develop)
- Fixed: Localization issues with Korean where chapter marker could still be in front of edge
- Fixed: Ensure comic libraries prioritize volume tab over specials tab when no issues
- Fixed: Fixed localization switching not updating the UI correctly

Closes #4472

