### PR TITLE
Fixed: Inverted greater/less than comparisons on the Read Last filter

### DIFF
--- a/Kavita.Database/Extensions/Filters/SeriesFilter.cs
+++ b/Kavita.Database/Extensions/Filters/SeriesFilter.cs
@@ -319,24 +319,33 @@ public static class SeriesFilter
 
             var date = DateTime.Now.AddDays(-timeDeltaDays);
 
+            // ReadLast filters on the number of days since the series was last read, not on a raw date.
+            // A larger day-delta means the series was last read further in the past, i.e. an *earlier*
+            // MaxDate, so the numeric comparisons are inverted relative to the date they map to. For
+            // example 'read last greater than 30 days' means 'haven't read in over a month', which is
+            // MaxDate < date. (See #4716)
             switch (comparison)
             {
                 case FilterComparison.Equal:
                     subQuery = subQuery.Where(s => s.MaxDate != null && s.MaxDate.Equals(date));
                     break;
-                case FilterComparison.IsAfter:
                 case FilterComparison.GreaterThan:
-                    subQuery = subQuery.Where(s => s.MaxDate != null && s.MaxDate > date);
-                    break;
-                case FilterComparison.GreaterThanEqual:
-                    subQuery = subQuery.Where(s => s.MaxDate != null && s.MaxDate >= date);
-                    break;
-                case FilterComparison.IsBefore:
-                case FilterComparison.LessThan:
                     subQuery = subQuery.Where(s => s.MaxDate != null && s.MaxDate < date);
                     break;
-                case FilterComparison.LessThanEqual:
+                case FilterComparison.GreaterThanEqual:
                     subQuery = subQuery.Where(s => s.MaxDate != null && s.MaxDate <= date);
+                    break;
+                case FilterComparison.LessThan:
+                    subQuery = subQuery.Where(s => s.MaxDate != null && s.MaxDate > date);
+                    break;
+                case FilterComparison.LessThanEqual:
+                    subQuery = subQuery.Where(s => s.MaxDate != null && s.MaxDate >= date);
+                    break;
+                case FilterComparison.IsAfter:
+                    subQuery = subQuery.Where(s => s.MaxDate != null && s.MaxDate > date);
+                    break;
+                case FilterComparison.IsBefore:
+                    subQuery = subQuery.Where(s => s.MaxDate != null && s.MaxDate < date);
                     break;
                 case FilterComparison.NotEqual:
                     subQuery = subQuery.Where(s => s.MaxDate != null && !s.MaxDate.Equals(date));

--- a/Kavita.Server.Tests/ManualMigrations/ManualMigrateReadLastSmartFilterComparisonTests.cs
+++ b/Kavita.Server.Tests/ManualMigrations/ManualMigrateReadLastSmartFilterComparisonTests.cs
@@ -1,0 +1,108 @@
+using System.Linq;
+using Kavita.Models.DTOs.Filtering.v2;
+using Kavita.Models.DTOs.Filtering.v2.Requests;
+using Kavita.Server.ManualMigrations.v0._9._1;
+using Kavita.Services.Helpers.SmartFilter;
+
+namespace Kavita.Server.Tests.ManualMigrations;
+
+public class ManualMigrateReadLastSmartFilterComparisonTests
+{
+    private static string Encode(params SeriesFilterStatementDto[] statements)
+    {
+        var dto = new SeriesFilterV2Dto();
+        foreach (var statement in statements)
+        {
+            dto.Statements.Add(statement);
+        }
+
+        return SmartFilterHelper.Encode(dto);
+    }
+
+    private static SeriesFilterStatementDto Statement(SeriesFilterField field, FilterComparison comparison, string value = "30")
+    {
+        return new SeriesFilterStatementDto
+        {
+            Field = field,
+            Comparison = comparison,
+            Value = value
+        };
+    }
+
+    private static SeriesFilterV2Dto Decode(string encoded)
+    {
+        return (SeriesFilterV2Dto) SmartFilterHelper.Decode(encoded);
+    }
+
+    [Theory]
+    [InlineData(FilterComparison.GreaterThan, FilterComparison.LessThan)]
+    [InlineData(FilterComparison.LessThan, FilterComparison.GreaterThan)]
+    [InlineData(FilterComparison.GreaterThanEqual, FilterComparison.LessThanEqual)]
+    [InlineData(FilterComparison.LessThanEqual, FilterComparison.GreaterThanEqual)]
+    public void FlipsNumericReadLastComparison(FilterComparison stored, FilterComparison expected)
+    {
+        var encoded = Encode(Statement(SeriesFilterField.ReadLast, stored));
+
+        var migrated = ManualMigrateReadLastSmartFilterComparison.FlipReadLastComparisons(encoded);
+        var dto = Decode(migrated);
+
+        var statement = Assert.Single(dto.Statements);
+        Assert.Equal(SeriesFilterField.ReadLast, statement.Field);
+        Assert.Equal(expected, statement.Comparison);
+        // Value must be preserved exactly.
+        Assert.Equal("30", statement.Value);
+    }
+
+    [Theory]
+    [InlineData(FilterComparison.Equal)]
+    [InlineData(FilterComparison.NotEqual)]
+    [InlineData(FilterComparison.IsAfter)]
+    [InlineData(FilterComparison.IsBefore)]
+    public void LeavesNonNumericReadLastComparisonUntouched(FilterComparison comparison)
+    {
+        var encoded = Encode(Statement(SeriesFilterField.ReadLast, comparison));
+
+        var migrated = ManualMigrateReadLastSmartFilterComparison.FlipReadLastComparisons(encoded);
+
+        // No numeric operator to flip -> the encoded string is returned unchanged.
+        Assert.Equal(encoded, migrated);
+        Assert.Equal(comparison, Assert.Single(Decode(migrated).Statements).Comparison);
+    }
+
+    [Fact]
+    public void LeavesNonReadLastStatementsUntouched()
+    {
+        // A filter without any Read Last statement must round-trip unchanged.
+        var encoded = Encode(
+            Statement(SeriesFilterField.AgeRating, FilterComparison.GreaterThan, "10"),
+            Statement(SeriesFilterField.ReadProgress, FilterComparison.LessThanEqual, "50"));
+
+        var migrated = ManualMigrateReadLastSmartFilterComparison.FlipReadLastComparisons(encoded);
+
+        Assert.Equal(encoded, migrated);
+    }
+
+    [Fact]
+    public void OnlyFlipsReadLastStatementInAMixedFilter()
+    {
+        var encoded = Encode(
+            Statement(SeriesFilterField.AgeRating, FilterComparison.GreaterThan, "10"),
+            Statement(SeriesFilterField.ReadLast, FilterComparison.GreaterThan, "30"),
+            Statement(SeriesFilterField.ReadProgress, FilterComparison.LessThan, "50"));
+
+        var migrated = ManualMigrateReadLastSmartFilterComparison.FlipReadLastComparisons(encoded);
+        var dto = Decode(migrated);
+
+        var ageRating = dto.Statements.Single(s => s.Field == SeriesFilterField.AgeRating);
+        var readLast = dto.Statements.Single(s => s.Field == SeriesFilterField.ReadLast);
+        var readProgress = dto.Statements.Single(s => s.Field == SeriesFilterField.ReadProgress);
+
+        // Only the Read Last statement flips; the others keep both their operator and value.
+        Assert.Equal(FilterComparison.GreaterThan, ageRating.Comparison);
+        Assert.Equal("10", ageRating.Value);
+        Assert.Equal(FilterComparison.LessThan, readLast.Comparison);
+        Assert.Equal("30", readLast.Value);
+        Assert.Equal(FilterComparison.LessThan, readProgress.Comparison);
+        Assert.Equal("50", readProgress.Value);
+    }
+}

--- a/Kavita.Server/ManualMigrations/v0.9.1/ManualMigrateReadLastSmartFilterComparison.cs
+++ b/Kavita.Server/ManualMigrations/v0.9.1/ManualMigrateReadLastSmartFilterComparison.cs
@@ -1,0 +1,97 @@
+using System.Threading.Tasks;
+using Kavita.Database;
+using Kavita.Models.DTOs.Filtering.v2;
+using Kavita.Models.DTOs.Filtering.v2.Requests;
+using Kavita.Services.Helpers.SmartFilter;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Kavita.Server.ManualMigrations.v0._9._1;
+
+/// <summary>
+/// The "Read Last" Series smart filter compares on days-since-last-read, which maps to a cutoff date of
+/// <c>Now - N days</c>. A larger day count therefore corresponds to an *earlier* last-read date, so the numeric
+/// comparisons had been applied inverted (see #4716). The code fix flips GreaterThan/LessThan (and their -OrEqual
+/// variants) for this field. Existing saved smart filters were built against the old (inverted) behaviour, so this
+/// migration flips those same numeric operators on every stored "Read Last" statement. The net effect is that a
+/// saved filter keeps returning exactly the same series it did before the fix.
+/// </summary>
+/// <remarks>
+/// Only GreaterThan &lt;-&gt; LessThan and GreaterThanEqual &lt;-&gt; LessThanEqual are flipped. Equal/NotEqual are
+/// symmetric, and IsAfter/IsBefore keep raw-date semantics in both the old and new code, so none of those change.
+/// Only <see cref="SeriesFilterField.ReadLast"/> statements are touched; every other field and filter is left as-is.
+/// </remarks>
+public class ManualMigrateReadLastSmartFilterComparison : ManualMigration
+{
+    protected override string MigrationName => nameof(ManualMigrateReadLastSmartFilterComparison);
+
+    protected override async Task ExecuteAsync(DataContext context, ILogger<Program> logger)
+    {
+        var filters = await context.AppUserSmartFilter.ToListAsync();
+        if (filters.Count == 0) return;
+
+        var updated = 0;
+        foreach (var filter in filters)
+        {
+            var migrated = FlipReadLastComparisons(filter.Filter);
+            if (migrated == filter.Filter) continue;
+
+            filter.Filter = migrated;
+            updated++;
+        }
+
+        if (updated > 0)
+        {
+            await context.SaveChangesAsync();
+        }
+
+        logger.LogInformation("[ManualMigrateReadLastSmartFilterComparison] Corrected Read Last comparison(s) in {Count} smart filter(s)", updated);
+    }
+
+    /// <summary>
+    /// Decodes an encoded smart filter, inverts the numeric comparison on any "Read Last" statement, and re-encodes.
+    /// Returns the original string unchanged when the filter is not a Series filter or has no numeric Read Last
+    /// statement to flip. Exposed for unit testing.
+    /// </summary>
+    public static string FlipReadLastComparisons(string encodedFilter)
+    {
+        if (SmartFilterHelper.Decode(encodedFilter) is not SeriesFilterV2Dto dto) return encodedFilter;
+        if (!FlipReadLastStatements(dto)) return encodedFilter;
+
+        return SmartFilterHelper.Encode(dto);
+    }
+
+    /// <summary>
+    /// Flips the numeric comparison operator on every <see cref="SeriesFilterField.ReadLast"/> statement in place.
+    /// Returns <c>true</c> when at least one statement was changed.
+    /// </summary>
+    public static bool FlipReadLastStatements(SeriesFilterV2Dto dto)
+    {
+        var changed = false;
+        foreach (var statement in dto.Statements)
+        {
+            if (statement.Field != SeriesFilterField.ReadLast) continue;
+
+            var flipped = FlipComparison(statement.Comparison);
+            if (flipped == statement.Comparison) continue;
+
+            statement.Comparison = flipped;
+            changed = true;
+        }
+
+        return changed;
+    }
+
+    /// <summary>
+    /// Inverts the numeric comparison operators. All non-numeric comparisons (Equal, NotEqual, IsAfter, IsBefore, ...)
+    /// are returned unchanged because their semantics did not change with the #4716 fix.
+    /// </summary>
+    private static FilterComparison FlipComparison(FilterComparison comparison) => comparison switch
+    {
+        FilterComparison.GreaterThan => FilterComparison.LessThan,
+        FilterComparison.LessThan => FilterComparison.GreaterThan,
+        FilterComparison.GreaterThanEqual => FilterComparison.LessThanEqual,
+        FilterComparison.LessThanEqual => FilterComparison.GreaterThanEqual,
+        _ => comparison
+    };
+}

--- a/Kavita.Server/Startup.cs
+++ b/Kavita.Server/Startup.cs
@@ -533,6 +533,7 @@ public class Startup
                     await new ManualMigrationOAuthMigration().RunAsync(dataContext, logger);
                     await new ManualMigrateRelationshipAuditHistory().RunAsync(dataContext, logger);
                     await new ManualMigrationSetDefaultMetadataProvidersForLibrary().RunAsync(dataContext, logger);
+                    await new ManualMigrateReadLastSmartFilterComparison().RunAsync(dataContext, logger);
 
                     #endregion
 

--- a/Kavita.Services.Tests/Extensions/SeriesFilterTests.cs
+++ b/Kavita.Services.Tests/Extensions/SeriesFilterTests.cs
@@ -1102,7 +1102,125 @@ public class SeriesFilterTests(ITestOutputHelper outputHelper): AbstractDbTest(o
 
     #region HasReadLast
 
+    /// <summary>
+    /// Creates two series with reading progress: 'Recent' was last read today and 'Old' was last read 30 days ago.
+    /// </summary>
+    private async Task<AppUser> SetupHasReadLast(IUnitOfWork unitOfWork, DataContext context)
+    {
+        var library = new LibraryBuilder("Manga")
+            .WithSeries(new SeriesBuilder("Recent").WithPages(10)
+                .WithVolume(new VolumeBuilder("1")
+                    .WithChapter(new ChapterBuilder("1").WithPages(10).Build())
+                    .Build())
+                .Build())
+            .WithSeries(new SeriesBuilder("Old").WithPages(10)
+                .WithVolume(new VolumeBuilder("1")
+                    .WithChapter(new ChapterBuilder("1").WithPages(10).Build())
+                    .Build())
+                .Build())
+            .Build();
+        var user = new AppUserBuilder("user", "user@gmail.com")
+            .WithLibrary(library)
+            .Build();
 
+        context.Users.Add(user);
+        await context.SaveChangesAsync();
+
+        var readerService = new ReaderService(unitOfWork, Substitute.For<ILogger<ReaderService>>(),
+            Substitute.For<IEventHub>(), Substitute.For<IImageService>(),
+            Substitute.For<IDirectoryService>(), Substitute.For<IScrobblingService>(),
+            Substitute.For<IReadingSessionService>(), Substitute.For<IClientInfoAccessor>(),
+            Substitute.For<ISeriesService>(), Substitute.For<IEntityNamingService>(),
+            Substitute.For<ILocalizationService>(), Substitute.For<IBookService>());
+
+        var recentSeries = await unitOfWork.SeriesRepository.GetSeriesByIdAsync(1);
+        var recentChapter = recentSeries.Volumes.First().Chapters.First();
+        Assert.True(await readerService.SaveReadingProgress(new ProgressDto()
+        {
+            ChapterId = recentChapter.Id,
+            LibraryId = 1,
+            SeriesId = recentSeries.Id,
+            PageNum = 5,
+            VolumeId = recentChapter.VolumeId
+        }, user.Id));
+
+        var oldSeries = await unitOfWork.SeriesRepository.GetSeriesByIdAsync(2);
+        var oldChapter = oldSeries.Volumes.First().Chapters.First();
+        Assert.True(await readerService.SaveReadingProgress(new ProgressDto()
+        {
+            ChapterId = oldChapter.Id,
+            LibraryId = 1,
+            SeriesId = oldSeries.Id,
+            PageNum = 5,
+            VolumeId = oldChapter.VolumeId
+        }, user.Id));
+
+        // Back-date the 'Old' progress to 30 days ago. ExecuteUpdate bypasses change tracking so the
+        // DataContext IEntityDate hook doesn't reset LastModified back to now.
+        var thirtyDaysAgo = DateTime.Now.AddDays(-30);
+        await context.AppUserProgresses
+            .Where(p => p.SeriesId == oldSeries.Id)
+            .ExecuteUpdateAsync(setters => setters
+                .SetProperty(p => p.LastModified, thirtyDaysAgo)
+                .SetProperty(p => p.LastModifiedUtc, thirtyDaysAgo.ToUniversalTime()));
+
+        return user;
+    }
+
+    [Fact]
+    public async Task HasReadLast_GreaterThan_ReturnsSeriesNotReadRecently()
+    {
+        // 'Read Last greater than 10 days' means the last read was more than 10 days ago, i.e. 'Old'.
+        var (unitOfWork, context, _) = await CreateDatabase();
+        var user = await SetupHasReadLast(unitOfWork, context);
+
+        var queryResult = await context.Series.HasReadLast(true, FilterComparison.GreaterThan, 10, user.Id)
+            .ToListAsync();
+
+        Assert.Single(queryResult);
+        Assert.Equal("Old", queryResult.First().Name);
+    }
+
+    [Fact]
+    public async Task HasReadLast_LessThan_ReturnsSeriesReadRecently()
+    {
+        // 'Read Last less than 10 days' means the last read was within the last 10 days, i.e. 'Recent'.
+        var (unitOfWork, context, _) = await CreateDatabase();
+        var user = await SetupHasReadLast(unitOfWork, context);
+
+        var queryResult = await context.Series.HasReadLast(true, FilterComparison.LessThan, 10, user.Id)
+            .ToListAsync();
+
+        Assert.Single(queryResult);
+        Assert.Equal("Recent", queryResult.First().Name);
+    }
+
+    [Fact]
+    public async Task HasReadLast_GreaterThanEqual_IncludesBoundary()
+    {
+        // Boundary of exactly 30 days should include the 'Old' series (read 30 days ago) for 'more than or
+        // equal to' 30 days, and exclude the 'Recent' series read today.
+        var (unitOfWork, context, _) = await CreateDatabase();
+        var user = await SetupHasReadLast(unitOfWork, context);
+
+        var queryResult = await context.Series.HasReadLast(true, FilterComparison.GreaterThanEqual, 30, user.Id)
+            .ToListAsync();
+
+        Assert.Single(queryResult);
+        Assert.Equal("Old", queryResult.First().Name);
+    }
+
+    [Fact]
+    public async Task HasReadLast_ConditionFalse_ReturnsAll()
+    {
+        var (unitOfWork, context, _) = await CreateDatabase();
+        await SetupHasReadLast(unitOfWork, context);
+
+        var queryResult = await context.Series.HasReadLast(false, FilterComparison.GreaterThan, 10, 1)
+            .ToListAsync();
+
+        Assert.Equal(2, queryResult.Count);
+    }
 
     #endregion
 


### PR DESCRIPTION
# Fixed
- Fixed: The 'Read Last' smart filter had its 'greater than' and 'less than' comparisons reversed. Because this filter matches on how many days it has been since a series was last read, 'read last greater than N days' now correctly returns the series you have not read in over N days, instead of the ones you just read (and vice versa for 'less than'). (Fixes #4716)
