### PR TITLE
Fixed OPDS Downloads using wrong auth guard 

### DIFF
--- a/Kavita.Server/Controllers/OPDSController.cs
+++ b/Kavita.Server/Controllers/OPDSController.cs
@@ -658,7 +658,7 @@ public class OpdsController(
     /// <param name="filename">Not used. Only for Chunky to allow download links</param>
     /// <returns></returns>
     [ChapterAccess]
-    [Authorize(PolicyConstants.DownloadRole)]
+    [Authorize(PolicyGroups.DownloadPolicy)]
     [HttpGet("{apiKey}/series/{seriesId}/volume/{volumeId}/chapter/{chapterId}/download/{filename}")]
     public async Task<ActionResult> DownloadFile(string apiKey, int seriesId, int volumeId, int chapterId, string filename)
     {


### PR DESCRIPTION
# Fixed
- Fixed: The auth guard for the OPDS download endpoint was using the Download role instead of the policy. The original version was causing an error. (Fixes #4526)