### PR TITLE
[skip ci] Add Zenith Hosting deploy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ Thank you to [Weblate](https://hosted.weblate.org/engage/kavita/) who hosts our 
 <img src="https://hosted.weblate.org/widget/kavita/horizontal-auto.svg" alt="Translation status" />
 </a>
 
+## Zenith
+[![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/kavita)
+
+One-click managed Kavita: storage, backups, email and a free subdomain included. A share of every subscription goes back to Kavita.
+
+
 ## PikaPods
 If you are looking to try your hand at self-hosting but lack the machine, [PikaPods](https://www.pikapods.com/pods?run=kavita) is a great service that 
 allows you to easily spin up a server. 20% of app revenues are contributed back to Kavita via OpenCollective.


### PR DESCRIPTION
hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added Kavita to our marketplace, so this PR adds a small 'Deploy with Zenith' badge in a short hosting section right above the PikaPods one (links to https://zenith.hosting/host/kavita).

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting

no PR template in the repo, so nothing else to fill. docs-only change (one section added to the README), no code, tests/builds N/A.
