### PR TITLE
Small amount of polish

### DIFF
--- a/Kavita.API/Services/IOpdsService.cs
+++ b/Kavita.API/Services/IOpdsService.cs
@@ -17,7 +17,7 @@ public interface IOpdsService
     Task<Feed> GetRecentlyUpdated(OpdsPaginatedCatalogueRequest request, CancellationToken ct = default);
     Task<Feed> GetOnDeck(OpdsPaginatedCatalogueRequest request, CancellationToken ct = default);
 
-    Task<Feed> GetSeriesFromSmartFilter(OpdsItemsFromEntityIdRequest request, CancellationToken ct = default);
+    Task<Feed> ResolveSmartFilter(OpdsItemsFromEntityIdRequest request, CancellationToken ct = default);
     Task<Feed> GetSeriesFromCollection(OpdsItemsFromEntityIdRequest request, CancellationToken ct = default);
     Task<Feed> GetSeriesFromLibrary(OpdsItemsFromEntityIdRequest request, CancellationToken ct = default);
     Task<Feed> GetReadingListItems(OpdsItemsFromEntityIdRequest request, CancellationToken ct = default);

--- a/Kavita.API/Services/ITachiyomiService.cs
+++ b/Kavita.API/Services/ITachiyomiService.cs
@@ -18,6 +18,7 @@ public interface ITachiyomiService
     /// If it's a volume, the volume number gets returned in the 'Number' attribute of a chapterDto encoded.
     /// The volume number gets divided by 10,000 because that's how Tachiyomi interprets volumes</returns>
     Task<TachiyomiChapterDto?> GetLatestChapter(int seriesId, int userId, CancellationToken ct = default);
+
     /// <summary>
     /// Marks every chapter and volume that is sorted below the passed number as Read. This will not mark any specials as read.
     /// Passed number will also be marked as read
@@ -25,6 +26,7 @@ public interface ITachiyomiService
     /// <param name="user"></param>
     /// <param name="seriesId"></param>
     /// <param name="chapterNumber">Can also be a Tachiyomi encoded volume number</param>
+    /// <param name="generateReadingSessions"></param>
     /// <param name="ct"></param>
-    Task<bool> MarkChaptersUntilAsRead(AppUser user, int seriesId, float chapterNumber, CancellationToken ct = default);
+    Task<bool> MarkChaptersUntilAsRead(AppUser user, int seriesId, float chapterNumber, bool generateReadingSessions, CancellationToken ct = default);
 }

--- a/Kavita.Server/Controllers/OPDSController.cs
+++ b/Kavita.Server/Controllers/OPDSController.cs
@@ -73,8 +73,9 @@ public class OpdsController(
     }
 
     /// <summary>
-    /// Get the User's Smart Filter series - Supports Pagination
+    /// Get the User's Smart Filter - Supports Pagination
     /// </summary>
+    /// <remarks>Smart filters have different entity types, this will resolve to the underlying entity</remarks>
     /// <returns></returns>
     [Produces("application/xml")]
     [HttpGet("{apiKey}/smart-filters/{filterId}")]
@@ -83,7 +84,7 @@ public class OpdsController(
         var userId = UserId;
         var (baseUrl, prefix) = await GetPrefix();
 
-        var feed = await opdsService.GetSeriesFromSmartFilter(new OpdsItemsFromEntityIdRequest()
+        var feed = await opdsService.ResolveSmartFilter(new OpdsItemsFromEntityIdRequest()
         {
             ApiKey = apiKey,
             Prefix =  prefix,

--- a/Kavita.Server/Controllers/ReaderController.cs
+++ b/Kavita.Server/Controllers/ReaderController.cs
@@ -527,6 +527,17 @@ public class ReaderController(ICacheService cacheService,
         if (user == null) return Unauthorized();
         user.Progresses ??= new List<AppUserProgress>();
 
+        Dictionary<int, Dictionary<int, int>> progressDictionaries = [];
+
+        if (dto.GenerateReadingSession)
+        {
+            foreach (var sId in dto.SeriesIds)
+            {
+                progressDictionaries[sId] = await unitOfWork.AppUserProgressRepository
+                    .GetUserProgressForChaptersBySeries(UserId, sId, HttpContext.RequestAborted);
+            }
+        }
+
         var volumes = await unitOfWork.VolumeRepository.GetVolumesForSeriesAsync(dto.SeriesIds.ToArray(), true);
         foreach (var volume in volumes)
         {
@@ -540,14 +551,11 @@ public class ReaderController(ICacheService cacheService,
             BackgroundJob.Enqueue(() => scrobblingService.ScrobbleReadingUpdate(user.Id, sId));
             BackgroundJob.Enqueue(() => unitOfWork.SeriesRepository.ClearOnDeckRemovalAsync(sId, user.Id));
 
-            var progressDictionary = await unitOfWork.AppUserProgressRepository
-                .GetUserProgressForChaptersBySeries(UserId, sId, HttpContext.RequestAborted);
+            if (!dto.GenerateReadingSession) continue;
 
-            if (dto.GenerateReadingSession)
-            {
-                BackgroundJob.Enqueue<IReadingSessionService>(s
-                    => s.GenerateReadingSessionForChapters(UserId, sId, progressDictionary, CancellationToken.None));
-            }
+            var progressDictionary = progressDictionaries[sId];
+            BackgroundJob.Enqueue<IReadingSessionService>(s
+                => s.GenerateReadingSessionForChapters(UserId, sId, progressDictionary, CancellationToken.None));
         }
         return Ok();
     }

--- a/Kavita.Server/Controllers/TachiyomiController.cs
+++ b/Kavita.Server/Controllers/TachiyomiController.cs
@@ -21,9 +21,9 @@ public class TachiyomiController(
     /// Given the series Id, this should return the latest chapter that has been fully read.
     /// </summary>
     /// <param name="seriesId"></param>
-    /// <returns>ChapterDTO of latest chapter. Only Chapter number is used by consuming app. All other fields may be missing.</returns>
+    /// <returns>TachiyomiChapterDto of latest chapter. Only Chapter number is used by consuming app. All other fields may be missing.</returns>
     [HttpGet("latest-chapter")]
-    public async Task<ActionResult<ChapterDto>> GetLatestChapter(int seriesId)
+    public async Task<ActionResult<TachiyomiChapterDto>> GetLatestChapter(int seriesId)
     {
         if (seriesId < 1) return BadRequest(await localizationService.TranslateAsync(UserId, "greater-0", "SeriesId"));
         return Ok(await tachiyomiService.GetLatestChapter(seriesId, UserId));
@@ -35,10 +35,13 @@ public class TachiyomiController(
     /// <remarks>This is built for Tachiyomi and is not expected to be called by any other place</remarks>
     /// <returns></returns>
     [HttpPost("mark-chapter-until-as-read")]
-    public async Task<ActionResult<bool>> MarkChaptersUntilAsRead(int seriesId, float chapterNumber)
+    public async Task<ActionResult<bool>> MarkChaptersUntilAsRead(
+        [FromQuery] int seriesId,
+        [FromQuery] float chapterNumber,
+        [FromQuery] bool generateReadingSessions = true)
     {
-        var user = (await unitOfWork.UserRepository.GetUserByUsernameAsync(Username!,
-            AppUserIncludes.Progress))!;
-        return Ok(await tachiyomiService.MarkChaptersUntilAsRead(user, seriesId, chapterNumber));
+        var user = (await unitOfWork.UserRepository.GetUserByUsernameAsync(Username!, AppUserIncludes.Progress))!;
+
+        return Ok(await tachiyomiService.MarkChaptersUntilAsRead(user, seriesId, chapterNumber, generateReadingSessions, HttpContext.RequestAborted));
     }
 }

--- a/Kavita.Server/Logging/LogLevelOptions.cs
+++ b/Kavita.Server/Logging/LogLevelOptions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.RegularExpressions;
+using Microsoft.Extensions.Hosting;
 using Serilog;
 using Serilog.Core;
 using Serilog.Events;
@@ -36,11 +37,11 @@ public static class LogLevelOptions
     /// </summary>
     private static readonly LoggingLevelSwitch AspNetCoreLogLevelSwitch = new (LogEventLevel.Error);
 
-    public static LoggerConfiguration CreateConfig(LoggerConfiguration configuration)
+    public static LoggerConfiguration CreateConfig(HostBuilderContext context, LoggerConfiguration configuration)
     {
         return configuration
-            .MinimumLevel
-            .ControlledBy(LogLevelSwitch)
+            .MinimumLevel.ControlledBy(LogLevelSwitch)
+            .ReadFrom.Configuration(context.Configuration)
             .MinimumLevel.Override("Microsoft", MicrosoftLogLevelSwitch)
             .MinimumLevel.Override("Microsoft.Hosting.Lifetime", MicrosoftHostingLifetimeLogLevelSwitch)
             .MinimumLevel.Override("Hangfire", HangfireLogLevelSwitch)

--- a/Kavita.Server/Program.cs
+++ b/Kavita.Server/Program.cs
@@ -209,9 +209,9 @@ public class Program
 
     private static IHostBuilder CreateHostBuilder(string[] args) =>
         Host.CreateDefaultBuilder(args)
-            .UseSerilog((_, services, configuration) =>
+            .UseSerilog((ctx, services, configuration) =>
             {
-                LogLevelOptions.CreateConfig(configuration)
+                LogLevelOptions.CreateConfig(ctx, configuration)
                     .WriteTo.SignalRSink<LogHub, ILogHub>(
                         LogEventLevel.Information,
                         services);

--- a/Kavita.Services.Tests/OpdsServiceTests.cs
+++ b/Kavita.Services.Tests/OpdsServiceTests.cs
@@ -189,13 +189,13 @@ public class OpdsServiceTests(ITestOutputHelper testOutputHelper) : AbstractDbTe
         return readingList;
     }
 
-    private static async Task<AppUserSmartFilter> CreateSmartFilter(DataContext context, int userId, string name, string filter)
+    private static async Task<AppUserSmartFilter> CreateSmartFilter(DataContext context, int userId, string name, string filter, FilterEntityType entityType = FilterEntityType.Series)
     {
         var smartFilter = new AppUserSmartFilter
         {
             Name = name,
             Filter = filter,
-            EntityType = FilterEntityType.Series,
+            EntityType = entityType,
             AppUserId = userId
         };
 
@@ -805,7 +805,7 @@ public class OpdsServiceTests(ITestOutputHelper testOutputHelper) : AbstractDbTe
         var smartFilter = await CreateSmartFilter(context, user.Id, "Test Filter", "combination=0");
 
         // Test page 1
-        var feed = await opdsService.GetSeriesFromSmartFilter(new OpdsItemsFromEntityIdRequest
+        var feed = await opdsService.ResolveSmartFilter(new OpdsItemsFromEntityIdRequest
         {
             ApiKey = user.GetOpdsAuthKey(),
             Prefix = OpdsService.DefaultApiPrefix,

--- a/Kavita.Services.Tests/TachiyomiServiceTests.cs
+++ b/Kavita.Services.Tests/TachiyomiServiceTests.cs
@@ -180,7 +180,7 @@ public class TachiyomiServiceTests(ITestOutputHelper outputHelper): AbstractDbTe
 
 
         var user = await unitOfWork.UserRepository.GetUserByUsernameAsync("majora2007", AppUserIncludes.Progress);
-        await tachiyomiService.MarkChaptersUntilAsRead(user,1,21);
+        await tachiyomiService.MarkChaptersUntilAsRead(user,1,21, false);
 
         await context.SaveChangesAsync();
 
@@ -233,7 +233,7 @@ public class TachiyomiServiceTests(ITestOutputHelper outputHelper): AbstractDbTe
 
         var user = await unitOfWork.UserRepository.GetUserByUsernameAsync("majora2007", AppUserIncludes.Progress);
 
-        await tachiyomiService.MarkChaptersUntilAsRead(user,1,1/10_000F);
+        await tachiyomiService.MarkChaptersUntilAsRead(user,1,1/10_000F, false);
 
         await context.SaveChangesAsync();
 
@@ -332,7 +332,7 @@ public class TachiyomiServiceTests(ITestOutputHelper outputHelper): AbstractDbTe
 
         var user = await unitOfWork.UserRepository.GetUserByUsernameAsync("majora2007", AppUserIncludes.Progress);
 
-        await tachiyomiService.MarkChaptersUntilAsRead(user,1,2002/10_000F);
+        await tachiyomiService.MarkChaptersUntilAsRead(user,1,2002/10_000F, false);
 
         await context.SaveChangesAsync();
 
@@ -482,7 +482,7 @@ public class TachiyomiServiceTests(ITestOutputHelper outputHelper): AbstractDbTe
         await context.SaveChangesAsync();
 
         var user = await unitOfWork.UserRepository.GetUserByUsernameAsync("majora2007", AppUserIncludes.Progress);
-        await tachiyomiService.MarkChaptersUntilAsRead(user,1,21);
+        await tachiyomiService.MarkChaptersUntilAsRead(user,1,21, false);
 
         await context.SaveChangesAsync();
 
@@ -532,7 +532,7 @@ public class TachiyomiServiceTests(ITestOutputHelper outputHelper): AbstractDbTe
 
         var user = await unitOfWork.UserRepository.GetUserByUsernameAsync("majora2007", AppUserIncludes.Progress);
 
-        await tachiyomiService.MarkChaptersUntilAsRead(user,1,1/10_000F);
+        await tachiyomiService.MarkChaptersUntilAsRead(user,1,1/10_000F, false);
 
         await context.SaveChangesAsync();
 

--- a/Kavita.Services/OpdsService.cs
+++ b/Kavita.Services/OpdsService.cs
@@ -384,6 +384,7 @@ public class OpdsService(
     /// <param name="request"></param>
     /// <param name="ct"></param>
     /// <returns></returns>
+    /// <exception cref="ArgumentOutOfRangeException"></exception>
     public async Task<Feed> ResolveSmartFilter(OpdsItemsFromEntityIdRequest request, CancellationToken ct = default)
     {
         var userId = UnpackRequest(request, out var apiKey, out var prefix, out var baseUrl);
@@ -423,11 +424,9 @@ public class OpdsService(
                 AddPagination(feed, readingLists, $"{prefix}{apiKey}/smart-filters/{request.EntityId}/");
                 break;
             case FilterEntityType.Person:
-                //var list = await unitOfWork.PersonRepository.GetBrowsePersonDtos(userId, (PersonFilterDto) decodedFilter, userParams, ct);
-
-                break;
+                throw new OpdsException("OPDS feed generation is not implemented for Person smart filters");
             case FilterEntityType.Annotation:
-                break;
+                throw new OpdsException("OPDS feed generation is not implemented for Annotation smart filters");
         }
 
         return feed;

--- a/Kavita.Services/OpdsService.cs
+++ b/Kavita.Services/OpdsService.cs
@@ -379,12 +379,12 @@ public class OpdsService(
     }
 
     /// <summary>
-    /// Returns the Series matching this smart filter.
+    /// Returns the Entities matching this smart filter.
     /// </summary>
     /// <param name="request"></param>
     /// <param name="ct"></param>
     /// <returns></returns>
-    public async Task<Feed> GetSeriesFromSmartFilter(OpdsItemsFromEntityIdRequest request, CancellationToken ct = default)
+    public async Task<Feed> ResolveSmartFilter(OpdsItemsFromEntityIdRequest request, CancellationToken ct = default)
     {
         var userId = UnpackRequest(request, out var apiKey, out var prefix, out var baseUrl);
 
@@ -397,17 +397,38 @@ public class OpdsService(
         var feed = CreateFeed(await localizationService.TranslateAsync(userId, "smartFilters-" + filter.Id), $"{apiKey}/smart-filters/{filter.Id}/", apiKey, prefix);
         SetFeedId(feed, "smartFilters-" + filter.Id);
 
-        var decodedFilter = (SeriesFilterV2Dto) SmartFilterHelper.Decode(filter.Filter);
-        var series = await unitOfWork.SeriesRepository.GetSeriesDtoForLibraryIdAsync(userId, GetUserParams(request.PageNumber),
-            decodedFilter, ct: ct);
-        var seriesMetadatas = await unitOfWork.SeriesRepository.GetSeriesMetadataForIdsAsync(series.Select(s => s.Id), ct);
+        var decodedFilter = SmartFilterHelper.Decode(filter.Filter);
+        var userParams = GetUserParams(request.PageNumber);
 
-        foreach (var seriesDto in series)
+
+        switch (decodedFilter.EntityType)
         {
-            feed.Entries.Add(CreateSeries(seriesDto, seriesMetadatas.First(s => s.SeriesId == seriesDto.Id), apiKey, prefix, baseUrl));
-        }
+            case FilterEntityType.Series:
+                var series = await unitOfWork.SeriesRepository.GetSeriesDtoForLibraryIdAsync(userId, userParams,
+                    (SeriesFilterV2Dto) decodedFilter, ct: ct);
+                var seriesMetadatas = await unitOfWork.SeriesRepository.GetSeriesMetadataForIdsAsync(series.Select(s => s.Id), ct);
 
-        AddPagination(feed, series, $"{prefix}{apiKey}/smart-filters/{request.EntityId}/");
+                foreach (var seriesDto in series)
+                {
+                    feed.Entries.Add(CreateSeries(seriesDto, seriesMetadatas.First(s => s.SeriesId == seriesDto.Id), apiKey, prefix, baseUrl));
+                }
+                AddPagination(feed, series, $"{prefix}{apiKey}/smart-filters/{request.EntityId}/");
+                break;
+            case FilterEntityType.ReadingList:
+                var readingLists = await unitOfWork.ReadingListRepository.GetBrowseReadingListDtos(userId, (ReadingListFilterDto) decodedFilter, userParams, ct);
+                foreach (var readingList in readingLists)
+                {
+                    feed.Entries.Add(CreateReadingListFeedEntry(readingList, prefix, apiKey, baseUrl));
+                }
+                AddPagination(feed, readingLists, $"{prefix}{apiKey}/smart-filters/{request.EntityId}/");
+                break;
+            case FilterEntityType.Person:
+                //var list = await unitOfWork.PersonRepository.GetBrowsePersonDtos(userId, (PersonFilterDto) decodedFilter, userParams, ct);
+
+                break;
+            case FilterEntityType.Annotation:
+                break;
+        }
 
         return feed;
     }
@@ -840,24 +861,29 @@ public class OpdsService(
 
         foreach (var readingListDto in readingLists)
         {
-            feed.Entries.Add(new FeedEntry()
-            {
-                Id = readingListDto.Id.ToString(),
-                Title = readingListDto.Title,
-                Summary = readingListDto.Summary,
-                Links =
-                [
-                    CreateLink(FeedLinkRelation.SubSection, FeedLinkType.AtomNavigation,
-                        $"{prefix}{apiKey}/reading-list/{readingListDto.Id}"),
-                    CreateLink(FeedLinkRelation.Image, FeedLinkType.Image,
-                        $"{baseUrl}api/image/readinglist-cover?readingListId={readingListDto.Id}&apiKey={apiKey}"),
-                    CreateLink(FeedLinkRelation.Thumbnail, FeedLinkType.Image,
-                        $"{baseUrl}api/image/readinglist-cover?readingListId={readingListDto.Id}&apiKey={apiKey}")
-                ]
-            });
+            feed.Entries.Add(CreateReadingListFeedEntry(readingListDto, prefix, apiKey, baseUrl));
         }
 
         return feed;
+    }
+
+    private static FeedEntry CreateReadingListFeedEntry(ReadingListDto readingListDto, string prefix, string apiKey, string baseUrl)
+    {
+        return new FeedEntry()
+        {
+            Id = readingListDto.Id.ToString(),
+            Title = readingListDto.Title,
+            Summary = readingListDto.Summary,
+            Links =
+            [
+                CreateLink(FeedLinkRelation.SubSection, FeedLinkType.AtomNavigation,
+                    $"{prefix}{apiKey}/reading-list/{readingListDto.Id}"),
+                CreateLink(FeedLinkRelation.Image, FeedLinkType.Image,
+                    $"{baseUrl}api/image/readinglist-cover?readingListId={readingListDto.Id}&apiKey={apiKey}"),
+                CreateLink(FeedLinkRelation.Thumbnail, FeedLinkType.Image,
+                    $"{baseUrl}api/image/readinglist-cover?readingListId={readingListDto.Id}&apiKey={apiKey}")
+            ]
+        };
     }
 
     private static int UnpackRequest(IOpdsRequest request, out string apiKey, out string prefix,

--- a/Kavita.Services/Reading/ReadingSessionService.cs
+++ b/Kavita.Services/Reading/ReadingSessionService.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using AutoMapper;
+using Hangfire;
 using Kavita.API.Database;
 using Kavita.API.Services;
 using Kavita.API.Services.Reading;
@@ -96,6 +97,7 @@ public sealed class ReadingSessionService : IReadingSessionService, IDisposable,
         }
     }
 
+    [AutomaticRetry(Attempts = 0)]
     public async Task GenerateReadingSessionForChapters(int userId, int seriesId, Dictionary<int, int> chaptersMap, CancellationToken ct = default)
     {
         using var scope = _serviceScopeFactory.CreateScope();

--- a/Kavita.Services/Reading/ReadingSessionService.cs
+++ b/Kavita.Services/Reading/ReadingSessionService.cs
@@ -111,6 +111,9 @@ public sealed class ReadingSessionService : IReadingSessionService, IDisposable,
 
         var chapterIds = chaptersMap.Keys.ToList();
 
+        _logger.LogDebug("Generating Reading Session for {UserId} on {SeriesId} for {ChapterCount} chapters",
+            userId, seriesId, chapterIds.Count);
+
         var chapters = await context.Chapter
             .Where(cp => chapterIds.Contains(cp.Id) && cp.Volume.SeriesId == seriesId)
             .ApplyDefaultChapterOrdering()
@@ -137,10 +140,17 @@ public sealed class ReadingSessionService : IReadingSessionService, IDisposable,
         foreach (var chapter in chapters)
         {
             var estimate = estimatedHoursByChapter[chapter.Id];
-            if (estimate is { PageCount: 0, WordCount: 0 }) continue;
+            if (estimate is { PageCount: 0, WordCount: 0 })
+            {
+                _logger.LogTrace("Not generating reading session for chapter {ChapterId} as nothing would be read", chapter.Id);
+                continue;
+            }
 
             var schedule = chapterSchedule[chapter.Id];
             var chapterDate = schedule.Start.Date;
+
+            _logger.LogTrace("Chapter {ChapterId} will be read from {Start} to {End} [{Minutes}m]",
+                chapter.Id, schedule.Start, schedule.End, schedule.End.Subtract(schedule.Start).TotalMinutes);
 
             if (currentSession == null || chapterDate != currentSessionDate)
             {
@@ -185,6 +195,9 @@ public sealed class ReadingSessionService : IReadingSessionService, IDisposable,
             s.EndTime = s.ActivityData.Max(ad => ad.EndTime);
             s.EndTimeUtc = s.ActivityData.Max(ad => ad.EndTimeUtc);
         }
+
+        _logger.LogTrace("Generated {Count} reading sessions for {UserId} on {SeriesId} for {ChapterCount} chapters",
+            addedSessions.Count, userId, seriesId, chapterIds.Count);
 
         await context.SaveChangesAsync(ct);
     }

--- a/Kavita.Services/TachiyomiService.cs
+++ b/Kavita.Services/TachiyomiService.cs
@@ -107,7 +107,7 @@ public class TachiyomiService(
         CancellationToken ct = default)
     {
 
-        logger.LogDebug("[Tachiyomi] Marking chapters until {ChapterNumber} for series {SeriesId} for user {UserId}",
+        logger.LogDebug("Marking chapters until {ChapterNumber} for series {SeriesId} for user {UserId}",
             chapterNumber, seriesId, user.Id);
 
         user.Progresses ??= [];

--- a/Kavita.Services/TachiyomiService.cs
+++ b/Kavita.Services/TachiyomiService.cs
@@ -103,7 +103,7 @@ public class TachiyomiService(
         };
     }
 
-    public async Task<bool> MarkChaptersUntilAsRead(AppUser user, int seriesId, float chapterNumber,
+    public async Task<bool> MarkChaptersUntilAsRead(AppUser user, int seriesId, float chapterNumber, bool generateReadingSessions,
         CancellationToken ct = default)
     {
         user.Progresses ??= [];
@@ -128,9 +128,11 @@ public class TachiyomiService(
 
         await readerService.MarkChaptersAsRead(user, seriesId, chapters);
 
-        // Generate reading sessions
-        BackgroundJob.Enqueue<IReadingSessionService>(s
-            => s.GenerateReadingSessionForChapters(user.Id, seriesId, progressDictionary, CancellationToken.None));
+        if (generateReadingSessions)
+        {
+            BackgroundJob.Enqueue<IReadingSessionService>(s
+                => s.GenerateReadingSessionForChapters(user.Id, seriesId, progressDictionary, CancellationToken.None));
+        }
 
         try {
             if (!unitOfWork.HasChanges()) return true;

--- a/Kavita.Services/TachiyomiService.cs
+++ b/Kavita.Services/TachiyomiService.cs
@@ -106,6 +106,10 @@ public class TachiyomiService(
     public async Task<bool> MarkChaptersUntilAsRead(AppUser user, int seriesId, float chapterNumber, bool generateReadingSessions,
         CancellationToken ct = default)
     {
+
+        logger.LogDebug("[Tachiyomi] Marking chapters until {ChapterNumber} for series {SeriesId} for user {UserId}",
+            chapterNumber, seriesId, user.Id);
+
         user.Progresses ??= [];
 
         var chapters = chapterNumber switch

--- a/UI/Web/src/_series-detail-common.scss
+++ b/UI/Web/src/_series-detail-common.scss
@@ -156,11 +156,6 @@
   }
 }
 
-::ng-deep .image-container.mobile-bg app-image img {
-  max-height: 100dvh !important;
-  object-fit: cover !important;
-}
-
 /* col-lg */
 @media (max-width: theme.$grid-breakpoints-lg) {
   .image-container.mobile-bg{

--- a/UI/Web/src/app/_models/modal/modal-options.ts
+++ b/UI/Web/src/app/_models/modal/modal-options.ts
@@ -29,9 +29,6 @@ export function fullscreenModal(): Partial<NgbModalOptions> {
   return {...DefaultModalOptions, size: 'xl', fullscreen: true};
 }
 
-export function xxlModal(): Partial<NgbModalOptions> {
-  return {...DefaultModalOptions, size: 'xxl', fullscreen: 'xxl'};
-}
 
 /** Non-dismissible - for refresh-required modals only */
 export function versionRefreshModal(): Partial<NgbModalOptions> {

--- a/UI/Web/src/app/_models/modal/modal-options.ts
+++ b/UI/Web/src/app/_models/modal/modal-options.ts
@@ -29,6 +29,10 @@ export function fullscreenModal(): Partial<NgbModalOptions> {
   return {...DefaultModalOptions, size: 'xl', fullscreen: true};
 }
 
+export function xxlModal(): Partial<NgbModalOptions> {
+  return {...DefaultModalOptions, size: 'xxl', fullscreen: 'xxl'};
+}
+
 /** Non-dismissible - for refresh-required modals only */
 export function versionRefreshModal(): Partial<NgbModalOptions> {
   return {

--- a/UI/Web/src/app/_pipes/manga-format.pipe.ts
+++ b/UI/Web/src/app/_pipes/manga-format.pipe.ts
@@ -1,13 +1,14 @@
-import { Pipe, PipeTransform, inject } from '@angular/core';
-import { MangaFormat } from '../_models/manga-format';
-import {translate, TranslocoService} from "@jsverse/transloco";
+import {Pipe, PipeTransform} from '@angular/core';
+import {MangaFormat} from '../_models/manga-format';
+import {translate} from "@jsverse/transloco";
 
 /**
  * Returns the string name for the format
  */
 @Pipe({
   name: 'mangaFormat',
-  standalone: true
+  standalone: true,
+  pure: true
 })
 export class MangaFormatPipe implements PipeTransform {
 

--- a/UI/Web/src/app/_single-module/details-tab/details-tab.component.html
+++ b/UI/Web/src/app/_single-module/details-tab/details-tab.component.html
@@ -131,7 +131,7 @@
     <div class="">
       <app-carousel-reel [items]="metadata().writers" [title]="t('writers-title')" headerClass="kv-section-header dark-exempt">
         <ng-template #carouselItem let-item>
-          <app-person-badge [person]="item" size="medium" />
+          <app-person-badge [person]="item" />
         </ng-template>
       </app-carousel-reel>
     </div>
@@ -139,7 +139,7 @@
     <div class="">
       <app-carousel-reel [items]="metadata().colorists" [title]="t('colorists-title')" headerClass="kv-section-header dark-exempt">
         <ng-template #carouselItem let-item>
-          <app-person-badge [person]="item" size="medium" />
+          <app-person-badge [person]="item" />
         </ng-template>
       </app-carousel-reel>
     </div>
@@ -147,7 +147,7 @@
     <div class="mb-3">
       <app-carousel-reel [items]="metadata().editors" [title]="t('editors-title')" headerClass="kv-section-header dark-exempt">
         <ng-template #carouselItem let-item>
-          <app-person-badge [person]="item" size="medium" />
+          <app-person-badge [person]="item" />
         </ng-template>
       </app-carousel-reel>
     </div>
@@ -155,7 +155,7 @@
     <div class="mb-3">
       <app-carousel-reel [items]="metadata().coverArtists" [title]="t('cover-artists-title')" headerClass="kv-section-header dark-exempt">
         <ng-template #carouselItem let-item>
-          <app-person-badge [person]="item" size="medium" />
+          <app-person-badge [person]="item" />
         </ng-template>
       </app-carousel-reel>
     </div>
@@ -163,7 +163,7 @@
     <div class="mb-3">
       <app-carousel-reel [items]="metadata().inkers" [title]="t('inkers-title')" headerClass="kv-section-header dark-exempt">
         <ng-template #carouselItem let-item>
-          <app-person-badge [person]="item" size="medium" />
+          <app-person-badge [person]="item" />
         </ng-template>
       </app-carousel-reel>
     </div>
@@ -171,7 +171,7 @@
     <div class="mb-3">
       <app-carousel-reel [items]="metadata().letterers" [title]="t('letterers-title')" headerClass="kv-section-header dark-exempt">
         <ng-template #carouselItem let-item>
-          <app-person-badge [person]="item" size="medium" />
+          <app-person-badge [person]="item" />
         </ng-template>
       </app-carousel-reel>
     </div>
@@ -179,7 +179,7 @@
     <div class="mb-3">
       <app-carousel-reel [items]="metadata().pencillers" [title]="t('pencillers-title')" headerClass="kv-section-header dark-exempt">
         <ng-template #carouselItem let-item>
-          <app-person-badge [person]="item" size="medium" />
+          <app-person-badge [person]="item" />
         </ng-template>
       </app-carousel-reel>
     </div>
@@ -187,7 +187,7 @@
     <div class="mb-3">
       <app-carousel-reel [items]="metadata().translators" [title]="t('translators-title')" headerClass="kv-section-header dark-exempt">
         <ng-template #carouselItem let-item>
-          <app-person-badge [person]="item" size="medium" />
+          <app-person-badge [person]="item" />
         </ng-template>
       </app-carousel-reel>
     </div>
@@ -195,7 +195,7 @@
     <div class="mb-3">
       <app-carousel-reel [items]="metadata().characters" [title]="t('characters-title')" headerClass="kv-section-header dark-exempt">
         <ng-template #carouselItem let-item>
-          <app-person-badge [person]="item" size="medium" />
+          <app-person-badge [person]="item" />
         </ng-template>
       </app-carousel-reel>
     </div>
@@ -203,7 +203,7 @@
     <div class="mb-3">
       <app-carousel-reel [items]="metadata().locations" [title]="t('locations-title')" headerClass="kv-section-header dark-exempt">
         <ng-template #carouselItem let-item>
-          <app-person-badge [person]="item" size="medium" />
+          <app-person-badge [person]="item" />
         </ng-template>
       </app-carousel-reel>
     </div>
@@ -211,7 +211,7 @@
     <div class="mb-3">
       <app-carousel-reel [items]="metadata().teams" [title]="t('teams-title')" headerClass="kv-section-header dark-exempt">
         <ng-template #carouselItem let-item>
-          <app-person-badge [person]="item" size="medium" />
+          <app-person-badge [person]="item" />
         </ng-template>
       </app-carousel-reel>
     </div>
@@ -219,7 +219,7 @@
     <div class="mb-3">
       <app-carousel-reel [items]="metadata().imprints" [title]="t('imprints-title')" headerClass="kv-section-header dark-exempt">
         <ng-template #carouselItem let-item>
-          <app-person-badge [person]="item" size="medium" />
+          <app-person-badge [person]="item" />
         </ng-template>
       </app-carousel-reel>
     </div>

--- a/UI/Web/src/app/_single-module/edit-chapter-modal/edit-chapter-modal.component.ts
+++ b/UI/Web/src/app/_single-module/edit-chapter-modal/edit-chapter-modal.component.ts
@@ -157,7 +157,7 @@ export class EditChapterModalComponent implements OnInit {
     this.initChapter = Object.assign({}, this.chapter);
     this.imageUrls.push(this.imageService.getChapterCoverImage(this.chapter.id));
 
-    this.size = this.utilityService.asChapter(this.chapter).files.reduce((sum, v) => sum + v.bytes, 0);
+    this.size = (<Chapter>this.chapter).files.reduce((sum, v) => sum + v.bytes, 0);
 
     this.editForm.addControl('titleName', new FormControl(this.chapter.titleName, []));
     this.editForm.addControl('sortOrder', new FormControl(Math.max(0, this.chapter.sortOrder), [Validators.required, Validators.min(0)]));

--- a/UI/Web/src/app/cards/_modals/edit-series-modal/edit-series-modal.component.html
+++ b/UI/Web/src/app/cards/_modals/edit-series-modal/edit-series-modal.component.html
@@ -741,7 +741,7 @@
                                         {{t('pages-title')}} {{file.pages}}
                                       </div>
                                       <div class="col">
-                                        {{t('format-title')}} <span class="badge badge-secondary">{{utilityService.mangaFormatToText(file.format)}}</span>
+                                        {{t('format-title')}} <span class="badge badge-secondary">{{file.format | mangaFormat}}</span>
                                       </div>
                                     </div>
                                   </li>

--- a/UI/Web/src/app/cards/_modals/edit-series-modal/edit-series-modal.component.ts
+++ b/UI/Web/src/app/cards/_modals/edit-series-modal/edit-series-modal.component.ts
@@ -100,8 +100,7 @@ import {MangaFormat} from "../../../_models/manga-format";
     DecimalPipe,
     TitleCasePipe,
     TabTitlePipe,
-    EditExternalMetadataFormComponent,
-    MangaFormatPipe
+    EditExternalMetadataFormComponent
   ],
   templateUrl: './edit-series-modal.component.html',
   styleUrls: ['./edit-series-modal.component.scss'],

--- a/UI/Web/src/app/cards/_modals/edit-series-modal/edit-series-modal.component.ts
+++ b/UI/Web/src/app/cards/_modals/edit-series-modal/edit-series-modal.component.ts
@@ -67,6 +67,7 @@ import {TabTitlePipe} from "../../../_pipes/tab-title.pipe";
 import {
   EditExternalMetadataFormComponent
 } from "../../../shared/_components/edit-external-metadata-form/edit-external-metadata-form.component";
+import {MangaFormat} from "../../../_models/manga-format";
 
 
 @Component({
@@ -100,6 +101,7 @@ import {
     TitleCasePipe,
     TabTitlePipe,
     EditExternalMetadataFormComponent,
+    MangaFormatPipe
   ],
   templateUrl: './edit-series-modal.component.html',
   styleUrls: ['./edit-series-modal.component.scss'],
@@ -592,4 +594,5 @@ export class EditSeriesModalComponent implements OnInit {
   }
 
   protected readonly LooseLeafOrDefaultNumber = LooseLeafOrDefaultNumber;
+  protected readonly MangaFormat = MangaFormat;
 }

--- a/UI/Web/src/app/registration/_components/register/register.component.ts
+++ b/UI/Web/src/app/registration/_components/register/register.component.ts
@@ -2,7 +2,6 @@ import {ChangeDetectionStrategy, Component, inject} from '@angular/core';
 import {FormControl, FormGroup, ReactiveFormsModule, Validators} from '@angular/forms';
 import {Router} from '@angular/router';
 import {ToastrService} from 'ngx-toastr';
-import {take} from 'rxjs/operators';
 import {AccountService} from 'src/app/_services/account.service';
 import {MemberService} from 'src/app/_services/member.service';
 import {NgbTooltip} from '@ng-bootstrap/ng-bootstrap';

--- a/UI/Web/src/app/shared/_services/utility.service.ts
+++ b/UI/Web/src/app/shared/_services/utility.service.ts
@@ -1,12 +1,8 @@
 import {HttpParams} from '@angular/common/http';
-import {inject, Injectable} from '@angular/core';
-import {Chapter} from 'src/app/_models/chapter';
-import {MangaFormat} from 'src/app/_models/manga-format';
+import {Injectable} from '@angular/core';
 import {PaginatedResult} from 'src/app/_models/pagination';
-import {Series} from 'src/app/_models/series';
-import {Volume} from 'src/app/_models/volume';
-import {DOCUMENT} from "@angular/common";
 import {ActionItem} from "../../_models/actionables/action-item";
+import {AbstractControl, FormArray, FormGroup, ValidationErrors} from "@angular/forms";
 
 export enum KEY_CODES {
   RIGHT_ARROW = 'ArrowRight',
@@ -29,23 +25,75 @@ export enum KEY_CODES {
   ALT = 'Alt',
 }
 
+export interface FormErrorEntry {
+  path: string;
+  level: 'group' | 'array' | 'control';
+  errors: ValidationErrors;
+}
+
+/**
+ * Recursively walks an AbstractControl tree and collects all errors.
+ * Captures errors at group/array level (cross-field validators) AND control level.
+ */
+export function collectFormErrors(
+  control: AbstractControl,
+  path: string = ''
+): FormErrorEntry[] {
+  const results: FormErrorEntry[] = [];
+
+  // Capture errors at the current node (works for groups, arrays, and controls)
+  if (control.errors) {
+    const level: FormErrorEntry['level'] =
+      control instanceof FormGroup ? 'group'
+        : control instanceof FormArray ? 'array'
+          : 'control';
+
+    results.push({
+      path: path || '(root)',
+      level,
+      errors: control.errors,
+    });
+  }
+
+  // Recurse into children
+  if (control instanceof FormGroup) {
+    for (const key of Object.keys(control.controls)) {
+      const childPath = path ? `${path}.${key}` : key;
+      results.push(...collectFormErrors(control.controls[key], childPath));
+    }
+  } else if (control instanceof FormArray) {
+    control.controls.forEach((child, i) => {
+      const childPath = `${path}[${i}]`;
+      results.push(...collectFormErrors(child, childPath));
+    });
+  }
+
+  return results;
+}
+
+/**
+ * Prints all errors to the console in a readable format.
+ */
+export function printFormErrors(control: AbstractControl, label = 'Form'): void {
+  const entries = collectFormErrors(control);
+
+  if (entries.length === 0) {
+    console.log(`[${label}] No errors`);
+    return;
+  }
+
+  console.group(`[${label}] ${entries.length} error entr${entries.length === 1 ? 'y' : 'ies'}`);
+  for (const { path, level, errors } of entries) {
+    console.log(`(${level}) ${path}:`, errors);
+  }
+  console.groupEnd();
+}
+
 
 @Injectable({
   providedIn: 'root'
 })
 export class UtilityService {
-  private document = inject<Document>(DOCUMENT);
-
-  mangaFormatKeys: string[] = [];
-
-
-  mangaFormatToText(format: MangaFormat): string {
-    if (this.mangaFormatKeys === undefined || this.mangaFormatKeys.length === 0) {
-      this.mangaFormatKeys = Object.keys(MangaFormat);
-    }
-
-    return this.mangaFormatKeys.filter(item => MangaFormat[format] === item)[0];
-  }
 
   filter(input: string, filter: string): boolean {
     if (input === null || filter === null || input === undefined || filter === undefined) return false;
@@ -77,18 +125,6 @@ export class UtilityService {
 
   isUserCollection(d: unknown) {
     return d != null && d.hasOwnProperty('title') && d.hasOwnProperty('itemCount') && !d.hasOwnProperty('startingYear');
-  }
-
-  asVolume(d: any) {
-    return <Volume>d;
-  }
-
-  asChapter(d: any) {
-    return <Chapter>d;
-  }
-
-  asSeries(d: any) {
-    return <Series>d;
   }
 
   isInViewport(element: Element, additionalTopOffset: number = 0) {
@@ -155,16 +191,6 @@ export class UtilityService {
     }
 
     return paginatedVariable;
-  }
-
-  getWindowDimensions() {
-    const windowWidth = window.innerWidth
-                  || document.documentElement.clientWidth
-                  || document.body.clientWidth;
-    const windowHeight = window.innerHeight
-                  || document.documentElement.clientHeight
-                  || document.body.clientHeight;
-    return [windowWidth, windowHeight];
   }
 
   copyActionItem(item: ActionItem<any>): ActionItem<any> {

--- a/UI/Web/src/app/user-settings/cbl-manager/cbl-manager.component.ts
+++ b/UI/Web/src/app/user-settings/cbl-manager/cbl-manager.component.ts
@@ -22,7 +22,7 @@ import {ImageService} from '../../_services/image.service';
 import {ReadMoreComponent} from '../../shared/read-more/read-more.component';
 import {ImageComponent} from '../../shared/image/image.component';
 import {RouterLink} from '@angular/router';
-import {xxlModal} from "../../_models/modal/modal-options";
+import {fullscreenModal} from "../../_models/modal/modal-options";
 import {ModalResult} from "../../_models/modal/modal-result";
 import {
   FileDragAndDropUploadComponent
@@ -226,7 +226,7 @@ export class CblManagerComponent implements OnInit {
   }
 
   private openImportModal(savedFiles: CblSavedFile[]) {
-    const ref = this.modalService.open(ImportCblModalComponent, xxlModal());
+    const ref = this.modalService.open(ImportCblModalComponent, fullscreenModal());
     ref.setInput('savedFiles', savedFiles);
     ref.closed.subscribe((res: ModalResult) => {
       this.refreshLists();

--- a/UI/Web/src/app/user-settings/cbl-manager/cbl-manager.component.ts
+++ b/UI/Web/src/app/user-settings/cbl-manager/cbl-manager.component.ts
@@ -22,7 +22,7 @@ import {ImageService} from '../../_services/image.service';
 import {ReadMoreComponent} from '../../shared/read-more/read-more.component';
 import {ImageComponent} from '../../shared/image/image.component';
 import {RouterLink} from '@angular/router';
-import {editModal} from "../../_models/modal/modal-options";
+import {xxlModal} from "../../_models/modal/modal-options";
 import {ModalResult} from "../../_models/modal/modal-result";
 import {
   FileDragAndDropUploadComponent
@@ -226,7 +226,7 @@ export class CblManagerComponent implements OnInit {
   }
 
   private openImportModal(savedFiles: CblSavedFile[]) {
-    const ref = this.modalService.open(ImportCblModalComponent, editModal());
+    const ref = this.modalService.open(ImportCblModalComponent, xxlModal());
     ref.setInput('savedFiles', savedFiles);
     ref.closed.subscribe((res: ModalResult) => {
       this.refreshLists();


### PR DESCRIPTION
# Changed
- Changed: CBL Import modal is fullscreen by default
- Changed: Allow reading overrides for logging levels for subsystems from appsettings.json

# Fixed
- Fixed: Fixed an issue in session generation for bulk mark as read (develop)
- Fixed: OPDS Smart filters were not entity-aware (develop)
- Fixed: Reverted the size of the details people change to avoid extra crop issues (Fixes #4635) (develop) 
- Fixed: Fixed the cover image on detail pages being too large sometimes  

# API
- Added a query parameter for reading sessions (generateSessions) for Mihon, defaults to true