### PR TITLE
Fix non-passive touch event listeners on EntityCardComponent

### DIFF
--- a/UI/Web/src/app/cards/entity-card/entity-card.component.ts
+++ b/UI/Web/src/app/cards/entity-card/entity-card.component.ts
@@ -4,6 +4,7 @@ import {
   Component,
   computed,
   DestroyRef,
+  ElementRef,
   HostListener,
   inject,
   input,
@@ -66,6 +67,7 @@ import {UserProgressUpdateEvent} from "../../_models/events/user-progress-update
 export class EntityCardComponent<T> implements OnInit {
   private readonly cdRef = inject(ChangeDetectorRef);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly elementRef = inject(ElementRef);
   private readonly scrollService = inject(ScrollService);
   private readonly themeService = inject(ThemeService);
   private readonly messageHub = inject(MessageHubService);
@@ -255,6 +257,18 @@ export class EntityCardComponent<T> implements OnInit {
 
   ngOnInit() {
     this.setupProgressTracking();
+    const el = this.elementRef.nativeElement;
+    const onTouchMove = () => {
+      if (!this.config().allowSelection) return;
+      this.selectionInProgress = false;
+      this.cdRef.markForCheck();
+    };
+    el.addEventListener('touchmove', onTouchMove, { passive: true });
+    this.destroyRef.onDestroy(() => el.removeEventListener('touchmove', onTouchMove));
+
+    const onTouchStart = (event: TouchEvent) => this.onTouchStart(event);
+    el.addEventListener('touchstart', onTouchStart, { passive: true });
+    this.destroyRef.onDestroy(() => el.removeEventListener('touchstart', onTouchStart));
   }
 
   private setupProgressTracking() {
@@ -307,14 +321,6 @@ export class EntityCardComponent<T> implements OnInit {
     this.progressUpdated.emit(result);
   }
 
-  @HostListener('touchmove')
-  onTouchMove() {
-    if (!this.config().allowSelection) return;
-    this.selectionInProgress = false;
-    this.cdRef.markForCheck();
-  }
-
-  @HostListener('touchstart', ['$event'])
   onTouchStart(event: TouchEvent) {
     if (!this.config().allowSelection) return;
     this.prevTouchTime = event.timeStamp;


### PR DESCRIPTION
Fixes scroll-blocking violations caused by non-passive touch event listeners on entity cards with large series (100+ issues).

Angular's @HostListener has no mechanism to register passive event listeners. This replaces touchmove and touchstart handlers with manual addEventListener calls using { passive: true }, properly wired up in ngOnInit and cleaned up via destroyRef.onDestroy().

The touchend listener remains non-passive since its handler calls preventDefault() to suppress tap-after-long-press navigation.