### PR TITLE
OIDC Network Validation Changes and a Host of Bugfixes

### DIFF
--- a/Kavita.Database/Repositories/ChapterRepository.cs
+++ b/Kavita.Database/Repositories/ChapterRepository.cs
@@ -268,20 +268,16 @@ public class ChapterRepository(DataContext context, IMapper mapper) : IChapterRe
 
     public async Task<int> GetAverageUserRating(int chapterId, int userId, CancellationToken ct = default)
     {
-        // If there is a 0 or 1 rating and that rating is you, return 0 back
-        var countOfRatingsThatAreUser = await context.AppUserChapterRating
+        var ratings = await context.AppUserChapterRating
             .Where(r => r.ChapterId == chapterId && r.HasBeenRated)
-            .CountAsync(u => u.AppUserId == userId, ct);
+            .ToListAsync(ct);
 
-        if (countOfRatingsThatAreUser == 1)
+        if (ratings.Count == 0 || (ratings.Count == 1 && ratings[0].AppUserId == userId))
         {
             return 0;
         }
 
-        var avg = await context.AppUserChapterRating
-            .Where(r => r.ChapterId == chapterId && r.HasBeenRated)
-            .AverageAsync(r => (int?) r.Rating, ct);
-
+        var avg = ratings.Average(r => (int?) r.Rating);
         return avg.HasValue ? (int) (avg.Value * 20) : 0;
     }
 

--- a/Kavita.Database/Repositories/SeriesRepository.cs
+++ b/Kavita.Database/Repositories/SeriesRepository.cs
@@ -245,8 +245,16 @@ public class SeriesRepository(DataContext context, IMapper mapper) : ISeriesRepo
                 (EF.Functions.Like(s.Name, $"%{searchQuery}%")
                  || (s.OriginalName != null && EF.Functions.Like(s.OriginalName, $"%{searchQuery}%"))
                  || (s.LocalizedName != null && EF.Functions.Like(s.LocalizedName, $"%{searchQuery}%"))
-                 || EF.Functions.Like(s.NormalizedName, $"%{searchQueryNormalized}%"))
-                && (!hasYearInQuery || s.Metadata.ReleaseYear == yearComparison))
+                 || EF.Functions.Like(s.NormalizedName, $"%{searchQueryNormalized}%")))
+            .WhereIf(hasYearInQuery, s =>
+                s.Metadata.ReleaseYear == yearComparison
+                || s.Name.Contains(justYear)
+                || (s.OriginalName != null &&
+                    s.OriginalName.Contains(justYear))
+                || (s.LocalizedName != null &&
+                    s.LocalizedName.Contains(justYear))
+                || (s.NormalizedName != null &&
+                    s.NormalizedName.Contains(justYear)))
             .OrderBy(s => s.SortName!.Length)
             .ThenBy(s => s.SortName!.ToLower())
             .Take(maxRecords)

--- a/Kavita.Database/Repositories/SeriesRepository.cs
+++ b/Kavita.Database/Repositories/SeriesRepository.cs
@@ -1643,17 +1643,16 @@ public class SeriesRepository(DataContext context, IMapper mapper) : ISeriesRepo
     /// <param name="ct"></param>
     public async Task<int> GetAverageUserRatingAsync(int seriesId, int userId, CancellationToken ct = default)
     {
-        // If there is 0 or 1 rating and that rating is you, return 0 back
-        var countOfRatingsThatAreUser = await context.AppUserRating
+        var ratings = await context.AppUserRating
             .Where(r => r.SeriesId == seriesId && r.HasBeenRated)
-            .CountAsync(u => u.AppUserId == userId, cancellationToken: ct);
-        if (countOfRatingsThatAreUser == 1)
+            .ToListAsync(ct);
+
+        if (ratings.Count == 0 || (ratings.Count == 1 && ratings[0].AppUserId == userId))
         {
             return 0;
         }
-        var avg = (await context.AppUserRating
-            .Where(r => r.SeriesId == seriesId && r.HasBeenRated)
-            .AverageAsync(r => (int?) r.Rating, cancellationToken: ct));
+
+        var avg = ratings.Average(r => (int?) r.Rating);
         return avg.HasValue ? (int) (avg.Value * 20) : 0;
     }
 

--- a/Kavita.Models/DTOs/SignalR/MessageFactory.cs
+++ b/Kavita.Models/DTOs/SignalR/MessageFactory.cs
@@ -187,7 +187,10 @@ public static class MessageFactory
     /// A reading list was updated via a Sync Operation
     /// </summary>
     public const string ReadingListUpdated = nameof(ReadingListUpdated);
-
+    /// <summary>
+    /// A series was updated (E.x. K+ match)
+    /// </summary>
+    public const string SeriesUpdated = nameof(SeriesUpdated);
 
 
     public static SignalRMessage DashboardUpdateEvent(int userId)
@@ -816,6 +819,18 @@ public static class MessageFactory
         return new SignalRMessage
         {
             Name = ReadingListUpdated,
+            Body = new
+            {
+                Id = id
+            }
+        };
+    }
+
+    public static SignalRMessage SeriesUpdatedEvent(int id)
+    {
+        return new SignalRMessage
+        {
+            Name = SeriesUpdated,
             Body = new
             {
                 Id = id

--- a/Kavita.Models/DTOs/SignalR/MessageFactory.cs
+++ b/Kavita.Models/DTOs/SignalR/MessageFactory.cs
@@ -826,14 +826,14 @@ public static class MessageFactory
         };
     }
 
-    public static SignalRMessage SeriesUpdatedEvent(int id)
+    public static SignalRMessage SeriesUpdatedEvent(int seriesId)
     {
         return new SignalRMessage
         {
             Name = SeriesUpdated,
             Body = new
             {
-                Id = id
+                Id = seriesId
             }
         };
     }

--- a/Kavita.Models/Entities/Series.cs
+++ b/Kavita.Models/Entities/Series.cs
@@ -162,10 +162,8 @@ public class Series : IEntityDate, IHasReadTimeEstimate, IHasCoverImage, IHasMet
 
     public bool MatchesSeriesByName(string nameNormalized, string localizedNameNormalized)
     {
-        return NormalizedName == nameNormalized ||
-               NormalizedLocalizedName == nameNormalized ||
-               NormalizedName == localizedNameNormalized ||
-               NormalizedLocalizedName == localizedNameNormalized;
+        return (!string.IsNullOrEmpty(NormalizedName) && (NormalizedName == nameNormalized || NormalizedName == localizedNameNormalized)) ||
+               (!string.IsNullOrEmpty(NormalizedLocalizedName) && (NormalizedLocalizedName == nameNormalized || NormalizedLocalizedName == localizedNameNormalized));
     }
 
     public void ResetColorScape()

--- a/Kavita.Server/Controllers/CBLController.cs
+++ b/Kavita.Server/Controllers/CBLController.cs
@@ -124,16 +124,10 @@ public class CblController(IReadingListService readingListService, IDirectorySer
     private async Task<(bool IsInvalid, ActionResult<CblSavedFileDto>? ActionResult)> HasInvalidExtensionAsync(string filename, string fullPath)
     {
         var ext = Path.GetExtension(filename);
-        if (!ext.Equals(".cbl", StringComparison.OrdinalIgnoreCase)
-            && !ext.Equals(".json", StringComparison.OrdinalIgnoreCase))
+        if (!ext.Equals(".cbl", StringComparison.OrdinalIgnoreCase) && !ext.Equals(".json", StringComparison.OrdinalIgnoreCase))
         {
             if (System.IO.File.Exists(fullPath) && filename != fullPath) System.IO.File.Delete(fullPath);
             return (true, BadRequest(await localizationService.TranslateAsync("cbl-import-validation-types")));
-        }
-
-        if (filename.Contains(".exe", StringComparison.OrdinalIgnoreCase))
-        {
-            return (true, BadRequest(await localizationService.TranslateAsync("invalid-filename")));
         }
 
         return (false, null);

--- a/Kavita.Server/Controllers/RatingController.cs
+++ b/Kavita.Server/Controllers/RatingController.cs
@@ -69,6 +69,7 @@ public class RatingController(
     /// Overall rating from all Kavita users for a given Series
     /// </summary>
     /// <param name="seriesId"></param>
+    /// <remarks>If the authenticated user is the only user to have rated the series, returns 0</remarks>
     /// <returns></returns>
     [SeriesAccess]
     [HttpGet("overall-series")]
@@ -86,6 +87,7 @@ public class RatingController(
     /// Overall rating from all Kavita users for a given Chapter
     /// </summary>
     /// <param name="chapterId"></param>
+    /// <remarks>If the authenticated user is the only user to have rated the chapter, returns 0</remarks>
     /// <returns></returns>
     [ChapterAccess]
     [HttpGet("overall-chapter")]

--- a/Kavita.Server/Controllers/ReaderController.cs
+++ b/Kavita.Server/Controllers/ReaderController.cs
@@ -963,9 +963,9 @@ public class ReaderController(ICacheService cacheService,
     /// <returns></returns>
     [ChapterAccess]
     [HttpGet("ptoc")]
-    public ActionResult<IEnumerable<PersonalToCDto>> GetPersonalToC(int chapterId)
+    public async Task<ActionResult<IEnumerable<PersonalToCDto>>> GetPersonalToC(int chapterId)
     {
-        return Ok(unitOfWork.UserTableOfContentRepository.GetPersonalToC(UserId, chapterId));
+        return Ok(await unitOfWork.UserTableOfContentRepository.GetPersonalToC(UserId, chapterId));
     }
 
     /// <summary>

--- a/Kavita.Services.Tests/Helpers/AnnotationHelperTests.cs
+++ b/Kavita.Services.Tests/Helpers/AnnotationHelperTests.cs
@@ -1,0 +1,35 @@
+using HtmlAgilityPack;
+using Kavita.Models.DTOs.Reader;
+using Kavita.Services.Helpers;
+
+namespace Kavita.Services.Tests.Helpers;
+
+public class AnnotationHelperTests
+{
+
+    [Fact]
+    public void Test_InjectSingleElementAnnotations_WhitespacePositions()
+    {
+        var doc = new HtmlDocument();
+        doc.LoadHtml("<html><body><p id='para1'>Spice and    Wolf is       Amazing!</p></body></html>");
+
+        var annotation = new AnnotationDto
+        {
+            XPath = """id("para1")""",
+            EndingXPath = """id("para1")""",
+            SelectedText = "Wolf",
+            ChapterId = 0,
+            VolumeId = 0,
+            SeriesId = 0,
+            LibraryId = 0,
+            OwnerUserId = 0,
+        };
+
+        AnnotationHelper.InjectSingleElementAnnotations(doc, [annotation]);
+        Assert.Equal(
+            """Spice and    <app-epub-highlight id="epub-highlight-0">Wolf</app-epub-highlight> is       Amazing!""",
+            doc.GetElementbyId("para1").InnerHtml
+            );
+    }
+
+}

--- a/Kavita.Services/BookService.cs
+++ b/Kavita.Services/BookService.cs
@@ -103,9 +103,9 @@ public partial class BookService(
 
     private static bool HasClickableHrefPart(HtmlNode anchor)
     {
-        return anchor.GetAttributeValue("href", string.Empty).Contains('#')
-               || anchor.GetAttributeValue("href", string.Empty).Contains(".xhtml")
-               || anchor.GetAttributeValue("href", string.Empty).Contains(".html")
+        return (anchor.GetAttributeValue("href", string.Empty).Contains('#')
+                || anchor.GetAttributeValue("href", string.Empty).Contains(".xhtml")
+                || anchor.GetAttributeValue("href", string.Empty).Contains(".html"))
                && anchor.GetAttributeValue("tabindex", string.Empty) != "-1"
                && anchor.GetAttributeValue("role", string.Empty) != "presentation"
                // External links should not be caught (may contain the above in their url)

--- a/Kavita.Services/BookService.cs
+++ b/Kavita.Services/BookService.cs
@@ -107,7 +107,9 @@ public partial class BookService(
                || anchor.GetAttributeValue("href", string.Empty).Contains(".xhtml")
                || anchor.GetAttributeValue("href", string.Empty).Contains(".html")
                && anchor.GetAttributeValue("tabindex", string.Empty) != "-1"
-               && anchor.GetAttributeValue("role", string.Empty) != "presentation";
+               && anchor.GetAttributeValue("role", string.Empty) != "presentation"
+               // External links should not be caught (may contain the above in their url)
+               && !anchor.GetAttributeValue("href", string.Empty).StartsWith("http");
     }
 
     public static string GetContentType(EpubContentType type)

--- a/Kavita.Services/Helpers/AnnotationHelper.cs
+++ b/Kavita.Services/Helpers/AnnotationHelper.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using HtmlAgilityPack;
 using Kavita.Models.DTOs.Reader;
+using Serilog;
 
 namespace Kavita.Services.Helpers;
 
@@ -59,10 +60,12 @@ public static partial class AnnotationHelper
 
                 foreach (var item in sortedAnnotations)
                 {
+                    var realStartPos = MapNormalizedPositionToOriginal(originalText, item.StartPos);
+
                     // Add text before highlight
-                    if (item.StartPos > currentPos)
+                    if (realStartPos > currentPos)
                     {
-                        var beforeText = originalText.Substring(currentPos, item.StartPos - currentPos);
+                        var beforeText = originalText.Substring(currentPos, realStartPos - currentPos);
                         elem.AppendChild(HtmlNode.CreateNode(beforeText));
                     }
 
@@ -71,17 +74,18 @@ public static partial class AnnotationHelper
                         $"<app-epub-highlight id=\"epub-highlight-{item.Annotation.Id}\">{item.Annotation.SelectedText}</app-epub-highlight>");
                     elem.AppendChild(highlightNode);
 
-                    currentPos = item.StartPos + item.Annotation.SelectedText.Length;
+                    currentPos = realStartPos + item.Annotation.SelectedText.Length;
                 }
 
                 // Add remaining text
                 if (currentPos < originalText.Length)
                 {
-                    elem.AppendChild(HtmlNode.CreateNode(originalText.Substring(currentPos + 1)));
+                    elem.AppendChild(HtmlNode.CreateNode(originalText[currentPos..]));
                 }
             }
             catch (Exception ex)
             {
+                Log.Logger.Debug(ex, "Failed to inject annotation into element");
                 /* Swallow */
                 return;
             }
@@ -115,7 +119,11 @@ public static partial class AnnotationHelper
 
                 var selectionStartPos = normalizedFullText.IndexOf(normalizedSelectedText, StringComparison.Ordinal);
 
-                if (selectionStartPos == -1) continue;
+                if (selectionStartPos == -1)
+                {
+                    Log.Logger.Debug("Failed to inject annotation {AnnotationId}, selected text not found", annotation.Id);
+                    continue;
+                }
 
                 var selectionEndPos = selectionStartPos + normalizedSelectedText.Length;
 
@@ -144,8 +152,9 @@ public static partial class AnnotationHelper
                     InjectHighlightInElement(element, highlightStart, highlightEnd, annotation.Id);
                 }
             }
-            catch (Exception)
+            catch (Exception ex)
             {
+                Log.Logger.Debug(ex, "Failed to inject annotation {AnnotationId} into elements", annotation.Id);
                 /* Swallow */
             }
         }
@@ -244,7 +253,7 @@ public static partial class AnnotationHelper
         // Add text before highlight
         if (startPos > 0)
         {
-            element.AppendChild(HtmlNode.CreateNode(originalText.Substring(0, startPos)));
+            element.AppendChild(HtmlNode.CreateNode(originalText[..startPos]));
         }
 
         // Add highlight
@@ -256,7 +265,7 @@ public static partial class AnnotationHelper
         // Add text after highlight
         if (endPos < originalText.Length)
         {
-            element.AppendChild(HtmlNode.CreateNode(originalText.Substring(endPos + 1)));
+            element.AppendChild(HtmlNode.CreateNode(originalText[endPos..]));
         }
     }
 

--- a/Kavita.Services/Helpers/AnnotationHelper.cs
+++ b/Kavita.Services/Helpers/AnnotationHelper.cs
@@ -169,7 +169,10 @@ public static partial class AnnotationHelper
     private static HtmlNode? NormalizeToBlockElement(HtmlNode? node)
     {
         while (node != null && InlineTags.Contains(node.Name.ToLower()))
+        {
             node = node.ParentNode;
+        }
+
         return node;
     }
 

--- a/Kavita.Services/Helpers/AnnotationHelper.cs
+++ b/Kavita.Services/Helpers/AnnotationHelper.cs
@@ -11,6 +11,11 @@ namespace Kavita.Services.Helpers;
 public static partial class AnnotationHelper
 {
     private const string UiXPathScope = "//BODY/DIV[1]"; // Div[1] is the div we inject reader contents into
+    /// <summary>
+    /// Used to break out of inline elements when selecting start- and end-elements.
+    /// If we don't do this; <p><em>foo</em></p> will have em selected as start and <see cref="GetElementsInRange"/>
+    /// fails to select the correct elements
+    /// </summary>
     private static readonly HashSet<string> InlineTags = ["em", "strong", "i", "b", "span", "a", "cite"];
 
     [GeneratedRegex("""^id\("([^"]+)"\)$""")]

--- a/Kavita.Services/Helpers/AnnotationHelper.cs
+++ b/Kavita.Services/Helpers/AnnotationHelper.cs
@@ -240,7 +240,10 @@ public static partial class AnnotationHelper
         }
 
         if (current == endElement)
+        {
             elements.Add(endElement);
+        }
+
 
         return elements;
     }

--- a/Kavita.Services/Helpers/AnnotationHelper.cs
+++ b/Kavita.Services/Helpers/AnnotationHelper.cs
@@ -11,6 +11,7 @@ namespace Kavita.Services.Helpers;
 public static partial class AnnotationHelper
 {
     private const string UiXPathScope = "//BODY/DIV[1]"; // Div[1] is the div we inject reader contents into
+    private static readonly HashSet<string> InlineTags = ["em", "strong", "i", "b", "span", "a", "cite"];
 
     [GeneratedRegex("""^id\("([^"]+)"\)$""")]
     private static partial Regex IdXPathRegex();
@@ -101,8 +102,8 @@ public static partial class AnnotationHelper
                 var startXPath = DescopeXpath(annotation.XPath);
                 var endXPath = DescopeXpath(annotation.EndingXPath);
 
-                var startElement = FindElementByXPath(doc, startXPath);
-                var endElement = FindElementByXPath(doc, endXPath);
+                var startElement = NormalizeToBlockElement(FindElementByXPath(doc, startXPath));
+                var endElement = NormalizeToBlockElement(FindElementByXPath(doc, endXPath));
 
                 if (startElement == null || endElement == null) continue;
 
@@ -165,6 +166,13 @@ public static partial class AnnotationHelper
         return WhitespaceRegex().Replace(text.Trim(), " ");
     }
 
+    private static HtmlNode? NormalizeToBlockElement(HtmlNode? node)
+    {
+        while (node != null && InlineTags.Contains(node.Name.ToLower()))
+            node = node.ParentNode;
+        return node;
+    }
+
     private static int MapNormalizedPositionToOriginal(string originalText, int normalizedPosition)
     {
         var normalizedText = NormalizeWhitespace(originalText);
@@ -212,20 +220,24 @@ public static partial class AnnotationHelper
         var elements = new List<HtmlNode>();
         var current = startElement;
 
-        elements.Add(current);
-
         // If start and end are the same, return just that element
-        if (startElement == endElement) return elements;
+        if (startElement == endElement)
+        {
+            elements.Add(current);
+            return elements;
+        }
 
         // Traverse siblings until we reach the end element
         while (current != null && current != endElement)
         {
-            current = current.NextSibling;
-            if (current is {NodeType: HtmlNodeType.Element}) // Only include element nodes (skip text nodes, comments, etc.)
-            {
+            if (current.NodeType == HtmlNodeType.Element)
                 elements.Add(current);
-            }
+
+            current = current.NextSibling;
         }
+
+        if (current == endElement)
+            elements.Add(endElement);
 
         return elements;
     }

--- a/Kavita.Services/Helpers/PersonHelper.cs
+++ b/Kavita.Services/Helpers/PersonHelper.cs
@@ -39,9 +39,19 @@ public static class PersonHelper
     public static void UpdateSeriesMetadataPeople(
         Dictionary<string, Person> databasePeople,
         SeriesMetadata metadata,
-        IEnumerable<ChapterPeople> chapterPeople,
+        List<ChapterPeople> chapterPeople,
         PersonRole role)
     {
+        if (chapterPeople.Count == 0)
+        {
+            var allPeopleInRole = metadata.People.Where(mp => mp.Role == role).ToList();
+            foreach (var person in allPeopleInRole)
+            {
+                metadata.People.Remove(person);
+            }
+            return;
+        }
+
         var normalizedPeople = chapterPeople
             .Where(cp => cp.Role == role)
             .Select(cp => cp.Person.NormalizedName)

--- a/Kavita.Services/Plus/ExternalMetadataService.cs
+++ b/Kavita.Services/Plus/ExternalMetadataService.cs
@@ -320,6 +320,8 @@ public class ExternalMetadataService : IExternalMetadataService
             // Regenerate all events for the series for all users
             BackgroundJob.Enqueue(() => _scrobblingService.CreateEventsFromExistingHistoryForSeries(seriesId, CancellationToken.None));
 
+            await _eventHub.SendMessageAsync(MessageFactory.SeriesUpdated, MessageFactory.SeriesUpdatedEvent(series.Id), ct: ct);
+
             // Name can be null on Series even with a direct match
             _logger.LogInformation("Matched {SeriesName} with Kavita+ Series {MatchSeriesName}", series.Name,
                 metadata.Series.Name);

--- a/Kavita.Services/Scanner/ProcessSeries.cs
+++ b/Kavita.Services/Scanner/ProcessSeries.cs
@@ -410,7 +410,7 @@ public class ProcessSeries(
     /// <returns></returns>
     private static bool ShouldUpdatePeopleForRole(Series series, List<ChapterPeople> chapterPeople, PersonRole role)
     {
-        if (chapterPeople.Count == 0) return false;
+        if (chapterPeople.Count == 0) return true;
 
         // If metadata already has this role, but all entries are from KavitaPlus, we should retain them
         if (series.Metadata.AnyOfRole(role))

--- a/Kavita.Services/SettingsService.cs
+++ b/Kavita.Services/SettingsService.cs
@@ -524,7 +524,8 @@ public class SettingsService(
             var hasTrailingSlash = authority.EndsWith('/');
             var url = authority + (hasTrailingSlash ? string.Empty : "/") + ".well-known/openid-configuration";
 
-            var json = await FlurlConfiguration.CreateSafeRequest(url)
+            // We allow non-SSRF protected urls for OIDC Validity (#4663)
+            var json = await url
                 .GetStringAsync(cancellationToken: ct);
             var config = OpenIdConnectConfiguration.Create(json);
             return config.Issuer == authority ? AuthorityValidationResult.Success : AuthorityValidationResult.InvalidAuthority;

--- a/UI/Web/src/app/_models/events/series-update-event.ts
+++ b/UI/Web/src/app/_models/events/series-update-event.ts
@@ -1,0 +1,3 @@
+export interface SeriesUpdateEvent {
+  id: number;
+}

--- a/UI/Web/src/app/_models/readers/personal-toc.ts
+++ b/UI/Web/src/app/_models/readers/personal-toc.ts
@@ -1,4 +1,5 @@
 export interface PersonalToC {
+  id: number;
   chapterId: number;
   pageNumber: number;
   title: string;

--- a/UI/Web/src/app/_models/reading-list/reading-list-tag.ts
+++ b/UI/Web/src/app/_models/reading-list/reading-list-tag.ts
@@ -1,7 +1,5 @@
 import {BaseTag} from "../tag";
 
 export interface ReadingListTag extends BaseTag {
-  id: number;
-  title: string;
   normalizedTitle: string;
 }

--- a/UI/Web/src/app/_models/reading-list/reading-list-tag.ts
+++ b/UI/Web/src/app/_models/reading-list/reading-list-tag.ts
@@ -1,4 +1,6 @@
-export interface ReadingListTag {
+import {BaseTag} from "../tag";
+
+export interface ReadingListTag extends BaseTag {
   id: number;
   title: string;
   normalizedTitle: string;

--- a/UI/Web/src/app/_models/tag.ts
+++ b/UI/Web/src/app/_models/tag.ts
@@ -3,6 +3,4 @@ export interface BaseTag {
   title: string;
 }
 export interface Tag extends BaseTag {
-    id: number,
-    title: string;
 }

--- a/UI/Web/src/app/_models/tag.ts
+++ b/UI/Web/src/app/_models/tag.ts
@@ -1,4 +1,8 @@
-export interface Tag {
+export interface BaseTag {
+  id: number,
+  title: string;
+}
+export interface Tag extends BaseTag {
     id: number,
     title: string;
 }

--- a/UI/Web/src/app/_pipes/filter.pipe.ts
+++ b/UI/Web/src/app/_pipes/filter.pipe.ts
@@ -5,9 +5,9 @@ import { Pipe, PipeTransform } from '@angular/core';
   pure: false,
   standalone: true
 })
-export class FilterPipe implements PipeTransform {
+export class FilterPipe<T> implements PipeTransform {
 
-  transform(items: any[], callback: (item: any) => boolean): any {
+  transform(items: T[], callback: (item: T) => boolean): T[] {
     if (!items || !callback) {
         return items;
     }

--- a/UI/Web/src/app/_services/action.service.ts
+++ b/UI/Web/src/app/_services/action.service.ts
@@ -233,7 +233,7 @@ export class ActionService {
         ref.setInput('series', series);
         return from(ref.closed).pipe(
           filter((saved: boolean) => saved),
-          map(() => this.fromAction(action, series, 'reload'))
+          map(() => this.fromAction(action, series, 'none'))
         );
       }
 

--- a/UI/Web/src/app/_services/message-hub.service.ts
+++ b/UI/Web/src/app/_services/message-hub.service.ts
@@ -146,7 +146,11 @@ export enum EVENTS {
   /**
    * A Reading List was updated (like via Sync operation)
    */
-  ReadingListUpdated = 'ReadingListUpdated'
+  ReadingListUpdated = 'ReadingListUpdated',
+  /**
+   * A series was updated (E.x. K+ match)
+   */
+  SeriesUpdated = 'SeriesUpdated'
 }
 
 export interface Message<T> {
@@ -435,6 +439,13 @@ export class MessageHubService {
     this.hubConnection.on(EVENTS.AuthKeyDeleted, resp => {
       this.messagesSource.next({
         event: EVENTS.AuthKeyDeleted,
+        payload: resp.body
+      });
+    });
+
+    this.hubConnection.on(EVENTS.SeriesUpdated, resp => {
+      this.messagesSource.next({
+        event: EVENTS.SeriesUpdated,
         payload: resp.body
       });
     });

--- a/UI/Web/src/app/_services/message-hub.service.ts
+++ b/UI/Web/src/app/_services/message-hub.service.ts
@@ -15,6 +15,7 @@ import {AnnotationUpdateEvent} from "../_models/events/annotation-update-event";
 import {toSignal} from "@angular/core/rxjs-interop";
 import {ReadingSessionCloseEvent, ReadingSessionUpdateEvent} from "../_models/events/reading-session-close-event";
 import {ReadingListUpdatedEvent} from "../_models/events/reading-list-updated-event";
+import {SeriesUpdateEvent} from "../_models/events/series-update-event";
 
 export enum EVENTS {
   UpdateAvailable = 'UpdateAvailable',
@@ -446,7 +447,7 @@ export class MessageHubService {
     this.hubConnection.on(EVENTS.SeriesUpdated, resp => {
       this.messagesSource.next({
         event: EVENTS.SeriesUpdated,
-        payload: resp.body
+        payload: resp.body as SeriesUpdateEvent
       });
     });
   }

--- a/UI/Web/src/app/_single-module/details-tab/details-tab.component.ts
+++ b/UI/Web/src/app/_single-module/details-tab/details-tab.component.ts
@@ -8,7 +8,7 @@ import {SeriesFilterField} from '../../_models/metadata/v2/series-filter-field';
 import {FilterComparison} from '../../_models/metadata/v2/filter-comparison';
 import {FilterUtilitiesService} from '../../shared/_services/filter-utilities.service';
 import {Genre} from '../../_models/metadata/genre';
-import {Tag} from '../../_models/tag';
+import {BaseTag} from '../../_models/tag';
 import {ImageComponent} from '../../shared/image/image.component';
 import {ImageService} from '../../_services/image.service';
 import {MangaFormat} from '../../_models/manga-format';
@@ -89,7 +89,7 @@ export class DetailsTabComponent {
   metadata = input.required<IHasCast>();
   entity = input<Series | Volume | Chapter>();
   genres = input<Genre[]>([]);
-  tags = input<Tag[]>([]);
+  tags = input<BaseTag[]>([]);
   webLinks = input<string[]>([]);
   suppressEmptyGenres = input<boolean>(false);
   suppressEmptyTags = input<boolean>(false);

--- a/UI/Web/src/app/book-reader/_components/_drawers/view-bookmarks-drawer/view-bookmark-drawer.component.html
+++ b/UI/Web/src/app/book-reader/_components/_drawers/view-bookmarks-drawer/view-bookmark-drawer.component.html
@@ -11,15 +11,15 @@
   <div class="offcanvas-body">
 
     <ul #subnav="ngbNav" ngbNav [(activeId)]="tocId" class="reader-pills nav nav-pills mb-2" [destroyOnHide]="false">
-      <li [ngbNavItem]="Tabs.BookmarkImageTab">
-        <a ngbNavLink>{{Tabs.BookmarkImageTab | tabTitle}}</a>
+      <li [ngbNavItem]="Tabs.BookmarkTextTab">
+        <a ngbNavLink>{{Tabs.BookmarkTextTab | tabTitle}}</a>
         <ng-template ngbNavContent>
           <app-personal-table-of-contents [chapterId]="chapterId()!" [pageNum]="pageNum()" (loadChapter)="loadChapterPart($event)"
                                           [tocRefresh]="refreshPToC" />
         </ng-template>
       </li>
-      <li [ngbNavItem]="Tabs.BookmarkTextTab">
-        <a ngbNavLink>{{Tabs.BookmarkTextTab | tabTitle}}</a>
+      <li [ngbNavItem]="Tabs.BookmarkImageTab">
+        <a ngbNavLink>{{Tabs.BookmarkImageTab | tabTitle}}</a>
         <ng-template ngbNavContent>
           @let items = bookmarks();
 

--- a/UI/Web/src/app/book-reader/_components/personal-table-of-contents/personal-table-of-contents.component.html
+++ b/UI/Web/src/app/book-reader/_components/personal-table-of-contents/personal-table-of-contents.component.html
@@ -1,8 +1,6 @@
 <ng-container *transloco="let t; prefix: 'personal-table-of-contents'">
   <div class="table-of-contents">
-    @let bookmarks = ptocBookmarks();
-
-    @if(bookmarks.length >= ShowFilterAfterItems) {
+    @if(ptocBookmarks().length >= ShowFilterAfterItems) {
       <form [formGroup]="formGroup">
         <div class="row g-0 mb-3">
           <div class="col-md-12">
@@ -15,7 +13,7 @@
       </form>
     }
 
-    @for(bookmark of bookmarks | filter: filterList; track bookmark.id) {
+    @for(bookmark of visibleBookmarks(); track bookmark.id) {
       <div class="mb-2">
         <app-text-bookmark-item [bookmark]="bookmark"
                                 (loadBookmark)="loadChapterPage($event.pageNumber, $event.bookScrollId)"

--- a/UI/Web/src/app/book-reader/_components/personal-table-of-contents/personal-table-of-contents.component.ts
+++ b/UI/Web/src/app/book-reader/_components/personal-table-of-contents/personal-table-of-contents.component.ts
@@ -11,11 +11,10 @@ import {
 } from '@angular/core';
 import {ReaderService} from "../../../_services/reader.service";
 import {PersonalToC} from "../../../_models/readers/personal-toc";
-import {takeUntilDestroyed} from "@angular/core/rxjs-interop";
+import {takeUntilDestroyed, toSignal} from "@angular/core/rxjs-interop";
 import {translate, TranslocoDirective} from "@jsverse/transloco";
 import {TextBookmarkItemComponent} from "../text-bookmark-item/text-bookmark-item.component";
 import {ConfirmService} from "../../../shared/confirm.service";
-import {FilterPipe} from "../../../_pipes/filter.pipe";
 import {FormControl, FormGroup, FormsModule, ReactiveFormsModule} from "@angular/forms";
 
 export interface PersonalToCEvent {
@@ -25,7 +24,7 @@ export interface PersonalToCEvent {
 
 @Component({
   selector: 'app-personal-table-of-contents',
-  imports: [TranslocoDirective, TextBookmarkItemComponent, FilterPipe, FormsModule, ReactiveFormsModule],
+  imports: [TranslocoDirective, TextBookmarkItemComponent, FormsModule, ReactiveFormsModule],
   templateUrl: './personal-table-of-contents.component.html',
   styleUrls: ['./personal-table-of-contents.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush
@@ -45,11 +44,20 @@ export class PersonalTableOfContentsComponent implements OnInit {
 
 
   ptocBookmarks = signal<PersonalToC[]>([]);
-  visibleBookmarks = computed(() => this.ptocBookmarks()
-    .filter(bookmark => this.filterList(bookmark)));
+  visibleBookmarks = computed(() => {
+    const query = this.query()?.toLowerCase() ?? '';
+
+    return this.ptocBookmarks().filter(bookMark => {
+      return bookMark.title.toLowerCase().indexOf(query) >= 0
+        || bookMark.pageNumber.toString().indexOf(query) >= 0
+        || (bookMark.chapterTitle ?? '').toLowerCase().indexOf(query) >= 0;
+    });
+  });
+
   formGroup = new FormGroup({
     filter: new FormControl('', [])
   });
+  query = toSignal(this.formGroup.get('filter')!.valueChanges, {initialValue: ''});
 
   ngOnInit() {
     this.tocRefresh.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
@@ -76,11 +84,6 @@ export class PersonalTableOfContentsComponent implements OnInit {
     this.readerService.removePersonalToc(bookmark.chapterId, bookmark.pageNumber, bookmark.title).subscribe(() => {
       this.ptocBookmarks.set(this.ptocBookmarks().filter(t => t.title !== bookmark.title));
     });
-  }
-
-  filterList = (listItem: PersonalToC) => {
-    const query = (this.formGroup.get('filter')?.value || '').toLowerCase();
-    return listItem.title.toLowerCase().indexOf(query) >= 0 || listItem.pageNumber.toString().indexOf(query) >= 0 || (listItem.chapterTitle ?? '').toLowerCase().indexOf(query) >= 0;
   }
 
 }

--- a/UI/Web/src/app/book-reader/_components/personal-table-of-contents/personal-table-of-contents.component.ts
+++ b/UI/Web/src/app/book-reader/_components/personal-table-of-contents/personal-table-of-contents.component.ts
@@ -1,6 +1,6 @@
 import {
   ChangeDetectionStrategy,
-  Component,
+  Component, computed,
   DestroyRef,
   EventEmitter,
   inject,
@@ -45,6 +45,8 @@ export class PersonalTableOfContentsComponent implements OnInit {
 
 
   ptocBookmarks = signal<PersonalToC[]>([]);
+  visibleBookmarks = computed(() => this.ptocBookmarks()
+    .filter(bookmark => this.filterList(bookmark)));
   formGroup = new FormGroup({
     filter: new FormControl('', [])
   });

--- a/UI/Web/src/app/reading-list/_components/reading-list-detail/reading-list-detail.component.html
+++ b/UI/Web/src/app/reading-list/_components/reading-list-detail/reading-list-detail.component.html
@@ -248,6 +248,7 @@
                 <ng-template ngbNavContent>
                   @defer (when activeTabId === Tabs.Details; prefetch on idle) {
                     <app-details-tab [metadata]="castInfo()"
+                                     [tags]="readingList().tags"
                                      [suppressEmptyGenres]="true"
                                      [suppressEmptyTags]="true"
                     />

--- a/UI/Web/src/app/series-detail/_components/series-detail/series-detail.component.ts
+++ b/UI/Web/src/app/series-detail/_components/series-detail/series-detail.component.ts
@@ -530,6 +530,10 @@ class SeriesDetailComponent implements OnInit, AfterViewInit {
         if (volumeRemoveEvent.seriesId === this.seriesId()) {
           this.loadPageSource.next(false);
         }
+      } else if (event.event === EVENTS.SeriesUpdated) {
+        if (event.payload.id === this.seriesId()) {
+          this.loadPageSource.next(false);
+        }
       }
     });
 

--- a/UI/Web/src/app/series-detail/_components/series-detail/series-detail.component.ts
+++ b/UI/Web/src/app/series-detail/_components/series-detail/series-detail.component.ts
@@ -123,6 +123,7 @@ import {ReadingHistoryItem} from "src/app/_models/stats/reading-history-item";
 import {StatisticsService} from "src/app/_services/statistics.service";
 import {Pagination} from "src/app/_models/pagination";
 import {ReadingHistoryViewerComponent} from "src/app/shared/reading-history-viewer/reading-history-viewer.component";
+import {SeriesUpdateEvent} from "../../../_models/events/series-update-event";
 
 interface StoryLineItem {
   chapter?: ChapterCardEntity;
@@ -531,7 +532,7 @@ class SeriesDetailComponent implements OnInit, AfterViewInit {
           this.loadPageSource.next(false);
         }
       } else if (event.event === EVENTS.SeriesUpdated) {
-        if (event.payload.id === this.seriesId()) {
+        if ((event.payload as SeriesUpdateEvent).id === this.seriesId()) {
           this.loadPageSource.next(false);
         }
       }

--- a/UI/Web/src/app/shared/reading-history-viewer/reading-history-viewer.component.html
+++ b/UI/Web/src/app/shared/reading-history-viewer/reading-history-viewer.component.html
@@ -97,6 +97,7 @@
   @let entry = item.value.entry;
 
   <div class="d-flex flex-grow-1 justify-content-between align-items-center"
+       style="min-width: 0;"
        [routerLink]="['/library', entry.libraryId, 'series', entry.seriesId, 'chapter', chapter.chapterId]">
     <div class="col-auto d-none d-sm-block chapter-cover me-2">
       <app-image [imageUrl]="imageService.getChapterCoverImage(chapter.chapterId)" class="d-block"
@@ -110,40 +111,41 @@
 </ng-template>
 
 <ng-template #readStats let-entry let-label="label" let-showInfo="showInfo">
-  <div class="d-flex flex-wrap gap-3 small text-muted me-2 flex-grow-1" *transloco="let t; prefix: 'profile-activity'">
+  <div class="d-flex align-items-center gap-3 small text-muted me-2 flex-grow-1 overflow-hidden" *transloco="let t; prefix: 'profile-activity'">
 
     @if (label) {
-      <span class="d-flex align-items-center flex-grow-1 ms-5" id="label-{{entry.id}}">
+      <span class="text-truncate flex-shrink-1 ms-5"
+            id="label-{{entry.id}}"
+            [title]="label">
         {{label}}
       </span>
     }
 
-    <span [attr.aria-label]="t('duration')" class="d-flex align-items-center gap-1">
+    <span [attr.aria-label]="t('duration')" class="d-flex align-items-center gap-1 text-nowrap flex-shrink-0">
       <i aria-hidden="true" class="fa-regular fa-clock"></i>
       {{ entry.durationSeconds | duration }}
     </span>
 
     @if (entry.pagesRead > 0) {
-      <span [attr.aria-label]="t('pages-read')" class="d-flex align-items-center gap-1">
+      <span [attr.aria-label]="t('pages-read')" class="d-flex align-items-center gap-1 text-nowrap flex-shrink-0">
         <i aria-hidden="true" class="fa-regular fa-file"></i>
         {{t('pages-count', {num: entry.pagesRead | compactNumber})}}
       </span>
     }
 
     @if (entry.wordsRead > 0) {
-      <span [attr.aria-label]="t('words-read')" class="d-flex align-items-center gap-1">
-         <i aria-hidden="true" class="fa fa-book"></i>
+      <span [attr.aria-label]="t('words-read')" class="d-flex align-items-center gap-1 text-nowrap flex-shrink-0">
+        <i aria-hidden="true" class="fa fa-book"></i>
         {{t('words-count', {num: entry.wordsRead | compactNumber})}}
       </span>
     }
 
-
-    <span [attr.aria-label]="t('time')" class="d-flex align-items-center gap-1">
+    <span [attr.aria-label]="t('time')" class="d-flex align-items-center gap-1 text-nowrap flex-shrink-0">
       {{ entry.startTimeUtc | utcToLocalTime:'shortTime' }} - {{ entry.endTimeUtc | utcToLocalTime:'shortTime' }}
     </span>
 
     @if (showInfo) {
-      <button class="btn btn-icon" (click)="displayInfo(entry)" aria-labelledby="label-{{entry.id}}">
+      <button class="btn btn-icon flex-shrink-0" (click)="displayInfo(entry)" aria-labelledby="label-{{entry.id}}">
         <i class="fa fa-info" aria-hidden="true"></i>
         <span class="visually-hidden">{{t('info-alt')}}</span>
       </button>


### PR DESCRIPTION
# Changed
- Changed: OIDC validation no longer requires super safe urls. (Closes #4663, Closes #4667)

# Fixed
- Fixed: Fixed reading list detail tab not having tabs wired up. (Fixes #4666)
- Fixed: Fixed series/chapter rating always returning 0 if you had rated it.
- Fixed: Fixed bookmarks not loading. (Fixes #4680)
- Fixed: Fixed text & image bookmarks being switched. (Fixes #4681)
- Fixed: Fixed long chapter names causing wrapping in activity overview. (Fixes #4665)
- Fixed: Fixed epub bookmarks not loading. (Fixes #4680)
- Fixed: Fixed text & image bookmarks being switched. (Fixes #4681)
- Fixed: Fixed long chapter names causing wrapping in activity overview. (Fixes #4665)
- Fixed: Fixed people not being removed from series if chapter metadata has none. (Fixes #4685)
- Fixed: Fixed series not being added to a collection under some circumstances. (Fixes #4684)
- Fixed: Fixed early reloading causing double K+ plus calls when matching on the series page.
- Fixed: Fixed annotations duplicating & swallowing text under some circumstances. (Fixes #4375)
- Fixed: Fixed annotations not being shown under specific circumstances. (Fixes #4444)
- Fixed: Fixed external links containing sometimes being scoped out of a book. (Fixes #4671)
- Fixed: Fixed search being unreliable when searching with year metadata. (Fixes #4682)