### PR TITLE
Fixed: Bound parse concurrency to prevent ThreadPool starvation during scans

### DIFF
--- a/Kavita.Services.Tests/ParseScannedFilesTests.cs
+++ b/Kavita.Services.Tests/ParseScannedFilesTests.cs
@@ -668,4 +668,103 @@ public class ParseScannedFilesTests: AbstractDbTest
         Assert.Single(scannedSeries);
         Assert.Single(scannedSeries.Values.First().DistinctBy(x => x.Series));
     }
+
+    #region ParseFiles Concurrency
+
+    /// <summary>
+    /// Wraps <see cref="MockReadingItemService"/> and records how many ParseFile calls run
+    /// concurrently, so we can assert the parallel parse path is bounded.
+    /// </summary>
+    private sealed class ConcurrencyTrackingReadingItemService : IReadingItemService
+    {
+        private readonly MockReadingItemService _inner;
+        private int _current;
+        private int _max;
+        private int _totalCalls;
+
+        public int MaxObservedConcurrency => _max;
+        public int TotalCalls => _totalCalls;
+
+        public ConcurrencyTrackingReadingItemService(IDirectoryService directoryService, IBookService bookService)
+        {
+            _inner = new MockReadingItemService(directoryService, bookService);
+        }
+
+        public ParserInfo ParseFile(string path, string rootPath, string libraryRoot, LibraryType type, bool enableMetadata)
+        {
+            Interlocked.Increment(ref _totalCalls);
+            var running = Interlocked.Increment(ref _current);
+            int observedMax;
+            while (running > (observedMax = _max))
+            {
+                Interlocked.CompareExchange(ref _max, running, observedMax);
+            }
+
+            try
+            {
+                // Hold the slot briefly so concurrent parses actually overlap
+                Thread.Sleep(10);
+
+                return _inner.ParseFile(path, rootPath, libraryRoot, type, enableMetadata);
+            }
+            finally
+            {
+                Interlocked.Decrement(ref _current);
+            }
+        }
+
+        public ParserInfo Parse(string path, string rootPath, string libraryRoot, LibraryType type, bool enableMetadata)
+            => _inner.Parse(path, rootPath, libraryRoot, type, enableMetadata);
+
+        public ComicInfo GetComicInfo(string filePath) => _inner.GetComicInfo(filePath);
+
+        public int GetNumberOfPages(string filePath, MangaFormat format) => _inner.GetNumberOfPages(filePath, format);
+
+        public string GetCoverImage(string fileFilePath, string fileName, MangaFormat format, EncodeFormat encodeFormat, CoverImageSize size = CoverImageSize.Default)
+            => _inner.GetCoverImage(fileFilePath, fileName, format, encodeFormat, size);
+
+        public void Extract(string fileFilePath, string targetDirectory, MangaFormat format, int imageCount = 1)
+            => _inner.Extract(fileFilePath, targetDirectory, format, imageCount);
+    }
+
+    [Fact]
+    public async Task ScanLibrariesForSeries_LargeFolder_BoundsParseConcurrencyAndParsesEveryFile()
+    {
+        var (unitOfWork, context, mapper) = await CreateDatabase();
+        _ = await Setup(unitOfWork);
+
+        // A single folder with >= 100 files takes the parallel parse path in ParseFiles
+        const int fileCount = 150;
+        var fileSystem = new MockFileSystem();
+        fileSystem.AddDirectory(Root + "Data/");
+        for (var i = 0; i < fileCount; i++)
+        {
+            fileSystem.AddFile(Root + $"Data/Accel World v{i:D3}.cbz", new MockFileData(string.Empty));
+        }
+
+        var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), fileSystem);
+        var readingItemService = new ConcurrencyTrackingReadingItemService(ds, Substitute.For<IBookService>());
+        var psf = new ParseScannedFiles(Substitute.For<ILogger<ParseScannedFiles>>(), ds,
+            readingItemService, Substitute.For<IEventHub>(), Substitute.For<IMediaErrorService>());
+
+        var library = await unitOfWork.LibraryRepository.GetLibraryForIdAsync(1,
+            LibraryIncludes.Folders | LibraryIncludes.FileTypes);
+        Assert.NotNull(library);
+        library.Type = LibraryType.Manga;
+
+        await psf.ScanLibrariesForSeries(library, new List<string> { Root + "Data/" }, false,
+            await unitOfWork.SeriesRepository.GetFolderPathMapAsync(1));
+
+        // Every file still goes through the parser
+        Assert.Equal(fileCount, readingItemService.TotalCalls);
+
+        // ...and the parallel parse path never exceeds the scanner's concurrency cap.
+        // Before the fix this branch was an unbounded Task.WhenAll over one Task.Run per file,
+        // which let all 150 parses run at once and exhaust the ThreadPool.
+        var expectedMax = Math.Max(1, Environment.ProcessorCount / 2);
+        Assert.True(readingItemService.MaxObservedConcurrency <= expectedMax,
+            $"Observed parse concurrency {readingItemService.MaxObservedConcurrency} exceeded the cap {expectedMax}");
+    }
+
+    #endregion
 }

--- a/Kavita.Services/Scanner/ParseScannedFiles.cs
+++ b/Kavita.Services/Scanner/ParseScannedFiles.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Kavita.API.Services;
 using Kavita.API.Services.SignalR;
@@ -779,10 +780,31 @@ public class ParseScannedFiles
         }
         else
         {
-            // Process files in parallel
-            var tasks = files.Select(file => Task.Run(() =>
-                _readingItemService.ParseFile(file, normalizedFolder, result.LibraryRoot, library.Type, library.EnableMetadata)));
+            // Process files in parallel, but bound the concurrency so that a folder with
+            // many files cannot flood the ThreadPool and starve request handling (the web UI
+            // and health checks become unresponsive during scans otherwise).
+            // Matches the scanner's existing parallelism convention (see ScannerService).
+            var maxConcurrency = Math.Max(1, Environment.ProcessorCount / 2);
+            using var throttler = new SemaphoreSlim(maxConcurrency);
 
+            var tasks = files.Select(async file =>
+            {
+                await throttler.WaitAsync();
+
+                try
+                {
+                    // Task.Run keeps the synchronous parser work off the enumerating thread
+                    // while the semaphore bounds how many parses run at once.
+                    return await Task.Run(() =>
+                        _readingItemService.ParseFile(file, normalizedFolder, result.LibraryRoot, library.Type, library.EnableMetadata));
+                }
+                finally
+                {
+                    throttler.Release();
+                }
+            });
+
+            // Task.WhenAll preserves input (file) order, which downstream series mapping relies on
             var infos = await Task.WhenAll(tasks);
             result.ParserInfos = infos.Where(info => info != null).ToList()!;
         }


### PR DESCRIPTION
tl;dr let the API server stay responsive during library scans.


# Fixed
- Fixed: Library scans of a folder containing many files (most noticeable on large EPUB libraries) could make the web UI and API unresponsive for the duration of the scan, sometimes long enough that a Docker or Kubernetes health check would restart the container in the middle of scanning. Scans now limit how many files are parsed at the same time, so a large folder no longer starves the server while it is being scanned.