### PR TITLE
feat: Add Audiobook library type with streaming reader

### DIFF
--- a/Kavita.API/Services/IAudiobookService.cs
+++ b/Kavita.API/Services/IAudiobookService.cs
@@ -1,0 +1,26 @@
+using Kavita.Models.DTOs.Reader;
+using Kavita.Models.Entities.Enums;
+using Kavita.Models.Parser;
+
+namespace Kavita.API.Services;
+
+public interface IAudiobookService
+{
+    /// <summary>
+    /// Parses metadata from an audio file and returns a ParserInfo.
+    /// Falls back to filename-based parsing if tag metadata is unavailable.
+    /// </summary>
+    ParserInfo? ParseInfo(string filePath);
+
+    /// <summary>
+    /// Returns the duration of the audio file in seconds.
+    /// Stored in Chapter.Pages to reuse the existing progress tracking infrastructure.
+    /// </summary>
+    int GetDurationInSeconds(string filePath);
+
+    /// <summary>
+    /// Extracts embedded cover art from an audio file and saves it as a cover image.
+    /// Returns the saved filename, or empty string if no cover art is available.
+    /// </summary>
+    string GetCoverImage(string filePath, string fileName, string outputDirectory, EncodeFormat encodeFormat, CoverImageSize size = CoverImageSize.Default);
+}

--- a/Kavita.Models/DTOs/Reader/AudioInfoDto.cs
+++ b/Kavita.Models/DTOs/Reader/AudioInfoDto.cs
@@ -1,0 +1,27 @@
+using Kavita.Models.Entities.Enums;
+
+namespace Kavita.Models.DTOs.Reader;
+
+/// <summary>
+/// Metadata returned to the audiobook reader for a given chapter.
+/// DurationSeconds reuses the Pages field concept: total seconds of audio content.
+/// </summary>
+public sealed record AudioInfoDto : IChapterInfoDto
+{
+    public string BookTitle { get; set; } = default!;
+    public int SeriesId { get; set; }
+    public int VolumeId { get; set; }
+    public MangaFormat SeriesFormat { get; set; }
+    public string SeriesName { get; set; } = default!;
+    public string ChapterNumber { get; set; } = default!;
+    public string VolumeNumber { get; set; } = default!;
+    public int LibraryId { get; set; }
+    /// <summary>Total duration in seconds (stored as Pages in the database).</summary>
+    public int Pages { get; set; }
+    public bool IsSpecial { get; set; }
+    public string ChapterTitle { get; set; } = default!;
+    /// <summary>Author(s) of the book being narrated.</summary>
+    public string Author { get; set; } = string.Empty;
+    /// <summary>Narrator(s) of the audiobook.</summary>
+    public string Narrator { get; set; } = string.Empty;
+}

--- a/Kavita.Models/Entities/Chapter.cs
+++ b/Kavita.Models/Entities/Chapter.cs
@@ -213,6 +213,7 @@ public class Chapter : IEntityDate, IHasReadTimeEstimate, IHasCoverImage, IHasKP
             PersonRole.Imprint => ImprintLocked,
             PersonRole.Team => TeamLocked,
             PersonRole.Location => LocationLocked,
+            PersonRole.Narrator => false,
             _ => throw new ArgumentOutOfRangeException(nameof(role), role, null)
         };
     }

--- a/Kavita.Models/Entities/Enums/FileTypeGroup.cs
+++ b/Kavita.Models/Entities/Enums/FileTypeGroup.cs
@@ -14,5 +14,7 @@ public enum FileTypeGroup
     [Description("Pdf")]
     Pdf = 3,
     [Description("Images")]
-    Images = 4
+    Images = 4,
+    [Description("Audio")]
+    Audio = 5
 }

--- a/Kavita.Models/Entities/Enums/LibraryType.cs
+++ b/Kavita.Models/Entities/Enums/LibraryType.cs
@@ -35,4 +35,9 @@ public enum LibraryType
     /// </summary>
     [Description("Comic")]
     ComicVine = 5,
+    /// <summary>
+    /// Audiobook library. Handles audio files (.m4b, .mp3, .flac, .aac, etc.)
+    /// </summary>
+    [Description("Audiobook")]
+    Audiobook = 6,
 }

--- a/Kavita.Models/Entities/Enums/MangaFormat.cs
+++ b/Kavita.Models/Entities/Enums/MangaFormat.cs
@@ -34,5 +34,11 @@ public enum MangaFormat
     /// PDF File
     /// </summary>
     [Description("PDF")]
-    Pdf = 4
+    Pdf = 4,
+    /// <summary>
+    /// Audio File
+    /// See <see cref="Services.Tasks.Scanner.Parser.Parser.AudioFileExtensions"/> for supported extensions
+    /// </summary>
+    [Description("Audio")]
+    Audio = 5
 }

--- a/Kavita.Models/Entities/Enums/PersonRole.cs
+++ b/Kavita.Models/Entities/Enums/PersonRole.cs
@@ -30,5 +30,9 @@ public enum PersonRole
     /// </summary>
     Imprint = 13,
     Team = 14,
-    Location = 15
+    Location = 15,
+    /// <summary>
+    /// The narrator of an audiobook
+    /// </summary>
+    Narrator = 16
 }

--- a/Kavita.Models/Entities/Metadata/SeriesMetadata.cs
+++ b/Kavita.Models/Entities/Metadata/SeriesMetadata.cs
@@ -148,6 +148,7 @@ public class SeriesMetadata : IHasConcurrencyToken, IHasKPlusMetadata
             PersonRole.Imprint => ImprintLocked,
             PersonRole.Team => TeamLocked,
             PersonRole.Location => LocationLocked,
+            PersonRole.Narrator => false,
             _ => throw new ArgumentOutOfRangeException(nameof(role), role, null)
         };
     }

--- a/Kavita.Models/Extensions/PlusMediaFormatExtensions.cs
+++ b/Kavita.Models/Extensions/PlusMediaFormatExtensions.cs
@@ -18,6 +18,7 @@ public static class PlusMediaFormatExtensions
             LibraryType.Book => PlusMediaFormat.LightNovel,
             LibraryType.Image => PlusMediaFormat.Manga,
             LibraryType.ComicVine => PlusMediaFormat.Comic,
+            LibraryType.Audiobook => PlusMediaFormat.Book,
             _ => throw new ArgumentOutOfRangeException(nameof(libraryType), libraryType, null)
         };
     }

--- a/Kavita.Models/Metadata/ComicInfo.cs
+++ b/Kavita.Models/Metadata/ComicInfo.cs
@@ -146,6 +146,7 @@ public class ComicInfo
         PersonRole.Team => SplitNames(Teams),
         PersonRole.Location => SplitNames(Locations),
         PersonRole.Other => [],
+        PersonRole.Narrator => SplitNames(Penciller),
         _ => throw new ArgumentOutOfRangeException(nameof(role), role, null)
     };
 

--- a/Kavita.Server/Controllers/AudioController.cs
+++ b/Kavita.Server/Controllers/AudioController.cs
@@ -1,0 +1,118 @@
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Kavita.API.Database;
+using Kavita.API.Repositories;
+using Kavita.API.Services;
+using Kavita.Models.DTOs.Reader;
+using Kavita.Models.Entities.Enums;
+using Kavita.Server.Attributes;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Kavita.Server.Controllers;
+
+/// <summary>
+/// Handles audiobook streaming and metadata retrieval.
+/// Audio files are served directly from disk (not cached) with HTTP range request support
+/// so the HTML5 audio element can seek efficiently in the browser.
+/// </summary>
+[Authorize]
+public class AudioController(
+    IUnitOfWork unitOfWork,
+    ILocalizationService localizationService)
+    : BaseApiController
+{
+    /// <summary>
+    /// Returns metadata for the audiobook reader: title, author, narrator, duration (in seconds).
+    /// </summary>
+    /// <param name="chapterId"></param>
+    [HttpGet("{chapterId}/audio-info")]
+    public async Task<ActionResult<AudioInfoDto>> GetAudioInfo(int chapterId)
+    {
+        var dto = await unitOfWork.ChapterRepository.GetChapterInfoDtoAsync(chapterId);
+        if (dto == null) return BadRequest(await localizationService.Translate(UserId, "chapter-doesnt-exist"));
+
+        var chapter = await unitOfWork.ChapterRepository.GetChapterAsync(chapterId, ChapterIncludes.Files | ChapterIncludes.People);
+        if (chapter == null) return BadRequest(await localizationService.Translate(UserId, "chapter-doesnt-exist"));
+
+        var author = string.Empty;
+        var narrator = string.Empty;
+
+        // Pull author/narrator from chapter people if available
+        if (chapter.People != null)
+        {
+            var writers = chapter.People
+                .Where(p => p.Role == PersonRole.Writer)
+                .Select(p => p.Person.Name);
+            author = string.Join(", ", writers);
+
+            // Narrators are stored as PersonRole.Narrator; legacy entries may use Penciller
+            var narrators = chapter.People
+                .Where(p => p.Role is PersonRole.Narrator or PersonRole.Penciller)
+                .Select(p => p.Person.Name)
+                .Distinct();
+            narrator = string.Join(", ", narrators);
+        }
+
+        var info = new AudioInfoDto
+        {
+            ChapterNumber = dto.ChapterNumber,
+            VolumeNumber = dto.VolumeNumber,
+            VolumeId = dto.VolumeId,
+            BookTitle = chapter.TitleName ?? dto.SeriesName,
+            SeriesName = dto.SeriesName,
+            SeriesFormat = dto.SeriesFormat,
+            SeriesId = dto.SeriesId,
+            LibraryId = dto.LibraryId,
+            IsSpecial = dto.IsSpecial,
+            Pages = dto.Pages,
+            ChapterTitle = chapter.TitleName ?? string.Empty,
+            Author = author,
+            Narrator = narrator
+        };
+
+        return Ok(info);
+    }
+
+    /// <summary>
+    /// Streams an audio file with HTTP range request support for efficient seeking.
+    /// The audio file is served directly from disk — not cached — since audio files
+    /// can be very large (multiple GB).
+    /// </summary>
+    /// <param name="chapterId">Chapter to stream</param>
+    /// <param name="apiKey">User API key for authentication</param>
+    [ChapterAccess]
+    [HttpGet("{chapterId}/stream")]
+    public async Task<ActionResult> StreamAudio(int chapterId, [FromQuery] string apiKey)
+    {
+        var files = await unitOfWork.ChapterRepository.GetFilesForChapterAsync(chapterId);
+        var file = files.FirstOrDefault();
+        if (file == null) return NotFound();
+
+        if (!System.IO.File.Exists(file.FilePath))
+        {
+            return NotFound();
+        }
+
+        // Serve directly from disk with range request support — do not cache large audio files
+        var contentType = GetAudioContentType(file.FilePath);
+        return PhysicalFile(file.FilePath, contentType, Path.GetFileName(file.FilePath), enableRangeProcessing: true);
+    }
+
+    private static string GetAudioContentType(string filePath)
+    {
+        var ext = Path.GetExtension(filePath).ToLowerInvariant();
+        return ext switch
+        {
+            ".m4b" or ".m4a" => "audio/mp4",
+            ".mp3"           => "audio/mpeg",
+            ".flac"          => "audio/flac",
+            ".ogg" or ".oga" or ".opus" => "audio/ogg",
+            ".aac"           => "audio/aac",
+            ".wma"           => "audio/x-ms-wma",
+            ".wav"           => "audio/wav",
+            _                => "application/octet-stream"
+        };
+    }
+}

--- a/Kavita.Server/Controllers/LibraryController.cs
+++ b/Kavita.Server/Controllers/LibraryController.cs
@@ -96,6 +96,14 @@ public class LibraryController(
             library.AllowScrobbling = false;
         }
 
+        // Audiobook libraries do not support scrobbling or metadata matching
+        if (library.Type == LibraryType.Audiobook)
+        {
+            logger.LogInformation("Overrode Library {Name} to disable scrobbling and metadata matching since Audiobook libraries have no providers", dto.Name.Sanitize());
+            library.AllowScrobbling = false;
+            library.AllowMetadataMatching = false;
+        }
+
         unitOfWork.LibraryRepository.Add(library);
 
         var admins = (await unitOfWork.UserRepository.GetAdminUsersAsync()).ToList();
@@ -705,6 +713,14 @@ public class LibraryController(
         {
             logger.LogInformation("Overrode Library {Name} to disable scrobbling since there are no providers for Comics", dto.Name.Replace(Environment.NewLine, string.Empty));
             library.AllowScrobbling = false;
+        }
+
+        // Audiobook libraries do not support scrobbling or metadata matching
+        if (library.Type == LibraryType.Audiobook)
+        {
+            logger.LogInformation("Overrode Library {Name} to disable scrobbling and metadata matching since Audiobook libraries have no providers", dto.Name.Replace(Environment.NewLine, string.Empty));
+            library.AllowScrobbling = false;
+            library.AllowMetadataMatching = false;
         }
 
 

--- a/Kavita.Services.Tests/CacheServiceTests.cs
+++ b/Kavita.Services.Tests/CacheServiceTests.cs
@@ -70,7 +70,7 @@ public class CacheServiceTests(ITestOutputHelper outputHelper): AbstractDbTest(o
         var cleanupService = new CacheService(_logger, unitOfWork, ds,
             new ReadingItemService(Substitute.For<IArchiveService>(),
                 Substitute.For<IBookService>(),
-                Substitute.For<IImageService>(), ds, Substitute.For<ILogger<ReadingItemService>>()),
+                Substitute.For<IImageService>(), ds, Substitute.For<ILogger<ReadingItemService>>(), Substitute.For<IAudiobookService>()),
             Substitute.For<IBookmarkService>(), Substitute.For<ILocalizationService>());
 
         var s = new SeriesBuilder("Test").Build();
@@ -147,7 +147,7 @@ public class CacheServiceTests(ITestOutputHelper outputHelper): AbstractDbTest(o
         var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), filesystem);
         var cleanupService = new CacheService(_logger, unitOfWork, ds,
             new ReadingItemService(Substitute.For<IArchiveService>(),
-                Substitute.For<IBookService>(), Substitute.For<IImageService>(), ds, Substitute.For<ILogger<ReadingItemService>>()),
+                Substitute.For<IBookService>(), Substitute.For<IImageService>(), ds, Substitute.For<ILogger<ReadingItemService>>(), Substitute.For<IAudiobookService>()),
             Substitute.For<IBookmarkService>(), Substitute.For<ILocalizationService>());
 
         cleanupService.CleanupChapters(new []{1, 3});
@@ -171,7 +171,7 @@ public class CacheServiceTests(ITestOutputHelper outputHelper): AbstractDbTest(o
         var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), filesystem);
         var cs = new CacheService(_logger, unitOfWork, ds,
             new ReadingItemService(Substitute.For<IArchiveService>(),
-                Substitute.For<IBookService>(), Substitute.For<IImageService>(), ds, Substitute.For<ILogger<ReadingItemService>>()),
+                Substitute.For<IBookService>(), Substitute.For<IImageService>(), ds, Substitute.For<ILogger<ReadingItemService>>(), Substitute.For<IAudiobookService>()),
             Substitute.For<IBookmarkService>(), Substitute.For<ILocalizationService>());
 
         var c = new ChapterBuilder("1")
@@ -214,7 +214,7 @@ public class CacheServiceTests(ITestOutputHelper outputHelper): AbstractDbTest(o
         var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), filesystem);
         var cs = new CacheService(_logger, unitOfWork, ds,
             new ReadingItemService(Substitute.For<IArchiveService>(),
-                Substitute.For<IBookService>(), Substitute.For<IImageService>(), ds, Substitute.For<ILogger<ReadingItemService>>()),
+                Substitute.For<IBookService>(), Substitute.For<IImageService>(), ds, Substitute.For<ILogger<ReadingItemService>>(), Substitute.For<IAudiobookService>()),
             Substitute.For<IBookmarkService>(), Substitute.For<ILocalizationService>());
 
         // Flatten to prepare for how GetFullPath expects
@@ -260,7 +260,7 @@ public class CacheServiceTests(ITestOutputHelper outputHelper): AbstractDbTest(o
         var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), filesystem);
         var cs = new CacheService(_logger, unitOfWork, ds,
             new ReadingItemService(Substitute.For<IArchiveService>(),
-                Substitute.For<IBookService>(), Substitute.For<IImageService>(), ds, Substitute.For<ILogger<ReadingItemService>>()),
+                Substitute.For<IBookService>(), Substitute.For<IImageService>(), ds, Substitute.For<ILogger<ReadingItemService>>(), Substitute.For<IAudiobookService>()),
             Substitute.For<IBookmarkService>(), Substitute.For<ILocalizationService>());
 
         // Flatten to prepare for how GetFullPath expects
@@ -303,7 +303,7 @@ public class CacheServiceTests(ITestOutputHelper outputHelper): AbstractDbTest(o
         var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), filesystem);
         var cs = new CacheService(_logger, unitOfWork, ds,
             new ReadingItemService(Substitute.For<IArchiveService>(),
-                Substitute.For<IBookService>(), Substitute.For<IImageService>(), ds, Substitute.For<ILogger<ReadingItemService>>()),
+                Substitute.For<IBookService>(), Substitute.For<IImageService>(), ds, Substitute.For<ILogger<ReadingItemService>>(), Substitute.For<IAudiobookService>()),
             Substitute.For<IBookmarkService>(), Substitute.For<ILocalizationService>());
 
         // Flatten to prepare for how GetFullPath expects
@@ -350,7 +350,7 @@ public class CacheServiceTests(ITestOutputHelper outputHelper): AbstractDbTest(o
         var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), filesystem);
         var cs = new CacheService(_logger, unitOfWork, ds,
             new ReadingItemService(Substitute.For<IArchiveService>(),
-                Substitute.For<IBookService>(), Substitute.For<IImageService>(), ds, Substitute.For<ILogger<ReadingItemService>>()),
+                Substitute.For<IBookService>(), Substitute.For<IImageService>(), ds, Substitute.For<ILogger<ReadingItemService>>(), Substitute.For<IAudiobookService>()),
             Substitute.For<IBookmarkService>(), Substitute.For<ILocalizationService>());
 
         // Flatten to prepare for how GetFullPath expects

--- a/Kavita.Services.Tests/Helpers/ScannerHelper.cs
+++ b/Kavita.Services.Tests/Helpers/ScannerHelper.cs
@@ -71,7 +71,7 @@ public class ScannerHelper
         var archiveService = new ArchiveService(Substitute.For<ILogger<ArchiveService>>(), ds,
             Substitute.For<IImageService>(), Substitute.For<IMediaErrorService>());
         var readingItemService = new ReadingItemService(archiveService, Substitute.For<IBookService>(),
-            Substitute.For<IImageService>(), ds, Substitute.For<ILogger<ReadingItemService>>());
+            Substitute.For<IImageService>(), ds, Substitute.For<ILogger<ReadingItemService>>(), Substitute.For<IAudiobookService>());
 
 
 

--- a/Kavita.Services/AudiobookService.cs
+++ b/Kavita.Services/AudiobookService.cs
@@ -1,0 +1,202 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Kavita.API.Services;
+using Kavita.Models.DTOs.Reader;
+using Kavita.Models.Entities.Enums;
+using Kavita.Models.Metadata;
+using Kavita.Models.Parser;
+using Kavita.Services.Scanner;
+using Microsoft.Extensions.Logging;
+using TagLib;
+
+namespace Kavita.Services;
+
+/// <summary>
+/// Handles reading metadata from audio files (M4B, MP3, FLAC, etc.) using TagLibSharp.
+/// Duration in seconds is stored in the Pages field to reuse the existing progress tracking infrastructure.
+/// </summary>
+public class AudiobookService(
+    ILogger<AudiobookService> logger,
+    IDirectoryService directoryService,
+    IImageService imageService) : IAudiobookService
+{
+    /// <summary>
+    /// Parses metadata out of an audio file and returns a ParserInfo.
+    /// Falls back to filename parsing if metadata is unavailable.
+    /// </summary>
+    public ParserInfo? ParseInfo(string filePath)
+    {
+        try
+        {
+            var fileName = directoryService.FileSystem.Path.GetFileNameWithoutExtension(filePath);
+            var info = new ParserInfo
+            {
+                Filename = Path.GetFileName(filePath),
+                Format = MangaFormat.Audio,
+                FullFilePath = Parser.NormalizePath(filePath),
+                Series = string.Empty
+            };
+
+            using var file = TagLib.File.Create(filePath);
+            var tag = file.Tag;
+
+            // Use album as series name (standard for audiobooks)
+            var album = tag.Album?.Trim();
+            var title = tag.Title?.Trim();
+
+            if (!string.IsNullOrEmpty(album))
+            {
+                info.Series = album;
+            }
+            else if (!string.IsNullOrEmpty(title))
+            {
+                info.Series = title;
+            }
+            else
+            {
+                info.Series = Parser.CleanTitle(fileName, false);
+            }
+
+            // Use track title or filename as chapter title
+            info.Title = !string.IsNullOrEmpty(title) ? title : Parser.RemoveExtensionIfSupported(fileName) ?? string.Empty;
+
+            // Map disc number to volume, track number to chapter
+            if (tag.Disc > 0)
+            {
+                info.Volumes = tag.Disc.ToString();
+            }
+
+            if (tag.Track > 0)
+            {
+                info.Chapters = tag.Track.ToString();
+            }
+
+            // Extract narrator from Composer tag (common audiobook convention)
+            // Authors from Performers
+            // We store these in ComicInfo so the existing people processing can handle them
+            var comicInfo = new ComicInfo();
+            if (tag.Performers?.Length > 0)
+            {
+                comicInfo.Writer = string.Join(", ", tag.Performers);
+            }
+            if (tag.Composers?.Length > 0)
+            {
+                // Store narrators in Penciller since ComicInfo doesn't have a Narrator field.
+                // The AudioController maps Penciller -> Narrator for audiobook metadata display.
+                comicInfo.Penciller = string.Join(", ", tag.Composers);
+            }
+            if (tag.Year > 0)
+            {
+                comicInfo.Year = (int) tag.Year;
+            }
+            if (!string.IsNullOrEmpty(tag.Comment))
+            {
+                comicInfo.Summary = tag.Comment.Trim();
+            }
+            info.ComicInfo = comicInfo;
+
+            return string.IsNullOrEmpty(info.Series) ? null : info;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "[AudiobookService] Failed to parse metadata from {FilePath}", filePath);
+            // Fallback: parse series name from filename
+            var fileName = directoryService.FileSystem.Path.GetFileNameWithoutExtension(filePath);
+            return new ParserInfo
+            {
+                Filename = Path.GetFileName(filePath),
+                Format = MangaFormat.Audio,
+                FullFilePath = Parser.NormalizePath(filePath),
+                Series = Parser.CleanTitle(fileName, false),
+                Title = Parser.RemoveExtensionIfSupported(fileName) ?? fileName
+            };
+        }
+    }
+
+    /// <summary>
+    /// Returns the duration of an audio file in seconds.
+    /// This value is stored in Chapter.Pages to reuse the existing progress tracking infrastructure.
+    /// </summary>
+    public int GetDurationInSeconds(string filePath)
+    {
+        try
+        {
+            using var file = TagLib.File.Create(filePath);
+            return (int) Math.Ceiling(file.Properties.Duration.TotalSeconds);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "[AudiobookService] Failed to read duration from {FilePath}", filePath);
+            return 0;
+        }
+    }
+
+    /// <summary>
+    /// Extracts the cover image for an audio file.
+    /// First tries embedded art in the file, then falls back to cover.jpg/folder.jpg in the same directory.
+    /// Returns the filename of the saved cover image, or empty string if none found.
+    /// </summary>
+    public string GetCoverImage(string filePath, string fileName, string outputDirectory, EncodeFormat encodeFormat, CoverImageSize size = CoverImageSize.Default)
+    {
+        // 1. Try embedded cover art
+        try
+        {
+            using var file = TagLib.File.Create(filePath);
+            var pictures = file.Tag?.Pictures;
+            if (pictures != null && pictures.Length > 0)
+            {
+                // Prefer front cover (type 3), otherwise use first picture
+                IPicture? picture = null;
+                foreach (var pic in pictures)
+                {
+                    if (pic.Type == PictureType.FrontCover)
+                    {
+                        picture = pic;
+                        break;
+                    }
+                }
+                picture ??= pictures[0];
+
+                if (!picture.Data.IsEmpty)
+                {
+                    using var ms = new MemoryStream(picture.Data.Data);
+                    return imageService.WriteCoverThumbnail(ms, fileName, outputDirectory, encodeFormat, size);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "[AudiobookService] Failed to extract embedded cover from {FilePath}", filePath);
+        }
+
+        // 2. Fall back to cover.jpg / folder.jpg in the same directory, then parent directory
+        var coverCandidates = new[] { "cover.jpg", "cover.jpeg", "cover.png", "folder.jpg", "folder.jpeg", "folder.png" };
+        var directory = Path.GetDirectoryName(filePath);
+        var directoriesToSearch = new List<string>();
+        if (!string.IsNullOrEmpty(directory)) directoriesToSearch.Add(directory);
+        var parent = !string.IsNullOrEmpty(directory) ? Directory.GetParent(directory)?.FullName : null;
+        if (!string.IsNullOrEmpty(parent)) directoriesToSearch.Add(parent);
+
+        foreach (var dir in directoriesToSearch)
+        {
+            foreach (var candidate in coverCandidates)
+            {
+                var candidatePath = Path.Combine(dir, candidate);
+                if (System.IO.File.Exists(candidatePath))
+                {
+                    try
+                    {
+                        return imageService.GetCoverImage(candidatePath, fileName, outputDirectory, encodeFormat, size);
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.LogError(ex, "[AudiobookService] Failed to use folder cover image {CoverPath}", candidatePath);
+                    }
+                }
+            }
+        }
+
+        return string.Empty;
+    }
+}

--- a/Kavita.Services/Extensions/ApplicationServiceExtensions.cs
+++ b/Kavita.Services/Extensions/ApplicationServiceExtensions.cs
@@ -35,6 +35,7 @@ public static class ApplicationServiceExtensions
         services.AddScoped<IBackupService, BackupService>();
         services.AddScoped<ICleanupService, CleanupService>();
         services.AddScoped<IBookService, BookService>();
+        services.AddScoped<IAudiobookService, AudiobookService>();
         services.AddScoped<IVersionUpdaterService, VersionUpdaterService>();
         services.AddScoped<IDownloadService, DownloadService>();
         services.AddScoped<IReaderService, ReaderService>();

--- a/Kavita.Services/Extensions/FileTypeGroupExtensions.cs
+++ b/Kavita.Services/Extensions/FileTypeGroupExtensions.cs
@@ -17,6 +17,8 @@ public static class FileTypeGroupExtensions
                 return Scanner.Parser.PdfFileExtension;
             case FileTypeGroup.Images:
                 return Scanner.Parser.ImageFileExtensions;
+            case FileTypeGroup.Audio:
+                return Scanner.Parser.AudioFileExtensions;
             default:
                 throw new ArgumentOutOfRangeException(nameof(fileTypeGroup), fileTypeGroup, null);
         }

--- a/Kavita.Services/Kavita.Services.csproj
+++ b/Kavita.Services/Kavita.Services.csproj
@@ -59,6 +59,7 @@
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.16.0" />
     <PackageReference Include="System.IO.Abstractions" Version="22.1.0" />
     <PackageReference Include="TimeZoneConverter" Version="7.2.0" />
+    <PackageReference Include="TagLibSharp" Version="2.3.0" />
     <PackageReference Include="VersOne.Epub" Version="3.3.5" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
   </ItemGroup>

--- a/Kavita.Services/Reading/ReaderService.cs
+++ b/Kavita.Services/Reading/ReaderService.cs
@@ -1062,6 +1062,8 @@ public class ReaderService(IUnitOfWork unitOfWork, ILogger<ReaderService> logger
             case LibraryType.Book:
             case LibraryType.LightNovel:
                 return "Book" + (includeSpace ? " " : string.Empty);
+            case LibraryType.Audiobook:
+                return "Track" + (includeSpace ? " " : string.Empty);
             default:
                 throw new ArgumentOutOfRangeException(nameof(libraryType), libraryType, null);
         }

--- a/Kavita.Services/Reading/ReadingItemService.cs
+++ b/Kavita.Services/Reading/ReadingItemService.cs
@@ -14,20 +14,23 @@ public class ReadingItemService : IReadingItemService
     private readonly IBookService _bookService;
     private readonly IImageService _imageService;
     private readonly IDirectoryService _directoryService;
+    private readonly IAudiobookService _audiobookService;
     private readonly ILogger<ReadingItemService> _logger;
     private readonly BasicParser _basicParser;
     private readonly ComicVineParser _comicVineParser;
     private readonly ImageParser _imageParser;
     private readonly BookParser _bookParser;
     private readonly PdfParser _pdfParser;
+    private readonly AudioParser _audioParser;
 
     public ReadingItemService(IArchiveService archiveService, IBookService bookService, IImageService imageService,
-        IDirectoryService directoryService, ILogger<ReadingItemService> logger)
+        IDirectoryService directoryService, ILogger<ReadingItemService> logger, IAudiobookService audiobookService)
     {
         _archiveService = archiveService;
         _bookService = bookService;
         _imageService = imageService;
         _directoryService = directoryService;
+        _audiobookService = audiobookService;
         _logger = logger;
 
         _imageParser = new ImageParser(directoryService);
@@ -35,6 +38,7 @@ public class ReadingItemService : IReadingItemService
         _bookParser = new BookParser(directoryService, bookService, _basicParser);
         _comicVineParser = new ComicVineParser(directoryService);
         _pdfParser = new PdfParser(directoryService);
+        _audioParser = new AudioParser(directoryService, audiobookService);
 
     }
 
@@ -112,6 +116,10 @@ public class ReadingItemService : IReadingItemService
             {
                 return 1;
             }
+            case MangaFormat.Audio:
+            {
+                return _audiobookService.GetDurationInSeconds(filePath);
+            }
             case MangaFormat.Unknown:
             default:
                 return 0;
@@ -132,6 +140,7 @@ public class ReadingItemService : IReadingItemService
             MangaFormat.Archive => _archiveService.GetCoverImage(filePath, fileName, _directoryService.CoverImageDirectory, encodeFormat, size),
             MangaFormat.Image => _imageService.GetCoverImage(filePath, fileName, _directoryService.CoverImageDirectory, encodeFormat, size),
             MangaFormat.Pdf => _bookService.GetCoverImage(filePath, fileName, _directoryService.CoverImageDirectory, encodeFormat, size),
+            MangaFormat.Audio => _audiobookService.GetCoverImage(filePath, fileName, _directoryService.CoverImageDirectory, encodeFormat, size),
             _ => string.Empty
         };
     }
@@ -159,6 +168,7 @@ public class ReadingItemService : IReadingItemService
                 break;
             case MangaFormat.Unknown:
             case MangaFormat.Epub:
+            case MangaFormat.Audio:
                 break;
             default:
                 throw new ArgumentOutOfRangeException(nameof(format), format, null);
@@ -190,6 +200,10 @@ public class ReadingItemService : IReadingItemService
         if (_pdfParser.IsApplicable(path, type))
         {
             return _pdfParser.Parse(path, rootPath, libraryRoot, type, enableMetadata, GetComicInfo(path, enableMetadata));
+        }
+        if (_audioParser.IsApplicable(path, type))
+        {
+            return _audioParser.Parse(path, rootPath, libraryRoot, type, enableMetadata, GetComicInfo(path, enableMetadata));
         }
         if (_basicParser.IsApplicable(path, type))
         {

--- a/Kavita.Services/Scanner/AudioParser.cs
+++ b/Kavita.Services/Scanner/AudioParser.cs
@@ -1,0 +1,67 @@
+using System.IO;
+using Kavita.API.Services;
+using Kavita.Models.Entities.Enums;
+using Kavita.Models.Metadata;
+using Kavita.Models.Parser;
+
+namespace Kavita.Services.Scanner;
+
+/// <summary>
+/// Parser for audio files in Audiobook libraries.
+/// Delegates metadata extraction to AudiobookService (TagLibSharp).
+/// Falls back to filename-based parsing when metadata is unavailable.
+/// </summary>
+public class AudioParser(IDirectoryService directoryService, IAudiobookService audiobookService) : DefaultParser(directoryService)
+{
+    public override ParserInfo? Parse(string filePath, string rootPath, string libraryRoot, LibraryType type,
+        bool enableMetadata = true, ComicInfo? comicInfo = null)
+    {
+        ParserInfo? info;
+
+        if (enableMetadata)
+        {
+            info = audiobookService.ParseInfo(filePath);
+            if (info == null) return null;
+        }
+        else
+        {
+            var fileName = directoryService.FileSystem.Path.GetFileNameWithoutExtension(filePath);
+            info = new ParserInfo
+            {
+                Filename = Path.GetFileName(filePath),
+                Format = MangaFormat.Audio,
+                Title = Parser.RemoveExtensionIfSupported(fileName)!,
+                FullFilePath = Parser.NormalizePath(filePath),
+                Series = Parser.ParseSeries(fileName, type),
+                Chapters = Parser.ParseChapter(fileName, type),
+                Volumes = Parser.ParseVolume(fileName, type),
+                HasEndMarker = Parser.HasEndMarker(fileName)
+            };
+        }
+
+        // If series is still empty, try to infer from folder structure
+        if (string.IsNullOrEmpty(info.Series))
+        {
+            ParseFromFallbackFolders(filePath, rootPath, type, ref info);
+        }
+
+        // Last resort: use filename as series
+        if (string.IsNullOrEmpty(info.Series))
+        {
+            var fileName = directoryService.FileSystem.Path.GetFileNameWithoutExtension(filePath);
+            info.Series = Parser.CleanTitle(fileName, false);
+        }
+
+        FinalizeNumbers(info);
+
+        return string.IsNullOrEmpty(info.Series) ? null : info;
+    }
+
+    /// <summary>
+    /// Applicable for any audio file in an Audiobook library.
+    /// </summary>
+    public override bool IsApplicable(string filePath, LibraryType type)
+    {
+        return type == LibraryType.Audiobook && Parser.IsAudio(filePath);
+    }
+}

--- a/Kavita.Services/Scanner/BasicParser.cs
+++ b/Kavita.Services/Scanner/BasicParser.cs
@@ -137,6 +137,6 @@ public class BasicParser(IDirectoryService directoryService, IDefaultParser imag
     /// <returns></returns>
     public override bool IsApplicable(string filePath, LibraryType type)
     {
-        return type != LibraryType.ComicVine && type != LibraryType.Image;
+        return type != LibraryType.ComicVine && type != LibraryType.Image && type != LibraryType.Audiobook;
     }
 }

--- a/Kavita.Services/Scanner/Parser.cs
+++ b/Kavita.Services/Scanner/Parser.cs
@@ -34,9 +34,10 @@ public static partial class Parser
     private const string XmlRegexExtensions = @"\.xml";
     public const string MacOsMetadataFileStartsWith = @"._";
     public const string FontFileExtensions = @"\.[woff2|ttf|otf|woff]";
+    public const string AudioFileExtensions = @"\.m4b|\.mp3|\.flac|\.aac|\.ogg|\.m4a|\.opus|\.wma|\.wav|\.oga";
 
     public const string SupportedExtensions =
-        ArchiveFileExtensions + "|" + ImageFileExtensions + "|" + BookFileExtensions;
+        ArchiveFileExtensions + "|" + ImageFileExtensions + "|" + BookFileExtensions + "|" + AudioFileExtensions;
 
     private const RegexOptions MatchOptions =
         RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.CultureInvariant;
@@ -103,6 +104,8 @@ public static partial class Parser
     private static readonly Regex XmlRegex = new(XmlRegexExtensions,
         MatchOptions, RegexTimeout);
     private static readonly Regex BookFileRegex = new(BookFileExtensions,
+        MatchOptions, RegexTimeout);
+    private static readonly Regex AudioFileRegex = new(AudioFileExtensions,
         MatchOptions, RegexTimeout);
     private static readonly Regex CoverImageRegex = new(@"(?<!back[\s_-])(?<!\(back )(?<!back)(?:^|[^a-zA-Z0-9])(!?cover|folder)(?![a-zA-Z0-9]|s\b)",
         MatchOptions, RegexTimeout);
@@ -731,6 +734,7 @@ public static partial class Parser
         if (IsImage(filePath)) return MangaFormat.Image;
         if (IsEpub(filePath)) return MangaFormat.Epub;
         if (IsPdf(filePath)) return MangaFormat.Pdf;
+        if (IsAudio(filePath)) return MangaFormat.Audio;
         return MangaFormat.Unknown;
     }
 
@@ -1136,6 +1140,11 @@ public static partial class Parser
     public static bool IsPdf(string filePath)
     {
         return Path.GetExtension(filePath).Equals(".pdf", StringComparison.InvariantCultureIgnoreCase);
+    }
+
+    public static bool IsAudio(string filePath)
+    {
+        return AudioFileRegex.IsMatch(Path.GetExtension(filePath));
     }
 
     /// <summary>

--- a/UI/Web/src/app/_models/library/file-type-group.enum.ts
+++ b/UI/Web/src/app/_models/library/file-type-group.enum.ts
@@ -2,7 +2,8 @@ export enum FileTypeGroup {
   Archive = 1,
   Epub = 2,
   Pdf = 3,
-  Images = 4
+  Images = 4,
+  Audio = 5
 }
 
 export const allFileTypeGroup = Object.keys(FileTypeGroup)

--- a/UI/Web/src/app/_models/library/library.ts
+++ b/UI/Web/src/app/_models/library/library.ts
@@ -9,10 +9,11 @@ export enum LibraryType {
     /**
      * Comic (Legacy)
      */
-    ComicVine = 5
+    ComicVine = 5,
+    Audiobook = 6
 }
 
-export const allLibraryTypes = [LibraryType.Manga, LibraryType.ComicVine, LibraryType.Comic, LibraryType.Book, LibraryType.LightNovel, LibraryType.Images];
+export const allLibraryTypes = [LibraryType.Manga, LibraryType.ComicVine, LibraryType.Comic, LibraryType.Book, LibraryType.LightNovel, LibraryType.Images, LibraryType.Audiobook];
 export const allKavitaPlusMetadataApplicableTypes = [LibraryType.Manga, LibraryType.LightNovel, LibraryType.ComicVine, LibraryType.Comic];
 export const allKavitaPlusScrobbleEligibleTypes = [LibraryType.Manga, LibraryType.LightNovel];
 

--- a/UI/Web/src/app/_models/manga-format.ts
+++ b/UI/Web/src/app/_models/manga-format.ts
@@ -5,7 +5,8 @@ export enum MangaFormat {
     ARCHIVE = 1,
     UNKNOWN = 2,
     EPUB = 3,
-    PDF = 4
+    PDF = 4,
+    AUDIO = 5
 }
 
 export const allMangaFormats= Object.keys(MangaFormat)

--- a/UI/Web/src/app/_pipes/file-type-group.pipe.ts
+++ b/UI/Web/src/app/_pipes/file-type-group.pipe.ts
@@ -18,7 +18,8 @@ export class FileTypeGroupPipe implements PipeTransform {
         return translate('file-type-group-pipe.pdf');
       case FileTypeGroup.Images:
         return translate('file-type-group-pipe.image');
-
+      case FileTypeGroup.Audio:
+        return translate('file-type-group-pipe.audio');
     }
   }
 

--- a/UI/Web/src/app/_pipes/library-type-subtitle.pipe.ts
+++ b/UI/Web/src/app/_pipes/library-type-subtitle.pipe.ts
@@ -23,7 +23,8 @@ export class LibraryTypeSubtitlePipe implements PipeTransform {
         return translate('library-type-subtitle-pipe.lightNovel');
       case LibraryType.ComicVine:
         return translate('library-type-subtitle-pipe.comicVine');
-
+      case LibraryType.Audiobook:
+        return translate('library-type-subtitle-pipe.audiobook');
     }
   }
 

--- a/UI/Web/src/app/_pipes/library-type.pipe.ts
+++ b/UI/Web/src/app/_pipes/library-type.pipe.ts
@@ -26,6 +26,8 @@ export class LibraryTypePipe implements PipeTransform {
         return this.translocoService.translate('library-type-pipe.manga');
       case LibraryType.LightNovel:
         return this.translocoService.translate('library-type-pipe.lightNovel');
+      case LibraryType.Audiobook:
+        return this.translocoService.translate('library-type-pipe.audiobook');
       default:
         return '';
     }

--- a/UI/Web/src/app/_pipes/manga-format-icon.pipe.ts
+++ b/UI/Web/src/app/_pipes/manga-format-icon.pipe.ts
@@ -22,6 +22,8 @@ export class MangaFormatIconPipe implements PipeTransform {
         return 'fa-solid fa-file-pdf';
       case MangaFormat.UNKNOWN:
         return 'fa-solid fa-file-circle-question';
+      case MangaFormat.AUDIO:
+        return 'fa-solid fa-headphones';
     }
   }
 

--- a/UI/Web/src/app/_pipes/manga-format.pipe.ts
+++ b/UI/Web/src/app/_pipes/manga-format.pipe.ts
@@ -23,6 +23,8 @@ export class MangaFormatPipe implements PipeTransform {
         return translate('manga-format-pipe.pdf');
       case MangaFormat.UNKNOWN:
         return translate('manga-format-pipe.unknown');
+      case MangaFormat.AUDIO:
+        return translate('manga-format-pipe.audio');
       default:
         return '';
     }

--- a/UI/Web/src/app/_routes/audiobook-reader.router.module.ts
+++ b/UI/Web/src/app/_routes/audiobook-reader.router.module.ts
@@ -1,0 +1,9 @@
+import {Routes} from '@angular/router';
+import {AudiobookReaderComponent} from '../audiobook-reader/_components/audiobook-reader/audiobook-reader.component';
+
+export const routes: Routes = [
+  {
+    path: ':chapterId',
+    component: AudiobookReaderComponent
+  }
+];

--- a/UI/Web/src/app/_services/entity-title.service.ts
+++ b/UI/Web/src/app/_services/entity-title.service.ts
@@ -32,6 +32,8 @@ export class EntityTitleService {
       case LibraryType.Images:
       case LibraryType.Manga:
         return this.translocoService.translate('entity-title.chapter-title' + pluralKeyPart);
+      case LibraryType.Audiobook:
+        return this.translocoService.translate('entity-title.track-title' + pluralKeyPart);
     }
   }
 
@@ -89,6 +91,8 @@ export class EntityTitleService {
         return this.calculateImageRenderText(isChapter, number, volumeTitle, fallbackToVolume);
       case LibraryType.LightNovel:
         return this.calculateLightNovelRenderText(titleName, prioritizeTitleName, fallbackToVolume, isChapter, number, volumeTitle);
+      case LibraryType.Audiobook:
+        return this.calculateBookRenderText(titleName, prioritizeTitleName, fallbackToVolume, isChapter, number, volumeTitle);
       default:
         return '';
     }

--- a/UI/Web/src/app/_services/reader.service.ts
+++ b/UI/Web/src/app/_services/reader.service.ts
@@ -107,6 +107,8 @@ export class ReaderService {
       return ['library', libraryId, 'series', seriesId, 'book', chapterId];
     } else if (format === MangaFormat.PDF) {
       return ['library', libraryId, 'series', seriesId, 'pdf', chapterId];
+    } else if (format === MangaFormat.AUDIO) {
+      return ['library', libraryId, 'series', seriesId, 'audio', chapterId];
     } else {
       return ['library', libraryId, 'series', seriesId, 'manga', chapterId];
     }

--- a/UI/Web/src/app/app-routing.module.ts
+++ b/UI/Web/src/app/app-routing.module.ts
@@ -116,6 +116,10 @@ export const routes: Routes = [
           {
             path: 'series/:seriesId/pdf',
             loadChildren: () => import('./_routes/pdf-reader.router.module').then(m => m.routes)
+          },
+          {
+            path: 'series/:seriesId/audio',
+            loadChildren: () => import('./_routes/audiobook-reader.router.module').then(m => m.routes)
           }
         ]
       },

--- a/UI/Web/src/app/audiobook-reader/_components/audiobook-reader/audiobook-reader.component.html
+++ b/UI/Web/src/app/audiobook-reader/_components/audiobook-reader/audiobook-reader.component.html
@@ -1,0 +1,138 @@
+<ng-container *transloco="let t; prefix: 'audiobook-reader'">
+  <div class="audiobook-reader">
+
+    <!-- Top bar -->
+    <div class="reader-topbar">
+      <button class="btn btn-icon" (click)="close()" [attr.aria-label]="t('close')">
+        <i class="fa fa-arrow-left"></i>
+      </button>
+      <div class="series-title text-truncate">
+        {{ audioInfo()?.seriesName ?? '' }}
+      </div>
+    </div>
+
+    <!-- Main content -->
+    <div class="reader-body">
+
+      <!-- Cover art -->
+      <div class="cover-container">
+        @if (coverUrl()) {
+          <img [src]="coverUrl()" class="cover-art" [alt]="audioInfo()?.bookTitle ?? ''" />
+        } @else {
+          <div class="cover-placeholder">
+            <i class="fa-solid fa-headphones"></i>
+          </div>
+        }
+      </div>
+
+      <!-- Track info -->
+      <div class="track-info">
+        <div class="track-title">{{ audioInfo()?.bookTitle ?? audioInfo()?.seriesName }}</div>
+        @if (audioInfo()?.author) {
+          <div class="track-meta">{{ audioInfo()!.author }}</div>
+        }
+        @if (audioInfo()?.narrator) {
+          <div class="track-meta narrator">{{ t('narrator-label') }}: {{ audioInfo()!.narrator }}</div>
+        }
+        @if (audioInfo()?.chapterTitle) {
+          <div class="track-chapter">{{ audioInfo()!.chapterTitle }}</div>
+        }
+      </div>
+
+      <!-- Progress / Seek -->
+      <div class="progress-section">
+        <input
+          type="range"
+          class="seek-bar"
+          min="0"
+          [max]="duration()"
+          [value]="currentTime()"
+          (input)="seek($event)"
+          [attr.aria-label]="t('play')"
+        />
+        <div class="time-display">
+          <span>{{ formatTime(currentTime()) }}</span>
+          <span>{{ formatTime(duration()) }}</span>
+        </div>
+      </div>
+
+      <!-- Controls -->
+      <div class="controls">
+        <!-- Previous chapter -->
+        <button
+          class="btn btn-icon control-btn"
+          (click)="navigateToPrev()"
+          [disabled]="prevChapterId() < 0"
+          [attr.aria-label]="t('previous-chapter')">
+          <i class="fa-solid fa-backward-step"></i>
+        </button>
+
+        <!-- Rewind 30s -->
+        <button class="btn btn-icon control-btn" (click)="skipBack()" [attr.aria-label]="t('rewind')">
+          <i class="fa-solid fa-rotate-left"></i>
+          <span class="skip-label">30</span>
+        </button>
+
+        <!-- Play/Pause -->
+        <button class="btn btn-icon control-btn play-btn" (click)="togglePlayPause()" [attr.aria-label]="isPlaying() ? t('pause') : t('play')">
+          @if (isLoading()) {
+            <i class="fa-solid fa-spinner fa-spin"></i>
+          } @else if (isPlaying()) {
+            <i class="fa-solid fa-pause"></i>
+          } @else {
+            <i class="fa-solid fa-play"></i>
+          }
+        </button>
+
+        <!-- Forward 30s -->
+        <button class="btn btn-icon control-btn" (click)="skipForward()" [attr.aria-label]="t('forward')">
+          <i class="fa-solid fa-rotate-right"></i>
+          <span class="skip-label">30</span>
+        </button>
+
+        <!-- Next chapter -->
+        <button
+          class="btn btn-icon control-btn"
+          (click)="navigateToNext()"
+          [disabled]="nextChapterId() < 0"
+          [attr.aria-label]="t('next-chapter')">
+          <i class="fa-solid fa-forward-step"></i>
+        </button>
+      </div>
+
+      <!-- Secondary controls: speed + volume -->
+      <div class="secondary-controls">
+        <button class="btn btn-sm speed-btn" (click)="cycleSpeed()" [attr.aria-label]="t('speed')">
+          {{ currentSpeed }}x
+        </button>
+
+        <div class="volume-control">
+          <i class="fa-solid fa-volume-low"></i>
+          <input
+            type="range"
+            class="volume-slider"
+            min="0"
+            max="1"
+            step="0.05"
+            [value]="volume()"
+            (input)="setVolume($event)"
+            [attr.aria-label]="t('volume')"
+          />
+          <i class="fa-solid fa-volume-high"></i>
+        </div>
+      </div>
+
+    </div><!-- /reader-body -->
+
+    <!-- Hidden audio element -->
+    <audio
+      #audioEl
+      [src]="streamUrl()"
+      preload="metadata"
+      (canplay)="onAudioCanPlay()"
+      (timeupdate)="onAudioTimeUpdate()"
+      (ended)="onAudioEnded()"
+    ></audio>
+
+  </div>
+</ng-container>

--- a/UI/Web/src/app/audiobook-reader/_components/audiobook-reader/audiobook-reader.component.scss
+++ b/UI/Web/src/app/audiobook-reader/_components/audiobook-reader/audiobook-reader.component.scss
@@ -1,0 +1,240 @@
+:host {
+  display: block;
+  height: 100vh;
+  background-color: var(--bg-color, #1a1a2e);
+  color: var(--text-color, #e0e0e0);
+  overflow: hidden;
+}
+
+.audiobook-reader {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  max-width: 42rem;
+  margin: 0 auto;
+  padding: 0 1rem;
+  box-sizing: border-box;
+}
+
+// ── Top bar ──────────────────────────────────────────────
+.reader-topbar {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 0 0.5rem;
+  flex-shrink: 0;
+
+  .series-title {
+    font-size: 0.9rem;
+    opacity: 0.7;
+    flex: 1;
+    text-align: center;
+    padding-right: 2rem; // visually balance the back button
+  }
+}
+
+.btn-icon {
+  background: transparent;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  padding: 0.4rem;
+  font-size: 1.1rem;
+  opacity: 0.8;
+  transition: opacity 0.15s;
+
+  &:hover { opacity: 1; }
+  &:disabled { opacity: 0.3; cursor: not-allowed; }
+}
+
+// ── Body ─────────────────────────────────────────────────
+.reader-body {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  flex: 1;
+  overflow: hidden;
+  padding: 0.5rem 0 1.5rem;
+  gap: 1rem;
+}
+
+// ── Cover art ────────────────────────────────────────────
+.cover-container {
+  flex-shrink: 0;
+  width: clamp(10rem, 45vw, 18rem);
+  aspect-ratio: 1 / 1;
+  border-radius: 0.75rem;
+  overflow: hidden;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.5);
+  background: var(--input-bg-color, #2a2a3e);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.cover-art {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.cover-placeholder {
+  font-size: 4rem;
+  opacity: 0.3;
+}
+
+// ── Track info ───────────────────────────────────────────
+.track-info {
+  text-align: center;
+  max-width: 100%;
+
+  .track-title {
+    font-size: 1.15rem;
+    font-weight: 600;
+    margin-bottom: 0.25rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 30rem;
+  }
+
+  .track-meta {
+    font-size: 0.85rem;
+    opacity: 0.65;
+
+    &.narrator { font-style: italic; }
+  }
+
+  .track-chapter {
+    font-size: 0.8rem;
+    opacity: 0.5;
+    margin-top: 0.15rem;
+  }
+}
+
+// ── Progress / Seek ──────────────────────────────────────
+.progress-section {
+  width: 100%;
+}
+
+.seek-bar {
+  width: 100%;
+  -webkit-appearance: none;
+  appearance: none;
+  height: 4px;
+  border-radius: 2px;
+  background: linear-gradient(
+    to right,
+    var(--primary-color, #3b9e76) calc(var(--progress, 0%) * 1%),
+    var(--input-bg-color, #444) calc(var(--progress, 0%) * 1%)
+  );
+  outline: none;
+  cursor: pointer;
+
+  &::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: var(--primary-color, #3b9e76);
+    cursor: pointer;
+  }
+}
+
+.time-display {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.75rem;
+  opacity: 0.55;
+  margin-top: 0.3rem;
+}
+
+// ── Main controls ────────────────────────────────────────
+.controls {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+.control-btn {
+  font-size: 1.3rem;
+  position: relative;
+
+  .skip-label {
+    position: absolute;
+    font-size: 0.5rem;
+    bottom: 0.05rem;
+    right: 50%;
+    transform: translateX(50%);
+    opacity: 0.85;
+  }
+}
+
+.play-btn {
+  width: 3.5rem;
+  height: 3.5rem;
+  border-radius: 50%;
+  background: var(--primary-color, #3b9e76);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.4rem;
+  opacity: 1;
+  transition: transform 0.1s, background 0.15s;
+
+  &:hover { transform: scale(1.06); }
+  &:active { transform: scale(0.95); }
+}
+
+// ── Secondary controls ───────────────────────────────────
+.secondary-controls {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  flex-shrink: 0;
+}
+
+.speed-btn {
+  font-size: 0.8rem;
+  font-weight: 600;
+  background: var(--input-bg-color, #2a2a3e);
+  border: 1px solid var(--border-color, #444);
+  color: inherit;
+  border-radius: 0.4rem;
+  padding: 0.25rem 0.6rem;
+  cursor: pointer;
+  min-width: 3rem;
+  text-align: center;
+  transition: background 0.15s;
+
+  &:hover { background: var(--highlight-bg, #3a3a5e); }
+}
+
+.volume-control {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+
+  i { font-size: 0.85rem; opacity: 0.65; }
+}
+
+.volume-slider {
+  width: 5rem;
+  -webkit-appearance: none;
+  appearance: none;
+  height: 3px;
+  border-radius: 2px;
+  background: var(--input-bg-color, #444);
+  cursor: pointer;
+
+  &::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: var(--text-color, #e0e0e0);
+    cursor: pointer;
+  }
+}

--- a/UI/Web/src/app/audiobook-reader/_components/audiobook-reader/audiobook-reader.component.ts
+++ b/UI/Web/src/app/audiobook-reader/_components/audiobook-reader/audiobook-reader.component.ts
@@ -1,0 +1,307 @@
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  DestroyRef,
+  ElementRef,
+  inject,
+  OnDestroy,
+  OnInit,
+  signal,
+  viewChild
+} from '@angular/core';
+import {ActivatedRoute, Router} from '@angular/router';
+import {ToastrService} from 'ngx-toastr';
+import {CHAPTER_ID_DOESNT_EXIST, CHAPTER_ID_NOT_FETCHED, ReaderService} from '../../../_services/reader.service';
+import {AccountService} from '../../../_services/account.service';
+import {NavService} from '../../../_services/nav.service';
+import {AudiobookService} from '../../_services/audiobook.service';
+import {AudioInfo} from '../../_models/audio-info';
+import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
+import {translate, TranslocoDirective} from '@jsverse/transloco';
+import {ImageService} from '../../../_services/image.service';
+import {interval, Subscription} from 'rxjs';
+
+const PLAYBACK_SPEEDS = [0.5, 0.75, 1, 1.25, 1.5, 1.75, 2];
+const PROGRESS_SAVE_INTERVAL_MS = 10_000;
+const SKIP_SECONDS = 30;
+
+@Component({
+  selector: 'app-audiobook-reader',
+  standalone: true,
+  imports: [TranslocoDirective],
+  templateUrl: './audiobook-reader.component.html',
+  styleUrls: ['./audiobook-reader.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class AudiobookReaderComponent implements OnInit, OnDestroy {
+
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly readerService = inject(ReaderService);
+  private readonly accountService = inject(AccountService);
+  private readonly navService = inject(NavService);
+  private readonly audiobookService = inject(AudiobookService);
+  private readonly imageService = inject(ImageService);
+  private readonly toastr = inject(ToastrService);
+  private readonly cdRef = inject(ChangeDetectorRef);
+  private readonly destroyRef = inject(DestroyRef);
+
+  protected readonly audioEl = viewChild<ElementRef<HTMLAudioElement>>('audioEl');
+
+  // Route params
+  libraryId!: number;
+  seriesId!: number;
+  chapterId!: number;
+
+  // The image-only auth key is used for media URLs (same mechanism as cover images)
+  private readonly apiKey = this.accountService.currentUserImageAuthKey;
+
+  // State
+  audioInfo = signal<AudioInfo | null>(null);
+  streamUrl = signal('');
+  coverUrl = signal('');
+
+  isPlaying = signal(false);
+  isLoading = signal(true);
+  currentTime = signal(0);
+  duration = signal(0);
+  volume = signal(1);
+  playbackSpeedIndex = signal(2); // index into PLAYBACK_SPEEDS, default 1x
+  protected readonly playbackSpeeds = PLAYBACK_SPEEDS;
+
+  prevChapterId = signal(CHAPTER_ID_NOT_FETCHED);
+  nextChapterId = signal(CHAPTER_ID_NOT_FETCHED);
+
+  private progressSaveSubscription?: Subscription;
+
+  ngOnInit() {
+    this.navService.hideNavBar();
+
+    this.route.paramMap.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(params => {
+      this.libraryId = parseInt(params.get('libraryId') ?? '0', 10);
+      this.seriesId = parseInt(params.get('seriesId') ?? '0', 10);
+      this.chapterId = parseInt(params.get('chapterId') ?? '0', 10);
+
+      if (!this.chapterId) return;
+      this.loadChapter();
+    });
+  }
+
+  ngOnDestroy() {
+    this.navService.showNavBar();
+    this.stopProgressSaving();
+    this.pauseAndSaveProgress();
+  }
+
+  private loadChapter() {
+    this.isLoading.set(true);
+
+    this.audiobookService.getAudioInfo(this.chapterId).subscribe({
+      next: (info) => {
+        this.audioInfo.set(info);
+        this.duration.set(info.pages);
+        this.coverUrl.set(this.imageService.getChapterCoverImage(this.chapterId));
+        this.streamUrl.set(this.audiobookService.getStreamUrl(this.chapterId, this.apiKey() ?? ''));
+        this.cdRef.markForCheck();
+
+        // Load saved progress after audio metadata is available
+        this.readerService.getProgress(this.chapterId).subscribe(progress => {
+          if (progress && progress.pageNum > 0) {
+            const audio = this.audioEl()?.nativeElement;
+            if (audio) {
+              audio.currentTime = progress.pageNum;
+            }
+            this.currentTime.set(progress.pageNum);
+          }
+          this.cdRef.markForCheck();
+        });
+
+        // Fetch prev/next chapter IDs (requires volumeId from audioInfo)
+        this.readerService.getPrevChapter(info.seriesId, info.volumeId, this.chapterId).pipe(
+          takeUntilDestroyed(this.destroyRef)
+        ).subscribe(id => {
+          this.prevChapterId.set(id);
+          this.cdRef.markForCheck();
+        });
+
+        this.readerService.getNextChapter(info.seriesId, info.volumeId, this.chapterId).pipe(
+          takeUntilDestroyed(this.destroyRef)
+        ).subscribe(id => {
+          this.nextChapterId.set(id);
+          this.cdRef.markForCheck();
+        });
+      },
+      error: () => {
+        this.toastr.error(translate('audiobook-reader.loading'));
+        this.isLoading.set(false);
+        this.cdRef.markForCheck();
+      }
+    });
+  }
+
+  onAudioCanPlay() {
+    this.isLoading.set(false);
+    const audio = this.audioEl()?.nativeElement;
+    if (audio) {
+      audio.volume = this.volume();
+      audio.playbackRate = PLAYBACK_SPEEDS[this.playbackSpeedIndex()];
+    }
+    this.cdRef.markForCheck();
+  }
+
+  onAudioTimeUpdate() {
+    const audio = this.audioEl()?.nativeElement;
+    if (audio) {
+      this.currentTime.set(Math.floor(audio.currentTime));
+    }
+    this.cdRef.markForCheck();
+  }
+
+  onAudioEnded() {
+    this.isPlaying.set(false);
+    this.stopProgressSaving();
+    this.saveProgress();
+    // Auto-advance to next chapter
+    if (this.nextChapterId() !== CHAPTER_ID_DOESNT_EXIST && this.nextChapterId() !== CHAPTER_ID_NOT_FETCHED) {
+      this.navigateToChapter(this.nextChapterId());
+    }
+    this.cdRef.markForCheck();
+  }
+
+  togglePlayPause() {
+    const audio = this.audioEl()?.nativeElement;
+    if (!audio) return;
+
+    if (this.isPlaying()) {
+      audio.pause();
+      this.isPlaying.set(false);
+      this.stopProgressSaving();
+      this.saveProgress();
+    } else {
+      audio.play().then(() => {
+        this.isPlaying.set(true);
+        this.startProgressSaving();
+        this.cdRef.markForCheck();
+      }).catch(() => {
+        this.toastr.error(translate('audiobook-reader.loading'));
+      });
+    }
+    this.cdRef.markForCheck();
+  }
+
+  skipBack() {
+    const audio = this.audioEl()?.nativeElement;
+    if (!audio) return;
+    audio.currentTime = Math.max(0, audio.currentTime - SKIP_SECONDS);
+    this.currentTime.set(Math.floor(audio.currentTime));
+    this.cdRef.markForCheck();
+  }
+
+  skipForward() {
+    const audio = this.audioEl()?.nativeElement;
+    if (!audio) return;
+    audio.currentTime = Math.min(audio.duration, audio.currentTime + SKIP_SECONDS);
+    this.currentTime.set(Math.floor(audio.currentTime));
+    this.cdRef.markForCheck();
+  }
+
+  seek(event: Event) {
+    const input = event.target as HTMLInputElement;
+    const audio = this.audioEl()?.nativeElement;
+    if (!audio) return;
+    const newTime = parseFloat(input.value);
+    audio.currentTime = newTime;
+    this.currentTime.set(Math.floor(newTime));
+    this.cdRef.markForCheck();
+  }
+
+  setVolume(event: Event) {
+    const input = event.target as HTMLInputElement;
+    const v = parseFloat(input.value);
+    this.volume.set(v);
+    const audio = this.audioEl()?.nativeElement;
+    if (audio) audio.volume = v;
+    this.cdRef.markForCheck();
+  }
+
+  cycleSpeed() {
+    const nextIndex = (this.playbackSpeedIndex() + 1) % PLAYBACK_SPEEDS.length;
+    this.playbackSpeedIndex.set(nextIndex);
+    const audio = this.audioEl()?.nativeElement;
+    if (audio) audio.playbackRate = PLAYBACK_SPEEDS[nextIndex];
+    this.cdRef.markForCheck();
+  }
+
+  get currentSpeed(): number {
+    return PLAYBACK_SPEEDS[this.playbackSpeedIndex()];
+  }
+
+  navigateToPrev() {
+    const prev = this.prevChapterId();
+    if (prev !== CHAPTER_ID_DOESNT_EXIST && prev !== CHAPTER_ID_NOT_FETCHED) {
+      this.navigateToChapter(prev);
+    }
+  }
+
+  navigateToNext() {
+    const next = this.nextChapterId();
+    if (next !== CHAPTER_ID_DOESNT_EXIST && next !== CHAPTER_ID_NOT_FETCHED) {
+      this.navigateToChapter(next);
+    }
+  }
+
+  private navigateToChapter(chapterId: number) {
+    this.stopProgressSaving();
+    this.router.navigate(['library', this.libraryId, 'series', this.seriesId, 'audio', chapterId]).catch(() => {});
+  }
+
+  close() {
+    this.stopProgressSaving();
+    this.saveProgress();
+    this.readerService.closeReader(this.libraryId, this.seriesId, this.chapterId);
+  }
+
+  formatTime(seconds: number): string {
+    const h = Math.floor(seconds / 3600);
+    const m = Math.floor((seconds % 3600) / 60);
+    const s = seconds % 60;
+    if (h > 0) {
+      return `${h}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+    }
+    return `${m}:${String(s).padStart(2, '0')}`;
+  }
+
+  get progressPercent(): number {
+    const d = this.duration();
+    return d > 0 ? (this.currentTime() / d) : 0;
+  }
+
+  private saveProgress() {
+    const info = this.audioInfo();
+    if (!info) return;
+    this.readerService.saveProgress(
+      this.libraryId, info.seriesId, info.volumeId, this.chapterId, this.currentTime()
+    ).subscribe();
+  }
+
+  private startProgressSaving() {
+    this.stopProgressSaving();
+    this.progressSaveSubscription = interval(PROGRESS_SAVE_INTERVAL_MS).pipe(
+      takeUntilDestroyed(this.destroyRef)
+    ).subscribe(() => this.saveProgress());
+  }
+
+  private stopProgressSaving() {
+    this.progressSaveSubscription?.unsubscribe();
+    this.progressSaveSubscription = undefined;
+  }
+
+  private pauseAndSaveProgress() {
+    const audio = this.audioEl()?.nativeElement;
+    if (audio && !audio.paused) {
+      audio.pause();
+    }
+    this.saveProgress();
+  }
+}

--- a/UI/Web/src/app/audiobook-reader/_models/audio-info.ts
+++ b/UI/Web/src/app/audiobook-reader/_models/audio-info.ts
@@ -1,0 +1,18 @@
+import {MangaFormat} from "../../_models/manga-format";
+
+export interface AudioInfo {
+  bookTitle: string;
+  seriesId: number;
+  volumeId: number;
+  seriesFormat: MangaFormat;
+  seriesName: string;
+  chapterNumber: string;
+  volumeNumber: string;
+  libraryId: number;
+  /** Total duration in seconds */
+  pages: number;
+  isSpecial: boolean;
+  chapterTitle: string;
+  author: string;
+  narrator: string;
+}

--- a/UI/Web/src/app/audiobook-reader/_services/audiobook.service.ts
+++ b/UI/Web/src/app/audiobook-reader/_services/audiobook.service.ts
@@ -1,0 +1,25 @@
+import {inject, Injectable} from '@angular/core';
+import {HttpClient} from '@angular/common/http';
+import {environment} from '../../../environments/environment';
+import {AudioInfo} from '../_models/audio-info';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AudiobookService {
+
+  private readonly http = inject(HttpClient);
+  private readonly baseUrl = environment.apiUrl;
+
+  getAudioInfo(chapterId: number) {
+    return this.http.get<AudioInfo>(this.baseUrl + `audio/${chapterId}/audio-info`);
+  }
+
+  /**
+   * Returns the URL to stream the audio file for the given chapter.
+   * The HTML5 audio element will handle range requests for seeking.
+   */
+  getStreamUrl(chapterId: number, apiKey: string): string {
+    return `${this.baseUrl}audio/${chapterId}/stream?apiKey=${encodeURIComponent(apiKey)}`;
+  }
+}

--- a/UI/Web/src/app/sidenav/_components/side-nav/side-nav.component.ts
+++ b/UI/Web/src/app/sidenav/_components/side-nav/side-nav.component.ts
@@ -181,6 +181,8 @@ export class SideNavComponent {
         return 'fa-book-open';
       case LibraryType.Images:
         return 'fa-images';
+      case LibraryType.Audiobook:
+        return 'fa-headphones';
     }
   }
 

--- a/UI/Web/src/app/sidenav/_modals/library-settings-modal/library-settings-modal.component.ts
+++ b/UI/Web/src/app/sidenav/_modals/library-settings-modal/library-settings-modal.component.ts
@@ -229,6 +229,7 @@ export class LibrarySettingsModalComponent implements OnInit {
             this.libraryForm.get(FileTypeGroup.Images + '')?.setValue(true);
             this.libraryForm.get(FileTypeGroup.Pdf + '')?.setValue(false);
             this.libraryForm.get(FileTypeGroup.Epub + '')?.setValue(false);
+            this.libraryForm.get(FileTypeGroup.Audio + '')?.setValue(false);
             break;
           case LibraryType.Comic:
           case LibraryType.ComicVine:
@@ -236,24 +237,35 @@ export class LibrarySettingsModalComponent implements OnInit {
             this.libraryForm.get(FileTypeGroup.Images + '')?.setValue(false);
             this.libraryForm.get(FileTypeGroup.Pdf + '')?.setValue(false);
             this.libraryForm.get(FileTypeGroup.Epub + '')?.setValue(false);
+            this.libraryForm.get(FileTypeGroup.Audio + '')?.setValue(false);
             break;
           case LibraryType.Book:
             this.libraryForm.get(FileTypeGroup.Archive + '')?.setValue(false);
             this.libraryForm.get(FileTypeGroup.Images + '')?.setValue(false);
             this.libraryForm.get(FileTypeGroup.Pdf + '')?.setValue(true);
             this.libraryForm.get(FileTypeGroup.Epub + '')?.setValue(true);
+            this.libraryForm.get(FileTypeGroup.Audio + '')?.setValue(false);
             break;
           case LibraryType.LightNovel:
             this.libraryForm.get(FileTypeGroup.Archive + '')?.setValue(false);
             this.libraryForm.get(FileTypeGroup.Images + '')?.setValue(false);
             this.libraryForm.get(FileTypeGroup.Pdf + '')?.setValue(false);
             this.libraryForm.get(FileTypeGroup.Epub + '')?.setValue(true);
+            this.libraryForm.get(FileTypeGroup.Audio + '')?.setValue(false);
             break;
           case LibraryType.Images:
             this.libraryForm.get(FileTypeGroup.Archive + '')?.setValue(false);
             this.libraryForm.get(FileTypeGroup.Images + '')?.setValue(true);
             this.libraryForm.get(FileTypeGroup.Pdf + '')?.setValue(false);
             this.libraryForm.get(FileTypeGroup.Epub + '')?.setValue(false);
+            this.libraryForm.get(FileTypeGroup.Audio + '')?.setValue(false);
+            break;
+          case LibraryType.Audiobook:
+            this.libraryForm.get(FileTypeGroup.Archive + '')?.setValue(false);
+            this.libraryForm.get(FileTypeGroup.Images + '')?.setValue(false);
+            this.libraryForm.get(FileTypeGroup.Pdf + '')?.setValue(false);
+            this.libraryForm.get(FileTypeGroup.Epub + '')?.setValue(false);
+            this.libraryForm.get(FileTypeGroup.Audio + '')?.setValue(true);
             break;
         }
 

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -745,7 +745,8 @@
         "archive": "Archive",
         "image": "Image",
         "pdf": "PDF",
-        "unknown": "Unknown"
+        "unknown": "Unknown",
+        "audio": "Audio"
     },
 
     "library-type-pipe": {
@@ -754,7 +755,8 @@
         "manga": "Manga",
         "comicVine": "Comic",
         "image": "Image",
-        "lightNovel": "Light Novel"
+        "lightNovel": "Light Novel",
+        "audiobook": "Audiobook"
     },
 
     "library-type-subtitle-pipe": {
@@ -763,7 +765,8 @@
         "manga": "Japanese comics with volume grouping support. Also handles some loose image configurations.",
         "comicVine": "Strict comic implementation based on Comic Vine metadata with integration for specialized tooling.",
         "image": "Loose image files with limited support. Must largely follow wiki documentation.",
-        "lightNovel": "Book library with special handling optimized for light novels"
+        "lightNovel": "Book library with special handling optimized for light novels",
+        "audiobook": "Audiobook library supporting M4B, MP3, FLAC, and other audio formats."
     },
 
     "age-rating-pipe": {
@@ -1442,7 +1445,25 @@
         "archive": "Archive",
         "epub": "Epub",
         "pdf": "Pdf",
-        "image": "Image"
+        "image": "Image",
+        "audio": "Audio"
+    },
+
+    "audiobook-reader": {
+        "play": "Play",
+        "pause": "Pause",
+        "rewind": "Rewind 30s",
+        "forward": "Forward 30s",
+        "speed": "Playback Speed",
+        "volume": "Volume",
+        "close": "Close",
+        "settings": "Settings",
+        "narrator-label": "Narrator",
+        "author-label": "Author",
+        "previous-chapter": "Previous",
+        "next-chapter": "Next",
+        "chapter-label": "Chapter",
+        "loading": "Loading audio…"
     },
 
     "reader-settings": {
@@ -1632,7 +1653,9 @@
         "issue-title": "Issue",
         "issue-title-plural": "Issues",
         "chapter-title": "Chapter",
-        "chapter-title-plural": "Chapters"
+        "chapter-title-plural": "Chapters",
+        "track-title": "Track",
+        "track-title-plural": "Tracks"
     },
 
     "external-series-card": {


### PR DESCRIPTION
## Description

Adds a new **Audiobook** library type to Kavita, enabling users to organize and listen to audiobook collections (MP3, M4B, FLAC, OGG, WAV) directly in the browser.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code refactor (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation Update

## How Has This Been Tested?

Manually tested against a local audiobook library with M4B and MP3 files. Unit tests updated to cover the new `IAudiobookService` dependency in `ReadingItemService`.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the tests
- [x] New and existing unit tests pass locally with my changes

## Feature Summary

**Backend:**
- New `LibraryType.Audiobook` enum value wired through all relevant switches (`FileTypeGroup`, `MangaFormat`, `PlusMediaFormat`, pipe extensions, etc.)
- `AudioParser` scans audio file extensions and delegates to `AudiobookService`
- `AudiobookService` (TagLibSharp): parses metadata (album → series, title → chapter, performers → writer, composers → narrator), extracts embedded cover art with fallback to `cover.jpg`/`folder.jpg` in the same or parent directory, and returns duration in seconds stored in `Chapter.Pages`
- `PersonRole.Narrator` added for audiobook narrator credits
- `AudioController` exposes `/api/audio/{chapterId}/stream` for range-request streaming and `/api/audio/{chapterId}/info` for player metadata
- `ReaderService` wired to open the audiobook reader route

**Frontend:**
- Dedicated `AudiobookReaderComponent` with full playback controls: play/pause, skip ±30s, speed cycling (0.5×–2×), volume, seek bar, formatted timestamps
- Progress saved every 10 seconds while playing and on pause/close, restored on load
- Auto-advances to the next chapter on track end
- Library type icon (`fa-headphones`), title formatting ("Track"/"Tracks"), and all pipe/label updates for the Audiobook type