### PR TITLE
[skip ci] PWA Start Url fix for Chrome

### DIFF
--- a/UI/Web/src/site.webmanifest
+++ b/UI/Web/src/site.webmanifest
@@ -13,6 +13,7 @@
             "type": "image/png"
         }
     ],
+    "start_url": "/",
     "theme_color": "#000000",
     "background_color": "#000000",
     "display": "standalone"


### PR DESCRIPTION
The "Install" button wasn't showing up in chrome's address bar due to msising start_url.

<img width="476" height="278" alt="image" src="https://github.com/user-attachments/assets/908ecf8f-82c1-44e5-818f-c58567ca3cb0" />

This PR adds it. No more changes were made