### PR TITLE
Fix OPDS support for multi-file chapters

### DIFF
--- a/Kavita.Server/Controllers/OPDSController.cs
+++ b/Kavita.Server/Controllers/OPDSController.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using System.IO.Compression;
+using System.Linq;
 using System.Threading.Tasks;
 using System.Xml.Serialization;
 using Kavita.API.Database;
@@ -14,6 +16,7 @@ using Kavita.Models.DTOs.Progress;
 using Kavita.Models.Entities.Enums;
 using Kavita.Server.Attributes;
 using Kavita.Services;
+using Kavita.Services.Extensions;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using MimeTypes;
@@ -631,9 +634,36 @@ public class OpdsController(
     [HttpGet("{apiKey}/series/{seriesId}/volume/{volumeId}/chapter/{chapterId}/download/{filename}")]
     public async Task<ActionResult> DownloadFile(string apiKey, int seriesId, int volumeId, int chapterId, string filename)
     {
-        var files = await unitOfWork.ChapterRepository.GetFilesForChapterAsync(chapterId);
-        var (zipFile, contentType, fileDownloadName) = downloadService.GetFirstFileDownload(files);
-        return PhysicalFile(zipFile, contentType, fileDownloadName, true);
+        var files = (await unitOfWork.ChapterRepository.GetFilesForChapterAsync(chapterId)).ToList();
+
+        if (files.Count <= 1)
+        {
+            var (zipFile, contentType, fileDownloadName) = downloadService.GetFirstFileDownload(files);
+            return PhysicalFile(zipFile, contentType, fileDownloadName, true);
+        }
+
+        // Multi-file chapter: produce a single flat .cbz by reusing the
+        // page-streaming cache, which already extracts and orders pages
+        // across all the chapter's files. Otherwise OPDS clients only
+        // receive the first file of the chapter.
+        var chapter = await cacheService.Ensure(chapterId);
+        if (chapter == null)
+        {
+            return BadRequest(await localizationService.TranslateAsync(UserId, "cache-file-find"));
+        }
+
+        var series = await unitOfWork.SeriesRepository.GetSeriesByIdAsync(seriesId);
+        var downloadName = $"{series!.Name} - Chapter {chapter.GetNumberTitle()}.cbz";
+        var dateStr = DateTime.UtcNow.ToShortDateString().Replace("/", "_");
+        var outputPath = Path.Join(directoryService.TempDirectory, $"kavita_opds_merged_c{chapterId}_{dateStr}.cbz");
+
+        if (!System.IO.File.Exists(outputPath))
+        {
+            var cacheDir = cacheService.GetCachePath(chapterId);
+            ZipFile.CreateFromDirectory(cacheDir, outputPath);
+        }
+
+        return PhysicalFile(outputPath, "application/x-cbz", downloadName, true);
     }
 
     private static ContentResult CreateXmlResult(string xml)

--- a/Kavita.Services.Tests/OpdsServiceTests.cs
+++ b/Kavita.Services.Tests/OpdsServiceTests.cs
@@ -1050,6 +1050,81 @@ public class OpdsServiceTests(ITestOutputHelper testOutputHelper) : AbstractDbTe
         Assert.Single(feed.Entries); // Each chapter has 1 file
     }
 
+    [Fact]
+    public async Task PageStreamLink_p5count_ReflectsChapterTotalPagesForMultiFileChapter()
+    {
+        // Issue #4382: for a chapter composed of multiple MangaFiles, the OPDS-PSE
+        // stream link's p5:count must equal chapter.Pages (the total across all files),
+        // not Files.First().Pages — otherwise spec-compliant clients (Panels) stop
+        // streaming halfway through the chapter.
+        var (unitOfWork, context, mapper) = await CreateDatabase();
+        var (opdsService, _) = SetupService(unitOfWork, mapper);
+
+        var library = new LibraryBuilder("Test Lib").Build();
+        unitOfWork.LibraryRepository.Add(library);
+        await unitOfWork.CommitAsync();
+
+        context.AppUser.Add(new AppUserBuilder("majora2007", "majora2007")
+            .WithLibrary(library)
+            .WithLocale("en")
+            .WithRole(PolicyConstants.AdminRole)
+            .Build());
+        await context.SaveChangesAsync();
+
+        // chapter total = 45, but the first file is only 10 pages.
+        var series = new SeriesBuilder("MultiFile Test")
+            .WithVolume(new VolumeBuilder(Parser.LooseLeafVolume)
+                .WithChapter(new ChapterBuilder("1")
+                    .WithSortOrder(0)
+                    .WithPages(45)
+                    .WithFile(new MangaFileBuilder(_testFilePath, MangaFormat.Archive, 10).Build())
+                    .WithFile(new MangaFileBuilder(_testFilePath, MangaFormat.Archive, 15).Build())
+                    .WithFile(new MangaFileBuilder(_testFilePath, MangaFormat.Archive, 20).Build())
+                    .Build())
+                .Build())
+            .Build();
+        series.Library = library;
+        context.Series.Add(series);
+        await unitOfWork.CommitAsync();
+
+        var user = await unitOfWork.UserRepository.GetUserByIdAsync(1,
+            AppUserIncludes.Progress | AppUserIncludes.WantToRead | AppUserIncludes.Collections);
+        Assert.NotNull(user);
+        user.SideNavStreams = new List<AppUserSideNavStream>
+        {
+            new AppUserSideNavStream
+            {
+                Name = library.Name,
+                IsProvided = true,
+                Order = 0,
+                StreamType = SideNavStreamType.Library,
+                Visible = true,
+                LibraryId = library.Id,
+                AppUserId = user.Id
+            }
+        };
+        await unitOfWork.CommitAsync();
+
+        var feed = await opdsService.GetSeriesDetail(new OpdsItemsFromEntityIdRequest
+        {
+            ApiKey = user.GetOpdsAuthKey(),
+            Prefix = OpdsService.DefaultApiPrefix,
+            BaseUrl = string.Empty,
+            UserId = user.Id,
+            Preferences = await unitOfWork.UserRepository.GetOpdsPreferences(user.Id),
+            EntityId = 1,
+            PageNumber = OpdsService.FirstPageNumber
+        });
+
+        Assert.NotEmpty(feed.Entries);
+        var streamLink = feed.Entries
+            .First()
+            .Links
+            .SingleOrDefault(l => l.Rel == FeedLinkRelation.Stream);
+        Assert.NotNull(streamLink);
+        Assert.Equal(45, streamLink.TotalPages); // pre-fix this would be 10 (Files.First().Pages)
+    }
+
     #endregion
 
     #region XML Serialization

--- a/Kavita.Services/OpdsService.cs
+++ b/Kavita.Services/OpdsService.cs
@@ -1286,11 +1286,10 @@ public class OpdsService(
 
     private static FeedLink CreatePageStreamLink(int libraryId, int seriesId, ChapterDto chapter, IOpdsRequest request)
     {
-        var mangaFile = chapter.Files.First();
         // NOTE: Type could be wrong, there is nothing I can do in the spec
         var link = CreateLink(FeedLinkRelation.Stream, "image/jpeg",
             $"{request.Prefix}{request.ApiKey}/image?libraryId={libraryId}&seriesId={seriesId}&volumeId={chapter.VolumeId}&chapterId={chapter.Id}&pageNumber=" + "{pageNumber}");
-        link.TotalPages = mangaFile.Pages;
+        link.TotalPages = chapter.Pages;
         link.IsPageStream = true;
 
         if (chapter.LastReadingProgressUtc > DateTime.MinValue)


### PR DESCRIPTION
# Fixed
- Fixed: Fixed the OPDS-PSE stream link advertising only the first file's page count, causing Panels and other spec-compliant clients to stop streaming halfway through multi-file chapters. (Fixes #4382)
- Fixed: Fixed the OPDS download endpoint serving only the first file of a multi-file chapter. Multi-file chapters are now merged into a single flat `.cbz` on download by reusing the streaming cache. (Fixes #4382)
