### PR TITLE
Email Localization Support

### DIFF
--- a/Kavita.Models/DTOs/Email/ConfirmationEmailDto.cs
+++ b/Kavita.Models/DTOs/Email/ConfirmationEmailDto.cs
@@ -3,6 +3,10 @@
 public sealed record ConfirmationEmailDto
 {
     public string InvitingUser { get; init; } = default!;
+    /// <summary>
+    /// Who is receiving the email
+    /// </summary>
+    public required int EmailUserId { get; init; }
     public string EmailAddress { get; init; } = default!;
     public string ServerConfirmationLink { get; init; } = default!;
     /// <summary>

--- a/Kavita.Models/DTOs/Email/ConfirmationEmailDto.cs
+++ b/Kavita.Models/DTOs/Email/ConfirmationEmailDto.cs
@@ -4,9 +4,9 @@ public sealed record ConfirmationEmailDto
 {
     public string InvitingUser { get; init; } = default!;
     /// <summary>
-    /// Who is receiving the email
+    /// User Id to resolve the locale against
     /// </summary>
-    public required int EmailUserId { get; init; }
+    public required int LocaleUserId { get; init; }
     public string EmailAddress { get; init; } = default!;
     public string ServerConfirmationLink { get; init; } = default!;
     /// <summary>

--- a/Kavita.Models/DTOs/Email/PasswordResetEmailDto.cs
+++ b/Kavita.Models/DTOs/Email/PasswordResetEmailDto.cs
@@ -2,6 +2,7 @@
 
 public sealed record PasswordResetEmailDto
 {
+    public required int EmailUserId { get; init; }
     public string EmailAddress { get; init; } = default!;
     public string ServerConfirmationLink { get; init; } = default!;
     /// <summary>

--- a/Kavita.Models/DTOs/Email/SendToDto.cs
+++ b/Kavita.Models/DTOs/Email/SendToDto.cs
@@ -4,6 +4,7 @@ namespace Kavita.Models.DTOs.Email;
 
 public sealed record SendToDto
 {
+    public required int UserId { get; set; }
     public string DestinationEmail { get; set; } = default!;
     public IEnumerable<string> FilePaths { get; set; } = default!;
 }

--- a/Kavita.Server/Controllers/AccountController.cs
+++ b/Kavita.Server/Controllers/AccountController.cs
@@ -460,7 +460,7 @@ public class AccountController(UserManager<AppUser> userManager,
                 BackgroundJob.Enqueue(() => emailService.SendEmailChangeEmail(new ConfirmationEmailDto()
                 {
                     EmailAddress = string.IsNullOrEmpty(user.Email) ? dto.Email : user.Email,
-                    EmailUserId = user.Id,
+                    LocaleUserId = user.Id,
                     InstallId = BuildInfo.Version.ToString(),
                     InvitingUser = invitingUser,
                     ServerConfirmationLink = emailLink
@@ -796,7 +796,7 @@ public class AccountController(UserManager<AppUser> userManager,
             BackgroundJob.Enqueue(() => emailService.SendInviteEmail(new ConfirmationEmailDto()
             {
                 EmailAddress = dto.Email,
-                EmailUserId = user.Id,
+                LocaleUserId = adminUser.Id, // Use the admin's locale for the invite to server
                 InvitingUser = adminUser.UserName,
                 ServerConfirmationLink = emailLink
             }));
@@ -1100,7 +1100,7 @@ public class AccountController(UserManager<AppUser> userManager,
 
         BackgroundJob.Enqueue(() => emailService.SendInviteEmail(new ConfirmationEmailDto()
         {
-            EmailUserId = user.Id,
+            LocaleUserId = user.Id,
             EmailAddress = user.Email!,
             InvitingUser = Username!,
             ServerConfirmationLink = emailLink,

--- a/Kavita.Server/Controllers/AccountController.cs
+++ b/Kavita.Server/Controllers/AccountController.cs
@@ -460,6 +460,7 @@ public class AccountController(UserManager<AppUser> userManager,
                 BackgroundJob.Enqueue(() => emailService.SendEmailChangeEmail(new ConfirmationEmailDto()
                 {
                     EmailAddress = string.IsNullOrEmpty(user.Email) ? dto.Email : user.Email,
+                    EmailUserId = user.Id,
                     InstallId = BuildInfo.Version.ToString(),
                     InvitingUser = invitingUser,
                     ServerConfirmationLink = emailLink
@@ -783,7 +784,7 @@ public class AccountController(UserManager<AppUser> userManager,
             var settings = await unitOfWork.SettingsRepository.GetSettingsDtoAsync();
             if (!emailService.IsValidEmail(dto.Email) || !settings.IsEmailSetup())
             {
-                logger.LogInformation("[Invite User] {Email} doesn't appear to be an email or email is not setup", dto.Email.Replace(Environment.NewLine, string.Empty));
+                logger.LogInformation("[Invite User] {Email} doesn't appear to be an email or email is not setup", dto.Email.Sanitize());
                 return Ok(new InviteUserResponse
                 {
                     EmailLink = emailLink,
@@ -795,6 +796,7 @@ public class AccountController(UserManager<AppUser> userManager,
             BackgroundJob.Enqueue(() => emailService.SendInviteEmail(new ConfirmationEmailDto()
             {
                 EmailAddress = dto.Email,
+                EmailUserId = user.Id,
                 InvitingUser = adminUser.UserName,
                 ServerConfirmationLink = emailLink
             }));
@@ -1001,6 +1003,7 @@ public class AccountController(UserManager<AppUser> userManager,
         var installId = (await unitOfWork.SettingsRepository.GetSettingAsync(ServerSettingKey.InstallId)).Value;
         BackgroundJob.Enqueue(() => emailService.SendForgotPasswordEmail(new PasswordResetEmailDto()
         {
+            EmailUserId = user.Id,
             EmailAddress = user.Email,
             ServerConfirmationLink = emailLink,
             InstallId = installId
@@ -1097,6 +1100,7 @@ public class AccountController(UserManager<AppUser> userManager,
 
         BackgroundJob.Enqueue(() => emailService.SendInviteEmail(new ConfirmationEmailDto()
         {
+            EmailUserId = user.Id,
             EmailAddress = user.Email!,
             InvitingUser = Username!,
             ServerConfirmationLink = emailLink,

--- a/Kavita.Server/EmailTemplates/AuthKeyExpired.html
+++ b/Kavita.Server/EmailTemplates/AuthKeyExpired.html
@@ -18,7 +18,7 @@
                             <tr>
                                 <td style="border-radius: 50px; background: #153643; text-align: center;" class="button-td">
                                     <a rel="noopener noreferrer" href="{{Link}}" style="background: #153643; border: 15px solid #153643; font-family: 'Montserrat', sans-serif; font-size: 14px; line-height: 1.1; text-align: center; text-decoration: none; display: block; border-radius: 50px; font-weight: bold;" class="button-a">
-                                        <span style="color:#ffffff;" class="button-link">&nbsp;&nbsp;&nbsp;&nbsp;{{email.auth-key-expired.rotate-cta}}&nbsp;&nbsp;&nbsp;&nbsp;</span> </a>
+                                        <span style="color:#ffffff;" class="button-link">&nbsp;&nbsp;&nbsp;&nbsp;{{email.auth-key-expired.cta}}&nbsp;&nbsp;&nbsp;&nbsp;</span> </a>
                                 </td>
                             </tr>
                         </table>

--- a/Kavita.Server/EmailTemplates/AuthKeyExpired.html
+++ b/Kavita.Server/EmailTemplates/AuthKeyExpired.html
@@ -3,10 +3,10 @@
         <table>
             <tr>
                 <td valign="top" style="text-align: center; padding: 20px 0 10px 20px;">
-                    <h1 style="margin: 0; font-family: 'Montserrat', sans-serif; font-size: 30px; line-height: 36px; font-weight: bold;">One or more Auth Keys Expired!</h1></td>
+                    <h1 style="margin: 0; font-family: 'Montserrat', sans-serif; font-size: 30px; line-height: 36px; font-weight: bold;">{{email.auth-key-expired.header}}</h1></td>
             </tr>
             <tr>
-                <p style="margin: 0;">You will no longer be able to authenticate until you rotate the key.</p>
+                <p style="margin: 0;">{{email.auth-key-expired.description}}</p>
 
                 {{AuthKeyFragment}}
             </tr>
@@ -18,7 +18,7 @@
                             <tr>
                                 <td style="border-radius: 50px; background: #153643; text-align: center;" class="button-td">
                                     <a rel="noopener noreferrer" href="{{Link}}" style="background: #153643; border: 15px solid #153643; font-family: 'Montserrat', sans-serif; font-size: 14px; line-height: 1.1; text-align: center; text-decoration: none; display: block; border-radius: 50px; font-weight: bold;" class="button-a">
-                                        <span style="color:#ffffff;" class="button-link">&nbsp;&nbsp;&nbsp;&nbsp;ROTATE&nbsp;&nbsp;&nbsp;&nbsp;</span> </a>
+                                        <span style="color:#ffffff;" class="button-link">&nbsp;&nbsp;&nbsp;&nbsp;{{email.auth-key-expired.rotate-cta}}&nbsp;&nbsp;&nbsp;&nbsp;</span> </a>
                                 </td>
                             </tr>
                         </table>
@@ -26,7 +26,7 @@
                     <!-- Button : END -->
             <tr>
                 <td valign="top" style="text-align: center; padding: 10px 20px 15px 20px; font-family: sans-serif; font-size: 12px; line-height: 20px;">
-                    <p style="margin: 0;">If the button above does not work, please find the link here: <a style="color:inherit;margin: 0;width: 100%;word-break: break-all;" rel="noopener noreferrer" href="{{Link}}">{{Link}}</a></p>
+                    <p style="margin: 0;">{{email.auth-key-expired.fallback-link-label}} <a style="color:inherit;margin: 0;width: 100%;word-break: break-all;" rel="noopener noreferrer" href="{{Link}}" target="_blank">{{Link}}</a></p>
                 </td>
             </tr>
         </table>

--- a/Kavita.Server/EmailTemplates/AuthKeyExpiringFragment.html
+++ b/Kavita.Server/EmailTemplates/AuthKeyExpiringFragment.html
@@ -1,8 +1,8 @@
 ﻿<table>
     <thead>
         <tr>
-            <td><b>Name</b></td>
-            <td><b>Expires (Days)</b></td>
+            <td><b>{{email.auth-key-expiring-fragment.name-header}}</b></td>
+            <td><b>{{email.auth-key-expiring-fragment.expires-header}}</b></td>
         </tr>
     </thead>
     <tbody>

--- a/Kavita.Server/EmailTemplates/AuthKeyExpiringSoon.html
+++ b/Kavita.Server/EmailTemplates/AuthKeyExpiringSoon.html
@@ -3,7 +3,7 @@
         <table>
             <tr>
                 <td valign="top" style="text-align: center; padding: 20px 0 10px 20px;">
-                    <h1 style="margin: 0; font-family: 'Montserrat', sans-serif; font-size: 30px; line-height: 36px; font-weight: bold;">Your Auth Key {{AuthKeyName}} Token will Expire soon!</h1> </td>
+                    <h1 style="margin: 0; font-family: 'Montserrat', sans-serif; font-size: 30px; line-height: 36px; font-weight: bold;">{{email.auth-key-expiring-soon.preheader}}</h1> </td>
             </tr>
             <tr>
                 {{AuthKeyFragment}}
@@ -16,7 +16,7 @@
                             <tr>
                                 <td style="border-radius: 50px; background: #153643; text-align: center;" class="button-td">
                                     <a rel="noopener noreferrer" href="{{Link}}" style="background: #153643; border: 15px solid #153643; font-family: 'Montserrat', sans-serif; font-size: 14px; line-height: 1.1; text-align: center; text-decoration: none; display: block; border-radius: 50px; font-weight: bold;" class="button-a">
-                                        <span style="color:#ffffff;" class="button-link">&nbsp;&nbsp;&nbsp;&nbsp;ROTATE&nbsp;&nbsp;&nbsp;&nbsp;</span> </a>
+                                        <span style="color:#ffffff;" class="button-link">&nbsp;&nbsp;&nbsp;&nbsp;{{email.auth-key-expiring-soon.rotate-cta}}&nbsp;&nbsp;&nbsp;&nbsp;</span> </a>
                                 </td>
                             </tr>
                         </table>
@@ -24,7 +24,7 @@
                     <!-- Button : END -->
             <tr>
                 <td valign="top" style="text-align: center; padding: 10px 20px 15px 20px; font-family: sans-serif; font-size: 12px; line-height: 20px;">
-                    <p style="margin: 0;">If the button above does not work, please find the link here: <a style="color:inherit;margin: 0;width: 100%;word-break: break-all;" rel="noopener noreferrer" href="{{Link}}">{{Link}}</a></p>
+                    <p style="margin: 0;">{{email.auth-key-expiring-soon.fallback-link-label}} <a style="color:inherit;margin: 0;width: 100%;word-break: break-all;" rel="noopener noreferrer" href="{{Link}}">{{Link}}</a></p>
                 </td>
             </tr>
         </table>

--- a/Kavita.Server/EmailTemplates/AuthKeyExpiringSoon.html
+++ b/Kavita.Server/EmailTemplates/AuthKeyExpiringSoon.html
@@ -16,7 +16,7 @@
                             <tr>
                                 <td style="border-radius: 50px; background: #153643; text-align: center;" class="button-td">
                                     <a rel="noopener noreferrer" href="{{Link}}" style="background: #153643; border: 15px solid #153643; font-family: 'Montserrat', sans-serif; font-size: 14px; line-height: 1.1; text-align: center; text-decoration: none; display: block; border-radius: 50px; font-weight: bold;" class="button-a">
-                                        <span style="color:#ffffff;" class="button-link">&nbsp;&nbsp;&nbsp;&nbsp;{{email.auth-key-expiring-soon.rotate-cta}}&nbsp;&nbsp;&nbsp;&nbsp;</span> </a>
+                                        <span style="color:#ffffff;" class="button-link">&nbsp;&nbsp;&nbsp;&nbsp;{{email.auth-key-expiring-soon.cta}}&nbsp;&nbsp;&nbsp;&nbsp;</span> </a>
                                 </td>
                             </tr>
                         </table>

--- a/Kavita.Server/EmailTemplates/AuthKeyExpiringSoon.html
+++ b/Kavita.Server/EmailTemplates/AuthKeyExpiringSoon.html
@@ -3,7 +3,7 @@
         <table>
             <tr>
                 <td valign="top" style="text-align: center; padding: 20px 0 10px 20px;">
-                    <h1 style="margin: 0; font-family: 'Montserrat', sans-serif; font-size: 30px; line-height: 36px; font-weight: bold;">{{email.auth-key-expiring-soon.preheader}}</h1> </td>
+                    <h1 style="margin: 0; font-family: 'Montserrat', sans-serif; font-size: 30px; line-height: 36px; font-weight: bold;">{{email.auth-key-expiring-soon.subject}}</h1> </td>
             </tr>
             <tr>
                 {{AuthKeyFragment}}

--- a/Kavita.Server/EmailTemplates/EmailChange.html
+++ b/Kavita.Server/EmailTemplates/EmailChange.html
@@ -1,8 +1,8 @@
 <tr>
     <td>
-        <h1>Email Change Update</h1>
-        <p>Your account's email has been updated on {{InvitingUser}}'s Kavita instance.</p>
-        <p>Please click the following link to validate your email change. The email is not changed until you complete validation.</p>
+        <h1>{{email.email-change.title}}</h1>
+        <p>{{email.email-change.description-1}}</p>
+        <p>{{email.email-change.description-2}}</p>
 
 
         <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="btn btn-primary">
@@ -12,7 +12,7 @@
                     <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                         <tbody>
                         <tr>
-                            <td> <a href="{{Link}}" target="_blank">CONFIRM EMAIL</a> </td>
+                            <td> <a href="{{Link}}" target="_blank">{{email.email-change.cta}}</a> </td>
                         </tr>
                         </tbody>
                     </table>
@@ -21,7 +21,7 @@
             </tbody>
         </table>
 
-        <p class="small">If the button above does not work, please find the link here: <a class="small" href="{{Link}}" target="_blank">{{Link}}</a></p>
+        <p class="small">{{email.email-change.fallback-link-label}} <a class="small" href="{{Link}}" target="_blank">{{Link}}</a></p>
 
     </td>
 </tr>

--- a/Kavita.Server/EmailTemplates/EmailConfirm.html
+++ b/Kavita.Server/EmailTemplates/EmailConfirm.html
@@ -1,8 +1,8 @@
 <tr>
     <td>
-        <h1>You've Been Invited!</h1>
-        <p>You have been invited to {{InvitingUser}}'s Kavita instance.</p>
-        <p>Please click the following link to setup an account for yourself and start reading.</p>
+        <h1>{{email.email-confirm.header}}</h1>
+        <p>{{email.email-confirm.description}}</p>
+        <p>{{email.email-confirm.description-2}}</p>
 
         <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="btn btn-primary">
             <tbody>
@@ -11,7 +11,7 @@
                     <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                         <tbody>
                         <tr>
-                            <td> <a href="{{Link}}" target="_blank">ACCEPT INVITE</a> </td>
+                            <td> <a href="{{Link}}" target="_blank">{{email.email-confirm.cta}}</a> </td>
                         </tr>
                         </tbody>
                     </table>
@@ -20,7 +20,7 @@
             </tbody>
         </table>
 
-        <p class="small">If the button above does not work, please find the link here: <a class="small" href="{{Link}}" target="_blank">{{Link}}</a></p>
+        <p class="small">{{email.email-confirm.fallback-link-label}} <a class="small" href="{{Link}}" target="_blank">{{Link}}</a></p>
 
     </td>
 </tr>

--- a/Kavita.Server/EmailTemplates/EmailPasswordReset.html
+++ b/Kavita.Server/EmailTemplates/EmailPasswordReset.html
@@ -1,9 +1,9 @@
 <tr>
     <td>
-        <h1>Forgot your password?</h1>
-        <p>That's okay, it happens! Click on the button below to reset your password.</p>
+        <h1>{{email.password-reset.header}}</h1>
+        <p>{{email.password-reset.description}}</p>
 
-        <p>If you did not perform this action, ignore this email. Your account is safe.</p>
+        <p>{{email.password-reset.safe-notice}}</p>
 
         <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="btn btn-primary">
             <tbody>
@@ -12,7 +12,7 @@
                     <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                         <tbody>
                         <tr>
-                            <td> <a href="{{Link}}" target="_blank">RESET YOUR PASSWORD</a> </td>
+                            <td> <a href="{{Link}}" target="_blank">{{email.password-reset.cta}}</a> </td>
                         </tr>
                         </tbody>
                     </table>
@@ -21,7 +21,7 @@
             </tbody>
         </table>
 
-        <p class="small">If the button above does not work, please find the link here: <a class="small" href="{{Link}}" target="_blank">{{Link}}</a></p>
+        <p class="small">{{email.password-reset.fallback-link-label}} <a class="small" href="{{Link}}" target="_blank">{{Link}}</a></p>
 
     </td>
 </tr>

--- a/Kavita.Server/EmailTemplates/EmailTest.html
+++ b/Kavita.Server/EmailTemplates/EmailTest.html
@@ -1,8 +1,8 @@
 <tr>
     <td>
-        <h1>This is a Test Email</h1>
-        <p>Congrats! Your instance of Kavita is setup to email correctly!</p>
+        <h1>{{email.email-test.header}}</h1>
+        <p>{{email.email-test.description}}</p>
 
-        <p>If you did not perform this action, ignore this email. Your account is safe.</p>
+        <p>{{email.email-test.safe-notice}}</p>
     </td>
 </tr>

--- a/Kavita.Server/EmailTemplates/SendToDevice.html
+++ b/Kavita.Server/EmailTemplates/SendToDevice.html
@@ -1,6 +1,6 @@
 <tr>
     <td>
-        <h1>You sent file(s) from Kavita</h1>
-        <p>Please find attached the file(s) you've sent.</p>
+        <h1>{{email.send-to-device.header}}</h1>
+        <p>{{email.send-to-device.description}}</p>
     </td>
 </tr>

--- a/Kavita.Server/EmailTemplates/TokenExpiration.html
+++ b/Kavita.Server/EmailTemplates/TokenExpiration.html
@@ -1,10 +1,10 @@
 <tr>
     <td valign="top" style="text-align: center; padding: 20px 0 10px 20px;">
-        <h1 style="margin: 0; font-family: 'Montserrat', sans-serif; font-size: 30px; line-height: 36px; font-weight: bold;">Your {{Provider}} Token is Expired!</h1> </td>
+        <h1 style="margin: 0; font-family: 'Montserrat', sans-serif; font-size: 30px; line-height: 36px; font-weight: bold;">{{email.token-expired.header}}</h1> </td>
 </tr>
 <tr>
     <td valign="top" style="text-align: center; padding: 10px 20px 15px 20px; font-family: sans-serif; font-size: 18px; line-height: 20px;">
-        <p style="margin: 0;">Kavita will stop syncing with {{Provider}} until you renew your token.</p>
+        <p style="margin: 0;">{{email.token-expired.description}}</p>
     </td>
 </tr>
 <tr>
@@ -15,7 +15,7 @@
                 <tr>
                     <td style="border-radius: 50px; background: #153643; text-align: center;" class="button-td">
                         <a rel="noopener noreferrer" href="{{Link}}" style="background: #153643; border: 15px solid #153643; font-family: 'Montserrat', sans-serif; font-size: 14px; line-height: 1.1; text-align: center; text-decoration: none; display: block; border-radius: 50px; font-weight: bold;" class="button-a">
-                            <span style="color:#ffffff;" class="button-link">&nbsp;&nbsp;&nbsp;&nbsp;RENEW&nbsp;&nbsp;&nbsp;&nbsp;</span> </a>
+                            <span style="color:#ffffff;" class="button-link">&nbsp;&nbsp;&nbsp;&nbsp;{{email.token-expired.cta}}&nbsp;&nbsp;&nbsp;&nbsp;</span> </a>
                     </td>
                 </tr>
             </table>
@@ -23,6 +23,6 @@
         <!-- Button : END -->
 <tr>
     <td valign="top" style="text-align: center; padding: 10px 20px 15px 20px; font-family: sans-serif; font-size: 12px; line-height: 20px;">
-        <p style="margin: 0;">If the button above does not work, please find the link here: <a style="color:inherit;margin: 0;width: 100%;word-break: break-all;" rel="noopener noreferrer" href="{{Link}}">{{Link}}</a></p>
+        <p style="margin: 0;">{{email.token-expired.fallback-link-label}} <a style="color:inherit;margin: 0;width: 100%;word-break: break-all;" rel="noopener noreferrer" href="{{Link}}">{{Link}}</a></p>
     </td>
 </tr>

--- a/Kavita.Server/EmailTemplates/TokenExpiringSoon.html
+++ b/Kavita.Server/EmailTemplates/TokenExpiringSoon.html
@@ -1,10 +1,10 @@
 <tr>
     <td valign="top" style="text-align: center; padding: 20px 0 10px 20px;">
-        <h1 style="margin: 0; font-family: 'Montserrat', sans-serif; font-size: 30px; line-height: 36px; font-weight: bold;">Your {{Provider}} Token will Expire soon!</h1> </td>
+        <h1 style="margin: 0; font-family: 'Montserrat', sans-serif; font-size: 30px; line-height: 36px; font-weight: bold;">{{email.token-expiring-soon.header}}</h1> </td>
 </tr>
 <tr>
     <td valign="top" style="text-align: center; padding: 10px 20px 15px 20px; font-family: sans-serif; font-size: 18px; line-height: 20px;">
-        <p style="margin: 0;">Kavita will stop syncing with {{Provider}} until you renew your token.</p>
+        <p style="margin: 0;">{{email.token-expiring-soon.description}}</p>
     </td>
 </tr>
 <tr>
@@ -15,7 +15,7 @@
                 <tr>
                     <td style="border-radius: 50px; background: #153643; text-align: center;" class="button-td">
                         <a rel="noopener noreferrer" href="{{Link}}" style="background: #153643; border: 15px solid #153643; font-family: 'Montserrat', sans-serif; font-size: 14px; line-height: 1.1; text-align: center; text-decoration: none; display: block; border-radius: 50px; font-weight: bold;" class="button-a">
-                            <span style="color:#ffffff;" class="button-link">&nbsp;&nbsp;&nbsp;&nbsp;RENEW&nbsp;&nbsp;&nbsp;&nbsp;</span> </a>
+                            <span style="color:#ffffff;" class="button-link">&nbsp;&nbsp;&nbsp;&nbsp;{{email.token-expiring-soon.cta}}&nbsp;&nbsp;&nbsp;&nbsp;</span> </a>
                     </td>
                 </tr>
             </table>
@@ -23,6 +23,6 @@
         <!-- Button : END -->
 <tr>
     <td valign="top" style="text-align: center; padding: 10px 20px 15px 20px; font-family: sans-serif; font-size: 12px; line-height: 20px;">
-        <p style="margin: 0;">If the button above does not work, please find the link here: <a style="color:inherit;margin: 0;width: 100%;word-break: break-all;" rel="noopener noreferrer" href="{{Link}}">{{Link}}</a></p>
+        <p style="margin: 0;">{{email.token-expiring-soon.fallback-link-label}} <a style="color:inherit;margin: 0;width: 100%;word-break: break-all;" rel="noopener noreferrer" href="{{Link}}">{{Link}}</a></p>
     </td>
 </tr>

--- a/Kavita.Server/EmailTemplates/base.html
+++ b/Kavita.Server/EmailTemplates/base.html
@@ -346,15 +346,18 @@
 
         .preheader {
             color: transparent;
-            display: none;
             height: 0;
-            max-height: 0;
-            max-width: 0;
-            opacity: 0;
             overflow: hidden;
-            mso-hide: all;
             visibility: hidden;
             width: 0;
+
+            display: none;
+            font-size:1px;
+            line-height:1px;
+            max-height:0;
+            max-width:0;
+            opacity: 0;
+            font-family: sans-serif;
         }
 
         .powered-by a {
@@ -448,7 +451,7 @@
 <body class="">
 
 <!-- Visually Hidden Preheader Text-->
-<div style="display:none;font-size:1px;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;mso-hide:all;font-family: sans-serif;">{{Preheader}}</div>
+<div id="preheader" class="preheader">{{Preheader}}</div>
 
 <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="body">
     <tr>

--- a/Kavita.Server/EmailTemplates/base.html
+++ b/Kavita.Server/EmailTemplates/base.html
@@ -451,7 +451,7 @@
 <body class="">
 
 <!-- Visually Hidden Preheader Text-->
-<div id="preheader" class="preheader">{{Preheader}}</div>
+<div id="preheader" class="preheader" style="display: none; max-height: 0; max-width: 0; overflow: hidden; mso-hide: all; line-height: 1px; opacity: 0; visibility: hidden;">{{Preheader}}</div>
 
 <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="body">
     <tr>

--- a/Kavita.Server/I18N/en.json
+++ b/Kavita.Server/I18N/en.json
@@ -228,7 +228,7 @@
 
 
 
-    "email.auth-key-expired.subject": "Kavita - One or more Auth Keys has expired!",
+    "email.auth-key-expired.subject": "Kavita - One or more Auth Keys have expired!",
     "email.auth-key-expired.header": "One or more Auth Keys Expired!",
     "email.auth-key-expired.description": "You will no longer be able to authenticate until you rotate the key.",
     "email.auth-key-expired.cta": "ROTATE",
@@ -247,31 +247,24 @@
     "email.email-change.cta": "CONFIRM EMAIL",
     "email.email-change.fallback-link-label": "If the button above does not work, please find the link here:",
 
-    "email.auth-key-expired.preheader": "Kavita - One or more Auth Keys has expired!",
-    "email.auth-key-expiring-soon.preheader": "Kavita - You have Auth Keys expiring soon!",
-
     "email.email-test.subject": "Kavita - Email Test",
-    "email.email-test.preheader": "Kavita - Email Test",
     "email.email-test.header": "This is a Test Email",
     "email.email-test.description": "Congrats! Your instance of Kavita is setup to email correctly!",
     "email.email-test.safe-notice": "If you did not perform this action, ignore this email. Your account is safe.",
 
     "email.token-expired.subject": "Kavita - Your {{Provider}} token has expired and scrobbling events have stopped",
-    "email.token-expired.preheader": "Kavita - Your {{Provider}} token has expired and scrobbling events have stopped",
     "email.token-expired.header": "Your {{Provider}} Token is Expired!",
     "email.token-expired.description": "Kavita will stop syncing with {{Provider}} until you renew your token.",
     "email.token-expired.cta": "RENEW",
     "email.token-expired.fallback-link-label": "If the button above does not work, please find the link here:",
 
     "email.token-expiring-soon.subject": "Kavita - Your {{Provider}} token will expire soon!",
-    "email.token-expiring-soon.preheader": "Kavita - Your {{Provider}} token will expire soon!",
     "email.token-expiring-soon.header": "Your {{Provider}} Token will Expire soon!",
     "email.token-expiring-soon.description": "Kavita will stop syncing with {{Provider}} until you renew your token.",
     "email.token-expiring-soon.cta": "RENEW",
     "email.token-expiring-soon.fallback-link-label": "If the button above does not work, please find the link here:",
 
     "email.email-confirm.subject": "You've been invited to join {{InvitingUser}}'s Kavita Server",
-    "email.email-confirm.preheader": "You've been invited to join {{InvitingUser}}'s Kavita Server",
     "email.email-confirm.header": "You've Been Invited!",
     "email.email-confirm.description": "You have been invited to {{InvitingUser}}'s Kavita instance.",
     "email.email-confirm.description-2": "Please click the following link to setup an account for yourself and start reading.",
@@ -279,7 +272,7 @@
     "email.email-confirm.fallback-link-label": "If the button above does not work, please find the link here:",
 
     "email.password-reset.subject": "Kavita - A password reset has been requested",
-    "email.password-reset.preheader": "Email confirmation is required for continued access. Click the button to confirm your email.",
+    "email.password-reset.preheader": "You requested a password reset. Click the button to confirm your email and confirm the password change.",
     "email.password-reset.header": "Forgot your password?",
     "email.password-reset.description": "That's okay, it happens! Click on the button below to reset your password.",
     "email.password-reset.safe-notice": "If you did not perform this action, ignore this email. Your account is safe.",

--- a/Kavita.Server/I18N/en.json
+++ b/Kavita.Server/I18N/en.json
@@ -229,10 +229,16 @@
 
 
     "email.auth-key-expired.subject": "Kavita - One or more Auth Keys has expired!",
-    "email.auth-key-expired.preheader": "Kavita - One or more Auth Keys has expired!",
     "email.auth-key-expired.header": "One or more Auth Keys Expired!",
     "email.auth-key-expired.description": "You will no longer be able to authenticate until you rotate the key.",
     "email.auth-key-expired.rotate-cta": "ROTATE",
-    "email.auth-key-expired.fallback-link-label": "If the button above does not work, please find the link here:"
+    "email.auth-key-expired.fallback-link-label": "If the button above does not work, please find the link here:",
+
+    "email.auth-key-expiring-soon.subject": "Kavita - You have Auth Keys expiring soon!",
+    "email.auth-key-expiring-soon.rotate-cta": "ROTATE",
+    "email.auth-key-expiring-soon.fallback-link-label": "If the button above does not work, please find the link here:",
+    "email.auth-key-expiring-fragment.name-header": "Name",
+    "email.auth-key-expiring-fragment.expires-header": "Expires (Days)"
+
 
 }

--- a/Kavita.Server/I18N/en.json
+++ b/Kavita.Server/I18N/en.json
@@ -233,6 +233,6 @@
     "email.auth-key-expired.header": "One or more Auth Keys Expired!",
     "email.auth-key-expired.description": "You will no longer be able to authenticate until you rotate the key.",
     "email.auth-key-expired.rotate-cta": "ROTATE",
-    "email.auth-key-expired.fallback-link-label": "If the button above does not work, please find the link here: {0}"
+    "email.auth-key-expired.fallback-link-label": "If the button above does not work, please find the link here:"
 
 }

--- a/Kavita.Server/I18N/en.json
+++ b/Kavita.Server/I18N/en.json
@@ -231,14 +231,63 @@
     "email.auth-key-expired.subject": "Kavita - One or more Auth Keys has expired!",
     "email.auth-key-expired.header": "One or more Auth Keys Expired!",
     "email.auth-key-expired.description": "You will no longer be able to authenticate until you rotate the key.",
-    "email.auth-key-expired.rotate-cta": "ROTATE",
+    "email.auth-key-expired.cta": "ROTATE",
     "email.auth-key-expired.fallback-link-label": "If the button above does not work, please find the link here:",
 
     "email.auth-key-expiring-soon.subject": "Kavita - You have Auth Keys expiring soon!",
-    "email.auth-key-expiring-soon.rotate-cta": "ROTATE",
+    "email.auth-key-expiring-soon.cta": "ROTATE",
     "email.auth-key-expiring-soon.fallback-link-label": "If the button above does not work, please find the link here:",
     "email.auth-key-expiring-fragment.name-header": "Name",
-    "email.auth-key-expiring-fragment.expires-header": "Expires (Days)"
+    "email.auth-key-expiring-fragment.expires-header": "Expires (Days)",
 
+    "email.email-change.subject": "Your email has been changed on {{InvitingUser}}'s Server",
+    "email.email-change.title": "Email Change Update",
+    "email.email-change.description-1": "Your account's email has been updated on {{InvitingUser}}'s Kavita instance.",
+    "email.email-change.description-2": "Please click the following link to validate your email change. The email is not changed until you complete validation.",
+    "email.email-change.cta": "CONFIRM EMAIL",
+    "email.email-change.fallback-link-label": "If the button above does not work, please find the link here:",
 
+    "email.auth-key-expired.preheader": "Kavita - One or more Auth Keys has expired!",
+    "email.auth-key-expiring-soon.preheader": "Kavita - You have Auth Keys expiring soon!",
+
+    "email.email-test.subject": "Kavita - Email Test",
+    "email.email-test.preheader": "Kavita - Email Test",
+    "email.email-test.header": "This is a Test Email",
+    "email.email-test.description": "Congrats! Your instance of Kavita is setup to email correctly!",
+    "email.email-test.safe-notice": "If you did not perform this action, ignore this email. Your account is safe.",
+
+    "email.token-expired.subject": "Kavita - Your {{Provider}} token has expired and scrobbling events have stopped",
+    "email.token-expired.preheader": "Kavita - Your {{Provider}} token has expired and scrobbling events have stopped",
+    "email.token-expired.header": "Your {{Provider}} Token is Expired!",
+    "email.token-expired.description": "Kavita will stop syncing with {{Provider}} until you renew your token.",
+    "email.token-expired.cta": "RENEW",
+    "email.token-expired.fallback-link-label": "If the button above does not work, please find the link here:",
+
+    "email.token-expiring-soon.subject": "Kavita - Your {{Provider}} token will expire soon!",
+    "email.token-expiring-soon.preheader": "Kavita - Your {{Provider}} token will expire soon!",
+    "email.token-expiring-soon.header": "Your {{Provider}} Token will Expire soon!",
+    "email.token-expiring-soon.description": "Kavita will stop syncing with {{Provider}} until you renew your token.",
+    "email.token-expiring-soon.cta": "RENEW",
+    "email.token-expiring-soon.fallback-link-label": "If the button above does not work, please find the link here:",
+
+    "email.email-confirm.subject": "You've been invited to join {{InvitingUser}}'s Kavita Server",
+    "email.email-confirm.preheader": "You've been invited to join {{InvitingUser}}'s Kavita Server",
+    "email.email-confirm.header": "You've Been Invited!",
+    "email.email-confirm.description": "You have been invited to {{InvitingUser}}'s Kavita instance.",
+    "email.email-confirm.description-2": "Please click the following link to setup an account for yourself and start reading.",
+    "email.email-confirm.cta": "ACCEPT INVITE",
+    "email.email-confirm.fallback-link-label": "If the button above does not work, please find the link here:",
+
+    "email.password-reset.subject": "Kavita - A password reset has been requested",
+    "email.password-reset.preheader": "Email confirmation is required for continued access. Click the button to confirm your email.",
+    "email.password-reset.header": "Forgot your password?",
+    "email.password-reset.description": "That's okay, it happens! Click on the button below to reset your password.",
+    "email.password-reset.safe-notice": "If you did not perform this action, ignore this email. Your account is safe.",
+    "email.password-reset.cta": "RESET YOUR PASSWORD",
+    "email.password-reset.fallback-link-label": "If the button above does not work, please find the link here:",
+
+    "email.send-to-device.subject": "Kavita - Send file from Kavita",
+    "email.send-to-device.preheader": "File(s) sent from Kavita",
+    "email.send-to-device.header": "You sent file(s) from Kavita",
+    "email.send-to-device.description": "Please find attached the file(s) you've sent."
 }

--- a/Kavita.Server/I18N/en.json
+++ b/Kavita.Server/I18N/en.json
@@ -224,5 +224,15 @@
     "cbl-export-failed": "Unable to export CBL file, check logs",
     "download-not-allowed": "User does not have download permissions",
     "auth-key-unique": "The Auth Key name must be unique to your account",
-    "role-restricted": "Access forbidden: Your role does not permit this action"
+    "role-restricted": "Access forbidden: Your role does not permit this action",
+
+
+
+    "email.auth-key-expired.subject": "Kavita - One or more Auth Keys has expired!",
+    "email.auth-key-expired.preheader": "Kavita - One or more Auth Keys has expired!",
+    "email.auth-key-expired.header": "One or more Auth Keys Expired!",
+    "email.auth-key-expired.description": "You will no longer be able to authenticate until you rotate the key.",
+    "email.auth-key-expired.rotate-cta": "ROTATE",
+    "email.auth-key-expired.fallback-link-label": "If the button above does not work, please find the link here: {0}"
+
 }

--- a/Kavita.Services/DeviceService.cs
+++ b/Kavita.Services/DeviceService.cs
@@ -128,6 +128,7 @@ public class DeviceService(
 
         var success = await emailService.SendFilesToEmail(new SendToDto()
         {
+            UserId = device.AppUserId,
             DestinationEmail = device.EmailAddress!,
             FilePaths = files.Select(m => m.FilePath)
         });

--- a/Kavita.Services/EmailService.cs
+++ b/Kavita.Services/EmailService.cs
@@ -16,6 +16,7 @@ using Kavita.Common.Extensions;
 using Kavita.Models.DTOs.Email;
 using Kavita.Models.Entities;
 using Kavita.Models.Entities.Enums;
+using Kavita.Models.Entities.Enums.User;
 using Kavita.Models.Entities.User;
 using MailKit.Security;
 using Microsoft.AspNetCore.Http;
@@ -95,7 +96,15 @@ public class EmailService(
         }
 
         // DEBUG CODE
-        await SendAuthKeyExpiredEmail(defaultAdmin.Id, []);
+        await SendAuthKeyExpiringSoonEmail(defaultAdmin.Id, [
+            new AppUserAuthKey()
+            {
+                Name = "test",
+                Provider = AuthKeyProvider.User,
+                Key = "123abc",
+                ExpiresAtUtc = DateTime.UtcNow.AddDays(7)
+            }
+        ]);
 
         var placeholders = new List<KeyValuePair<string, string>>
         {
@@ -228,16 +237,18 @@ public class EmailService(
             new ("{{Link}}", $"{settings.HostName}/settings#account" ),
         };
 
+        var subjectText = await localizationService.Translate(userId, "email.auth-key-expiring-soon.subject");
+        var subject = UpdatePlaceHolders(subjectText, placeholders);
+
+
+
         var emailOptions = new EmailOptionsDto()
         {
-            Subject = UpdatePlaceHolders("Kavita - Your {{Provider}} token will expire soon!", placeholders),
+            Subject = subject,
+            Preheader = subject,
             Template = TokenExpiringSoonTemplate,
             Body = UpdatePlaceHolders(await GetEmailBody(TokenExpiringSoonTemplate), placeholders),
-            Preheader = UpdatePlaceHolders("Kavita - Your {{Provider}} token will expire soon!", placeholders),
-            ToEmails = new List<string>()
-            {
-                user.Email
-            }
+            ToEmails = [user.Email!]
         };
 
         await SendEmail(emailOptions);
@@ -251,28 +262,18 @@ public class EmailService(
         var settings = await unitOfWork.SettingsRepository.GetSettingsDtoAsync();
         if (user == null || !IsValidEmail(user.Email) || !settings.IsEmailSetup()) return false;
 
-        var d = keys.Select(k => new List<KeyValuePair<string, string>>()
+        var perItemData = keys.Select(k => new List<KeyValuePair<string, string>>()
         {
             new("{{Name}}", k.Name),
         });
 
-        var placeholders = new List<KeyValuePair<string, string>>
-        {
-            new ("{{AuthKeyFragment}}", await BuildFragment(AuthKeyExpiredFragment, d)),
-            new ("{{Link}}", $"{settings.HostName}/settings#account"),
-        };
-
-        var body = UpdatePlaceHolders(await GetEmailBody(AuthKeyExpiredTemplate), placeholders);
-        body = await ResolveLocalizationKeys(body, "auth-key-expired", userId, placeholders);
-
-        var emailOptions = new EmailOptionsDto()
-        {
-            Subject = await localizationService.Translate(userId, "email.auth-key-expired.subject"),
-            Preheader = await localizationService.Translate(userId, "email.auth-key-expired.preheader"),
-            Template = AuthKeyExpiredTemplate,
-            Body = body,
-            ToEmails = [user.Email!]
-        };
+        var emailOptions = await CreateEmail()
+            .ForTemplate(AuthKeyExpiredTemplate)
+            .WithLocalization(userId, "auth-key-expired")
+            .WithPlaceholder("{{Link}}", $"{settings.HostName}/settings#account")
+            .WithFragment("{{AuthKeyFragment}}", AuthKeyExpiredFragment, perItemData)
+            .To(user.Email!)
+            .Build();
 
         await SendEmail(emailOptions);
 
@@ -286,31 +287,21 @@ public class EmailService(
         var settings = await unitOfWork.SettingsRepository.GetSettingsDtoAsync();
         if (user == null || !IsValidEmail(user.Email) || !settings.IsEmailSetup()) return false;
 
-        var d = keys.Select(k => new List<KeyValuePair<string, string>>()
+        var perItemData = keys.Select(k => new List<KeyValuePair<string, string>>()
         {
             new("{{Name}}", k.Name),
-            new("{{DaysLeft}}", (k.ExpiresAtUtc.Value - DateTime.UtcNow).Days.ToString())
+            new("{{DaysLeft}}", (k.ExpiresAtUtc.Value - DateTime.UtcNow).Days.ToString()),
+
         });
 
-
-        var placeholders = new List<KeyValuePair<string, string>>
-        {
-            new ("{{UserName}}", user.UserName!),
-            new ("{{AuthKeyFragment}}", await BuildFragment(AuthKeyExpiringFragment, d)),
-            new ("{{Link}}", $"{settings.HostName}/settings#clients" ),
-        };
-
-        var emailOptions = new EmailOptionsDto()
-        {
-            Subject = "Kavita - One or more Auth Keys will expire soon!",
-            Template = AuthKeyExpiringSoonTemplate,
-            Body = UpdatePlaceHolders(await GetEmailBody(AuthKeyExpiringSoonTemplate), placeholders),
-            Preheader = "Kavita - One or more Auth Keys will expire soon!",
-            ToEmails = new List<string>()
-            {
-                user.Email
-            }
-        };
+        var emailOptions = await CreateEmail()
+            .ForTemplate(AuthKeyExpiringSoonTemplate)
+            .WithLocalization(userId, "auth-key-expiring-soon")
+            .WithPlaceholder("{{Link}}", $"{settings.HostName}/settings#clients")
+            .WithFragment("{{AuthKeyFragment}}", AuthKeyExpiringFragment, perItemData,
+                fragmentLocalizationScope: "auth-key-expiring-fragment")
+            .To(user.Email!)
+            .Build();
 
         await SendEmail(emailOptions);
 
@@ -611,5 +602,141 @@ public class EmailService(
         }
 
         return UpdatePlaceHolders(body, placeholders);
+    }
+
+    private Task<string> TranslateKey(int userId, string key) => localizationService.Translate(userId, key);
+
+    private EmailBuilder CreateEmail() => new EmailBuilder(this);
+
+    private class EmailBuilder
+    {
+        private readonly EmailService _service;
+        private string? _templateName;
+        private int? _userId;
+        private string? _keyScope;
+        private string? _manualSubject;
+        private string? _manualPreheader;
+        private readonly List<KeyValuePair<string, string>> _placeholders = [];
+        private readonly List<FragmentEntry> _fragments = [];
+        private readonly List<string> _toEmails = [];
+        private readonly List<string> _attachments = [];
+
+        private record FragmentEntry(
+            string PlaceholderKey,
+            string FragmentTemplate,
+            IEnumerable<IList<KeyValuePair<string, string>>> PerItemPlaceholders,
+            string? LocalizationScope);
+
+        public EmailBuilder(EmailService service) => _service = service;
+
+        public EmailBuilder ForTemplate(string templateName)
+        {
+            _templateName = templateName;
+            return this;
+        }
+
+        public EmailBuilder WithLocalization(int userId, string keyScope)
+        {
+            _userId = userId;
+            _keyScope = keyScope;
+            return this;
+        }
+
+        public EmailBuilder WithSubject(string subject)
+        {
+            _manualSubject = subject;
+            return this;
+        }
+
+        public EmailBuilder WithPreheader(string preheader)
+        {
+            _manualPreheader = preheader;
+            return this;
+        }
+
+        public EmailBuilder WithPlaceholder(string key, string value)
+        {
+            _placeholders.Add(new KeyValuePair<string, string>(key, value));
+            return this;
+        }
+
+        public EmailBuilder WithFragment(string placeholderKey, string fragmentTemplate,
+            IEnumerable<IList<KeyValuePair<string, string>>> perItemPlaceholders,
+            string? fragmentLocalizationScope = null)
+        {
+            _fragments.Add(new FragmentEntry(placeholderKey, fragmentTemplate, perItemPlaceholders, fragmentLocalizationScope));
+            return this;
+        }
+
+        public EmailBuilder To(params string[] emails)
+        {
+            _toEmails.AddRange(emails);
+            return this;
+        }
+
+        public EmailBuilder WithAttachments(params string[] filePaths)
+        {
+            _attachments.AddRange(filePaths);
+            return this;
+        }
+
+        public async Task<EmailOptionsDto> Build()
+        {
+            // 1. Build fragments: load fragment template, replace per-item placeholders, concatenate.
+            //    Resolve localization using fragmentLocalizationScope if set, otherwise fall back to main keyScope.
+            //    Then second-pass placeholders.
+            foreach (var fragment in _fragments)
+            {
+                var fragmentHtml = await _service.BuildFragment(fragment.FragmentTemplate, fragment.PerItemPlaceholders);
+
+                var fragmentScope = fragment.LocalizationScope ?? _keyScope;
+                if (fragmentScope != null && _userId.HasValue)
+                {
+                    fragmentHtml = await _service.ResolveLocalizationKeys(fragmentHtml, fragmentScope, _userId.Value, _placeholders);
+                }
+
+                // 2. Inject fragment results as additional placeholders
+                _placeholders.Add(new KeyValuePair<string, string>(fragment.PlaceholderKey, fragmentHtml));
+            }
+
+            // 3. Load main template and first-pass placeholder replacement
+            var body = UpdatePlaceHolders(await _service.GetEmailBody(_templateName!), _placeholders);
+
+            // 4. Resolve body localization: {{email.{scope}.*}} regex → translate → second-pass placeholders
+            if (_keyScope != null && _userId.HasValue)
+            {
+                body = await _service.ResolveLocalizationKeys(body, _keyScope, _userId.Value, _placeholders);
+            }
+
+            // 5. Resolve subject/preheader: translate or use manual, then apply placeholder replacement
+            string subject;
+            string preheader;
+            if (_keyScope != null && _userId.HasValue)
+            {
+                subject = _manualSubject
+                    ?? await _service.TranslateKey(_userId.Value, $"email.{_keyScope}.subject");
+                preheader = _manualPreheader
+                    ?? await _service.TranslateKey(_userId.Value, $"email.{_keyScope}.preheader");
+            }
+            else
+            {
+                subject = _manualSubject ?? throw new InvalidOperationException("Subject is required when localization is not configured");
+                preheader = _manualPreheader ?? subject;
+            }
+
+            subject = UpdatePlaceHolders(subject, _placeholders);
+            preheader = UpdatePlaceHolders(preheader, _placeholders);
+
+
+            return new EmailOptionsDto
+            {
+                Subject = subject,
+                Preheader = preheader,
+                Template = _templateName!,
+                Body = body,
+                ToEmails = _toEmails,
+                Attachments = _attachments.Count > 0 ? _attachments : null
+            };
+        }
     }
 }

--- a/Kavita.Services/EmailService.cs
+++ b/Kavita.Services/EmailService.cs
@@ -522,7 +522,7 @@ public class EmailService(
 
     private EmailBuilder CreateEmail() => new EmailBuilder(this);
 
-    private class EmailBuilder
+    private sealed class EmailBuilder
     {
         private readonly EmailService _service;
         private string? _templateName;
@@ -535,7 +535,7 @@ public class EmailService(
         private readonly List<string> _toEmails = [];
         private readonly List<string> _attachments = [];
 
-        private record FragmentEntry(
+        private sealed record FragmentEntry(
             string PlaceholderKey,
             string FragmentTemplate,
             IEnumerable<IList<KeyValuePair<string, string>>> PerItemPlaceholders,
@@ -596,6 +596,11 @@ public class EmailService(
 
         public async Task<EmailOptionsDto> Build()
         {
+
+            // Validate critical variables
+            if (string.IsNullOrEmpty(_templateName)) throw new InvalidOperationException("Template must be defined");
+            if (_toEmails.Count == 0) throw new InvalidOperationException("There must be at least one email to build");
+
             // 1. Build fragments: load fragment template, replace per-item placeholders, concatenate.
             //    Resolve localization using fragmentLocalizationScope if set, otherwise fall back to main keyScope.
             //    Then second-pass placeholders.

--- a/Kavita.Services/EmailService.cs
+++ b/Kavita.Services/EmailService.cs
@@ -95,17 +95,6 @@ public class EmailService(
             return result;
         }
 
-        // DEBUG CODE
-        await SendAuthKeyExpiringSoonEmail(defaultAdmin.Id, [
-            new AppUserAuthKey()
-            {
-                Name = "test",
-                Provider = AuthKeyProvider.User,
-                Key = "123abc",
-                ExpiresAtUtc = DateTime.UtcNow.AddDays(7)
-            }
-        ]);
-
         try
         {
             var emailOptions = await CreateEmail()
@@ -135,7 +124,7 @@ public class EmailService(
     {
         var emailOptions = await CreateEmail()
             .ForTemplate(EmailChangeTemplate)
-            .WithLocalization(data.EmailUserId, "email-change")
+            .WithLocalization(data.LocaleUserId, "email-change")
             .WithPlaceholder("{{InvitingUser}}", data.InvitingUser)
             .WithPlaceholder("{{Link}}", data.ServerConfirmationLink)
             .To(data.EmailAddress)
@@ -298,7 +287,7 @@ public class EmailService(
     {
         var emailOptions = await CreateEmail()
             .ForTemplate(EmailConfirmTemplate)
-            .WithLocalization(data.EmailUserId, "email-confirm")
+            .WithLocalization(data.LocaleUserId, "email-confirm")
             .WithPlaceholder("{{InvitingUser}}", data.InvitingUser)
             .WithPlaceholder("{{Link}}", data.ServerConfirmationLink)
             .To(data.EmailAddress)

--- a/Kavita.Services/EmailService.cs
+++ b/Kavita.Services/EmailService.cs
@@ -106,24 +106,14 @@ public class EmailService(
             }
         ]);
 
-        var placeholders = new List<KeyValuePair<string, string>>
-        {
-            new ("{{Host}}", settings.HostName),
-        };
-
         try
         {
-            var emailOptions = new EmailOptionsDto()
-            {
-                Subject = "Kavita - Email Test",
-                Template = EmailTestTemplate,
-                Body = UpdatePlaceHolders(await GetEmailBody(EmailTestTemplate), placeholders),
-                Preheader = "Kavita - Email Test",
-                ToEmails = new List<string>()
-                {
-                    adminEmail
-                },
-            };
+            var emailOptions = await CreateEmail()
+                .ForTemplate(EmailTestTemplate)
+                .WithLocalization(defaultAdmin.Id, "email-test")
+                .WithPlaceholder("{{Host}}", settings.HostName)
+                .To(adminEmail)
+                .Build();
 
             await SendEmail(emailOptions);
             result.Successful = true;
@@ -143,23 +133,13 @@ public class EmailService(
     /// <param name="data"></param>
     public async Task SendEmailChangeEmail(ConfirmationEmailDto data)
     {
-        var placeholders = new List<KeyValuePair<string, string>>
-        {
-            new ("{{InvitingUser}}", data.InvitingUser),
-            new ("{{Link}}", data.ServerConfirmationLink)
-        };
-
-        var emailOptions = new EmailOptionsDto()
-        {
-            Subject = UpdatePlaceHolders("Your email has been changed on {{InvitingUser}}'s Server", placeholders),
-            Template = EmailChangeTemplate,
-            Body = UpdatePlaceHolders(await GetEmailBody(EmailChangeTemplate), placeholders),
-            Preheader = UpdatePlaceHolders("Your email has been changed on {{InvitingUser}}'s Server", placeholders),
-            ToEmails = new List<string>()
-            {
-                data.EmailAddress
-            }
-        };
+        var emailOptions = await CreateEmail()
+            .ForTemplate(EmailChangeTemplate)
+            .WithLocalization(data.EmailUserId, "email-change")
+            .WithPlaceholder("{{InvitingUser}}", data.InvitingUser)
+            .WithPlaceholder("{{Link}}", data.ServerConfirmationLink)
+            .To(data.EmailAddress)
+            .Build();
 
         await SendEmail(emailOptions);
     }
@@ -200,24 +180,14 @@ public class EmailService(
         var settings = await unitOfWork.SettingsRepository.GetSettingsDtoAsync();
         if (user == null || !IsValidEmail(user.Email) || !settings.IsEmailSetup()) return false;
 
-        var placeholders = new List<KeyValuePair<string, string>>
-        {
-            new ("{{UserName}}", user.UserName!),
-            new ("{{Provider}}", provider.ToDescription()),
-            new ("{{Link}}", $"{settings.HostName}/settings#account" ),
-        };
-
-        var emailOptions = new EmailOptionsDto()
-        {
-            Subject = UpdatePlaceHolders("Kavita - Your {{Provider}} token has expired and scrobbling events have stopped", placeholders),
-            Template = TokenExpirationTemplate,
-            Body = UpdatePlaceHolders(await GetEmailBody(TokenExpirationTemplate), placeholders),
-            Preheader = UpdatePlaceHolders("Kavita - Your {{Provider}} token has expired and scrobbling events have stopped", placeholders),
-            ToEmails = new List<string>()
-            {
-                user.Email
-            }
-        };
+        var emailOptions = await CreateEmail()
+            .ForTemplate(TokenExpirationTemplate)
+            .WithLocalization(userId, "token-expired")
+            .WithPlaceholder("{{UserName}}", user.UserName!)
+            .WithPlaceholder("{{Provider}}", provider.ToDescription())
+            .WithPlaceholder("{{Link}}", $"{settings.HostName}/settings#account")
+            .To(user.Email!)
+            .Build();
 
         await SendEmail(emailOptions);
 
@@ -230,26 +200,14 @@ public class EmailService(
         var settings = await unitOfWork.SettingsRepository.GetSettingsDtoAsync();
         if (user == null || !IsValidEmail(user.Email) || !settings.IsEmailSetup()) return false;
 
-        var placeholders = new List<KeyValuePair<string, string>>
-        {
-            new ("{{UserName}}", user.UserName!),
-            new ("{{Provider}}", provider.ToDescription()),
-            new ("{{Link}}", $"{settings.HostName}/settings#account" ),
-        };
-
-        var subjectText = await localizationService.Translate(userId, "email.auth-key-expiring-soon.subject");
-        var subject = UpdatePlaceHolders(subjectText, placeholders);
-
-
-
-        var emailOptions = new EmailOptionsDto()
-        {
-            Subject = subject,
-            Preheader = subject,
-            Template = TokenExpiringSoonTemplate,
-            Body = UpdatePlaceHolders(await GetEmailBody(TokenExpiringSoonTemplate), placeholders),
-            ToEmails = [user.Email!]
-        };
+        var emailOptions = await CreateEmail()
+            .ForTemplate(TokenExpiringSoonTemplate)
+            .WithLocalization(userId, "token-expiring-soon")
+            .WithPlaceholder("{{UserName}}", user.UserName!)
+            .WithPlaceholder("{{Provider}}", provider.ToDescription())
+            .WithPlaceholder("{{Link}}", $"{settings.HostName}/settings#account")
+            .To(user.Email!)
+            .Build();
 
         await SendEmail(emailOptions);
 
@@ -318,24 +276,14 @@ public class EmailService(
         var settings = await unitOfWork.SettingsRepository.GetSettingsDtoAsync();
         if (!settings.IsEmailSetup()) return false;
 
-        var placeholders = new List<KeyValuePair<string, string>>
-        {
-            new ("{{InstallId}}", HashUtil.ServerToken()),
-            new ("{{Build}}", BuildInfo.Version.ToString()),
-        };
-
-        var emailOptions = new EmailOptionsDto()
-        {
-            Subject = UpdatePlaceHolders("Kavita+: A User needs manual registration", placeholders),
-            Template = KavitaPlusDebugTemplate,
-            Body = UpdatePlaceHolders(await GetEmailBody(KavitaPlusDebugTemplate), placeholders),
-            Preheader = UpdatePlaceHolders("Kavita+: A User needs manual registration", placeholders),
-            ToEmails =
-            [
-                // My kavita email
-                Encoding.UTF8.GetString(Convert.FromBase64String("a2F2aXRhcmVhZGVyQGdtYWlsLmNvbQ=="))
-            ]
-        };
+        var emailOptions = await CreateEmail()
+            .ForTemplate(KavitaPlusDebugTemplate)
+            .WithSubject("Kavita+: A User needs manual registration")
+            .WithPreheader("Kavita+: A User needs manual registration")
+            .WithPlaceholder("{{InstallId}}", HashUtil.ServerToken())
+            .WithPlaceholder("{{Build}}", BuildInfo.Version.ToString())
+            .To(Encoding.UTF8.GetString(Convert.FromBase64String("a2F2aXRhcmVhZGVyQGdtYWlsLmNvbQ==")))
+            .Build();
 
         await SendEmail(emailOptions);
 
@@ -348,23 +296,13 @@ public class EmailService(
     /// <param name="data"></param>
     public async Task SendInviteEmail(ConfirmationEmailDto data)
     {
-        var placeholders = new List<KeyValuePair<string, string>>
-        {
-            new ("{{InvitingUser}}", data.InvitingUser),
-            new ("{{Link}}", data.ServerConfirmationLink)
-        };
-
-        var emailOptions = new EmailOptionsDto()
-        {
-            Subject = UpdatePlaceHolders("You've been invited to join {{InvitingUser}}'s Kavita Server", placeholders),
-            Template = EmailConfirmTemplate,
-            Body = UpdatePlaceHolders(await GetEmailBody(EmailConfirmTemplate), placeholders),
-            Preheader = UpdatePlaceHolders("You've been invited to join {{InvitingUser}}'s Kavita Server", placeholders),
-            ToEmails = new List<string>()
-            {
-                data.EmailAddress
-            }
-        };
+        var emailOptions = await CreateEmail()
+            .ForTemplate(EmailConfirmTemplate)
+            .WithLocalization(data.EmailUserId, "email-confirm")
+            .WithPlaceholder("{{InvitingUser}}", data.InvitingUser)
+            .WithPlaceholder("{{Link}}", data.ServerConfirmationLink)
+            .To(data.EmailAddress)
+            .Build();
 
         await SendEmail(emailOptions);
     }
@@ -372,22 +310,12 @@ public class EmailService(
 
     public async Task<bool> SendForgotPasswordEmail(PasswordResetEmailDto dto)
     {
-        var placeholders = new List<KeyValuePair<string, string>>
-        {
-            new ("{{Link}}", dto.ServerConfirmationLink),
-        };
-
-        var emailOptions = new EmailOptionsDto()
-        {
-            Subject = UpdatePlaceHolders("A password reset has been requested", placeholders),
-            Template = EmailPasswordResetTemplate,
-            Body = UpdatePlaceHolders(await GetEmailBody(EmailPasswordResetTemplate), placeholders),
-            Preheader = "Email confirmation is required for continued access. Click the button to confirm your email.",
-            ToEmails =
-            [
-                dto.EmailAddress
-            ]
-        };
+        var emailOptions = await CreateEmail()
+            .ForTemplate(EmailPasswordResetTemplate)
+            .WithLocalization(dto.EmailUserId, "password-reset")
+            .WithPlaceholder("{{Link}}", dto.ServerConfirmationLink)
+            .To(dto.EmailAddress)
+            .Build();
 
         await SendEmail(emailOptions);
         return true;
@@ -398,15 +326,12 @@ public class EmailService(
         var serverSetting = await unitOfWork.SettingsRepository.GetSettingsDtoAsync();
         if (!serverSetting.IsEmailSetupForSendToDevice()) return false;
 
-        var emailOptions = new EmailOptionsDto()
-        {
-            Subject = "Send file from Kavita",
-            Preheader = "File(s) sent from Kavita",
-            ToEmails = [data.DestinationEmail],
-            Template = SendToDeviceTemplate,
-            Body = await GetEmailBody(SendToDeviceTemplate),
-            Attachments = data.FilePaths.ToList()
-        };
+        var emailOptions = await CreateEmail()
+            .ForTemplate(SendToDeviceTemplate)
+            .WithLocalization(data.UserId, "send-to-device")
+            .To(data.DestinationEmail)
+            .WithAttachments(data.FilePaths.ToArray())
+            .Build();
 
         await SendEmail(emailOptions);
         return true;

--- a/Kavita.Services/EmailService.cs
+++ b/Kavita.Services/EmailService.cs
@@ -217,7 +217,7 @@ public class EmailService(
         var emailOptions = await CreateEmail()
             .ForTemplate(AuthKeyExpiredTemplate)
             .WithLocalization(userId, "auth-key-expired")
-            .WithPlaceholder("{{Link}}", $"{settings.HostName}/settings#account")
+            .WithPlaceholder("{{Link}}", $"{settings.HostName}/settings#clients")
             .WithFragment("{{AuthKeyFragment}}", AuthKeyExpiredFragment, perItemData)
             .To(user.Email!)
             .Build();
@@ -600,6 +600,7 @@ public class EmailService(
             // Validate critical variables
             if (string.IsNullOrEmpty(_templateName)) throw new InvalidOperationException("Template must be defined");
             if (_toEmails.Count == 0) throw new InvalidOperationException("There must be at least one email to build");
+            if (_keyScope == null && _manualSubject == null) throw new InvalidOperationException("Subject is required when localization is not configured");
 
             // 1. Build fragments: load fragment template, replace per-item placeholders, concatenate.
             //    Resolve localization using fragmentLocalizationScope if set, otherwise fall back to main keyScope.
@@ -634,12 +635,16 @@ public class EmailService(
             {
                 subject = _manualSubject
                     ?? await _service.TranslateKey(_userId.Value, $"email.{_keyScope}.subject");
-                preheader = _manualPreheader
-                    ?? await _service.TranslateKey(_userId.Value, $"email.{_keyScope}.preheader");
+
+                var preheaderKey = $"email.{_keyScope}.preheader";
+                var translatedPreheader = _manualPreheader
+                    ?? await _service.TranslateKey(_userId.Value, preheaderKey);
+                // If the key wasn't found (returned as-is), fall back to subject
+                preheader = translatedPreheader == preheaderKey ? subject : translatedPreheader;
             }
             else
             {
-                subject = _manualSubject ?? throw new InvalidOperationException("Subject is required when localization is not configured");
+                subject = _manualSubject!;
                 preheader = _manualPreheader ?? subject;
             }
 

--- a/Kavita.Services/EmailService.cs
+++ b/Kavita.Services/EmailService.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Web;
 using Kavita.API.Database;
@@ -93,6 +94,7 @@ public class EmailService(
             return result;
         }
 
+        // DEBUG CODE
         await SendAuthKeyExpiredEmail(defaultAdmin.Id, []);
 
         var placeholders = new List<KeyValuePair<string, string>>
@@ -256,28 +258,20 @@ public class EmailService(
 
         var placeholders = new List<KeyValuePair<string, string>>
         {
-            new ("{{UserName}}", user.UserName!),
             new ("{{AuthKeyFragment}}", await BuildFragment(AuthKeyExpiredFragment, d)),
             new ("{{Link}}", $"{settings.HostName}/settings#account"),
-
-            new ("{{email.auth-key-expired.header}}", await localizationService.Translate(userId, "email.auth-key-expired.header")),
-            new ("{{email.auth-key-expired.description}}", await localizationService.Translate(userId, "email.auth-key-expired.description")),
-            new ("{{email.auth-key-expired.rotate-cta}}", await localizationService.Translate(userId, "email.auth-key-expired.rotate-cta")),
-            new ("{{email.auth-key-expired.fallback-link-label}}", await localizationService.Translate(userId, "email.auth-key-expired.fallback-link-label")),
         };
 
-
+        var body = UpdatePlaceHolders(await GetEmailBody(AuthKeyExpiredTemplate), placeholders);
+        body = await ResolveLocalizationKeys(body, "auth-key-expired", userId, placeholders);
 
         var emailOptions = new EmailOptionsDto()
         {
             Subject = await localizationService.Translate(userId, "email.auth-key-expired.subject"),
-            Template = AuthKeyExpiredTemplate,
-            Body = UpdatePlaceHolders(await GetEmailBody(AuthKeyExpiredTemplate), placeholders),
             Preheader = await localizationService.Translate(userId, "email.auth-key-expired.preheader"),
-            ToEmails = new List<string>()
-            {
-                user.Email
-            }
+            Template = AuthKeyExpiredTemplate,
+            Body = body,
+            ToEmails = [user.Email!]
         };
 
         await SendEmail(emailOptions);
@@ -593,5 +587,29 @@ public class EmailService(
         }
 
         return builder.ToString();
+    }
+
+    /// <summary>
+    /// Find all occurrences of {{email.{templateKey}.*}} and resolve them via the user's locale. Patches the email body with data
+    /// </summary>
+    /// <param name="body"></param>
+    /// <param name="templateKey">The template segment, e.g. "auth-key-expired"</param>
+    /// <param name="userId"></param>
+    /// <param name="placeholders">Placeholders that may need transformation after localization</param>
+    /// <returns></returns>
+    private async Task<string> ResolveLocalizationKeys(string body, string templateKey, int userId,
+        List<KeyValuePair<string, string>> placeholders)
+    {
+        var regex = new Regex(@"\{\{(email\." + Regex.Escape(templateKey) + @"\.[^}]+)\}\}");
+        var matches = regex.Matches(body);
+
+        foreach (Match match in matches)
+        {
+            var key = match.Groups[1].Value;
+            var translated = await localizationService.Translate(userId, key);
+            body = body.Replace(match.Value, translated);
+        }
+
+        return UpdatePlaceHolders(body, placeholders);
     }
 }

--- a/Kavita.Services/EmailService.cs
+++ b/Kavita.Services/EmailService.cs
@@ -77,9 +77,10 @@ public class EmailService(
         };
 
         var settings = await unitOfWork.SettingsRepository.GetSettingsDtoAsync();
+        var defaultAdmin = await unitOfWork.UserRepository.GetDefaultAdminUser();
         if (!IsValidEmail(adminEmail))
         {
-            var defaultAdmin = await unitOfWork.UserRepository.GetDefaultAdminUser();
+
             result.ErrorMessage = await localizationService.Translate(defaultAdmin.Id, "account-email-invalid");
             result.Successful = false;
             return result;
@@ -87,11 +88,12 @@ public class EmailService(
 
         if (!settings.IsEmailSetup())
         {
-            var defaultAdmin = await unitOfWork.UserRepository.GetDefaultAdminUser();
             result.ErrorMessage = await localizationService.Translate(defaultAdmin.Id, "email-settings-invalid");
             result.Successful = false;
             return result;
         }
+
+        await SendAuthKeyExpiredEmail(defaultAdmin.Id, []);
 
         var placeholders = new List<KeyValuePair<string, string>>
         {
@@ -256,15 +258,22 @@ public class EmailService(
         {
             new ("{{UserName}}", user.UserName!),
             new ("{{AuthKeyFragment}}", await BuildFragment(AuthKeyExpiredFragment, d)),
-            new ("{{Link}}", $"{settings.HostName}/settings#account" ),
+            new ("{{Link}}", $"{settings.HostName}/settings#account"),
+
+            new ("{{email.auth-key-expired.header}}", await localizationService.Translate(userId, "email.auth-key-expired.header")),
+            new ("{{email.auth-key-expired.description}}", await localizationService.Translate(userId, "email.auth-key-expired.description")),
+            new ("{{email.auth-key-expired.rotate-cta}}", await localizationService.Translate(userId, "email.auth-key-expired.rotate-cta")),
+            new ("{{email.auth-key-expired.fallback-link-label}}", await localizationService.Translate(userId, "email.auth-key-expired.fallback-link-label")),
         };
+
+
 
         var emailOptions = new EmailOptionsDto()
         {
-            Subject = "Kavita - One or more Auth Keys has expired!",
+            Subject = await localizationService.Translate(userId, "email.auth-key-expired.subject"),
             Template = AuthKeyExpiredTemplate,
-            Body = UpdatePlaceHolders(await GetEmailBody(TokenExpirationTemplate), placeholders),
-            Preheader = "Kavita - One or more Auth Keys has expired!",
+            Body = UpdatePlaceHolders(await GetEmailBody(AuthKeyExpiredTemplate), placeholders),
+            Preheader = await localizationService.Translate(userId, "email.auth-key-expired.preheader"),
             ToEmails = new List<string>()
             {
                 user.Email

--- a/Kavita.Services/OidcService.cs
+++ b/Kavita.Services/OidcService.cs
@@ -477,7 +477,7 @@ public class OidcService(ILogger<OidcService> logger, UserManager<AppUser> userM
             var invitingUser = await unitOfWork.UserRepository.GetDefaultAdminUser();
             BackgroundJob.Enqueue(() => emailService.SendEmailChangeEmail(new ConfirmationEmailDto()
             {
-                EmailUserId = user.Id,
+                LocaleUserId = user.Id,
                 EmailAddress = string.IsNullOrEmpty(user.Email) ? email : user.Email,
                 InstallId = BuildInfo.Version.ToString(),
                 InvitingUser = invitingUser.UserName,

--- a/Kavita.Services/OidcService.cs
+++ b/Kavita.Services/OidcService.cs
@@ -477,6 +477,7 @@ public class OidcService(ILogger<OidcService> logger, UserManager<AppUser> userM
             var invitingUser = await unitOfWork.UserRepository.GetDefaultAdminUser();
             BackgroundJob.Enqueue(() => emailService.SendEmailChangeEmail(new ConfirmationEmailDto()
             {
+                EmailUserId = user.Id,
                 EmailAddress = string.IsNullOrEmpty(user.Email) ? email : user.Email,
                 InstallId = BuildInfo.Version.ToString(),
                 InvitingUser = invitingUser.UserName,


### PR DESCRIPTION
# Added
- Added: Emails can now be localized. By default, Kavita will use the target user's localization settings. Missing strings will fallback to English. Invite user will use the default admin's locale. (Closes #4546)

# Fixed
- Fixed: Fixed a few incorrect strings in emails (Auth Key expiring, Token expiring soon)
