### PR TITLE
v0.9.0 - Reading List Overhaul and Spring Cleaning

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -28,7 +28,7 @@ body:
       label: Kavita Version Number - If you don't see your version number listed, please update Kavita and see if your issue still persists.
       multiple: false
       options:
-        - 0.8.9.1 - Stable
+        - 0.9.0 - Stable
         - Nightly Testing Branch
     validations:
       required: true

--- a/Kavita.Common/Kavita.Common.csproj
+++ b/Kavita.Common/Kavita.Common.csproj
@@ -3,7 +3,7 @@
         <TargetFramework>net10.0</TargetFramework>
         <Company>kavitareader.com</Company>
         <Product>Kavita</Product>
-        <AssemblyVersion>0.8.9.51</AssemblyVersion>
+        <AssemblyVersion>0.9.0.0</AssemblyVersion>
         <NeutralLanguage>en</NeutralLanguage>
         <TieredPGO>true</TieredPGO>
     </PropertyGroup>


### PR DESCRIPTION
It seems almost like a hard rule that the 2nd release of the year is always a spring cleaning release and this time, we've really put the new knowledge we've built up back into Kavita to clean up old systems, rebuild foundations, and then deliver some massive improvements on top of it. This release is packed with nearly 200 change log items and overhauled 2 major UI systems that have already allowed some amazing enhancements. 

## Highlights 


### Performance and Security

This is first and foremost. Kavita had a few security issues brought against it and we've ensured that we fixed those issues (CVEs will be requested after the release) but also hardened more of the API to ensure no other issues. These issues are likely not going to be abused, but I would encourage everyone to update. 

In addition, we fixed one oversight around how often Kavita was writing to the DB (noticeable on non-SSD setups) and fixed the database is locked error (mostly) by changing how transactions are created in Kavita and implementing some extra waiting when concurrent writes are occurring. For me, I was seeing them a lot in the webtoon reader (which also got some nice love) and now I don't. 

### Reading List 

<img width="2783" height="1578" alt="image" src="https://github.com/user-attachments/assets/cb1a3aed-1b84-435d-b5a5-02797d89ef33" />

<img width="2874" height="1681" alt="image" src="https://github.com/user-attachments/assets/a5fb5b74-e269-487a-b9b2-2863b1162e47" />

<img width="2813" height="1621" alt="image" src="https://github.com/user-attachments/assets/8ac0f6a8-18d3-4168-9fab-54041f0034bc" />

There is a lot to cover but the long story short is, I redesigned the screens to bring forward more information, I added the ability to filter against reading lists by a number of fields, I added tags which are user-defined (or can come from CBL v2 lists), and I made Smart Filters work with Reading Lists, so you can bind them to your Side Nav/Dashboard. You can also export them as CBL (v1/v2) if you want to apply some arbitrary sorting in another program then re-import them. 


### CBL ~~Import~~ Manager

<img width="2864" height="1642" alt="image" src="https://github.com/user-attachments/assets/897d79fb-b279-4f6a-a671-554664da8b15" />

<img width="3226" height="1601" alt="image" src="https://github.com/user-attachments/assets/379d6599-2221-4d8c-afdc-998e8d8812cf" />

This has been on my mind since I first saw the v2 CBL spec and that is an overhaul to the CBL Import flow. Here's what I did:
- Rewrote the matching logic with tons of fallbacks to always try to make the best match [wiki](https://wiki.kavitareader.com/guides/features/cbl-import/)
- Allow the importer to make decisions and save those decisions as Remap Rules for future imports (admin's can promote so all users get the benefit)
- Allow users to browse lists from the CBL Repo in Kavita and just import from there (or a file/url)
- Auto-update lists for the users
- And of course, v2 support (with tags)

Of course there is more to the story, but overall I feel like the Reading List and CBL Flow is in a great place. 


### Multi-download Support

This has been an item I've been wanting for 2 years now and I finally got to finish it off. You can now multi-select series, collections, chapters, volumes, whatever and Kavita will deconstruct down to the individual items, queue them up and process one by one. For me, a bit problem was FF on Android, I had to deal with a prompt on every download, but no more! The download manager is smart and remembers what you've downloaded and will show a mark on the card to let you know you've synced it to the device. We got retry and cancel support and just a ton of polish. I hope you'll enjoy this as much as me. 
<img width="395" height="693" alt="image" src="https://github.com/user-attachments/assets/1b9d2213-ce68-4333-aaa2-569a7938f963" />





### Misc

Mihon and Panels users rejoice, the reading session system now works with these apps out of the box. In addition, users that want to stay on older versions of Kavita can without the nagging version update modal popping up. I've overhauled the system to a) use a backoff system when you dismiss before it pops again and b) allow you to stay on an older version without Kavita pinging you again (but I don't recommend this due to security patches).

Lastly, the scanner got some bug fixes that might affect you:
1. Whenever fields are cleared out in the underlying metadata file, Kavita used to ignore those changes. It will now clear those fields.
2. Genres/Tags used to normalize and merge, but no longer. This may cause new genres to show up but should be better overall for users.


### What's next
Next up, we will be focusing on Kavita+ and giving it it's own spring cleaning along with bringing some much needed provider changes (Hardcover, MangaBaka) and new features. While we don't have anything else planned, I'm sure something fun will come up for non-Kavita+ users. 

I want to also extend a special thanks to @falo2k and @DieselTech from the CBL Group and @LegendaryLass for the massive amount of work designing and testing the Reading List Overhaul project.

# Added
- Added: Kavita now has a dedicated queue for downloads with auto-processing, series will now deconstruct to individual items, and it's persistent between reloads.
- Added: Added ability to bulk download series/chapter/volumes via bulk operations bar
- Added: Added the ability to download Reading Lists and Collections from Kavita
- Added: Added a button to unlink your account from OIDC 
- Added: Added the ability to export a reading list to CBL v1 or v2 support
- Added: Kavita now can store external metadata Ids for Series/Volume/Chapter entities for (AniList, MAL, MangaBaka, ComicVine, Metron, Hardcover). 
- Added: Kavita will try to fill in External Metadata ids from ComicInfo Notes tags based on tagger signatures and from Kavita+ when applicable. Inherit weblink from first chapter libraries will bubble up the metadata to Series. 
- Added: Series/Volumes/Chapters can now be marked as read, with the option to generate reading sessions (4 upvotes, FR #4400)
- Added: Added support for a limited set of Korean End markers ( 완결, 완, 完 in () or [] exclusively ) that can be parsed from the filename and provide an alternative to ComicInfo.Count property, since ComicInfo isn't well known in Korea. (Thanks @aha-hyeong for inspiration, @daydreamrabbit for filenames and explanation)
- Added: Added a dropdown to pick which AuthKey to use in your copy-able OPDS url. (FR #4555, 1 upvote)
- Added: Added extra information for KOReader progress logging to help debug issues. (FR #3889, 2 upvotes)
- Added: Added the ability to import a CBL File (v1/v2) via a URL, file, or Browse directly from the CBL Repo. 
- Added: Added the ability to designate a correction as a remap rule locked to your account. It will be used in future CBL Import/Update to ensure the correct issue/series is matched. For example, if you have Issue 12.5 instead of 12 for some reason, you can correct a CBL Import and save a rule to say, in future, always map this series and issue to 12.5 without manual effort.
- Added: Emails can now be localized. By default, Kavita will use the target user's localization settings. Missing strings will fallback to English. Invite user will use the default admin's locale.
- Added: The search input closing is now hooked up to the Escape keybind
- Added: Added an activity tab to series page which displays your reading sessions for this series
- Added: Added a reading profile option to disable bookmark icons altogether in the Epub reader (FR #4270, 3 upvotes)
- Added: Added a loading indicator while Kavita checks if your OIDC authority is correct
- Added: CBL Lists created via the network are now syncable. Kavita will check Github or the Url and compare the hash to see if any work is needed to consume updates. Kavita processes the lists behind the scenes. You can always force a sync manually either thru the manager screen or re-import flow. Bad matches will be skipped. It is your responsibility to build your rematch rules ahead of time.
- Added: New background task (4am, daily) for the CBL Sync. Admins can customize on Tasks screen. Job processes lists every 3 days.
- Added: Reading Lists now have persistent cover images. Previously on-the-fly, a temp reading list merged cover would be created. Now, Kavita will generate once at least 3 issues with covers exist. This will bring colorscape functionality to the reading list detail page.
- Added: When importing CBLs from the reading list manager, Kavita will track the items the list SHOULD have vs how many you have and show you that on CBL Manager and Reading List design page. This does not include a migration, re-import your lists (you don't have to delete them) to get the field set.
- Added: When images fail to load in webtooon mode, Kavita will set the height to prevent continuous scroller from triggering, set a border to help indicate the failed page and then try to resolve it 3 times in a background thread. This will help when there is fallout when reading on plane wifi.
- Added: Added a client-side filter on reading list detail page when there is more than 10 items. It will sort against: title, series name, chapter number, volume number, issue's title, writer name, and penciller (first only).
- Added: Added the ability to filter reading lists by Title, Release Year, Item Count and Writer/Artist. You can sort by Title, Release Year Start/End, and Item Count.
- Added: Added a migration to ensure there are no readonly admin accounts
- Added 4 new keybinds to the readers: First/Last Page, Previous/Next Chapter. PDF does not support Previous/Next Chapter loading currently. (FR #4585, 1 upvote)
- Added: Added the ability to change your username on the server. An email will be sent to inform you if email is setup.
- Added: Added Shortcut modal to PDF and Epub readers
- Added: Added volume range support for a manga regex pattern 
- Added: Added unread chapter count sort option for series
- Added: Added the ability to filter by libraries for Browse People page
- Added: Added Is Not Empty comparison for all fields that have Is Empty (FR #4616, 1 upvote)
- Added: You can now craft and save Smart Filters for Reading lists and bind them to your Side Nav/Dashboard as you would Series-based.
- Added: Added Provider Equal/NotEqual and Missing Item Count filter support for Reading Lists
- Added: Added an actionable menu to reading list on side nav to get to the manage cbl screen
- Added: Added actions to add smart filters to your Dashboard & Side Nav from the smart filter screen.
- Added: Added an action to regenerate reading list covers

# Changed
- Changed: Manga reader menu now uses a cubic-bezier easing for its animation (Thanks @kindlyfire)
- Changed: Improved the UX of the Annotation drawer to allow large annotations to be fully viewable. (Thanks @Ark1369)
- Changed: Version update checking has been drastically streamlined and made less annoying. Backoff support is implemented, after 5 prompts, Kavita will stop pestering you to update. 
- Changed: All tab titles in Kavita are now localizable and much cleaner
- Changed: Kavita now respects prefers-reduce-motion and will slow animations down. Disabled animations will still affect, but is now applied with no-animations class on body.
- Changed: Tweaked the card layout to try and squeeze more spacing out
- Changed: Slightly widened the gap on carousels to align with spacing of the card grid
- Changed: Properly ensure readonly users cannot trigger reorder on side nav
- Changed: Series downloads no longer create a big zip, but deconstruct into individual items and are queued up.
- Changed: While a download is in queue, the download indicator will show on the card.
- Changed: (Performance) Entity size is in the DB, change the size checks to avoid touching the underlying disk
- Changed: Updated dependencies, including security vulnerabilities
- Changed: Errored out smart filters can now be deleted from the smart filter page
- Changed: User preferences and keybinds will now be disabled for users with the Read Only role to avoid confusion (Thanks @IbrahimHamshari )
- Changed: Allow Kavita+ to match against a series during a manual match always regardless if the library has automatic metadata matching off. 
- Changed: (Performance) Refactored UpdateUserAsActiveMiddleware to not write on every request and instead queue up and flush to the DB every 5 mins.
- Changed: Added an ellipses on Profile activity tab when a session contains more than 5 chapters
- Changed: Improved the UX of the Annotation drawer to allow large annotations to be fully viewable. (Thanks @Ark1369 )
- Changed: Importing a CBL only updates/inserts. You no longer need to delete and reimport. 
- Changed: Drastically overhauled/improved the CBL matching logic. 
- Changed: Opening the OnDeck filter will now sort by last read instead of last chapter added
- Changed: The reading session info popup will now show the closest time first as opposed to the last
- Changed: Opening a chapter which has missing files will not clearly show an error and navigate back instead of silently failing
- Changed: Kavita will prevent your device from going to sleep while downloading
- Changed: External sources no longer require an api-key to be provided
- Changed: The OIDC Authority check will now display more descriptive errors to help users debug
- Changed: Setting items will now be forced into edit mode and display errors if they're invalid
- Changed: The library page will now fully refresh after a scan has completed
- Changed: Send To Actions will now be hidden if email has not been set up
- Changed: Series names are now required to contain meaningful information (I.e. they cannot only be special characters). A media issue will be created if a file is ignored because of this
- Changed: A media issue will now be created when a file is fully skipped after parsing
- Changed: Improved security in a few APIs
- Changed: Kavita will prompt to confirm delete before removing read items from a reading list (FR #4530, 1 upvote)
- Changed: (UX) Reading List detail page will now use a list layout instead of cards. Based on feedback, reading list titles were much longer and thus the card was a poor experience (FR #4053, 3 upvotes)
- Changed: (UX) Changed the reading list item cards to bring more information forward and more responsive. (Thanks to whomever supplied the original design for inspiration)
- Changed: Removed the drag and drop ordering for reading list detail page. It didn't work well on mobile and was only used when < 100 items, but most reading lists are above that.
- Changed: Read-only rule warning will now show on invite modal to prevent users from using it without fully understanding the repercussions.
- Changed: Removed the forced sentence case for Tag/Genres. Kavita will still merge into the first for basic normalization. 
- Changed: Read-only rule warning will now show on invite modal to prevent users from using it without fully understanding the repercussions.
- Changed: Webtoon Reader continuous reader now uses a pull to load (mobile) mechanism. When you get to the top or bottom, a small time out arms the component then the pulling will trigger a progress until the next/prev chapter loads. For PC users, it will be a scroll like normal. (FR #4590, 1 upvote)
- Changed: Don't send progress events when we are on the same page. This should help reduce database is locked issues when reading.
- Changed: Tab titles will now be Context (Kavita)
- Changed: Reading List and Collection pages now use an Uppercase sorting
- Changed: Changed the design of the Shortcut modal button
- Changed: (Performance) Slightly improved the Progress API to avoid an extra read
- Changed: (Performance) Webtoon reader no longer debounces but just sends unique page numbers
- Changed: Ensure we clear out metadata from ComicInfo even if it's now empty 
- Changed: (Performance) Removed 2 joins on the scrobble code as it wasn't needed.
- Changed: Fixed how Kavita creates transactions with SQLite to reduce the 'database is locked' issue. From my testing, database is locked which was happening during reading (webtoon) and from some concurrent scans were eliminated. 
- Changed: Kavita will now log when Hangfire (our task scheduling system) errors out and retain the stack trace
- Changed: More in Genre is now removed from default dashboards. If you really loved it, raise a Feature Request about it.
- Changed: All Smart Filters page now has a filter for the type of entity to display (Series/Reading List)
- Changed: A revamped UX for details screen
- Changed: Mihon will now generate reading sessions
- Changed: Tweaked the search query so that we require the year to match if present, instead of matching all in that year 
- Changed: Allow reading overrides for logging levels for subsystems from appsettings.json
- Changed: Search results will prioritize showing the series title over the localized title more

# Fixed
- Fixed: (Kavita+) Fixed a bug where the check license button only worked on the first load
- Fixed: Bulk Actions on customize side nav wasn't showing the bulk operations bar
- Fixed: Read only accounts were able to make changes to settings in the UI (Thanks @IbrahimHamshari)
- Fixed: Fixed a bug where comic readers (like Chunky or Kybook 3 for example) could not read recently-updated feed (or read only first page - in Kybook 3 case) (Thanks @ghostxwheel )
- Fixed: Fixed a bug where after adding a custom theme, the page was left in a half-broken state.
- Fixed: Fixed an issue with apple-mobile-web-app-status-bar-style on iOS where we were passing incorrect values. Now we send black or default based on if the theme is dark or not.
- Fixed: Fixed the spacing on the buttons on small screen in manga reader 
- Fixed: Fixed a localization bug where locale number positioning for chapter/book/volume numbers weren't taking into effect. For example Korean Volume was showing as 권 1 when locale specified 1 권
- Fixed: Fixed a lot of endpoints missing access checks
- Fixed: Fixed users not being able to upload collection covers unless they're admin
- Fixed: Fixed schema in API docs for /api/Plugin/authkey-expires.
- Fixed: Fixed recommendations always showing as unread for users with an admin account
- Fixed: Fixed read progress not being included on the person page
- Fixed: Fixed being unable to update a reading lists name if it matches itself. 
- Fixed: Fixed orphaned tags not being cleaned up
- Fixed: Fixed paging back in the image reading opening chapters at the start
- Fixed: Fixed the annotation drawer in the book reader hanging when a large amount of annotations are present
- Fixed: Fixed smart filters with no results being completely hidden on the smart filter page
- Fixed: Fixed reading sessions in which an epub chapter was finished not having a recorded word count
- Fixed: Fixed epub reader not saving the correct reading position under specific circumstances (Thanks @vipin2310 )
- Fixed: Fixed Known Issue parsing from Github using wrong header
- Fixed: Fixed Markdown parsing not working on sub-nested lists
- Fixed: Fixed an issue where specials weren't prioritizing title comicinfo 
- Fixed: Fixed the No Transitions setting not properly applying to all animations in the site
- Fixed: Localization issues with Korean where chapter marker could still be in front of edge
- Fixed: Ensure comic libraries prioritize volume tab over specials tab when no issues
- Fixed: Fixed localization switching not updating the UI correctly
- Fixed: Fixed a bug where card actionable menu wasn't properly closing the submenu after highlighting off it.
- Fixed: The auth guard for the OPDS download endpoint was using the Download role instead of the policy. The original version was causing an error.  (Thanks @jfenske89 )
- Fixed: Fixed an off-by-1 issue which caused duplicate characters at the end of an annotation 
- Fixed: Fixed a migration failing to run if you had data during Daylight savings time jump. 
- Fixed: Fixed related series not having progress
- Fixed: Fixed a few incorrect strings in emails (Auth Key expiring, Token expiring soon)
- Fixed: Fixed using escape to close the search input not losing focussed and closing full screen
- Fixed: Fixed reading session history (Activity tabs) being paginated weirdly
- Fixed: Fixed reading estimates being wrong for EPUBs
- Fixed: Fixed ToC in the book reader not displaying all chapters under some circumstances. (Thanks @DreamAvalon)
- Fixed: Fixed chapters sometimes not being full read while reading in webtoon mode
- Fixed: Fixed the scanner merging several series into one under specific circumstances
- Fixed: Fixed a missing localization in import MAL stacks
- Fixed: Fixed a bug where the manga reader could try and preload a chapter when we haven't resolved the next/prev chapter id yet.
- Fixed: Fixed jumpbars being broken on Collection and Reading List page
- Fixed: Ensure Weblinks from ComicInfo can be extracted when space separated
- Fixed: Fixed regex for Korean Volume being recognized as Episode word (화)
- Fixed: Fixed a few missed auth apis not returning auth keys correctly
- Fixed: Fixed reading direction changes not being saved to implicit profiles
- Fixed: Fixed fonts not being shown after uploading one
- Fixed: Fixed series metadata failing to update under specific circumstances
- Fixed: Fixed encode/decode errors for non-series entities
- Fixed: Fixed a case where a Korean volume marker could trigger the wrong regex and recognize as a chapter as well
- Fixed: Ensure annotation and bookmark uses the same selected text calculation method to ensure the full word is carried into the overlay form 
- Fixed: Fixed an edge case where Never showed for last active
- Fixed: Fixed Volume progress tracking not working on Mihon (Thanks @Nedra1998 )
- Fixed: Fixed a fallback in epub writer parsing not being guarded when valid, 3.2 role refinement is used (
- Fixed: Fixed arrow keys not working without first clicking on the manga reader
- Fixed: Fixed not being able to use arrow keys to scroll on FF in manage reader 
- Fixed: Fixed the cover image on detail pages being too large sometimes
- Fixed: Fixed panels not properly working with the new reading sessions
- Fixed: Fixed an edge case where ReadingHistory (table not used) could have an index exception


# Theme
- --card-image-height,  --card-image-width are now usable
- Converted the whole UI to use REM (except 2 cases where px is required)
- Added theme variables for download indicator: --card-download-indicator-size, --card-download-indicator-icon-size, --card-download-indicator-icon-color, --card-download-indicator-box-shadow, --card-download-indicator-active-color, --card-download-indicator-active-track-color, --card-download-indicator-completed-color, --card-download-indicator-queued-color


# API
- Added: Added the ability for Kavita to expose how it parses information via plugin/parse and plugin/parse-bulk API.
- Unknown or inaccessible resources will now return 404 Not Found when trying to be accessed
- POST /volume/update is now available for updating metadata ids on the Volume itself
- Fixed the enums not rendering out the description field with Swagger and fixed up some of the auth information.
- Removed all Deprecated APIs (this was communicated last release, I reached out to the big app providers)
- filter/encode and filter/decode have been replaced by entity-flavored variants.
- Added a query parameter for reading sessions (generateSessions) for Mihon, defaults to true

