### PR TITLE
A pile of bug fixes

### DIFF
--- a/Kavita.API/Repositories/IExternalSeriesMetadataRepository.cs
+++ b/Kavita.API/Repositories/IExternalSeriesMetadataRepository.cs
@@ -22,6 +22,6 @@ public interface IExternalSeriesMetadataRepository
     Task<bool> NeedsDataRefresh(int seriesId, CancellationToken ct = default);
     Task<SeriesDetailPlusDto?> GetSeriesDetailPlusDto(int seriesId, CancellationToken ct = default);
     Task LinkRecommendationsToSeries(Series series, CancellationToken ct = default);
-    Task<IList<int>> GetSeriesThatNeedExternalMetadata(int limit, bool includeStaleData = false, CancellationToken ct = default);
+    Task<List<int>> GetSeriesThatNeedExternalMetadata(int limit, bool includeStaleData = false, CancellationToken ct = default);
     Task<PagedList<ManageMatchSeriesDto>> GetAllSeries(ManageMatchFilterDto filter, UserParams userParams, CancellationToken ct = default);
 }

--- a/Kavita.API/Services/IImageService.cs
+++ b/Kavita.API/Services/IImageService.cs
@@ -22,6 +22,7 @@ public interface IImageService
     /// <param name="targetDirectory">If null, will write to <see cref="DirectoryService.CoverImageDirectory"/></param>
     /// <returns>File name with extension of the file. </returns>
     string CreateThumbnailFromBase64(string encodedImage, string fileName, EncodeFormat encodeFormat, int thumbnailWidth = 320, int thumbnailHeight = 455, string? targetDirectory = null);
+
     /// <summary>
     /// Creates a thumbnail from an image file already on disk (e.g. one staged in the temp directory).
     /// </summary>
@@ -29,9 +30,10 @@ public interface IImageService
     /// <param name="fileName"></param>
     /// <param name="encodeFormat">Convert and save as encoding format</param>
     /// <param name="thumbnailWidth">Width of thumbnail</param>
+    /// <param name="thumbnailHeight"></param>
     /// <param name="targetDirectory">If null, will write to <see cref="DirectoryService.CoverImageDirectory"/></param>
     /// <returns>File name with extension of the file.</returns>
-    string CreateThumbnailFromFile(string sourceFile, string fileName, EncodeFormat encodeFormat, int thumbnailWidth = 320, string? targetDirectory = null);
+    string CreateThumbnailFromFile(string sourceFile, string fileName, EncodeFormat encodeFormat, int thumbnailWidth = 320, int thumbnailHeight = 455, string? targetDirectory = null);
     /// <summary>
     /// Writes out a thumbnail by stream input
     /// </summary>

--- a/Kavita.API/Services/IImageService.cs
+++ b/Kavita.API/Services/IImageService.cs
@@ -18,9 +18,10 @@ public interface IImageService
     /// <param name="fileName"></param>
     /// <param name="encodeFormat">Convert and save as encoding format</param>
     /// <param name="thumbnailWidth">Width of thumbnail</param>
+    /// <param name="thumbnailHeight">Height of thumbnail</param>
     /// <param name="targetDirectory">If null, will write to <see cref="DirectoryService.CoverImageDirectory"/></param>
     /// <returns>File name with extension of the file. </returns>
-    string CreateThumbnailFromBase64(string encodedImage, string fileName, EncodeFormat encodeFormat, int thumbnailWidth = 320, string? targetDirectory = null);
+    string CreateThumbnailFromBase64(string encodedImage, string fileName, EncodeFormat encodeFormat, int thumbnailWidth = 320, int thumbnailHeight = 455, string? targetDirectory = null);
     /// <summary>
     /// Writes out a thumbnail by stream input
     /// </summary>
@@ -67,6 +68,7 @@ public interface IImageService
     /// <param name="fileName">Filename without extension</param>
     /// <param name="encodeFormat">Convert and save as encoding format</param>
     /// <param name="thumbnailWidth">Width of thumbnail</param>
+    /// <param name="thumbnailHeight">Height of thumbnail</param>
     /// <returns>File name with extension of the saved file, or empty string on failure</returns>
-    Task<string> CreateThumbnailFromUrl(string url, string fileName, EncodeFormat encodeFormat, int thumbnailWidth = 320);
+    Task<string> CreateThumbnailFromUrl(string url, string fileName, EncodeFormat encodeFormat, int thumbnailWidth = 320, int thumbnailHeight = 455);
 }

--- a/Kavita.Common/Configuration.cs
+++ b/Kavita.Common/Configuration.cs
@@ -28,7 +28,7 @@ public static class Configuration
         var environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
         var isDevelopment = environment == Environments.Development;
 
-        if (isDevelopment ) //&& Environment.UserName.Equals("Joe", StringComparison.OrdinalIgnoreCase))
+        if (isDevelopment && string.IsNullOrEmpty(Environment.GetEnvironmentVariable("KAVITAPLUS_PROD")))
         {
             return "http://localhost:5020";
         }

--- a/Kavita.Database/Repositories/ExternalSeriesMetadataRepository.cs
+++ b/Kavita.Database/Repositories/ExternalSeriesMetadataRepository.cs
@@ -175,7 +175,7 @@ public class ExternalSeriesMetadataRepository(DataContext context, IMapper mappe
         await context.SaveChangesAsync(ct);
     }
 
-    public async Task<IList<int>> GetSeriesThatNeedExternalMetadata(int limit, bool includeStaleData = false,
+    public async Task<List<int>> GetSeriesThatNeedExternalMetadata(int limit, bool includeStaleData = false,
         CancellationToken ct = default)
     {
         return await context.Series

--- a/Kavita.Database/Repositories/SeriesRepository.cs
+++ b/Kavita.Database/Repositories/SeriesRepository.cs
@@ -760,46 +760,56 @@ public class SeriesRepository(DataContext context, IMapper mapper) : ISeriesRepo
     private async Task<IQueryable<Series>> ApplyCollectionFilter(SeriesFilterV2Dto seriesFilter, IQueryable<Series> query,
         int userId, AgeRestriction userRating, CancellationToken ct = default)
     {
-        var collectionStmt = seriesFilter.Statements.FirstOrDefault(stmt => stmt.Field == SeriesFilterField.CollectionTags);
-        if (collectionStmt == null) return query;
+        var collectionStmts = seriesFilter.Statements
+            .Where(stmt => stmt.Field == SeriesFilterField.CollectionTags)
+            .ToList();
+        if (collectionStmts.Count == 0) return query;
 
-        var value = (IList<int>) SeriesFilterFieldValueConverter.ConvertValue(collectionStmt.Field, collectionStmt.Value);
-
-        if (value.Count == 0)
+        foreach (var collectionStmt in collectionStmts)
         {
-            return query;
+            var value = (IList<int>) SeriesFilterFieldValueConverter.ConvertValue(collectionStmt.Field, collectionStmt.Value);
+
+            if (value.Count == 0)
+            {
+                continue;
+            }
+
+            if (collectionStmt.Comparison != FilterComparison.MustContains)
+            {
+                var collectionSeries = await context.AppUserCollection
+                    .Where(uc => uc.Promoted || uc.AppUserId == userId)
+                    .Where(uc => value.Contains(uc.Id))
+                    .SelectMany(uc => uc.Items)
+                    .RestrictAgainstAgeRestriction(userRating)
+                    .Select(s => s.Id)
+                    .Distinct()
+                    .ToListAsync(ct);
+
+                query = query.HasCollectionTags(true, collectionStmt.Comparison, value, collectionSeries);
+                continue;
+            }
+
+            var collectionSeriesTasks = value.Select(async collectionId =>
+            {
+                return await context.AppUserCollection
+                    .Where(uc => uc.Promoted || uc.AppUserId == userId)
+                    .Where(uc => uc.Id == collectionId)
+                    .SelectMany(uc => uc.Items)
+                    .RestrictAgainstAgeRestriction(userRating)
+                    .Select(s => s.Id)
+                    .ToListAsync(ct);
+            });
+
+            var collectionSeriesLists = await Task.WhenAll(collectionSeriesTasks);
+
+            var commonSeries = collectionSeriesLists
+                .Aggregate((common, next) => common.Intersect(next)
+                    .ToList());
+
+            query = query.Where(s => commonSeries.Contains(s.Id));
         }
 
-        var collectionSeries = await context.AppUserCollection
-            .Where(uc => uc.Promoted || uc.AppUserId == userId)
-            .Where(uc => value.Contains(uc.Id))
-            .SelectMany(uc => uc.Items)
-            .RestrictAgainstAgeRestriction(userRating)
-            .Select(s => s.Id)
-            .Distinct()
-            .ToListAsync(ct);
-
-        if (collectionStmt.Comparison != FilterComparison.MustContains)
-            return query.HasCollectionTags(true, collectionStmt.Comparison, value, collectionSeries);
-
-        var collectionSeriesTasks = value.Select(async collectionId =>
-        {
-            return await context.AppUserCollection
-                .Where(uc => uc.Promoted || uc.AppUserId == userId)
-                .Where(uc => uc.Id == collectionId)
-                .SelectMany(uc => uc.Items)
-                .RestrictAgainstAgeRestriction(userRating)
-                .Select(s => s.Id)
-                .ToListAsync(ct);
-        });
-
-        var collectionSeriesLists = await Task.WhenAll(collectionSeriesTasks);
-
-        // Find the common series among all collections
-        var commonSeries = collectionSeriesLists.Aggregate((common, next) => common.Intersect(next).ToList());
-
-        // Filter the original query based on the common series
-        return query.Where(s => commonSeries.Contains(s.Id));
+        return query;
     }
 
     private IQueryable<Series> ApplyWantToReadFilter(SeriesFilterV2Dto seriesFilter, IQueryable<Series> query, int userId)

--- a/Kavita.Server/Controllers/AccountController.cs
+++ b/Kavita.Server/Controllers/AccountController.cs
@@ -252,7 +252,7 @@ public class AccountController(UserManager<AppUser> userManager,
         var oidcConfig = (await unitOfWork.SettingsRepository.GetSettingsDtoAsync()).OidcConfig;
         // Setting only takes effect if OIDC is functional, and if we're not logging in via ApiKey
         var disablePasswordAuthentication = oidcConfig is {Enabled: true, DisablePasswordAuthentication: true} && string.IsNullOrEmpty(loginDto.ApiKey);
-        if (disablePasswordAuthentication && !roles.Contains(PolicyConstants.AdminRole)) return Unauthorized(await localizationService.TranslateAsync(user.Id, "password-authentication-disabled"));
+        if (disablePasswordAuthentication) return Unauthorized(await localizationService.TranslateAsync(user.Id, "password-authentication-disabled"));
 
         if (string.IsNullOrEmpty(loginDto.ApiKey))
         {

--- a/Kavita.Server/Controllers/FilterController.cs
+++ b/Kavita.Server/Controllers/FilterController.cs
@@ -6,12 +6,14 @@ using System.Threading.Tasks;
 using Kavita.API.Database;
 using Kavita.API.Repositories;
 using Kavita.API.Services;
+using Kavita.API.Services.SignalR;
 using Kavita.Common;
 using Kavita.Models;
 using Kavita.Models.Constants;
 using Kavita.Models.DTOs.Dashboard;
 using Kavita.Models.DTOs.Filtering.v2;
 using Kavita.Models.DTOs.Filtering.v2.Requests;
+using Kavita.Models.DTOs.SignalR;
 using Kavita.Models.Entities.User;
 using Kavita.Server.Attributes;
 using Kavita.Services.Helpers.SmartFilter;
@@ -24,7 +26,8 @@ public class FilterController(
     IUnitOfWork unitOfWork,
     ILocalizationService localizationService,
     IStreamService streamService,
-    ILogger<FilterController> logger)
+    ILogger<FilterController> logger,
+    IEventHub eventHub)
     : BaseApiController
 {
     /// <summary>
@@ -182,6 +185,10 @@ public class FilterController(
 
         unitOfWork.AppUserSmartFilterRepository.Delete(filter);
         await unitOfWork.CommitAsync();
+
+        await eventHub.SendMessageToAsync(MessageFactory.SideNavUpdate, MessageFactory.SideNavUpdateEvent(UserId),
+            UserId, HttpContext.RequestAborted);
+
         return Ok();
     }
 

--- a/Kavita.Server/Controllers/ImageController.cs
+++ b/Kavita.Server/Controllers/ImageController.cs
@@ -222,6 +222,11 @@ public class ImageController(IUnitOfWork unitOfWork, IDirectoryService directory
             }
         }
 
+        if (string.IsNullOrEmpty(domainFilePath))
+        {
+            return BadRequest(await localizationService.TranslateAsync(UserId, "generic-favicon"));
+        }
+
         return CachedFile(domainFilePath);
     }
 

--- a/Kavita.Server/Controllers/OPDSController.cs
+++ b/Kavita.Server/Controllers/OPDSController.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using System.IO.Compression;
+using System.Linq;
 using System.Threading.Tasks;
 using System.Xml.Serialization;
 using Kavita.API.Database;
@@ -14,6 +16,7 @@ using Kavita.Models.DTOs.Progress;
 using Kavita.Models.Entities.Enums;
 using Kavita.Server.Attributes;
 using Kavita.Services;
+using Kavita.Services.Extensions;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using MimeTypes;
@@ -631,9 +634,36 @@ public class OpdsController(
     [HttpGet("{apiKey}/series/{seriesId}/volume/{volumeId}/chapter/{chapterId}/download/{filename}")]
     public async Task<ActionResult> DownloadFile(string apiKey, int seriesId, int volumeId, int chapterId, string filename)
     {
-        var files = await unitOfWork.ChapterRepository.GetFilesForChapterAsync(chapterId);
-        var (zipFile, contentType, fileDownloadName) = downloadService.GetFirstFileDownload(files);
-        return PhysicalFile(zipFile, contentType, fileDownloadName, true);
+        var files = (await unitOfWork.ChapterRepository.GetFilesForChapterAsync(chapterId)).ToList();
+
+        if (files.Count <= 1)
+        {
+            var (zipFile, contentType, fileDownloadName) = downloadService.GetFirstFileDownload(files);
+            return PhysicalFile(zipFile, contentType, fileDownloadName, true);
+        }
+
+        // Multi-file chapter: produce a single flat .cbz by reusing the
+        // page-streaming cache, which already extracts and orders pages
+        // across all the chapter's files. Otherwise OPDS clients only
+        // receive the first file of the chapter.
+        var chapter = await cacheService.Ensure(chapterId);
+        if (chapter == null)
+        {
+            return BadRequest(await localizationService.TranslateAsync(UserId, "cache-file-find"));
+        }
+
+        var series = await unitOfWork.SeriesRepository.GetSeriesByIdAsync(seriesId);
+        var downloadName = $"{series!.Name} - Chapter {chapter.GetNumberTitle()}.cbz";
+        var dateStr = DateTime.UtcNow.ToShortDateString().Replace("/", "_");
+        var outputPath = Path.Join(directoryService.TempDirectory, $"kavita_opds_merged_c{chapterId}_{dateStr}.cbz");
+
+        if (!System.IO.File.Exists(outputPath))
+        {
+            var cacheDir = cacheService.GetCachePath(chapterId);
+            ZipFile.CreateFromDirectory(cacheDir, outputPath);
+        }
+
+        return PhysicalFile(outputPath, "application/x-cbz", downloadName, true);
     }
 
     private static ContentResult CreateXmlResult(string xml)

--- a/Kavita.Server/Controllers/SeriesController.cs
+++ b/Kavita.Server/Controllers/SeriesController.cs
@@ -184,8 +184,14 @@ public class SeriesController(
             series.SortName = updateSeries.SortName.Trim();
         }
 
-        series.LocalizedName = updateSeries.LocalizedName?.Trim();
-        series.NormalizedLocalizedName = series.LocalizedName?.ToNormalized();
+        var newNormalizedLocalizedName = updateSeries.LocalizedName?.Trim().ToNormalized();
+        if (series.NormalizedLocalizedName != newNormalizedLocalizedName)
+        {
+            series.LocalizedName = updateSeries.LocalizedName?.Trim();
+            series.NormalizedLocalizedName = newNormalizedLocalizedName;
+
+            series.Metadata.KPlusOverrides.Remove(MetadataSettingField.LocalizedName);
+        }
 
         series.SortNameLocked = updateSeries.SortNameLocked;
         series.LocalizedNameLocked = updateSeries.LocalizedNameLocked;

--- a/Kavita.Server/Controllers/UploadController.cs
+++ b/Kavita.Server/Controllers/UploadController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Flurl.Http;
 using Kavita.API.Attributes;
@@ -272,10 +272,9 @@ public class UploadController : BaseApiController
     {
         var settings = await _unitOfWork.SettingsRepository.GetSettingsDtoAsync();
         var encodeFormat = settings.EncodeMediaAs;
-        var coverImageSize = settings.CoverImageSize;
+        var (width, height) = settings.CoverImageSize.GetDimensions();
 
-        return _imageService.CreateThumbnailFromBase64(uploadCoverFileDto.Url,
-            filename, encodeFormat, coverImageSize.GetDimensions().Width);
+        return _imageService.CreateThumbnailFromBase64(uploadCoverFileDto.Url, filename, encodeFormat, width, height);
     }
 
     /// <summary>

--- a/Kavita.Server/Controllers/UploadController.cs
+++ b/Kavita.Server/Controllers/UploadController.cs
@@ -364,7 +364,7 @@ public class UploadController : BaseApiController
             var tempPath = ResolveTempCoverPath(uploadCoverFileDto.FileName)
                            ?? throw new KavitaException(await _localizationService.TranslateAsync(UserId, "invalid-filename"));
 
-            return _imageService.CreateThumbnailFromFile(tempPath, filename, encodeFormat, width);
+            return _imageService.CreateThumbnailFromFile(tempPath, filename, encodeFormat, width, height);
         }
 
         // Legacy fallback: base64 payload

--- a/Kavita.Server/Properties/launchSettings.json
+++ b/Kavita.Server/Properties/launchSettings.json
@@ -27,6 +27,18 @@
             "environmentVariables": {
                 "ASPNETCORE_ENVIRONMENT": "Development"
             }
+        },
+        "Server (K+ Prod)": {
+            "workingDirectory": ".",
+            "commandName": "Project",
+            "dotnetRunMessages": "true",
+            "launchBrowser": false,
+            "launchUrl": "swagger",
+            "applicationUrl": "https://localhost:5001;http://localhost:5000",
+            "environmentVariables": {
+                "ASPNETCORE_ENVIRONMENT": "Development",
+                "KAVITAPLUS_PROD": "True"
+            }
         }
     }
 }

--- a/Kavita.Services.Tests/Helpers/AnnotationHelperTests.cs
+++ b/Kavita.Services.Tests/Helpers/AnnotationHelperTests.cs
@@ -8,6 +8,31 @@ public class AnnotationHelperTests
 {
 
     [Fact]
+    public void Test_InjectSingleElementAnnotations_TrailingWhiteSpace()
+    {
+        var doc = new HtmlDocument();
+        doc.LoadHtml("<html><body><p id='para1'>　意識が芽生えてから二日が経過した。</p></body></html>");
+
+        var annotation = new AnnotationDto
+        {
+            XPath = """id("para1")""",
+            EndingXPath = """id("para1")""",
+            SelectedText = "意識が芽生",
+            ChapterId = 0,
+            VolumeId = 0,
+            SeriesId = 0,
+            LibraryId = 0,
+            OwnerUserId = 0,
+        };
+
+        AnnotationHelper.InjectSingleElementAnnotations(doc, [annotation]);
+        Assert.Equal(
+            """　<app-epub-highlight id="epub-highlight-0">意識が芽生</app-epub-highlight>えてから二日が経過した。""",
+            doc.GetElementbyId("para1").InnerHtml
+        );
+    }
+
+    [Fact]
     public void Test_InjectSingleElementAnnotations_WhitespacePositions()
     {
         var doc = new HtmlDocument();

--- a/Kavita.Services.Tests/Helpers/AnnotationHelperTests.cs
+++ b/Kavita.Services.Tests/Helpers/AnnotationHelperTests.cs
@@ -57,4 +57,30 @@ public class AnnotationHelperTests
             );
     }
 
+    [Fact]
+    public void Test_InjectSingleElementAnnotations_WhitespacePositionsSelectOver()
+    {
+        var doc = new HtmlDocument();
+        doc.LoadHtml("<html><body><p id='para1'>Spice and  Wolf is  Amazing!</p></body></html>");
+
+        var annotation = new AnnotationDto
+        {
+            XPath = """id("para1")""",
+            EndingXPath = """id("para1")""",
+            // Selected text will not include those whitespaces by the way browsers work with selecting text
+            SelectedText = "Spice and Wolf is Amazing!",
+            ChapterId = 0,
+            VolumeId = 0,
+            SeriesId = 0,
+            LibraryId = 0,
+            OwnerUserId = 0,
+        };
+
+        AnnotationHelper.InjectSingleElementAnnotations(doc, [annotation]);
+        Assert.Equal(
+            """<app-epub-highlight id="epub-highlight-0">Spice and  Wolf is  Amazing!</app-epub-highlight>""",
+            doc.GetElementbyId("para1").InnerHtml
+        );
+    }
+
 }

--- a/Kavita.Services.Tests/OpdsServiceTests.cs
+++ b/Kavita.Services.Tests/OpdsServiceTests.cs
@@ -1050,6 +1050,81 @@ public class OpdsServiceTests(ITestOutputHelper testOutputHelper) : AbstractDbTe
         Assert.Single(feed.Entries); // Each chapter has 1 file
     }
 
+    [Fact]
+    public async Task PageStreamLink_p5count_ReflectsChapterTotalPagesForMultiFileChapter()
+    {
+        // Issue #4382: for a chapter composed of multiple MangaFiles, the OPDS-PSE
+        // stream link's p5:count must equal chapter.Pages (the total across all files),
+        // not Files.First().Pages — otherwise spec-compliant clients (Panels) stop
+        // streaming halfway through the chapter.
+        var (unitOfWork, context, mapper) = await CreateDatabase();
+        var (opdsService, _) = SetupService(unitOfWork, mapper);
+
+        var library = new LibraryBuilder("Test Lib").Build();
+        unitOfWork.LibraryRepository.Add(library);
+        await unitOfWork.CommitAsync();
+
+        context.AppUser.Add(new AppUserBuilder("majora2007", "majora2007")
+            .WithLibrary(library)
+            .WithLocale("en")
+            .WithRole(PolicyConstants.AdminRole)
+            .Build());
+        await context.SaveChangesAsync();
+
+        // chapter total = 45, but the first file is only 10 pages.
+        var series = new SeriesBuilder("MultiFile Test")
+            .WithVolume(new VolumeBuilder(Parser.LooseLeafVolume)
+                .WithChapter(new ChapterBuilder("1")
+                    .WithSortOrder(0)
+                    .WithPages(45)
+                    .WithFile(new MangaFileBuilder(_testFilePath, MangaFormat.Archive, 10).Build())
+                    .WithFile(new MangaFileBuilder(_testFilePath, MangaFormat.Archive, 15).Build())
+                    .WithFile(new MangaFileBuilder(_testFilePath, MangaFormat.Archive, 20).Build())
+                    .Build())
+                .Build())
+            .Build();
+        series.Library = library;
+        context.Series.Add(series);
+        await unitOfWork.CommitAsync();
+
+        var user = await unitOfWork.UserRepository.GetUserByIdAsync(1,
+            AppUserIncludes.Progress | AppUserIncludes.WantToRead | AppUserIncludes.Collections);
+        Assert.NotNull(user);
+        user.SideNavStreams = new List<AppUserSideNavStream>
+        {
+            new AppUserSideNavStream
+            {
+                Name = library.Name,
+                IsProvided = true,
+                Order = 0,
+                StreamType = SideNavStreamType.Library,
+                Visible = true,
+                LibraryId = library.Id,
+                AppUserId = user.Id
+            }
+        };
+        await unitOfWork.CommitAsync();
+
+        var feed = await opdsService.GetSeriesDetail(new OpdsItemsFromEntityIdRequest
+        {
+            ApiKey = user.GetOpdsAuthKey(),
+            Prefix = OpdsService.DefaultApiPrefix,
+            BaseUrl = string.Empty,
+            UserId = user.Id,
+            Preferences = await unitOfWork.UserRepository.GetOpdsPreferences(user.Id),
+            EntityId = 1,
+            PageNumber = OpdsService.FirstPageNumber
+        });
+
+        Assert.NotEmpty(feed.Entries);
+        var streamLink = feed.Entries
+            .First()
+            .Links
+            .SingleOrDefault(l => l.Rel == FeedLinkRelation.Stream);
+        Assert.NotNull(streamLink);
+        Assert.Equal(45, streamLink.TotalPages); // pre-fix this would be 10 (Files.First().Pages)
+    }
+
     #endregion
 
     #region XML Serialization

--- a/Kavita.Services/Helpers/AnnotationHelper.cs
+++ b/Kavita.Services/Helpers/AnnotationHelper.cs
@@ -185,12 +185,16 @@ public static partial class AnnotationHelper
     {
         var normalizedText = NormalizeWhitespace(originalText);
 
-        if (normalizedPosition == 0) return 0;
         if (normalizedPosition >= normalizedText.Length) return originalText.Length;
 
         // Walk through both strings character by character to find the mapping
         var originalPos = 0;
         var normalizedPos = 0;
+
+        while (originalPos < originalText.Length && char.IsWhiteSpace(originalText[originalPos]))
+        {
+            originalPos++;
+        }
 
         while (originalPos < originalText.Length && normalizedPos < normalizedPosition)
         {

--- a/Kavita.Services/Helpers/AnnotationHelper.cs
+++ b/Kavita.Services/Helpers/AnnotationHelper.cs
@@ -42,7 +42,6 @@ public static partial class AnnotationHelper
         {
             try
             {
-                var scopedXPath = DescopeXpath(xpath);
                 var elem = FindElementByXPath(doc, xpath);
                 if (elem == null) continue;
 
@@ -67,6 +66,7 @@ public static partial class AnnotationHelper
                 foreach (var item in sortedAnnotations)
                 {
                     var realStartPos = MapNormalizedPositionToOriginal(originalText, item.StartPos);
+                    var realEndPos = MapNormalizedPositionToOriginal(originalText, item.StartPos + item.Annotation.SelectedText.Length);
 
                     // Add text before highlight
                     if (realStartPos > currentPos)
@@ -75,12 +75,14 @@ public static partial class AnnotationHelper
                         elem.AppendChild(HtmlNode.CreateNode(beforeText));
                     }
 
+                    var selectedText = originalText.Substring(realStartPos, realEndPos - realStartPos);
+
                     // Add highlight
                     var highlightNode = HtmlNode.CreateNode(
-                        $"<app-epub-highlight id=\"epub-highlight-{item.Annotation.Id}\">{item.Annotation.SelectedText}</app-epub-highlight>");
+                        $"<app-epub-highlight id=\"epub-highlight-{item.Annotation.Id}\">{selectedText}</app-epub-highlight>");
                     elem.AppendChild(highlightNode);
 
-                    currentPos = realStartPos + item.Annotation.SelectedText.Length;
+                    currentPos = realEndPos;
                 }
 
                 // Add remaining text

--- a/Kavita.Services/ImageService.cs
+++ b/Kavita.Services/ImageService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -526,13 +526,13 @@ public class ImageService(ILogger<ImageService> logger, IDirectoryService direct
 
 
     /// <inheritdoc />
-    public string CreateThumbnailFromBase64(string encodedImage, string fileName, EncodeFormat encodeFormat, int thumbnailWidth = ThumbnailWidth, string? targetDirectory = null)
+    public string CreateThumbnailFromBase64(string encodedImage, string fileName, EncodeFormat encodeFormat, int thumbnailWidth = ThumbnailWidth, int thumbnailHeight = ThumbnailHeight, string? targetDirectory = null)
     {
         // TODO: This code has no concept of cropping nor Thumbnail Size
         try
         {
             targetDirectory ??= directoryService.CoverImageDirectory;
-            using var thumbnail = Image.ThumbnailBuffer(Convert.FromBase64String(encodedImage), thumbnailWidth);
+            using var thumbnail = Image.ThumbnailBuffer(Convert.FromBase64String(encodedImage), thumbnailWidth, height: thumbnailHeight);
 
             fileName += encodeFormat.GetExtension();
             thumbnail.WriteToFile(directoryService.FileSystem.Path.Join(targetDirectory, fileName));
@@ -552,7 +552,7 @@ public class ImageService(ILogger<ImageService> logger, IDirectoryService direct
     }
 
     /// <inheritdoc />
-    public async Task<string> CreateThumbnailFromUrl(string url, string fileName, EncodeFormat encodeFormat, int thumbnailWidth = ThumbnailWidth)
+    public async Task<string> CreateThumbnailFromUrl(string url, string fileName, EncodeFormat encodeFormat, int thumbnailWidth = ThumbnailWidth, int thumbnailHeight = ThumbnailHeight)
     {
         try
         {
@@ -560,7 +560,7 @@ public class ImageService(ILogger<ImageService> logger, IDirectoryService direct
                 .AllowHttpStatus("2xx,304")
                 .GetStreamAsync();
 
-            using var thumbnail = Image.ThumbnailStream(imageStream, thumbnailWidth);
+            using var thumbnail = Image.ThumbnailStream(imageStream, thumbnailWidth, height: thumbnailHeight);
 
             fileName += encodeFormat.GetExtension();
             thumbnail.WriteToFile(directoryService.FileSystem.Path.Join(directoryService.CoverImageDirectory, fileName));

--- a/Kavita.Services/ImageService.cs
+++ b/Kavita.Services/ImageService.cs
@@ -552,12 +552,13 @@ public class ImageService(ILogger<ImageService> logger, IDirectoryService direct
     }
 
     /// <inheritdoc />
-    public string CreateThumbnailFromFile(string sourceFile, string fileName, EncodeFormat encodeFormat, int thumbnailWidth = ThumbnailWidth, string? targetDirectory = null)
+    public string CreateThumbnailFromFile(string sourceFile, string fileName, EncodeFormat encodeFormat,
+        int thumbnailWidth = 320, int thumbnailHeight = 455, string? targetDirectory = null)
     {
         try
         {
             targetDirectory ??= directoryService.CoverImageDirectory;
-            using var thumbnail = Image.Thumbnail(sourceFile, thumbnailWidth);
+            using var thumbnail = Image.Thumbnail(sourceFile, thumbnailWidth, thumbnailHeight);
 
             fileName += encodeFormat.GetExtension();
             thumbnail.WriteToFile(directoryService.FileSystem.Path.Join(targetDirectory, fileName));

--- a/Kavita.Services/Metadata/CoverDbService.cs
+++ b/Kavita.Services/Metadata/CoverDbService.cs
@@ -197,8 +197,9 @@ public class CoverDbService : ICoverDbService
             var res = await provider.GetAsync<string>(publisherName, ct);
             if (res.HasValue)
             {
-                _logger.LogInformation("Kavita has already tried to fetch Publisher: {PublisherName} and failed. Skipping duplicate check", publisherName);
-                throw new KavitaException($"Kavita has already tried to fetch Publisher: {publisherName} and failed. Skipping duplicate check");
+                _logger.LogDebug("Kavita has already tried to fetch Publisher: {PublisherName} and failed. Skipping duplicate check", publisherName);
+                // Do not throw to prevent duplicate log spam when visiting series
+                return string.Empty;
             }
 
             await provider.SetAsync(publisherName, string.Empty, _cacheTime, ct);

--- a/Kavita.Services/Metadata/CoverDbService.cs
+++ b/Kavita.Services/Metadata/CoverDbService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -797,8 +797,8 @@ public class CoverDbService : ICoverDbService
 
         if (fromBase64)
         {
-            return _imageService.CreateThumbnailFromBase64(url,
-                filenameWithoutExtension, encodeFormat, coverImageSize.GetDimensions().Width, targetDirectory);
+            var (width, height) = coverImageSize.GetDimensions();
+            return _imageService.CreateThumbnailFromBase64(url, filenameWithoutExtension, encodeFormat, width, height, targetDirectory);
         }
 
         return await DownloadImageFromUrl(filenameWithoutExtension, encodeFormat, url, targetDirectory);

--- a/Kavita.Services/OpdsService.cs
+++ b/Kavita.Services/OpdsService.cs
@@ -13,7 +13,6 @@ using Kavita.API.Services.Reading;
 using Kavita.API.Services.ReadingLists;
 using Kavita.Common.Helpers;
 using Kavita.Models.DTOs;
-using Kavita.Models.DTOs.Filtering;
 using Kavita.Models.DTOs.Filtering.v2;
 using Kavita.Models.DTOs.Filtering.v2.Requests;
 using Kavita.Models.DTOs.OPDS;
@@ -23,7 +22,6 @@ using Kavita.Models.DTOs.ReadingLists;
 using Kavita.Models.DTOs.Search;
 using Kavita.Models.Entities;
 using Kavita.Models.Entities.Enums;
-using Kavita.Services.Helpers;
 using Kavita.Services.Helpers.SmartFilter;
 
 namespace Kavita.Services;
@@ -204,7 +202,7 @@ public class OpdsService(
 
     public async Task<Feed> GetSmartFilters(OpdsPaginatedCatalogueRequest request, CancellationToken ct = default)
     {
-        var userId = UnpackRequest(request, out var apiKey, out var prefix, out var baseUrl);
+        var userId = UnpackRequest(request, out var apiKey, out var prefix, out _);
 
         var filters = await unitOfWork.AppUserSmartFilterRepository.GetPagedDtosByUserIdAsync(userId, GetUserParams(request.PageNumber), ct);
         var feed = CreateFeed(await localizationService.TranslateAsync(userId, "smartFilters"), $"{apiKey}/smart-filters", apiKey, prefix);
@@ -518,11 +516,6 @@ public class OpdsService(
         var chapters = (await unitOfWork.ChapterRepository .GetChapterDtosAsync(chapterIds, userId, ct))
             .ToDictionary(c => c.Id);
 
-        // Build naming contexts per library type (usually just 1-2)
-        var namingContexts = await BuildNamingContextsAsync(
-            items.Select(i => i.LibraryType).Distinct(), userId);
-
-
         // Check if there is reading progress or not, if so, inject a "continue-reading" item
 
         if (request.Preferences.IncludeContinueFrom && request.PageNumber == FirstPageNumber)
@@ -552,41 +545,12 @@ public class OpdsService(
                 continue; // Skip if chapter not found (shouldn't happen)
             }
 
-            var namingContext = namingContexts[item.LibraryType];
-
-            if (chapterDto.Files.Count == 1)
-            {
-                feed.Entries.Add(CreateReadingListEntry(item, chapterDto, request));
-            }
-            else
-            {
-                feed.Entries.Add(CreateChapter(
-                    $"{item.Order} - {item.SeriesName}: {namingContext.FormatReadingListItemTitle(item)}",
-                    item.Summary ?? string.Empty,
-                    item.ChapterId,
-                    item.VolumeId,
-                    item.SeriesId,
-                    request));
-            }
+            feed.Entries.Add(CreateReadingListEntry(item, chapterDto, request));
         }
 
         AddPagination(feed, request.PageNumber, totalItems, UserParams.Default.PageSize, $"{prefix}{apiKey}/reading-list/{readingListId}/");
 
         return feed;
-    }
-
-    private async Task<Dictionary<LibraryType, LocalizedNamingContext>> BuildNamingContextsAsync(
-        IEnumerable<LibraryType> libraryTypes, int userId)
-    {
-        var contexts = new Dictionary<LibraryType, LocalizedNamingContext>();
-
-        foreach (var libraryType in libraryTypes.Distinct())
-        {
-            contexts[libraryType] = await LocalizedNamingContext.CreateAsync(
-                namingService, localizationService, userId, libraryType);
-        }
-
-        return contexts;
     }
 
     public async Task<Feed> GetSeriesDetail(OpdsItemsFromEntityIdRequest request, CancellationToken ct = default)
@@ -600,7 +564,7 @@ public class OpdsService(
             throw new OpdsException(await localizationService.TranslateAsync(userId, "series-doesnt-exist"));
         }
 
-        var seriesDetailTask = seriesService.GetSeriesDetail(seriesId, userId);
+        var seriesDetailTask = seriesService.GetSeriesDetail(seriesId, userId, ct);
         var libraryTypeTask = unitOfWork.LibraryRepository.GetLibraryTypeAsync(series.LibraryId, ct);
 
         await Task.WhenAll(seriesDetailTask, libraryTypeTask);
@@ -633,7 +597,6 @@ public class OpdsService(
         }
 
         var chaptersSeen = new Dictionary<int, short>();
-        var filesSeen = new Dictionary<int, short>();
 
         foreach (var volume in seriesDetail.Volumes)
         {
@@ -641,13 +604,7 @@ public class OpdsService(
             {
                 if (!chaptersSeen.TryAdd(chapter.Id, 0)) continue;
 
-                foreach (var mangaFile in chapter.Files)
-                {
-                    // If a chapter has multiple files that are within one chapter, this dict prevents duplicate key exception
-                    if (!filesSeen.TryAdd(mangaFile.Id, 0)) continue;
-
-                    feed.Entries.Add(CreateChapterWithFile(series, volume, chapter, namingContext, request));
-                }
+                feed.Entries.Add(CreateChapterFeedEntry(series, volume, chapter, namingContext, request));
             }
         }
 
@@ -659,26 +616,14 @@ public class OpdsService(
         {
             volumesById.TryGetValue(chapter.VolumeId, out var volume);
 
-            foreach (var mangaFile in chapter.Files)
-            {
-                // If a chapter has multiple files that are within one chapter, this dict prevents duplicate key exception
-                if (!filesSeen.TryAdd(mangaFile.Id, 0)) continue;
-
-                feed.Entries.Add(CreateChapterWithFile(series, volume, chapter, namingContext, request));
-            }
+            feed.Entries.Add(CreateChapterFeedEntry(series, volume, chapter, namingContext, request));
         }
 
         foreach (var special in seriesDetail.Specials)
         {
             volumesById.TryGetValue(special.VolumeId, out var volume);
 
-            foreach (var mangaFile in special.Files)
-            {
-                // If a chapter has multiple files that are within one chapter, this dict prevents duplicate key exception
-                if (!filesSeen.TryAdd(mangaFile.Id, 0)) continue;
-
-                feed.Entries.Add(CreateChapterWithFile(series, volume, special, namingContext, request));
-            }
+            feed.Entries.Add(CreateChapterFeedEntry(series, volume, special, namingContext, request));
         }
 
         return feed;
@@ -724,10 +669,7 @@ public class OpdsService(
 
         foreach (var chapterDto in volume.Chapters)
         {
-            foreach (var _ in chapterDto.Files)
-            {
-                feed.Entries.Add(CreateChapterWithFile(series, volume, chapterDto, namingContext, request));
-            }
+            feed.Entries.Add(CreateChapterFeedEntry(series, volume, chapterDto, namingContext, request));
         }
 
         return feed;
@@ -769,10 +711,7 @@ public class OpdsService(
         SetFeedId(feed, $"series-{series.Id}-volume-{volumeId}-{chapterId}-files");
 
 
-        foreach (var _ in chapter.Files)
-        {
-            feed.Entries.Add(CreateChapterWithFile(series, volume, chapter, namingContext, request));
-        }
+        feed.Entries.Add(CreateChapterFeedEntry(series, volume, chapter, namingContext, request));
 
         return feed;
     }
@@ -1114,35 +1053,17 @@ public class OpdsService(
         };
     }
 
-    private static FeedEntry CreateChapter(string title, string? summary, int chapterId, int volumeId, int seriesId, IOpdsRequest request)
-    {
-        var _ = UnpackRequest(request, out var apiKey, out var prefix, out var baseUrl);
-        return new FeedEntry()
-        {
-            Id = chapterId.ToString(),
-            Title = title,
-            Summary = summary ?? string.Empty,
-
-            Links =
-            [
-                CreateLink(FeedLinkRelation.SubSection, FeedLinkType.AtomNavigation,
-                    $"{prefix}{apiKey}/series/{seriesId}/volume/{volumeId}/chapter/{chapterId}"),
-                CreateLink(FeedLinkRelation.Image, FeedLinkType.Image,
-                    $"{baseUrl}api/image/chapter-cover?chapterId={chapterId}&apiKey={apiKey}"),
-                CreateLink(FeedLinkRelation.Thumbnail, FeedLinkType.Image,
-                    $"{baseUrl}api/image/chapter-cover?chapterId={chapterId}&apiKey={apiKey}")
-            ]
-        };
-    }
-
-    private FeedEntry CreateChapterWithFile(SeriesDto series, VolumeDto? volume, ChapterDto chapter,
+    private FeedEntry CreateChapterFeedEntry(SeriesDto series, VolumeDto? volume, ChapterDto chapter,
         LocalizedNamingContext namingContext, IOpdsRequest request)
     {
-        var mangaFile = chapter.Files.First();
-        var fileSize = GetFileSize(mangaFile);
-        var fileType = downloadService.GetContentTypeFromFile(mangaFile.FilePath);
-        var filename = Uri.EscapeDataString(Path.GetFileName(mangaFile.FilePath));
+        var fileSize = GetFileSize(chapter);
 
+        var file = chapter.Files.First();
+        // We know chapters can only contain files from the same format so this is fine
+        var fileType = downloadService.GetContentTypeFromFile(file.FilePath);
+        // This isn't really file, as it is wrong. But the filename isn't truly used by the api, see OpdsController.DownloadFile
+        // So it's good enough
+        var filename = Uri.EscapeDataString(Path.GetFileName(file.FilePath));
 
         var title = namingContext.BuildFullTitle(series, volume, chapter);
 
@@ -1155,11 +1076,11 @@ public class OpdsService(
 
         var entry = new FeedEntry
         {
-            Id = mangaFile.Id.ToString(),
+            Id = chapter.Id.ToString(),
             Title = title,
             Extent = fileSize,
             Summary = BuildSummary(fileType, fileSize, chapter.Summary),
-            Format = mangaFile.Format.ToString(),
+            Format = chapter.Format.ToString(),
             Links =
             [
                 CreateLink(FeedLinkRelation.Image, FeedLinkType.Image,
@@ -1177,7 +1098,7 @@ public class OpdsService(
         };
 
         // Page streaming (non-epub only)
-        if (mangaFile.Format != MangaFormat.Epub)
+        if (chapter.Format != MangaFormat.Epub)
         {
             entry.Links.Add(CreatePageStreamLink(series.LibraryId, series.Id, chapter, request));
         }
@@ -1190,12 +1111,18 @@ public class OpdsService(
         return entry;
     }
 
-    private string GetFileSize(MangaFileDto mangaFile)
+    private string GetFileSize(ChapterDto chapter)
     {
-        var fileSize =
-            mangaFile.Bytes > 0 ? DirectoryService.GetHumanReadableBytes(mangaFile.Bytes) :
-                DirectoryService.GetHumanReadableBytes(directoryService.GetTotalSize((List<string>) [mangaFile.FilePath]));
-        return fileSize;
+        var totalSizeFilesWithBytes = chapter.Files
+            .Where(f => f.Bytes > 0)
+            .Sum(f => f.Bytes);
+
+        var totalSizeFilesWithOutBytes = directoryService.GetTotalSize(chapter.Files
+            .Where(f => f.Bytes == 0)
+            .Select(f => f.FilePath)
+        );
+
+        return DirectoryService.GetHumanReadableBytes(totalSizeFilesWithBytes + totalSizeFilesWithOutBytes);
     }
 
 
@@ -1211,10 +1138,14 @@ public class OpdsService(
 
     private FeedEntry CreateReadingListEntry(ReadingListItemDto item, ChapterDto chapter, IOpdsRequest request)
     {
-        var mangaFile = chapter.Files.First();
-        var fileSize = GetFileSize(mangaFile);
-        var fileType = downloadService.GetContentTypeFromFile(mangaFile.FilePath);
-        var filename = Uri.EscapeDataString(Path.GetFileName(mangaFile.FilePath));
+        var fileSize = GetFileSize(chapter);
+
+        var file = chapter.Files.First();
+        // We know chapters can only contain files from the same format so this is fine
+        var fileType = downloadService.GetContentTypeFromFile(file.FilePath);
+        // This isn't really file, as it is wrong. But the filename isn't truly used by the api, see OpdsController.DownloadFile
+        // So it's good enough
+        var filename = Uri.EscapeDataString(Path.GetFileName(file.FilePath));
 
         var title = namingService.FormatReadingListItemTitle(item);
         var displayTitle = $"{item.Order} - {item.SeriesName}: {title}";
@@ -1228,11 +1159,11 @@ public class OpdsService(
 
         var entry = new FeedEntry
         {
-            Id = mangaFile.Id.ToString(),
+            Id = chapter.Id.ToString(),
             Title = displayTitle,
             Extent = fileSize,
-            Summary = BuildSummary(fileType, fileSize, item.Summary),
-            Format = mangaFile.Format.ToString(),
+            Summary = BuildSummary(fileType, fileSize, chapter.Summary),
+            Format = chapter.Format.ToString(),
             Links =
             [
                 CreateLink(FeedLinkRelation.Image, FeedLinkType.Image,
@@ -1250,14 +1181,14 @@ public class OpdsService(
         };
 
         // Page streaming for non-epub
-        if (mangaFile.Format != MangaFormat.Epub)
+        if (chapter.Format != MangaFormat.Epub)
         {
             entry.Links.Add(CreatePageStreamLink(item.LibraryId, item.SeriesId, chapter, request));
         }
 
         if (request.Preferences.EmbedProgressIndicator)
         {
-            entry.Title = $"{GetReadingProgressIcon(item.PagesRead, item.PagesTotal)} {entry.Title}";
+            entry.Title = $"{GetReadingProgressIcon(item.PagesRead, chapter.Pages)} {entry.Title}";
         }
 
         return entry;
@@ -1315,7 +1246,7 @@ public class OpdsService(
     /// </summary>
     private async Task<FeedEntry> CreateContinueReadingEntryAsync( SeriesDto series, VolumeDto? volume, ChapterDto chapter, LocalizedNamingContext namingContext, IOpdsRequest request)
     {
-        var entry = CreateChapterWithFile(series, volume, chapter, namingContext, request);
+        var entry = CreateChapterFeedEntry(series, volume, chapter, namingContext, request);
 
         entry.Title = await localizationService.TranslateAsync(
             request.UserId, "opds-continue-reading-title", entry.Title);

--- a/Kavita.Services/OpdsService.cs
+++ b/Kavita.Services/OpdsService.cs
@@ -1286,11 +1286,10 @@ public class OpdsService(
 
     private static FeedLink CreatePageStreamLink(int libraryId, int seriesId, ChapterDto chapter, IOpdsRequest request)
     {
-        var mangaFile = chapter.Files.First();
         // NOTE: Type could be wrong, there is nothing I can do in the spec
         var link = CreateLink(FeedLinkRelation.Stream, "image/jpeg",
             $"{request.Prefix}{request.ApiKey}/image?libraryId={libraryId}&seriesId={seriesId}&volumeId={chapter.VolumeId}&chapterId={chapter.Id}&pageNumber=" + "{pageNumber}");
-        link.TotalPages = mangaFile.Pages;
+        link.TotalPages = chapter.Pages;
         link.IsPageStream = true;
 
         if (chapter.LastReadingProgressUtc > DateTime.MinValue)

--- a/Kavita.Services/Plus/ExternalMetadataService.cs
+++ b/Kavita.Services/Plus/ExternalMetadataService.cs
@@ -59,6 +59,8 @@ public class ExternalMetadataService : IExternalMetadataService
     private readonly IKavitaPlusApiService _kavitaPlusApiService;
     private readonly IFileCacheService _fileCacheService;
     private readonly IKavitaPlusAuditService _auditService;
+
+    private const int SeriesPerRefresh = 25;
     private readonly TimeSpan _externalSeriesMetadataCache = TimeSpan.FromDays(30);
     private static readonly HashSet<LibraryType> NonEligibleLibraryTypes = [LibraryType.Comic, LibraryType.Image];
     private readonly SeriesDetailPlusDto _defaultReturn = new()
@@ -105,10 +107,11 @@ public class ExternalMetadataService : IExternalMetadataService
     public async Task FetchExternalDataTask(CancellationToken ct = default)
     {
         // Find all Series that are eligible and limit
-        var ids = await _unitOfWork.ExternalSeriesMetadataRepository.GetSeriesThatNeedExternalMetadata(25, ct: ct);
-        if (ids.Count == 0)
+        var ids = await _unitOfWork.ExternalSeriesMetadataRepository.GetSeriesThatNeedExternalMetadata(SeriesPerRefresh, ct: ct);
+        if (ids.Count != SeriesPerRefresh)
         {
-            ids = await _unitOfWork.ExternalSeriesMetadataRepository.GetSeriesThatNeedExternalMetadata(25, true, ct);
+            var wanted = SeriesPerRefresh - ids.Count;
+            ids.AddRange(await _unitOfWork.ExternalSeriesMetadataRepository.GetSeriesThatNeedExternalMetadata(wanted, true, ct));
         }
 
         if (ids.Count == 0)

--- a/Kavita.Services/ReadingLists/CblImportService.cs
+++ b/Kavita.Services/ReadingLists/CblImportService.cs
@@ -253,11 +253,13 @@ public class CblImportService(IUnitOfWork unitOfWork, ICblGithubService cblGithu
             try
             {
                 await urlValidationService.ValidateUrlAsync(coverUrl);
+                var (width, height) = settings.CoverImageSize.GetDimensions();
                 var fileName = await imageService.CreateThumbnailFromUrl(
                     coverUrl,
                     ImageService.GetReadingListFormat(readingList.Id),
                     settings.EncodeMediaAs,
-                    settings.CoverImageSize.GetDimensions().Width);
+                    width,
+                    height);
 
                 if (!string.IsNullOrEmpty(fileName))
                 {

--- a/Kavita.Services/SeriesService.cs
+++ b/Kavita.Services/SeriesService.cs
@@ -153,10 +153,20 @@ public class SeriesService(
                     series.Metadata.Genres, allGenres, genre =>
                     {
                         series.Metadata.Genres.Add(genre);
-                    }, () => series.Metadata.GenresLocked = true);
+                    }, () =>
+                    {
+                        series.Metadata.GenresLocked = true;
+                        series.Metadata.KPlusOverrides.Remove(MetadataSettingField.Genres);
+                    });
             }
             else
             {
+                if (series.Metadata.Genres.Count > 0)
+                {
+                    series.Metadata.GenresLocked = true;
+                    series.Metadata.KPlusOverrides.Remove(MetadataSettingField.Genres);
+                }
+
                 series.Metadata.Genres = [];
             }
 
@@ -171,10 +181,19 @@ public class SeriesService(
                     series.Metadata.Tags, allTags, tag =>
                     {
                         series.Metadata.Tags.Add(tag);
-                    }, () => series.Metadata.TagsLocked = true);
+                    }, () =>
+                    {
+                        series.Metadata.TagsLocked = true;
+                        series.Metadata.KPlusOverrides.Remove(MetadataSettingField.Tags);
+                    });
             }
             else
             {
+                if (series.Metadata.Tags.Count > 0)
+                {
+                    series.Metadata.TagsLocked = true;
+                    series.Metadata.KPlusOverrides.Remove(MetadataSettingField.Tags);
+                }
                 series.Metadata.Tags = [];
             }
 
@@ -414,6 +433,11 @@ public class SeriesService(
         var peopleToRemove = metadataPeople
             .Where(mp => mp.Role == role && peopleToAdd.TrueForAll(p => p.NormalizedName != mp.Person.NormalizedName))
             .ToList();
+
+        if (peopleToRemove.Count != 0 || peopleToAdd.Count != 0)
+        {
+            metadata.KPlusOverrides.Remove(MetadataSettingField.People);
+        }
 
         foreach (var personToRemove in peopleToRemove)
         {

--- a/UI/Web/src/app/_services/reader.service.ts
+++ b/UI/Web/src/app/_services/reader.service.ts
@@ -82,12 +82,13 @@ export class ReaderService {
     })
   }
 
-  openShortcutModal(shortcuts: KeyboardShortcut[]) {
+  openShortcutModal(shortcuts: KeyboardShortcut[], inBookReader: boolean = false) {
     if (this.shortCutModalOpen()) return;
 
     this.shortCutModalOpen.set(true);
     this.shortCutModalRef = this.modalService.open(ShortcutsModalComponent, mediumModal());
     this.shortCutModalRef.setInput('shortcuts', shortcuts);
+    this.shortCutModalRef.setInput('inBookReader', inBookReader);
 
     merge(this.shortCutModalRef.closed, this.shortCutModalRef.dismissed).subscribe(() => this.shortCutModalOpen.set(false));
   }

--- a/UI/Web/src/app/_single-module/details-tab/details-tab.component.html
+++ b/UI/Web/src/app/_single-module/details-tab/details-tab.component.html
@@ -66,7 +66,7 @@
     @if (metadataEntity) {
       <section class="mb-3 ms-1">
         <h4 class="kv-section-header">{{t('external-metadata-title')}}</h4>
-        <app-external-metadata-detail [entity]="metadataEntity" [isbn]="isbn()" />
+        <app-external-metadata-detail [entity]="metadataEntity" [isbn]="isbn()" [individualWork]="individualWork()" />
       </section>
     }
 

--- a/UI/Web/src/app/_single-module/details-tab/details-tab.component.ts
+++ b/UI/Web/src/app/_single-module/details-tab/details-tab.component.ts
@@ -93,6 +93,7 @@ export class DetailsTabComponent {
   webLinks = input<string[]>([]);
   suppressEmptyGenres = input<boolean>(false);
   suppressEmptyTags = input<boolean>(false);
+  individualWork = input<boolean>(false);
   filePaths = input<string[]>([]);
   files = input<MangaFile[]>([]);
   basicMetadata = input<BasicMetadataInfo>();

--- a/UI/Web/src/app/admin/manage-library/manage-library.component.ts
+++ b/UI/Web/src/app/admin/manage-library/manage-library.component.ts
@@ -283,7 +283,7 @@ export class ManageLibraryComponent implements OnInit {
 
         // Prompt the user for the library, then wait for them to manually trigger applyBulkAction
         const ref = this.modalService.open(CopySettingsFromLibraryModalComponent, {size: 'lg', fullscreen: 'md'});
-        ref.componentInstance.libraries = this.libraries;
+        ref.setInput('libraries', this.libraries);
         ref.closed.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((res: number) => {
           // res will be the library the user chose
           this.bulkMode = true;

--- a/UI/Web/src/app/admin/manage-open-idconnect/manage-open-idconnect.component.html
+++ b/UI/Web/src/app/admin/manage-open-idconnect/manage-open-idconnect.component.html
@@ -177,7 +177,7 @@
 
         <div class="row g-0 mt-4 mb-4">
           @if(settingsForm.get('disablePasswordAuthentication'); as formControl) {
-            <app-setting-switch [title]="t('disable-password-authentication-label')" [subtitle]="t('disable-password-authentication-tooltip')">
+            <app-setting-switch [title]="t('disable-password-authentication-label')">
               <ng-template #switch>
                 <div class="form-check form-switch float-end">
                   <input id="disable-password-authentication" type="checkbox" class="form-check-input" formControlName="disablePasswordAuthentication">

--- a/UI/Web/src/app/book-reader/_components/_drawers/view-edit-annotation-drawer/view-edit-annotation-drawer.component.ts
+++ b/UI/Web/src/app/book-reader/_components/_drawers/view-edit-annotation-drawer/view-edit-annotation-drawer.component.ts
@@ -360,7 +360,12 @@ export class ViewEditAnnotationDrawerComponent implements OnInit {
     const annotation = this.annotation();
     if (!annotation) return;
 
-    if (!await this.confirmService.confirm(translate('toasts.confirm-delete-annotation'))) return;
+    const config = {
+      ...this.confirmService.defaultConfirm,
+      bookReader: true,
+    };
+
+    if (!await this.confirmService.confirm(translate('toasts.confirm-delete-annotation'), config)) return;
 
     this.annotationService.deleteAnnotation(annotation).subscribe(_ => {
       this.drawerService.dismiss();

--- a/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.ts
+++ b/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.ts
@@ -2439,7 +2439,7 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   openShortcutModal() {
-    this.readerService.openShortcutModal(KEYBIND_TARGETS);
+    this.readerService.openShortcutModal(KEYBIND_TARGETS, true);
   }
 
 

--- a/UI/Web/src/app/cards/cover-image-chooser/cover-image-chooser.component.ts
+++ b/UI/Web/src/app/cards/cover-image-chooser/cover-image-chooser.component.ts
@@ -1,4 +1,13 @@
-import {ChangeDetectionStrategy, Component, effect, inject, input, output, signal} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  effect,
+  inject,
+  input,
+  output,
+  signal
+} from '@angular/core';
 import {FileSystemFileEntry, NgxFileDropEntry} from 'ngx-file-drop';
 import {ToastrService} from 'ngx-toastr';
 import {ImageService} from 'src/app/_services/image.service';
@@ -35,9 +44,10 @@ import {NgTemplateOutlet} from "@angular/common";
 })
 export class CoverImageChooserComponent  {
 
-  public readonly imageService = inject(ImageService);
+  protected readonly imageService = inject(ImageService);
   private readonly toastr = inject(ToastrService);
   private readonly uploadService = inject(UploadService);
+  private readonly cdRef = inject(ChangeDetectorRef);
 
   config = input<CoverImageChooserConfig>({});
 
@@ -97,6 +107,7 @@ export class CoverImageChooserComponent  {
     const isDirty = sourceTab !== Tabs.Current;
 
     this.activeTabId = sourceTab;
+    this.cdRef.markForCheck();
 
     if (!isDirty) {
       // Selecting the existing cover - nothing to stage or upload.

--- a/UI/Web/src/app/cards/cover-image-chooser/cover-image-chooser.component.ts
+++ b/UI/Web/src/app/cards/cover-image-chooser/cover-image-chooser.component.ts
@@ -96,6 +96,8 @@ export class CoverImageChooserComponent  {
     this.selectedOptionKey.set(option.url);
     const isDirty = sourceTab !== Tabs.Current;
 
+    this.activeTabId = sourceTab;
+
     if (!isDirty) {
       // Selecting the existing cover - nothing to stage or upload.
       this.coverChanged.emit({ isDirty, fileName: '' });

--- a/UI/Web/src/app/chapter-detail/chapter-detail.component.html
+++ b/UI/Web/src/app/chapter-detail/chapter-detail.component.html
@@ -177,6 +177,7 @@
                                  [webLinks]="weblinks()"
                                  [files]="chapterValue.files"
                                  [basicMetadata]="chapterBasicMetadata()"
+                                 [individualWork]="true"
                 />
               }
             </ng-template>

--- a/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.ts
+++ b/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.ts
@@ -505,7 +505,8 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
         return this.bookmarks[this.pageNum];
       }
 
-      return chapterInfo?.chapterTitle || chapterInfo?.subtitle || '';
+      // chapterInfo.chapterTitle is already contained in title if present
+      return chapterInfo?.subtitle || '';
     });
 
     this.keyBindService.registerListener(

--- a/UI/Web/src/app/reader-shared/_modals/shortcuts-modal/shortcuts-modal.component.html
+++ b/UI/Web/src/app/reader-shared/_modals/shortcuts-modal/shortcuts-modal.component.html
@@ -1,9 +1,9 @@
 <ng-container *transloco="let t; prefix: 'shortcuts-modal'">
-  <div class="modal-header">
+  <div class="modal-header" [class.book-reader]="inBookReader()">
     <h4 class="modal-title" id="modal-basic-title">{{ t('title') }}</h4>
     <button type="button" class="btn-close" [attr.aria-label]="t('close')" (click)="modal.close()"></button>
   </div>
-  <div class="modal-body">
+  <div class="modal-body" [class.book-reader]="inBookReader()">
     <div class="row g-0">
       @for(shortcut of shortcuts(); track shortcut.keyBindTarget ?? shortcut.key ?? $index) {
         @if (shortcut.keyBindTarget) {
@@ -36,7 +36,7 @@
       }
     </div>
   </div>
-  <div class="modal-footer">
+  <div class="modal-footer" [class.book-reader]="inBookReader()">
     <button type="button" class="btn btn-primary" (click)="modal.close()">{{ t('close') }}</button>
   </div>
 </ng-container>

--- a/UI/Web/src/app/reader-shared/_modals/shortcuts-modal/shortcuts-modal.component.scss
+++ b/UI/Web/src/app/reader-shared/_modals/shortcuts-modal/shortcuts-modal.component.scss
@@ -1,0 +1,5 @@
+
+.book-reader {
+  color: var(--drawer-text-color);
+  background-color: var(--drawer-bg-color);
+}

--- a/UI/Web/src/app/reader-shared/_modals/shortcuts-modal/shortcuts-modal.component.ts
+++ b/UI/Web/src/app/reader-shared/_modals/shortcuts-modal/shortcuts-modal.component.ts
@@ -34,4 +34,6 @@ export class ShortcutsModalComponent {
   protected readonly modal = inject(NgbActiveModal);
 
   shortcuts = input<KeyboardShortcut[]>([]);
+  inBookReader = input<boolean>(false);
+
 }

--- a/UI/Web/src/app/registration/user-login/user-login.component.ts
+++ b/UI/Web/src/app/registration/user-login/user-login.component.ts
@@ -56,11 +56,6 @@ export class UserLoginComponent implements OnInit {
    * undefined until query params are read
    */
   skipAutoLogin = signal<boolean | undefined>(undefined);
-  /**
-   * Display the login form, regardless if the password authentication is disabled (admins can still log in)
-   * Set from query
-   */
-  forceShowPasswordLogin = signal(false);
   oidcConfig = signal<OidcPublicConfig | undefined>(undefined);
 
   /**
@@ -69,8 +64,6 @@ export class UserLoginComponent implements OnInit {
   showPasswordLogin = computed(() => {
     const loaded = this.isLoaded();
     const config = this.oidcConfig();
-    const force = this.forceShowPasswordLogin();
-    if (force) return true;
 
     return loaded && config && !(config.enabled && config.disablePasswordAuthentication);
   });
@@ -122,7 +115,6 @@ export class UserLoginComponent implements OnInit {
       }
 
       this.skipAutoLogin.set(params.get('skipAutoLogin') === 'true')
-      this.forceShowPasswordLogin.set(params.get('forceShowPassword') === 'true');
 
       const error = params.get('error');
       if (!error) return;

--- a/UI/Web/src/app/shared/_components/external-metadata-detail/external-metadata-detail.component.ts
+++ b/UI/Web/src/app/shared/_components/external-metadata-detail/external-metadata-detail.component.ts
@@ -15,6 +15,11 @@ const URLS = {
   cbrId: null,
 }
 
+const INDIVIDUAL_URLS = {
+  ...URLS,
+  hardcoverId: 'https://hardcover.app/id/book/{id}',
+}
+
 @Component({
   selector: 'app-external-metadata-detail',
   imports: [
@@ -32,12 +37,20 @@ export class ExternalMetadataDetailComponent {
   /** Extra id to show in this section for details-tab */
   isbn = input<string | null>(null);
 
+  /**
+   * Assume ids link to individual works instead of series where applicable
+   */
+  individualWork = input<boolean>(false);
+
   metadata = computed(() => {
     const e = this.entity();
+    const urls = this.individualWork() ? INDIVIDUAL_URLS : URLS;
+
     return (Object.keys(HAS_METADATA_DEFAULTS) as (keyof IHasMetadataIds)[]).map(key => {
       const rawValue = e[key];
       const value = rawValue === 0 || rawValue == null ? null : rawValue;
-      const urlTemplate = URLS[key];
+
+      const urlTemplate = urls[key];
       const linkUrl = urlTemplate && value != null ? urlTemplate.replace('{id}', String(value)) : null;
 
       return { key, value, linkUrl };

--- a/UI/Web/src/app/sidenav/_components/side-nav-item/side-nav-item.component.html
+++ b/UI/Web/src/app/sidenav/_components/side-nav-item/side-nav-item.component.html
@@ -52,7 +52,7 @@
         <div>
           {{title()}}
           @if (badgeCount() > 0) {
-            <span class="badge bg-danger rounded-pill ms-2">{{badgeCount()}}</span>
+            <span class="badge bg-danger rounded-pill ms-2">{{badgeCount() | compactNumber}}</span>
           }
         </div>
     </span>

--- a/UI/Web/src/app/sidenav/_components/side-nav-item/side-nav-item.component.ts
+++ b/UI/Web/src/app/sidenav/_components/side-nav-item/side-nav-item.component.ts
@@ -15,11 +15,12 @@ import {NgClass, NgTemplateOutlet} from "@angular/common";
 import {ImageComponent} from "../../../shared/image/image.component";
 import {UtilityService} from "../../../shared/_services/utility.service";
 import {BreakpointService} from "../../../_services/breakpoint.service";
+import {CompactNumberPipe} from "../../../_pipes/compact-number.pipe";
 
 
 @Component({
   selector: 'app-side-nav-item',
-  imports: [RouterLink, ImageComponent, NgTemplateOutlet, NgClass],
+  imports: [RouterLink, ImageComponent, NgTemplateOutlet, NgClass, CompactNumberPipe],
   templateUrl: './side-nav-item.component.html',
   styleUrls: ['./side-nav-item.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush

--- a/UI/Web/src/app/volume-detail/volume-detail.component.html
+++ b/UI/Web/src/app/volume-detail/volume-detail.component.html
@@ -233,6 +233,7 @@
                                [tags]="tags()"
                                [files]="files()"
                                [basicMetadata]="volumeBasicMetadata()"
+                               [individualWork]="true"
               />
             }
           </ng-template>

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -72,8 +72,7 @@
         "sync-user-settings-tooltip": "Users created via OIDC will be fully managed by the identity provider, including roles, library access, and age rating. If this option is disabled, users will not have access to any content after account creation. Refer to the documentation for more details.",
         "auto-login-label": "Auto login",
         "auto-login-tooltip": "Auto redirect to OIDC provider when opening the login screen",
-        "disable-password-authentication-label": "Disable password authentication",
-        "disable-password-authentication-tooltip": "Users with the admin role can bypass this restriction",
+        "disable-password-authentication-label": "Disable password authentication"
         "provider-name-label": "Provider name",
         "provider-name-tooltip": "Name shown on the login screen",
 

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -1569,6 +1569,7 @@
         "filter-metadata": "Metadata",
         "filter-scrobble": "Scrobble",
         "filter-sync": "Sync",
+        "filter-system": "System",
         "filter-status-label": "Status filter",
         "today": "Today",
         "yesterday": "Yesterday",

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -72,7 +72,7 @@
         "sync-user-settings-tooltip": "Users created via OIDC will be fully managed by the identity provider, including roles, library access, and age rating. If this option is disabled, users will not have access to any content after account creation. Refer to the documentation for more details.",
         "auto-login-label": "Auto login",
         "auto-login-tooltip": "Auto redirect to OIDC provider when opening the login screen",
-        "disable-password-authentication-label": "Disable password authentication"
+        "disable-password-authentication-label": "Disable password authentication",
         "provider-name-label": "Provider name",
         "provider-name-tooltip": "Name shown on the login screen",
 

--- a/UI/Web/src/theme/components/_anchors.scss
+++ b/UI/Web/src/theme/components/_anchors.scss
@@ -1,4 +1,4 @@
-a:not(.dark-exempt):not(.btn) {
+a:not(.dark-exempt, .btn) {
     color: var(--primary-color);
     > i {
       color: var(--primary-color);


### PR DESCRIPTION
# Changed
- Changed: Badges on the settings nav bar will now use compact numbers
- Changed: Disable password authentication (OIDC) now disabled it for everyone. In case of issues remove your OIDC config from appsettings.json (Closes #4749)
- Changed: Multi-file chapters will now only have one entry in OPDS feeds. Consumers can read and download everything from this entry
- Changed: The cover uploader will now automatically select the upload tab after uploading an image

# Fixed
- Fixed: Fixed the shortcuts modal not respecting the book theme in the book reader
- Fixed: Fixed hardcover not linking to books on the volume & chapter details page (develop)
- Fixed: Fixed the confirm prompt for deleting annotations not respecting the book theme in the book reader
- Fixed: Fixed annotations sometimes duplicating characters (Fixes #4375 again)
- Fixed: Fixed missing translations for the Kavita+ admin audit log page (develop)
- Fixed: Fixed Copy Settings From modal not opening on the manage library page (Fixes #4750)
- Fixed: Fixed only one collection tag statement being taken into account in the series filter (Fixes #4748)
- Fixed: Fixed the chapter title being displayed twice in the manga reader. And Vol. & Ch. numbers not being displayed
- Fixed: Fixed uploaded thumbnails not always respecting the configured cover image size (Fixes https://github.com/Kareadita/Kavita/issues/4148) (Thanks @KobraKid !)
- Fixed: Fixed several issues with multi-page chapters in our OPDS implementation. (Fixes #4382) (Thanks @TipToe08 !)
- Fixed: Fixed no stale metadata being refresh at night when at least one series has none at all
- Fixed: Fixed side nav not updating after deleting a smart filter
- Fixed: Fixed KPlus ownership of metadata fields not always being removed causing it to sometimes overwrite fields that were changed and locked in the UI
