### PR TITLE
Small scanner edge case fix

### DIFF
--- a/Kavita.Models/Entities/Enums/MediaErrorProducer.cs
+++ b/Kavita.Models/Entities/Enums/MediaErrorProducer.cs
@@ -3,5 +3,6 @@ namespace Kavita.Models.Entities.Enums;
 public enum MediaErrorProducer
 {
     BookService = 0,
-    ArchiveService = 1
+    ArchiveService = 1,
+    Scanner = 2,
 }

--- a/Kavita.Services.Tests/CacheServiceTests.cs
+++ b/Kavita.Services.Tests/CacheServiceTests.cs
@@ -70,7 +70,8 @@ public class CacheServiceTests(ITestOutputHelper outputHelper): AbstractDbTest(o
         var cleanupService = new CacheService(_logger, unitOfWork, ds,
             new ReadingItemService(Substitute.For<IArchiveService>(),
                 Substitute.For<IBookService>(),
-                Substitute.For<IImageService>(), ds, Substitute.For<ILogger<ReadingItemService>>()),
+                Substitute.For<IImageService>(), ds, Substitute.For<ILogger<ReadingItemService>>(),
+                Substitute.For<IMediaErrorService>()),
             Substitute.For<IBookmarkService>(), Substitute.For<ILocalizationService>());
 
         var s = new SeriesBuilder("Test").Build();
@@ -147,7 +148,8 @@ public class CacheServiceTests(ITestOutputHelper outputHelper): AbstractDbTest(o
         var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), filesystem);
         var cleanupService = new CacheService(_logger, unitOfWork, ds,
             new ReadingItemService(Substitute.For<IArchiveService>(),
-                Substitute.For<IBookService>(), Substitute.For<IImageService>(), ds, Substitute.For<ILogger<ReadingItemService>>()),
+                Substitute.For<IBookService>(), Substitute.For<IImageService>(), ds, Substitute.For<ILogger<ReadingItemService>>(),
+                Substitute.For<IMediaErrorService>()),
             Substitute.For<IBookmarkService>(), Substitute.For<ILocalizationService>());
 
         cleanupService.CleanupChapters(new []{1, 3});
@@ -171,7 +173,8 @@ public class CacheServiceTests(ITestOutputHelper outputHelper): AbstractDbTest(o
         var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), filesystem);
         var cs = new CacheService(_logger, unitOfWork, ds,
             new ReadingItemService(Substitute.For<IArchiveService>(),
-                Substitute.For<IBookService>(), Substitute.For<IImageService>(), ds, Substitute.For<ILogger<ReadingItemService>>()),
+                Substitute.For<IBookService>(), Substitute.For<IImageService>(), ds, Substitute.For<ILogger<ReadingItemService>>(),
+                Substitute.For<IMediaErrorService>()),
             Substitute.For<IBookmarkService>(), Substitute.For<ILocalizationService>());
 
         var c = new ChapterBuilder("1")
@@ -214,7 +217,8 @@ public class CacheServiceTests(ITestOutputHelper outputHelper): AbstractDbTest(o
         var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), filesystem);
         var cs = new CacheService(_logger, unitOfWork, ds,
             new ReadingItemService(Substitute.For<IArchiveService>(),
-                Substitute.For<IBookService>(), Substitute.For<IImageService>(), ds, Substitute.For<ILogger<ReadingItemService>>()),
+                Substitute.For<IBookService>(), Substitute.For<IImageService>(), ds, Substitute.For<ILogger<ReadingItemService>>(),
+                Substitute.For<IMediaErrorService>()),
             Substitute.For<IBookmarkService>(), Substitute.For<ILocalizationService>());
 
         // Flatten to prepare for how GetFullPath expects
@@ -260,7 +264,8 @@ public class CacheServiceTests(ITestOutputHelper outputHelper): AbstractDbTest(o
         var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), filesystem);
         var cs = new CacheService(_logger, unitOfWork, ds,
             new ReadingItemService(Substitute.For<IArchiveService>(),
-                Substitute.For<IBookService>(), Substitute.For<IImageService>(), ds, Substitute.For<ILogger<ReadingItemService>>()),
+                Substitute.For<IBookService>(), Substitute.For<IImageService>(), ds, Substitute.For<ILogger<ReadingItemService>>(),
+                Substitute.For<IMediaErrorService>()),
             Substitute.For<IBookmarkService>(), Substitute.For<ILocalizationService>());
 
         // Flatten to prepare for how GetFullPath expects
@@ -303,7 +308,8 @@ public class CacheServiceTests(ITestOutputHelper outputHelper): AbstractDbTest(o
         var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), filesystem);
         var cs = new CacheService(_logger, unitOfWork, ds,
             new ReadingItemService(Substitute.For<IArchiveService>(),
-                Substitute.For<IBookService>(), Substitute.For<IImageService>(), ds, Substitute.For<ILogger<ReadingItemService>>()),
+                Substitute.For<IBookService>(), Substitute.For<IImageService>(), ds, Substitute.For<ILogger<ReadingItemService>>(),
+                Substitute.For<IMediaErrorService>()),
             Substitute.For<IBookmarkService>(), Substitute.For<ILocalizationService>());
 
         // Flatten to prepare for how GetFullPath expects
@@ -350,7 +356,8 @@ public class CacheServiceTests(ITestOutputHelper outputHelper): AbstractDbTest(o
         var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), filesystem);
         var cs = new CacheService(_logger, unitOfWork, ds,
             new ReadingItemService(Substitute.For<IArchiveService>(),
-                Substitute.For<IBookService>(), Substitute.For<IImageService>(), ds, Substitute.For<ILogger<ReadingItemService>>()),
+                Substitute.For<IBookService>(), Substitute.For<IImageService>(), ds, Substitute.For<ILogger<ReadingItemService>>(),
+                Substitute.For<IMediaErrorService>()),
             Substitute.For<IBookmarkService>(), Substitute.For<ILocalizationService>());
 
         // Flatten to prepare for how GetFullPath expects

--- a/Kavita.Services.Tests/Helpers/ScannerHelper.cs
+++ b/Kavita.Services.Tests/Helpers/ScannerHelper.cs
@@ -71,7 +71,8 @@ public class ScannerHelper
         var archiveService = new ArchiveService(Substitute.For<ILogger<ArchiveService>>(), ds,
             Substitute.For<IImageService>(), Substitute.For<IMediaErrorService>());
         var readingItemService = new ReadingItemService(archiveService, Substitute.For<IBookService>(),
-            Substitute.For<IImageService>(), ds, Substitute.For<ILogger<ReadingItemService>>());
+            Substitute.For<IImageService>(), ds, Substitute.For<ILogger<ReadingItemService>>(),
+            Substitute.For<IMediaErrorService>());
 
 
 

--- a/Kavita.Services.Tests/Helpers/ScannerHelper.cs
+++ b/Kavita.Services.Tests/Helpers/ScannerHelper.cs
@@ -97,7 +97,8 @@ public class ScannerHelper
         var scanner = new ScannerService(_unitOfWork, Substitute.For<ILogger<ScannerService>>(),
             Substitute.For<IMetadataService>(),
             Substitute.For<ICacheService>(), Substitute.For<IEventHub>(), ds,
-            readingItemService, scopeFactory, Substitute.For<IWordCountAnalyzerService>());
+            readingItemService, scopeFactory, Substitute.For<IWordCountAnalyzerService>(),
+            Substitute.For<IMediaErrorService>());
         return scanner;
     }
 

--- a/Kavita.Services.Tests/ParseScannedFilesTests.cs
+++ b/Kavita.Services.Tests/ParseScannedFilesTests.cs
@@ -200,7 +200,8 @@ public class ParseScannedFilesTests: AbstractDbTest
 
         var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), fileSystem);
         var psf = new ParseScannedFiles(Substitute.For<ILogger<ParseScannedFiles>>(), ds,
-            new MockReadingItemService(ds, Substitute.For<IBookService>()), Substitute.For<IEventHub>());
+            new MockReadingItemService(ds, Substitute.For<IBookService>()), Substitute.For<IEventHub>(),
+            Substitute.For<IMediaErrorService>());
 
 
         var library =
@@ -249,7 +250,8 @@ public class ParseScannedFilesTests: AbstractDbTest
         var fileSystem = CreateTestFilesystem();
         var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), fileSystem);
         var psf = new ParseScannedFiles(Substitute.For<ILogger<ParseScannedFiles>>(), ds,
-            new MockReadingItemService(ds, Substitute.For<IBookService>()), Substitute.For<IEventHub>());
+            new MockReadingItemService(ds, Substitute.For<IBookService>()), Substitute.For<IEventHub>(),
+            Substitute.For<IMediaErrorService>());
 
         var directoriesSeen = new HashSet<string>();
         var library = await unitOfWork.LibraryRepository.GetLibraryForIdAsync(1,
@@ -272,7 +274,8 @@ public class ParseScannedFilesTests: AbstractDbTest
         var fileSystem = CreateTestFilesystem();
         var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), fileSystem);
         var psf = new ParseScannedFiles(Substitute.For<ILogger<ParseScannedFiles>>(), ds,
-            new MockReadingItemService(ds, Substitute.For<IBookService>()), Substitute.For<IEventHub>());
+            new MockReadingItemService(ds, Substitute.For<IBookService>()), Substitute.For<IEventHub>(),
+            Substitute.For<IMediaErrorService>());
 
         var library = await unitOfWork.LibraryRepository.GetLibraryForIdAsync(1,
             LibraryIncludes.Folders | LibraryIncludes.FileTypes);
@@ -310,7 +313,8 @@ public class ParseScannedFilesTests: AbstractDbTest
 
         var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), fileSystem);
         var psf = new ParseScannedFiles(Substitute.For<ILogger<ParseScannedFiles>>(), ds,
-            new MockReadingItemService(ds, Substitute.For<IBookService>()), Substitute.For<IEventHub>());
+            new MockReadingItemService(ds, Substitute.For<IBookService>()), Substitute.For<IEventHub>(),
+            Substitute.For<IMediaErrorService>());
 
         var library = await unitOfWork.LibraryRepository.GetLibraryForIdAsync(1,
             LibraryIncludes.Folders | LibraryIncludes.FileTypes);
@@ -342,7 +346,8 @@ public class ParseScannedFilesTests: AbstractDbTest
 
         var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), fileSystem);
         var psf = new ParseScannedFiles(Substitute.For<ILogger<ParseScannedFiles>>(), ds,
-            new MockReadingItemService(ds, Substitute.For<IBookService>()), Substitute.For<IEventHub>());
+            new MockReadingItemService(ds, Substitute.For<IBookService>()), Substitute.For<IEventHub>(),
+            Substitute.For<IMediaErrorService>());
 
         var library = await unitOfWork.LibraryRepository.GetLibraryForIdAsync(1,
             LibraryIncludes.Folders | LibraryIncludes.FileTypes);
@@ -376,7 +381,8 @@ public class ParseScannedFilesTests: AbstractDbTest
         var fs = new FileSystem();
         var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), fs);
         var psf = new ParseScannedFiles(Substitute.For<ILogger<ParseScannedFiles>>(), ds,
-            new MockReadingItemService(ds, Substitute.For<IBookService>()), Substitute.For<IEventHub>());
+            new MockReadingItemService(ds, Substitute.For<IBookService>()), Substitute.For<IEventHub>(),
+            Substitute.For<IMediaErrorService>());
 
         var scanner = scannerHelper.CreateServices(ds, fs);
         await scanner.ScanLibrary(library.Id);
@@ -431,7 +437,8 @@ public class ParseScannedFilesTests: AbstractDbTest
         var fs = new FileSystem();
         var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), fs);
         var psf = new ParseScannedFiles(Substitute.For<ILogger<ParseScannedFiles>>(), ds,
-            new MockReadingItemService(ds, Substitute.For<IBookService>()), Substitute.For<IEventHub>());
+            new MockReadingItemService(ds, Substitute.For<IBookService>()), Substitute.For<IEventHub>(),
+            Substitute.For<IMediaErrorService>());
 
         var scanner = scannerHelper.CreateServices(ds, fs);
         await scanner.ScanLibrary(library.Id);
@@ -477,7 +484,8 @@ public class ParseScannedFilesTests: AbstractDbTest
         var fs = new FileSystem();
         var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), fs);
         var psf = new ParseScannedFiles(Substitute.For<ILogger<ParseScannedFiles>>(), ds,
-            new MockReadingItemService(ds, Substitute.For<IBookService>()), Substitute.For<IEventHub>());
+            new MockReadingItemService(ds, Substitute.For<IBookService>()), Substitute.For<IEventHub>(),
+            Substitute.For<IMediaErrorService>());
 
         var scanner = scannerHelper.CreateServices(ds, fs);
         await scanner.ScanLibrary(library.Id);
@@ -516,7 +524,8 @@ public class ParseScannedFilesTests: AbstractDbTest
         var fs = new FileSystem();
         var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), fs);
         var psf = new ParseScannedFiles(Substitute.For<ILogger<ParseScannedFiles>>(), ds,
-            new MockReadingItemService(ds, Substitute.For<IBookService>()), Substitute.For<IEventHub>());
+            new MockReadingItemService(ds, Substitute.For<IBookService>()), Substitute.For<IEventHub>(),
+            Substitute.For<IMediaErrorService>());
 
         var scanner = scannerHelper.CreateServices(ds, fs);
         await scanner.ScanLibrary(library.Id);
@@ -561,7 +570,8 @@ public class ParseScannedFilesTests: AbstractDbTest
         var fs = new FileSystem();
         var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), fs);
         var psf = new ParseScannedFiles(Substitute.For<ILogger<ParseScannedFiles>>(), ds,
-            new MockReadingItemService(ds, Substitute.For<IBookService>()), Substitute.For<IEventHub>());
+            new MockReadingItemService(ds, Substitute.For<IBookService>()), Substitute.For<IEventHub>(),
+            Substitute.For<IMediaErrorService>());
 
         var scanner = scannerHelper.CreateServices(ds, fs);
         await scanner.ScanLibrary(library.Id);
@@ -618,7 +628,8 @@ public class ParseScannedFilesTests: AbstractDbTest
         ConcurrentDictionary<ParsedSeries, List<ParserInfo>> scannedSeries = [];
 
         var psd = new ParseScannedFiles(Substitute.For<ILogger<ParseScannedFiles>>(), Substitute.For<IDirectoryService>(),
-            Substitute.For<IReadingItemService>(), Substitute.For<IEventHub>());
+            Substitute.For<IReadingItemService>(), Substitute.For<IEventHub>(),
+            Substitute.For<IMediaErrorService>());
 
         psd.TrackSeriesAcrossScanResults(scanResults, scannedSeries);
 

--- a/Kavita.Services.Tests/ParseScannedFilesTests.cs
+++ b/Kavita.Services.Tests/ParseScannedFilesTests.cs
@@ -1,4 +1,5 @@
-﻿using System.IO.Abstractions;
+﻿using System.Collections.Concurrent;
+using System.IO.Abstractions;
 using System.IO.Abstractions.TestingHelpers;
 using Hangfire;
 using Kavita.API.Database;
@@ -586,5 +587,41 @@ public class ParseScannedFilesTests: AbstractDbTest
             await unitOfWork.SeriesRepository.GetFolderPathMap(postLib.Id), postLib);
         var changes = res.Count(sc => sc.HasChanged);
         Assert.Equal(2, changes);
+    }
+
+    [Fact]
+    public void TrackSeriesAcrossScanResults_MergingEverythingIntoSeriesWithNoMeaningfulInformation()
+    {
+        List<ScanResult> scanResults =
+        [
+            new()
+            {
+               ParserInfos = [
+                   // Should be ignored as the series does not contain meaningful information
+                   // Would previously suck all series into it (when having no localised series set)
+                   new ParserInfo
+                   {
+                       Series = "[&/"
+                   },
+                   new ParserInfo
+                   {
+                       Series = "Spice and Wolf"
+                   }
+                   ,new ParserInfo
+                   {
+                       Series = "Ikoku Nikki"
+                   }
+               ]
+            }
+        ];
+
+        ConcurrentDictionary<ParsedSeries, List<ParserInfo>> scannedSeries = [];
+
+        var psd = new ParseScannedFiles(Substitute.For<ILogger<ParseScannedFiles>>(), Substitute.For<IDirectoryService>(),
+            Substitute.For<IReadingItemService>(), Substitute.For<IEventHub>());
+
+        psd.TrackSeriesAcrossScanResults(scanResults, scannedSeries);
+
+        Assert.Equal(2, scannedSeries.Count);
     }
 }

--- a/Kavita.Services/Reading/ReadingItemService.cs
+++ b/Kavita.Services/Reading/ReadingItemService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using Kavita.API.Services;
 using Kavita.Models.Entities.Enums;
 using Kavita.Models.Metadata;
@@ -20,15 +21,17 @@ public class ReadingItemService : IReadingItemService
     private readonly ImageParser _imageParser;
     private readonly BookParser _bookParser;
     private readonly PdfParser _pdfParser;
+    private readonly IMediaErrorService _mediaErrorService;
 
     public ReadingItemService(IArchiveService archiveService, IBookService bookService, IImageService imageService,
-        IDirectoryService directoryService, ILogger<ReadingItemService> logger)
+        IDirectoryService directoryService, ILogger<ReadingItemService> logger, IMediaErrorService mediaErrorService)
     {
         _archiveService = archiveService;
         _bookService = bookService;
         _imageService = imageService;
         _directoryService = directoryService;
         _logger = logger;
+        _mediaErrorService = mediaErrorService;
 
         _imageParser = new ImageParser(directoryService);
         _basicParser = new BasicParser(directoryService, _imageParser);
@@ -66,6 +69,7 @@ public class ReadingItemService : IReadingItemService
     /// </summary>
     /// <param name="path">Path of a file</param>
     /// <param name="rootPath"></param>
+    /// <param name="libraryRoot"></param>
     /// <param name="type">Library type to determine parsing to perform</param>
     /// <param name="enableMetadata">Enable Metadata parsing overriding filename parsing</param>
     public ParserInfo? ParseFile(string path, string rootPath, string libraryRoot, LibraryType type, bool enableMetadata)
@@ -76,6 +80,9 @@ public class ReadingItemService : IReadingItemService
             if (info == null)
             {
                 _logger.LogError("Unable to parse any meaningful information out of file {FilePath}", path);
+                _mediaErrorService.ReportMediaIssue(Path.GetFileName(path), MediaErrorProducer.Scanner,
+                    "Unable to parse any meaningful information out of file", string.Empty);
+
                 return null;
             }
 
@@ -84,6 +91,9 @@ public class ReadingItemService : IReadingItemService
         catch (Exception ex)
         {
             _logger.LogError(ex, "There was an exception when parsing file {FilePath}", path);
+            _mediaErrorService.ReportMediaIssue(Path.GetFileName(path), MediaErrorProducer.Scanner,
+                "There was an exception when parsing file", ex.Message);
+
             return null;
         }
     }

--- a/Kavita.Services/Scanner/ParseScannedFiles.cs
+++ b/Kavita.Services/Scanner/ParseScannedFiles.cs
@@ -336,7 +336,7 @@ public class ParseScannedFiles
         // But until this is reported, we should ignore it and play it safe!
         if (string.IsNullOrEmpty(info.Series.ToNormalized()))
         {
-            _logger.LogCritical("[ScannerService] {SeriesName} @ {FileName} is empty when normalized, this file will not be ingested! This is a bug in the scanner, please report this! https://github.com/Kareadita/Kavita/issues",
+            _logger.LogCritical("[ScannerService] {SeriesName} @ {FileName} is empty when normalized, this file will not be ingested! The filename does not follow our guidelines or this is a bug in the parser, please report this! https://github.com/Kareadita/Kavita/issues",
                 info.Series, info.Filename);
             return;
         }

--- a/Kavita.Services/Scanner/ParseScannedFiles.cs
+++ b/Kavita.Services/Scanner/ParseScannedFiles.cs
@@ -352,17 +352,7 @@ public class ParseScannedFiles
 
         try
         {
-            var existingKey = scannedSeries.Keys.SingleOrDefault(ps =>
-            {
-                if (ps.Format != info.Format) return false;
-
-                // Never match on empty normalized names
-                if (string.IsNullOrEmpty(ps.NormalizedName)) return false;
-
-                return ps.NormalizedName.Equals(normalizedSeries)
-                       || ps.NormalizedName.Equals(normalizedLocalizedSeries)
-                       || ps.NormalizedName.Equals(normalizedSortSeries);
-            });
+            var existingKey = scannedSeries.Keys.SingleOrDefault(Guard);
             existingKey ??= new ParsedSeries()
             {
                 Format = info.Format,
@@ -383,14 +373,19 @@ public class ParseScannedFiles
         }
         catch (Exception ex)
         {
+            #pragma warning disable S6667
             _logger.LogCritical("[ScannerService] {SeriesName} matches against multiple series in the parsed series. This indicates a critical kavita issue. Key will be skipped", info.Series);
-            foreach (var seriesKey in scannedSeries.Keys.Where(ps =>
-                         ps.Format == info.Format && (ps.NormalizedName.Equals(normalizedSeries)
-                                                      || ps.NormalizedName.Equals(normalizedLocalizedSeries)
-                                                      || ps.NormalizedName.Equals(normalizedSortSeries))))
+            #pragma warning restore S6667
+            foreach (var seriesKey in scannedSeries.Keys.Where(Guard))
             {
                 _logger.LogCritical("[ScannerService] Matches: '{SeriesName}' matches on '{SeriesKey}'", info.Series, seriesKey.Name);
             }
+        }
+
+        bool Guard(ParsedSeries series)
+        {
+            return MergeNameGuard(series.Format, series.NormalizedName, info.Format,
+                normalizedSeries, normalizedSortSeries, normalizedLocalizedSeries);
         }
     }
 
@@ -404,12 +399,14 @@ public class ParseScannedFiles
     /// <returns>Series Name to group this info into</returns>
     private string MergeName(ConcurrentDictionary<ParsedSeries, List<ParserInfo>> scannedSeries, ParserInfo info)
     {
-        var normalizedSeries = info.Series.ToNormalized();
-        var normalizedLocalSeries = info.LocalizedSeries.ToNormalized();
+
+        var normalizedName = info.Series.ToNormalized();
+        var normalizedSortName = info.SeriesSort.ToNormalized();
+        var normalizedLocalizedName = info.LocalizedSeries.ToNormalized();
 
         try
         {
-            var existingName = scannedSeries.SingleOrDefault(MergeNameGuard).Key;
+            var existingName = scannedSeries.SingleOrDefault(Guard).Key;
 
             if (existingName == null)
             {
@@ -423,8 +420,10 @@ public class ParseScannedFiles
         }
         catch (Exception ex)
         {
+            #pragma warning disable S6667
             _logger.LogCritical("[ScannerService] Multiple series detected for {SeriesName} ({File})! This is critical to fix! There should only be 1", info.Series, info.FullFilePath);
-            var values = scannedSeries.Where(MergeNameGuard);
+            #pragma warning restore S6667
+            var values = scannedSeries.Where(Guard);
 
             foreach (var pair in values)
             {
@@ -435,15 +434,30 @@ public class ParseScannedFiles
 
         return info.Series;
 
-        bool MergeNameGuard(KeyValuePair<ParsedSeries, List<ParserInfo>> p)
+        bool Guard(KeyValuePair<ParsedSeries, List<ParserInfo>> p)
         {
-            if (p.Key.Format != info.Format) return false;
-
-            var key = p.Key.NormalizedName.ToNormalized();
-            if (string.IsNullOrEmpty(key)) return false;
-
-            return key.Equals(normalizedSeries) || key.Equals(normalizedLocalSeries);
+            return MergeNameGuard(p.Key.Format, info.Series, info.Format,
+                normalizedName, normalizedSortName, normalizedLocalizedName);
         }
+    }
+
+    /// <summary>
+    /// Checks if the given series should be merged into the other
+    /// </summary>
+    /// <param name="mergeIntoFormat"></param>
+    /// <param name="mergeIntoSeries">Normalised name of the series to be merged into</param>
+    /// <param name="format"></param>
+    /// <param name="normalizedNames"></param>
+    /// <returns></returns>
+    private static bool MergeNameGuard(
+        MangaFormat mergeIntoFormat, string mergeIntoSeries,
+        MangaFormat format, params string[] normalizedNames)
+    {
+        if (mergeIntoFormat != format) return false;
+
+        if (string.IsNullOrEmpty(mergeIntoSeries)) return false;
+
+        return normalizedNames.Any(n => n.Equals(mergeIntoSeries));
     }
 
     /// <summary>

--- a/Kavita.Services/Scanner/ParseScannedFiles.cs
+++ b/Kavita.Services/Scanner/ParseScannedFiles.cs
@@ -298,7 +298,7 @@ public class ParseScannedFiles
     /// </summary>
     /// <param name="scanResults">A collection of scan results</param>
     /// <param name="scannedSeries">A concurrent dictionary to store the tracked series</param>
-    private void TrackSeriesAcrossScanResults(IList<ScanResult> scanResults, ConcurrentDictionary<ParsedSeries, List<ParserInfo>> scannedSeries)
+    public void TrackSeriesAcrossScanResults(IList<ScanResult> scanResults, ConcurrentDictionary<ParsedSeries, List<ParserInfo>> scannedSeries)
     {
         // Flatten all ParserInfos from scanResults
         var allInfos = scanResults.SelectMany(sr => sr.ParserInfos).ToList();
@@ -330,6 +330,17 @@ public class ParseScannedFiles
     {
         if (info == null || info.Series == string.Empty) return;
 
+        // Do not ingest series with no meaningful information as title. These break merging as they'll all merge into each other
+        // They would also merge all series that don't have localised names previously
+        // This does create the edge case where some series may really not have any meaningful information.
+        // But until this is reported, we should ignore it and play it safe!
+        if (string.IsNullOrEmpty(info.Series.ToNormalized()))
+        {
+            _logger.LogCritical("[ScannerService] {SeriesName} @ {FileName} is empty when normalized, this file will not be ingested! This is a bug in the scanner, please report this! https://github.com/Kareadita/Kavita/issues",
+                info.Series, info.Filename);
+            return;
+        }
+
         // Check if normalized info.Series already exists and if so, update info to use that name instead
         info.Series = MergeName(scannedSeries, info);
 
@@ -342,9 +353,16 @@ public class ParseScannedFiles
         try
         {
             var existingKey = scannedSeries.Keys.SingleOrDefault(ps =>
-                ps.Format == info.Format && (ps.NormalizedName.Equals(normalizedSeries)
-                                             || ps.NormalizedName.Equals(normalizedLocalizedSeries)
-                                             || ps.NormalizedName.Equals(normalizedSortSeries)));
+            {
+                if (ps.Format != info.Format) return false;
+
+                // Never match on empty normalized names
+                if (string.IsNullOrEmpty(ps.NormalizedName)) return false;
+
+                return ps.NormalizedName.Equals(normalizedSeries)
+                       || ps.NormalizedName.Equals(normalizedLocalizedSeries)
+                       || ps.NormalizedName.Equals(normalizedSortSeries);
+            });
             existingKey ??= new ParsedSeries()
             {
                 Format = info.Format,
@@ -391,12 +409,7 @@ public class ParseScannedFiles
 
         try
         {
-            var existingName =
-                scannedSeries.SingleOrDefault(p =>
-                        (p.Key.NormalizedName.ToNormalized().Equals(normalizedSeries) ||
-                         p.Key.NormalizedName.ToNormalized().Equals(normalizedLocalSeries)) &&
-                        p.Key.Format == info.Format)
-                    .Key;
+            var existingName = scannedSeries.SingleOrDefault(MergeNameGuard).Key;
 
             if (existingName == null)
             {
@@ -411,10 +424,7 @@ public class ParseScannedFiles
         catch (Exception ex)
         {
             _logger.LogCritical("[ScannerService] Multiple series detected for {SeriesName} ({File})! This is critical to fix! There should only be 1", info.Series, info.FullFilePath);
-            var values = scannedSeries.Where(p =>
-                (p.Key.NormalizedName.ToNormalized() == normalizedSeries ||
-                 p.Key.NormalizedName.ToNormalized() == normalizedLocalSeries) &&
-                p.Key.Format == info.Format);
+            var values = scannedSeries.Where(MergeNameGuard);
 
             foreach (var pair in values)
             {
@@ -424,6 +434,16 @@ public class ParseScannedFiles
         }
 
         return info.Series;
+
+        bool MergeNameGuard(KeyValuePair<ParsedSeries, List<ParserInfo>> p)
+        {
+            if (p.Key.Format != info.Format) return false;
+
+            var key = p.Key.NormalizedName.ToNormalized();
+            if (string.IsNullOrEmpty(key)) return false;
+
+            return key.Equals(normalizedSeries) || key.Equals(normalizedLocalSeries);
+        }
     }
 
     /// <summary>

--- a/Kavita.Services/Scanner/ParseScannedFiles.cs
+++ b/Kavita.Services/Scanner/ParseScannedFiles.cs
@@ -28,6 +28,7 @@ public class ParseScannedFiles
     private readonly IDirectoryService _directoryService;
     private readonly IReadingItemService _readingItemService;
     private readonly IEventHub _eventHub;
+    private readonly IMediaErrorService _mediaErrorService;
 
     /// <summary>
     /// An instance of a pipeline for processing files and returning a Map of Series -> ParserInfos.
@@ -37,13 +38,15 @@ public class ParseScannedFiles
     /// <param name="directoryService">Directory Service</param>
     /// <param name="readingItemService">ReadingItemService Service for extracting information on a number of formats</param>
     /// <param name="eventHub">For firing off SignalR events</param>
+    /// <param name="mediaErrorService"></param>
     public ParseScannedFiles(ILogger logger, IDirectoryService directoryService,
-        IReadingItemService readingItemService, IEventHub eventHub)
+        IReadingItemService readingItemService, IEventHub eventHub, IMediaErrorService mediaErrorService)
     {
         _logger = logger;
         _directoryService = directoryService;
         _readingItemService = readingItemService;
         _eventHub = eventHub;
+        _mediaErrorService = mediaErrorService;
     }
 
     /// <summary>
@@ -338,6 +341,11 @@ public class ParseScannedFiles
         {
             _logger.LogCritical("[ScannerService] {SeriesName} @ {FileName} is empty when normalized, this file will not be ingested! The filename does not follow our guidelines or this is a bug in the parser, please report this! https://github.com/Kareadita/Kavita/issues",
                 info.Series, info.Filename);
+
+            _mediaErrorService.ReportMediaIssue(info.Filename, MediaErrorProducer.Scanner,
+                "Failed to parse a valid series name for a file",
+                $"{info.Series} is empty when normalized, this file will not be ingested! The filename does not follow our guidelines or this is a bug in the parser, please report this! https://github.com/Kareadita/Kavita/issues");
+
             return;
         }
 

--- a/Kavita.Services/Scanner/ScannerService.cs
+++ b/Kavita.Services/Scanner/ScannerService.cs
@@ -59,7 +59,8 @@ public class ScannerService(
     IDirectoryService directoryService,
     IReadingItemService readingItemService,
     IServiceScopeFactory scopeFactory,
-    IWordCountAnalyzerService wordCountAnalyzerService)
+    IWordCountAnalyzerService wordCountAnalyzerService,
+    IMediaErrorService mediaErrorService)
     : IScannerService
 {
     public const string Name = "ScannerService";
@@ -807,7 +808,7 @@ public class ScannerService(
     private async Task<Tuple<long, Dictionary<ParsedSeries, IList<ParserInfo>>>> ScanFiles(Library library, IList<string> dirs,
         bool isLibraryScan, bool forceChecks = false)
     {
-        var scanner = new ParseScannedFiles(logger, directoryService, readingItemService, eventHub);
+        var scanner = new ParseScannedFiles(logger, directoryService, readingItemService, eventHub, mediaErrorService);
         var scanWatch = Stopwatch.StartNew();
 
         var processedSeries = await scanner.ScanLibrariesForSeries(library, dirs,


### PR DESCRIPTION
# Changed
- Changed: Series names are now required to contain meaningful information (I.e. they cannot only be special characters). A media issue will be created if a file is ignored because of this
- Changed: A media issue will now be created when a file is fully skipped after parsing

# Fixed
- Fixed: Fixed the scanner merging several series into one under specific circumstances (Fixes #3132)