### PR TITLE
CBL Import Polish Pass 1

### DIFF
--- a/Kavita.Services.Tests/ReadingLists/CblImportServiceTests.cs
+++ b/Kavita.Services.Tests/ReadingLists/CblImportServiceTests.cs
@@ -231,7 +231,7 @@ public class CblImportServiceTests : AbstractDbTest
 
         var fablesIds = seed.Lookup[("Fables", "1", "1")];
 
-        // Add series-level remap rule: "Fable" → Fables series
+        // Add series-level remap rule: "Fable" -> Fables series
         unitOfWork.RemapRuleRepository.Add(new ReadingListRemapRule
         {
             NormalizedCblSeriesName = "Fable".ToNormalized(),
@@ -336,6 +336,61 @@ public class CblImportServiceTests : AbstractDbTest
             r.SeriesId == fablesIds.SeriesId);
     }
 
+    /// <summary>
+    /// A series-only remap (CblVolume=null) must not cause false positives when the CBL
+    /// contains multiple entries that share the same series name but differ by volume.
+    /// In Comic libraries the volume year is appended to the series name, so
+    /// "Batman" Vol 2014 -> "Batman (2014)" and "Batman" Vol 1994 -> "Batman (1994)".
+    /// A remap rule mapping "Batman" -> "Batman (2014)" should only succeed when
+    /// the volume actually resolves within "Batman (2014)". When the CBL entry has
+    /// Volume="1994", the remap should fall through and let Tier 3 (ComicVine naming)
+    /// resolve it to "Batman (1994)" instead.
+    /// </summary>
+    [Fact]
+    public async Task ValidateList_SeriesRemap_FallsThroughWhenVolumeDoesNotResolve()
+    {
+        var (unitOfWork, context, _) = await CreateDatabase();
+        using var helper = new CblTestHelper(unitOfWork);
+        var seed = await helper.SeedLibrary("comic-multi-volume-series.json");
+
+        var batman2014Ids = seed.Lookup[("Batman (2014)", "2014", "1")];
+        var batman1994Ids = seed.Lookup[("Batman (1994)", "1994", "1")];
+
+        // Series-only remap: "Batman" -> "Batman (2014)"
+        unitOfWork.RemapRuleRepository.Add(new ReadingListRemapRule
+        {
+            NormalizedCblSeriesName = "Batman".ToNormalized(),
+            CblSeriesName = "Batman",
+            SeriesId = batman2014Ids.SeriesId,
+            SeriesNameAtMapping = "Batman (2014)",
+            AppUserId = seed.User.Id,
+            CreatedUtc = DateTime.UtcNow
+        });
+        await unitOfWork.CommitAsync();
+
+        var cbl = CblFileBuilder.Create("Remap Fallthrough Test")
+            .AddBook("Batman", volume: "2014", number: "1") // Should match via remap
+            .AddBook("Batman", volume: "1994", number: "1") // Should NOT match via remap — must fall through
+            .Build();
+
+        var filePath = helper.WriteCblToDisk(cbl);
+        var svc = helper.CreateImportService();
+        var summary = await svc.ValidateList(seed.User.Id, filePath, new CblImportOptions());
+
+        Assert.Equal(CblImportResult.Success, summary.Success);
+        Assert.Equal(2, summary.SuccessfulInserts.Count);
+
+        // First item: matched via remap rule to Batman (2014)
+        var first = summary.SuccessfulInserts.First(r => r.Volume == "2014");
+        Assert.Equal(CblMatchTier.RemapRule, first.MatchTier);
+        Assert.Equal(batman2014Ids.SeriesId, first.SeriesId);
+
+        // Second item: remap fell through, matched via ComicVine naming tier to Batman (1994)
+        var second = summary.SuccessfulInserts.First(r => r.Volume == "1994");
+        Assert.NotEqual(CblMatchTier.RemapRule, second.MatchTier);
+        Assert.Equal(batman1994Ids.SeriesId, second.SeriesId);
+    }
+
     #endregion
 
     #region Group 4: Issue-Level Remap Rules
@@ -349,7 +404,7 @@ public class CblImportServiceTests : AbstractDbTest
 
         var ch2Ids = seed.Lookup[("Fables", "1", "2")];
 
-        // Add issue-level remap rule: Fables vol=1 #2 → specific chapter
+        // Add issue-level remap rule: Fables vol=1 #2 -> specific chapter
         unitOfWork.RemapRuleRepository.Add(new ReadingListRemapRule
         {
             NormalizedCblSeriesName = "Fables".ToNormalized(),

--- a/Kavita.Services.Tests/Test Data/CblImportService/comic-multi-volume-series.json
+++ b/Kavita.Services.Tests/Test Data/CblImportService/comic-multi-volume-series.json
@@ -1,0 +1,18 @@
+{
+  "libraryName": "Comics",
+  "libraryType": "Comic",
+  "series": [
+    {
+      "name": "Batman (2014)",
+      "volumes": [
+        { "number": "2014", "chapters": ["1", "2", "3"] }
+      ]
+    },
+    {
+      "name": "Batman (1994)",
+      "volumes": [
+        { "number": "1994", "chapters": ["1", "2"] }
+      ]
+    }
+  ]
+}

--- a/Kavita.Services/Extensions/ReadingListRemapRuleExtensions.cs
+++ b/Kavita.Services/Extensions/ReadingListRemapRuleExtensions.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Kavita.Models.DTOs.ReadingLists.CBL.Internal;
+using Kavita.Models.Entities.ReadingLists;
+
+namespace Kavita.Services.Extensions;
+
+public static class ReadingListRemapRuleExtensions
+{
+    public static ReadingListRemapRule? FirstMatchVolumeAndIssueOrDefault(this List<ReadingListRemapRule> rules, ParsedCblItem item)
+    {
+        return rules.FirstOrDefault(r =>
+            !string.IsNullOrEmpty(r.CblVolume) && r.CblVolume == item.Volume &&
+            !string.IsNullOrEmpty(r.CblNumber) && r.CblNumber == item.Number);
+    }
+
+    public static ReadingListRemapRule? FirstMatchIssueOrDefault(this List<ReadingListRemapRule> rules, ParsedCblItem item)
+    {
+        return rules.FirstOrDefault(r =>
+            !string.IsNullOrEmpty(r.CblNumber) && r.CblNumber == item.Number &&
+            string.IsNullOrEmpty(r.CblVolume));
+    }
+
+
+
+
+}

--- a/Kavita.Services/ReadingLists/CblSeriesMatcher.cs
+++ b/Kavita.Services/ReadingLists/CblSeriesMatcher.cs
@@ -194,12 +194,8 @@ internal static class CblSeriesMatcher
         if (!rulesByName.TryGetValue(normalizedName, out var rules)) return false;
 
         // Try most specific first (volume + number), then less specific
-        var rule = rules.FirstOrDefault(r =>
-                       !string.IsNullOrEmpty(r.CblVolume) && r.CblVolume == item.Volume &&
-                       !string.IsNullOrEmpty(r.CblNumber) && r.CblNumber == item.Number)
-                   ?? rules.FirstOrDefault(r =>
-                       !string.IsNullOrEmpty(r.CblNumber) && r.CblNumber == item.Number &&
-                       string.IsNullOrEmpty(r.CblVolume))
+        var rule = rules.FirstMatchVolumeAndIssueOrDefault(item)
+                   ?? rules.FirstMatchIssueOrDefault(item)
                    ?? rules.FirstOrDefault(r =>
                        string.IsNullOrEmpty(r.CblVolume) && string.IsNullOrEmpty(r.CblNumber));
 

--- a/Kavita.Services/ReadingLists/CblSeriesMatcher.cs
+++ b/Kavita.Services/ReadingLists/CblSeriesMatcher.cs
@@ -42,22 +42,14 @@ internal static class CblSeriesMatcher
     public static Dictionary<string, (string OriginalName, CblMatchTier Tier)> GenerateAllNameVariants(IList<ParsedCblItem> items)
     {
         var variants = new Dictionary<string, (string, CblMatchTier)>();
-        var uniqueItems = items.DistinctBy(i => i.SeriesName).ToList();
+        var uniqueNames = items.DistinctBy(i => i.SeriesName).ToList();
 
-        foreach (var item in uniqueItems)
+        foreach (var item in uniqueNames)
         {
             var name = item.SeriesName;
-            var volumeNumber = item.Volume;
 
             // Tier 2: Exact normalized
             AddVariants(variants, name, CblMatchTier.ExactName, name);
-
-            // Tier 3: Comic Vine handling: Series (Volume)
-            var comicVineTitle = GetComicNamingPattern(name, volumeNumber);
-            if (!string.IsNullOrEmpty(volumeNumber) && !string.Equals(comicVineTitle, name, StringComparison.OrdinalIgnoreCase))
-            {
-                AddVariants(variants, comicVineTitle, CblMatchTier.ComicVineNaming, name);
-            }
 
             // Tier 4: Article stripped
             var sortTitle = BookSortTitlePrefixHelper.GetSortTitle(name);
@@ -71,6 +63,23 @@ internal static class CblSeriesMatcher
             if (!string.Equals(stripped, name, StringComparison.OrdinalIgnoreCase))
             {
                 AddVariants(variants, stripped, CblMatchTier.ReprintStripped, name);
+            }
+        }
+
+        // Tier 3: Comic Vine handling — distinct by (series, volume) since different
+        // volumes of the same series name produce different naming variants
+        // (e.g. "Batman" vol 2014 -> "Batman (2014)", "Batman" vol 1994 -> "Batman (1994)")
+        var uniqueSeriesVolumes = items
+            .Where(i => !string.IsNullOrEmpty(i.Volume))
+            .DistinctBy(i => (i.SeriesName, i.Volume))
+            .ToList();
+
+        foreach (var item in uniqueSeriesVolumes)
+        {
+            var comicVineTitle = GetComicNamingPattern(item.SeriesName, item.Volume);
+            if (!string.Equals(comicVineTitle, item.SeriesName, StringComparison.OrdinalIgnoreCase))
+            {
+                AddVariants(variants, comicVineTitle, CblMatchTier.ComicVineNaming, item.SeriesName);
             }
         }
 
@@ -240,23 +249,26 @@ internal static class CblSeriesMatcher
             return true;
         }
 
-        // Rule only mapped to series — resolve chapter within the mapped series
+        // Rule only mapped to series — resolve chapter within the mapped series.
+        // If volume/chapter resolution fails, fall through to lower tiers so the
+        // original CBL data can match via name variants (e.g. Comic naming "Series (Volume)").
+        // This prevents false positives where a series-only remap for "Batman" -> "Batman (2014)"
+        // would incorrectly capture a CBL entry with Volume="1994".
         var series = matchedSeries.FirstOrDefault(s => s.Id == rule.SeriesId);
         if (series != null)
         {
-            resolvedResult = ResolveChapter(item, series, CblMatchTier.RemapRule);
+            var resolved = ResolveChapter(item, series, CblMatchTier.RemapRule);
+            if (resolved.Result.Reason is CblImportReason.VolumeMissing or CblImportReason.ChapterMissing)
+            {
+                return false;
+            }
+
+            resolvedResult = resolved;
             return true;
         }
 
-        // Series from the rule wasn't in our pre-fetched data — report as series matched but chapter unresolved
-        resolvedResult = (null, new CblBookResult(item)
-        {
-            Reason = CblImportReason.ChapterMissing,
-            MatchTier = CblMatchTier.RemapRule,
-            SeriesId = rule.SeriesId,
-            MatchedSeriesName = rule.SeriesNameAtMapping ?? string.Empty
-        });
-        return true;
+        // Series from the rule wasn't in our pre-fetched data — fall through to lower tiers
+        return false;
     }
 
     private static bool TryMatchByExternalId(ParsedCblItem item,
@@ -303,11 +315,22 @@ internal static class CblSeriesMatcher
         // Try each tier in order
         foreach (var candidateTier in new[] { CblMatchTier.ExactName, CblMatchTier.ComicVineNaming, CblMatchTier.ArticleStripped, CblMatchTier.ReprintStripped })
         {
-            var variantsForTier = nameVariants
-                .Where(kv => kv.Value.Tier == candidateTier &&
-                             string.Equals(kv.Value.OriginalName, item.SeriesName, StringComparison.OrdinalIgnoreCase))
-                .Select(kv => kv.Key)
-                .ToList();
+            // For ComicVineNaming, use only the variant derived from this item's volume
+            // to avoid cross-matching (e.g. "Batman" vol 1994 matching "Batman (2014)")
+            List<string> variantsForTier;
+            if (candidateTier == CblMatchTier.ComicVineNaming && !string.IsNullOrEmpty(item.Volume))
+            {
+                var comicVineVariant = GetComicNamingPattern(item.SeriesName, item.Volume).ToNormalized();
+                variantsForTier = !string.IsNullOrEmpty(comicVineVariant) ? [comicVineVariant] : [];
+            }
+            else
+            {
+                variantsForTier = nameVariants
+                    .Where(kv => kv.Value.Tier == candidateTier &&
+                                 string.Equals(kv.Value.OriginalName, item.SeriesName, StringComparison.OrdinalIgnoreCase))
+                    .Select(kv => kv.Key)
+                    .ToList();
+            }
 
             foreach (var variant in variantsForTier)
             {


### PR DESCRIPTION
At this point, I don't have the necessary files to really help polish the matching logic. The foundational logic and approach is there, but I will be doing small releases to tweak the logic based on the feedback from the nightly community.


# Changed
- Changed: Tweaked how the ComicVine matching was done so that a series remap rule of Batman vol 2014 -> Batman (2014) wouldn't early match on Batman vol 2024 as well. Volumes are now properly matched with correct fall-through.