### PR TITLE
Some bug fixes

### DIFF
--- a/.github/workflows/develop-workflow.yml
+++ b/.github/workflows/develop-workflow.yml
@@ -70,23 +70,23 @@ jobs:
 
       - name: Parse PR body
         id: parse-body
+        env:
+          BODY: ${{ steps.findPr.outputs.body }}
+          PR_NUM: ${{ steps.findPr.outputs.pr }}
         run: |
-          body="${{ steps.findPr.outputs.body }}"
+          body="$BODY"
           if [[ ${#body} -gt 1870 ]] ; then
             body=${body:0:1870}
             body="${body}...and much more.
-
-            Read full changelog: https://github.com/Kareadita/Kavita/pull/${{ steps.findPr.outputs.pr }}"
+            Read full changelog: https://github.com/Kareadita/Kavita/pull/${PR_NUM}"
           fi
-
           body=${body//\'/}
           body=${body//'%'/'%25'}
           body=${body//$'\n'/'%0A'}
           body=${body//$'\r'/'%0D'}
           body=${body//$'`'/'%60'}
           body=${body//$'>'/'%3E'}
-          echo $body
-          echo "BODY=$body" >> $GITHUB_OUTPUT
+          echo "BODY=$body" >> "$GITHUB_OUTPUT"
 
       - name: Check Out Repo
         uses: actions/checkout@v4

--- a/Kavita.API/Repositories/ISeriesRepository.cs
+++ b/Kavita.API/Repositories/ISeriesRepository.cs
@@ -132,4 +132,11 @@ public interface ISeriesRepository
     Task<SeriesDetailRequestV3Dto?> GetKavitaPlusSeriesDetailRequestV3Dto(int seriesId, CancellationToken ct = default);
     Task<Series?> MatchSeriesAsync(ExternalSeriesDetailDto externalSeries, CancellationToken ct = default);
     Task<List<Series>> GetSeriesForReadStatusTransitionRuleAsync(int userId, ReadStatusTransitionRule rule, bool requireUnReadChapters, CancellationToken ct);
+    /// <summary>
+    /// Returns the total amount of chapters, if all chapters in the series are specials
+    /// </summary>
+    /// <param name="seriesId"></param>
+    /// <param name="ct"></param>
+    /// <returns></returns>
+    Task<int?> GetChapterCountIfAllSpecials(int seriesId, CancellationToken ct = default);
 }

--- a/Kavita.Database/Repositories/SeriesRepository.cs
+++ b/Kavita.Database/Repositories/SeriesRepository.cs
@@ -14,6 +14,7 @@ using Kavita.Common.Helpers;
 using Kavita.Database.Converters;
 using Kavita.Database.Extensions;
 using Kavita.Database.Extensions.Filters;
+using Kavita.Models.Constants;
 using Kavita.Models.DTOs;
 using Kavita.Models.DTOs.Collection;
 using Kavita.Models.DTOs.Dashboard;
@@ -1914,5 +1915,20 @@ public class SeriesRepository(DataContext context, IMapper mapper) : ISeriesRepo
             .Select(x => x.Series)
             .Includes(SeriesIncludes.Chapters | SeriesIncludes.ExternalMetadata | SeriesIncludes.Metadata | SeriesIncludes.Library)
             .ToListAsync(ct);
+    }
+
+    public async Task<int?> GetChapterCountIfAllSpecials(int seriesId, CancellationToken ct = default)
+    {
+        var result = await context.Chapter
+            .Where(c => c.Volume.SeriesId == seriesId)
+            .GroupBy(c => c.Volume.SeriesId)
+            .Select(g => new
+            {
+                Count = g.Count(),
+                AllSpecial = g.All(c => c.Volume.MaxNumber == ParserConstants.SpecialVolumeNumber)
+            })
+            .FirstOrDefaultAsync(cancellationToken: ct);
+
+        return result is { AllSpecial: true } ? result.Count : null;
     }
 }

--- a/Kavita.Models/DTOs/SeriesDetail/SeriesDetailDto.cs
+++ b/Kavita.Models/DTOs/SeriesDetail/SeriesDetailDto.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using Kavita.Models.Entities.Enums;
 
 namespace Kavita.Models.DTOs.SeriesDetail;
 #nullable enable
@@ -25,6 +27,11 @@ public sealed record SeriesDetailDto
     /// These are chapters that are in Volume 0 and should be read AFTER the volumes
     /// </summary>
     public IEnumerable<ChapterDto> StorylineChapters { get; set; } = default!;
+    /// <summary>
+    /// Type of library this series is in.
+    /// </summary>
+    [EnumDataType(typeof(LibraryType))]
+    public LibraryType LibraryType { get; set; }
     /// <summary>
     /// How many chapters are unread
     /// </summary>

--- a/Kavita.Server/Controllers/ImageController.cs
+++ b/Kavita.Server/Controllers/ImageController.cs
@@ -35,7 +35,6 @@ public class ImageController(IUnitOfWork unitOfWork, IDirectoryService directory
     /// Returns cover image for Chapter
     /// </summary>
     /// <param name="chapterId"></param>
-    /// <param name="apiKey"></param>
     /// <returns></returns>
     [ChapterAccess]
     [HttpGet("chapter-cover")]
@@ -49,7 +48,6 @@ public class ImageController(IUnitOfWork unitOfWork, IDirectoryService directory
     /// Returns cover image for Library
     /// </summary>
     /// <param name="libraryId"></param>
-    /// <param name="apiKey"></param>
     /// <returns></returns>
     [LibraryAccess]
     [HttpGet("library-cover")]
@@ -63,7 +61,6 @@ public class ImageController(IUnitOfWork unitOfWork, IDirectoryService directory
     /// Returns cover image for Volume
     /// </summary>
     /// <param name="volumeId"></param>
-    /// <param name="apiKey"></param>
     /// <returns></returns>
     [VolumeAccess]
     [HttpGet("volume-cover")]
@@ -77,7 +74,6 @@ public class ImageController(IUnitOfWork unitOfWork, IDirectoryService directory
     /// Returns cover image for Series
     /// </summary>
     /// <param name="seriesId">Id of Series</param>
-    /// <param name="apiKey"></param>
     /// <returns></returns>
     [SeriesAccess]
     [HttpGet("series-cover")]
@@ -91,7 +87,6 @@ public class ImageController(IUnitOfWork unitOfWork, IDirectoryService directory
     /// Returns cover image for Collection
     /// </summary>
     /// <param name="collectionTagId"></param>
-    /// <param name="apiKey"></param>
     /// <returns></returns>
     [HttpGet("collection-cover")]
     public async Task<ActionResult> GetCollectionCoverImage(int collectionTagId)
@@ -112,7 +107,6 @@ public class ImageController(IUnitOfWork unitOfWork, IDirectoryService directory
     /// Returns cover image for a Reading List
     /// </summary>
     /// <param name="readingListId"></param>
-    /// <param name="apiKey"></param>
     /// <returns></returns>
     [HttpGet("readinglist-cover")]
     public async Task<ActionResult> GetReadingListCoverImage(int readingListId)
@@ -137,7 +131,6 @@ public class ImageController(IUnitOfWork unitOfWork, IDirectoryService directory
     /// <remarks>This request is served unauthenticated, but user must be passed via api key to validate</remarks>
     /// <param name="chapterId"></param>
     /// <param name="pageNum">Starts at 0</param>
-    /// <param name="apiKey">API Key for user. Needed to authenticate request</param>
     /// <param name="imageOffset">Only applicable for Epubs - handles multiple images on one page</param>
     /// <returns></returns>
     [ChapterAccess]
@@ -158,7 +151,6 @@ public class ImageController(IUnitOfWork unitOfWork, IDirectoryService directory
     /// Returns the image associated with a web-link
     /// </summary>
     /// <param name="url"></param>
-    /// <param name="apiKey"></param>
     /// <returns></returns>
     [HttpGet("web-link")]
     public async Task<ActionResult> GetWebLinkImage(string url)
@@ -194,7 +186,6 @@ public class ImageController(IUnitOfWork unitOfWork, IDirectoryService directory
     /// Returns the image associated with a publisher
     /// </summary>
     /// <param name="publisherName"></param>
-    /// <param name="apiKey"></param>
     /// <returns></returns>
     [HttpGet("publisher")]
     public async Task<ActionResult> GetPublisherImage(string publisherName)
@@ -234,7 +225,6 @@ public class ImageController(IUnitOfWork unitOfWork, IDirectoryService directory
     /// Returns cover image for Person
     /// </summary>
     /// <param name="personId"></param>
-    /// <param name="apiKey"></param>
     /// <returns></returns>
     [PersonAccess]
     [HttpGet("person-cover")]
@@ -248,7 +238,6 @@ public class ImageController(IUnitOfWork unitOfWork, IDirectoryService directory
     /// Returns cover image for User
     /// </summary>
     /// <param name="userId"></param>
-    /// <param name="apiKey"></param>
     /// <returns></returns>
     [HttpGet("user-cover")]
     public async Task<ActionResult> GetUserCoverImage(int userId)
@@ -265,7 +254,6 @@ public class ImageController(IUnitOfWork unitOfWork, IDirectoryService directory
     /// </summary>
     /// <remarks>Requires Admin Role to perform upload</remarks>
     /// <param name="filename">Filename of file. This is used with upload/upload-by-url</param>
-    /// <param name="apiKey"></param>
     /// <returns></returns>
     [HttpGet("cover-upload")]
     [Authorize(PolicyGroups.AdminPolicy)]

--- a/Kavita.Server/Controllers/ImageController.cs
+++ b/Kavita.Server/Controllers/ImageController.cs
@@ -39,7 +39,7 @@ public class ImageController(IUnitOfWork unitOfWork, IDirectoryService directory
     /// <returns></returns>
     [ChapterAccess]
     [HttpGet("chapter-cover")]
-    public async Task<ActionResult> GetChapterCoverImage(int chapterId, string apiKey)
+    public async Task<ActionResult> GetChapterCoverImage(int chapterId)
     {
         var path = Path.Join(directoryService.CoverImageDirectory, await unitOfWork.ChapterRepository.GetChapterCoverImageAsync(chapterId));
         return PhysicalFile(path);
@@ -53,7 +53,7 @@ public class ImageController(IUnitOfWork unitOfWork, IDirectoryService directory
     /// <returns></returns>
     [LibraryAccess]
     [HttpGet("library-cover")]
-    public async Task<ActionResult> GetLibraryCoverImage(int libraryId, string apiKey)
+    public async Task<ActionResult> GetLibraryCoverImage(int libraryId)
     {
         var path = Path.Join(directoryService.CoverImageDirectory, await unitOfWork.LibraryRepository.GetLibraryCoverImageAsync(libraryId));
         return PhysicalFile(path);
@@ -67,7 +67,7 @@ public class ImageController(IUnitOfWork unitOfWork, IDirectoryService directory
     /// <returns></returns>
     [VolumeAccess]
     [HttpGet("volume-cover")]
-    public async Task<ActionResult> GetVolumeCoverImage(int volumeId, string apiKey)
+    public async Task<ActionResult> GetVolumeCoverImage(int volumeId)
     {
         var path = Path.Join(directoryService.CoverImageDirectory, await unitOfWork.VolumeRepository.GetVolumeCoverImageAsync(volumeId));
         return PhysicalFile(path);
@@ -81,7 +81,7 @@ public class ImageController(IUnitOfWork unitOfWork, IDirectoryService directory
     /// <returns></returns>
     [SeriesAccess]
     [HttpGet("series-cover")]
-    public async Task<ActionResult> GetSeriesCoverImage(int seriesId, string apiKey)
+    public async Task<ActionResult> GetSeriesCoverImage(int seriesId)
     {
         var path = Path.Join(directoryService.CoverImageDirectory, await unitOfWork.SeriesRepository.GetSeriesCoverImageAsync(seriesId));
         return PhysicalFile(path);
@@ -94,7 +94,7 @@ public class ImageController(IUnitOfWork unitOfWork, IDirectoryService directory
     /// <param name="apiKey"></param>
     /// <returns></returns>
     [HttpGet("collection-cover")]
-    public async Task<ActionResult> GetCollectionCoverImage(int collectionTagId, string apiKey)
+    public async Task<ActionResult> GetCollectionCoverImage(int collectionTagId)
     {
         var collectionTag = await unitOfWork.CollectionTagRepository.GetCollectionAsync(collectionTagId, ct: HttpContext.RequestAborted);
         if (collectionTag == null || (collectionTag.AppUserId != UserId && !collectionTag.Promoted)) return NotFound();
@@ -115,7 +115,7 @@ public class ImageController(IUnitOfWork unitOfWork, IDirectoryService directory
     /// <param name="apiKey"></param>
     /// <returns></returns>
     [HttpGet("readinglist-cover")]
-    public async Task<ActionResult> GetReadingListCoverImage(int readingListId, string apiKey)
+    public async Task<ActionResult> GetReadingListCoverImage(int readingListId)
     {
         var readingList = await unitOfWork.ReadingListRepository.GetReadingListByIdAsync(readingListId, ct: HttpContext.RequestAborted);
         if (readingList == null || (readingList.AppUserId != UserId && !readingList.Promoted)) return NotFound();
@@ -142,7 +142,7 @@ public class ImageController(IUnitOfWork unitOfWork, IDirectoryService directory
     /// <returns></returns>
     [ChapterAccess]
     [HttpGet("bookmark")]
-    public async Task<ActionResult> GetBookmarkImage(int chapterId, int pageNum, string apiKey, int imageOffset = 0)
+    public async Task<ActionResult> GetBookmarkImage(int chapterId, int pageNum, int imageOffset = 0)
     {
         var bookmark = await unitOfWork.UserRepository.GetBookmarkForPage(pageNum, chapterId, imageOffset, UserId);
         if (bookmark == null) return BadRequest(await localizationService.TranslateAsync(UserId, "bookmark-doesnt-exist"));
@@ -161,7 +161,7 @@ public class ImageController(IUnitOfWork unitOfWork, IDirectoryService directory
     /// <param name="apiKey"></param>
     /// <returns></returns>
     [HttpGet("web-link")]
-    public async Task<ActionResult> GetWebLinkImage(string url, string apiKey)
+    public async Task<ActionResult> GetWebLinkImage(string url)
     {
         if (string.IsNullOrEmpty(url)) return BadRequest(await localizationService.TranslateAsync(UserId, "must-be-defined", "Url"));
 
@@ -197,7 +197,7 @@ public class ImageController(IUnitOfWork unitOfWork, IDirectoryService directory
     /// <param name="apiKey"></param>
     /// <returns></returns>
     [HttpGet("publisher")]
-    public async Task<ActionResult> GetPublisherImage(string publisherName, string apiKey)
+    public async Task<ActionResult> GetPublisherImage(string publisherName)
     {
         if (string.IsNullOrEmpty(publisherName)) return BadRequest(await localizationService.TranslateAsync(UserId, "must-be-defined", "publisherName"));
 
@@ -238,7 +238,7 @@ public class ImageController(IUnitOfWork unitOfWork, IDirectoryService directory
     /// <returns></returns>
     [PersonAccess]
     [HttpGet("person-cover")]
-    public async Task<ActionResult> GetPersonCoverImage(int personId, string apiKey)
+    public async Task<ActionResult> GetPersonCoverImage(int personId)
     {
         var path = Path.Join(directoryService.CoverImageDirectory, await unitOfWork.UserRepository.GetPersonCoverImageAsync(personId));
         return PhysicalFile(path);
@@ -251,7 +251,7 @@ public class ImageController(IUnitOfWork unitOfWork, IDirectoryService directory
     /// <param name="apiKey"></param>
     /// <returns></returns>
     [HttpGet("user-cover")]
-    public async Task<ActionResult> GetUserCoverImage(int userId, string apiKey)
+    public async Task<ActionResult> GetUserCoverImage(int userId)
     {
         var filename = await unitOfWork.UserRepository.GetCoverImageAsync(userId);
         if (filename == null) return NotFound();
@@ -269,7 +269,7 @@ public class ImageController(IUnitOfWork unitOfWork, IDirectoryService directory
     /// <returns></returns>
     [HttpGet("cover-upload")]
     [Authorize(PolicyGroups.AdminPolicy)]
-    public async Task<ActionResult> GetCoverUploadImage(string filename, string apiKey)
+    public async Task<ActionResult> GetCoverUploadImage(string filename)
     {
         if (!IsPathWithinDirectory(directoryService.TempDirectory, filename)) return BadRequest(await localizationService.TranslateAsync(UserId, "invalid-filename"));
 

--- a/Kavita.Server/Controllers/LicenseController.cs
+++ b/Kavita.Server/Controllers/LicenseController.cs
@@ -72,7 +72,13 @@ public class LicenseController(
         var ct = HttpContext.RequestAborted;
         try
         {
-            return Ok(await licenseService.GetLicenseInfo(forceCheck, ct));
+            var license = await licenseService.GetLicenseInfo(forceCheck, ct);
+            if (forceCheck && (license?.IsActive ?? false))
+            {
+                await taskScheduler.ScheduleKavitaPlusTasks(ct);
+            }
+
+            return Ok(license);
         }
         catch (Exception)
         {

--- a/Kavita.Server/Controllers/MetadataController.cs
+++ b/Kavita.Server/Controllers/MetadataController.cs
@@ -248,22 +248,26 @@ public class MetadataController(IUnitOfWork unitOfWork, IExternalMetadataService
             .ToList();
 
         var ret = await metadataService.TryMatchAndLoadMetadataForSeries(seriesId, libraryType, MetadataFetchTrigger.OnDemand, HttpContext.RequestAborted);
+        if (ret == null)
+        {
+            return Ok(new SeriesDetailPlusDto
+            {
+                Reviews = userReviews,
+            });
+        }
 
         await PrepareSeriesDetail(userReviews, ret);
         return Ok(ret);
     }
 
-    private async Task PrepareSeriesDetail(List<UserReviewDto> userReviews, SeriesDetailPlusDto? ret)
+    private async Task PrepareSeriesDetail(List<UserReviewDto> userReviews, SeriesDetailPlusDto ret)
     {
         var user = await unitOfWork.UserRepository.GetUserByIdAsync(UserId)!;
 
-        if (ret != null)
-        {
-            userReviews.AddRange(ReviewHelper.SelectSpectrumOfReviews(ret.Reviews.ToList()));
-            ret.Reviews = userReviews;
-        }
+        userReviews.AddRange(ReviewHelper.SelectSpectrumOfReviews(ret.Reviews.ToList()));
+        ret.Reviews = userReviews;
 
-        if (ret?.Recommendations != null && user != null)
+        if (ret.Recommendations != null && user != null)
         {
             // Re-obtain owned series and take into account age restriction and include series progress
             var seriesIds = ret.Recommendations.OwnedSeries.Select(s => s.Series.Id).ToList();
@@ -285,7 +289,7 @@ public class MetadataController(IUnitOfWork unitOfWork, IExternalMetadataService
                 RecommendationHelper.FilterExternalRecommendations(ret.Recommendations.ExternalSeries, restriction);
         }
 
-        if (ret?.Recommendations != null && user != null)
+        if (ret.Recommendations != null && user != null)
         {
             ret.Recommendations.OwnedSeries ??= [];
         }

--- a/Kavita.Server/Controllers/PluginController.cs
+++ b/Kavita.Server/Controllers/PluginController.cs
@@ -155,7 +155,7 @@ public class PluginController(IUnitOfWork unitOfWork, ITokenService tokenService
 
             if (name.Length > 1000)
             {
-                errorParses.Add(name, "Length > 1000 characters");
+                errorParses.TryAdd(name, "Length > 1000 characters");
                 continue;
             }
 

--- a/Kavita.Server/Controllers/PluginController.cs
+++ b/Kavita.Server/Controllers/PluginController.cs
@@ -161,15 +161,15 @@ public class PluginController(IUnitOfWork unitOfWork, ITokenService tokenService
 
             try
             {
-                successfulParses.Add(name, ParseText(name, dto.LibraryType));
+                successfulParses.TryAdd(name, ParseText(name, dto.LibraryType));
             }
             catch (RegexMatchTimeoutException)
             {
-                errorParses.Add(name, "Input could not be parsed in allowed time");
+                errorParses.TryAdd(name, "Input could not be parsed in allowed time");
             }
             catch (Exception)
             {
-                errorParses.Add(name, "Failed to parse input");
+                errorParses.TryAdd(name, "Failed to parse input");
             }
         }
 

--- a/Kavita.Services.Tests/ScrobblingServiceTests.cs
+++ b/Kavita.Services.Tests/ScrobblingServiceTests.cs
@@ -359,6 +359,8 @@ public class ScrobblingServiceTests(ITestOutputHelper outputHelper): AbstractDbT
         await readerService.MarkChaptersAsRead(user, 1, [chapter]);
         await unitOfWork.CommitAsync();
 
+        await service.ScrobbleReadingUpdate(user.Id, 1, chapter.Id);
+
         await service.ProcessUpdatesSinceLastSync();
 
         await kavitaPlusApiService.Received(1).PostScrobbleV3UpdateAsync(

--- a/Kavita.Services/Plus/ScrobbleService/SeriesScrobbleService.cs
+++ b/Kavita.Services/Plus/ScrobbleService/SeriesScrobbleService.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Kavita.API.Database;
+using Kavita.API.Repositories;
 using Kavita.API.Services.Plus;
 using Kavita.Models.DTOs.KavitaPlus;
 using Kavita.Models.DTOs.Scrobbling;
@@ -321,8 +322,12 @@ where T: IScrobbleProviderService
 
         if (evt.VolumeNumber is Parser.SpecialVolumeNumber)
         {
-            // We don't process Specials because they will never match on AniList
-            return;
+            var countIfAllSpecial = await unitOfWork.SeriesRepository.GetChapterCountIfAllSpecials(ctx.Series.Id, ct);
+            if (countIfAllSpecial is null or 0)
+                return;
+
+            // In case of a series only being specials, send the amount of specials as chapter count
+            evt.ChapterNumber = countIfAllSpecial;
         }
 
         unitOfWork.ScrobbleRepository.Attach(evt);
@@ -333,13 +338,13 @@ where T: IScrobbleProviderService
             {
                 Provider = Provider,
                 ScrobbleEventType = ScrobbleEventType.ChapterRead,
-                ChapterNumber = chapterNumber,
-                VolumeNumber = volumeNumber,
+                ChapterNumber = evt.ChapterNumber,
+                VolumeNumber = evt.VolumeNumber,
                 LibraryType = ctx.Series.Library.Type,
             }, AuditStatus.Info, userId: ctx.User.Id, ct: ct);
 
         logger.LogDebug("Created new scrobble read event for {Series} with Volume {Volume}, Chapter {Chapter} for User: {UserId}",
-            ctx.Series.Name, volumeNumber, chapterNumber, ctx.User.Id);
+            ctx.Series.Name, evt.VolumeNumber, evt.ChapterNumber, ctx.User.Id);
 
     }
 

--- a/Kavita.Services/Plus/ScrobblingService.cs
+++ b/Kavita.Services/Plus/ScrobblingService.cs
@@ -1221,19 +1221,6 @@ public class ScrobblingService : IScrobblingService
 
     private async Task ProcessReadEvents(ScrobbleSyncContext ctx, CancellationToken ct)
     {
-        // Recalculate the highest volume/chapter for non chapter events
-        foreach (var readEvt in ctx.ReadEvents.Where(e => e.ChapterId is null))
-        {
-            // Note: this causes skewing in the scrobble history because it makes it look like there are duplicate events
-            readEvt.VolumeNumber =
-                (int) await _unitOfWork.AppUserProgressRepository.GetHighestFullyReadVolumeForSeries(readEvt.SeriesId,
-                    readEvt.AppUser.Id, ct);
-            readEvt.ChapterNumber =
-                await _unitOfWork.AppUserProgressRepository.GetHighestFullyReadChapterForSeries(readEvt.SeriesId,
-                    readEvt.AppUser.Id, ct);
-            _unitOfWork.ScrobbleRepository.Update(readEvt);
-        }
-
         await ProcessEvents(ctx.ReadEvents, ctx, async evt => new ScrobbleV3Dto
         {
             Provider = evt.ScrobbleProvider,

--- a/Kavita.Services/SeriesService.cs
+++ b/Kavita.Services/SeriesService.cs
@@ -609,6 +609,7 @@ public class SeriesService(
             StorylineChapters = storylineChapters,
             TotalCount = chapters.Count,
             UnreadCount = chapters.Count(c => c.Pages > 0 && c.PagesRead < c.Pages),
+            LibraryType = libraryType,
             // default: See if we can get the ContinueFrom here
         };
     }

--- a/UI/Web/src/app/_models/series-detail/series-detail.ts
+++ b/UI/Web/src/app/_models/series-detail/series-detail.ts
@@ -1,5 +1,6 @@
 import { Chapter } from "../chapter";
 import { Volume } from "../volume";
+import {LibraryType} from "../library/library";
 
 /**
  * This is built for Series Detail itself
@@ -8,6 +9,7 @@ export interface SeriesDetail {
     specials: Array<Chapter>;
     chapters: Array<Chapter>;
     volumes: Array<Volume>;
+    libraryType: LibraryType;
     storylineChapters: Array<Chapter>;
     unreadCount: number;
     totalCount: number;

--- a/UI/Web/src/app/_single-module/match-series-modal/match-series-modal.component.html
+++ b/UI/Web/src/app/_single-module/match-series-modal/match-series-modal.component.html
@@ -31,6 +31,10 @@
               @if (kavitaSpecialCount() > 0) {
                 {{ t('special-count', {num: kavitaSpecialCount()}) }}
               }
+              <app-series-format [format]="series().format" [useTitle]="false" />
+              @if (seriesDetail(); as seriesDetail) {
+                {{seriesDetail.libraryType | libraryType}}
+              }
             </div>
           </div>
         </div>

--- a/UI/Web/src/app/_single-module/match-series-modal/match-series-modal.component.ts
+++ b/UI/Web/src/app/_single-module/match-series-modal/match-series-modal.component.ts
@@ -34,6 +34,9 @@ import {MetadataProvider} from "../../_models/kavitaplus/metadata-provider.enum"
 import {ScrobbleProvider} from "../../_services/scrobbling.service";
 import {MetadataProviderTitlePipe} from "../../_pipes/metadata-provider-title.pipe";
 import {ExternalEditionDto, PlusMediaFormat} from "../../_models/series-detail/external-series-detail";
+import {SeriesFormatComponent} from "../../shared/series-format/series-format.component";
+import {LibraryTypePipe} from "../../_pipes/library-type.pipe";
+import {TagBadgeComponent} from "../../shared/tag-badge/tag-badge.component";
 
 @Component({
   selector: 'app-match-series-modal',
@@ -46,6 +49,9 @@ import {ExternalEditionDto, PlusMediaFormat} from "../../_models/series-detail/e
     ImageComponent,
     ScrobbleProviderTagBadgeComponent,
     MetadataProviderTitlePipe,
+    SeriesFormatComponent,
+    LibraryTypePipe,
+    TagBadgeComponent,
   ],
   templateUrl: './match-series-modal.component.html',
   styleUrl: './match-series-modal.component.scss',

--- a/UI/Web/src/app/_single-module/review-card/review-card.component.scss
+++ b/UI/Web/src/app/_single-module/review-card/review-card.component.scss
@@ -33,8 +33,10 @@
 }
 
 .card-text.no-images {
-    text-overflow: ellipsis;
-    overflow: hidden;
+  -webkit-line-clamp: 5;
+  -webkit-box-orient: vertical;
+  text-overflow: ellipsis;
+  overflow: hidden;
 }
 
 .no-images img {
@@ -55,8 +57,9 @@
 }
 
 .card-body {
-    display: block;
-    visibility: visible;
-    min-height: 5.8438rem;
-    max-height: 5.8438rem;
+  display: block;
+  visibility: visible;
+  min-height: 5.8438rem;
+  max-height: 5.8438rem;
+  overflow: hidden;
 }

--- a/UI/Web/src/app/_single-module/user-scrobble-history/user-scrobble-history.component.html
+++ b/UI/Web/src/app/_single-module/user-scrobble-history/user-scrobble-history.component.html
@@ -92,7 +92,7 @@
           <ng-template let-item="row" ngx-datatable-cell-template>
             @switch (item.scrobbleEventType) {
               @case (ScrobbleEventType.ChapterRead) {
-                @if(item.volumeNumber === LooseLeafOrDefaultNumber) {
+                @if(item.volumeNumber === LooseLeafOrDefaultNumber || item.volumeNumber === SpecialVolumeNumber) {
                   @if (item.chapterNumber === LooseLeafOrDefaultNumber) {
                     {{t('special')}}
                   } @else {

--- a/UI/Web/src/app/_single-module/user-scrobble-history/user-scrobble-history.component.ts
+++ b/UI/Web/src/app/_single-module/user-scrobble-history/user-scrobble-history.component.ts
@@ -9,7 +9,7 @@ import {
   signal
 } from '@angular/core';
 
-import {ScrobbleProvider, ScrobblingService} from "../../_services/scrobbling.service";
+import {ScrobblingService} from "../../_services/scrobbling.service";
 import {takeUntilDestroyed} from "@angular/core/rxjs-interop";
 import {ScrobbleEvent, ScrobbleEventType} from "../../_models/scrobbling/scrobble-event";
 import {ScrobbleEventTypePipe} from "../../_pipes/scrobble-event-type.pipe";
@@ -18,24 +18,21 @@ import {ScrobbleEventSortField} from "../../_models/scrobbling/scrobble-event-fi
 import {debounceTime, take} from "rxjs/operators";
 import {PaginatedResult} from "../../_models/pagination";
 import {FormControl, FormGroup, ReactiveFormsModule} from "@angular/forms";
-import {translate, TranslocoModule} from "@jsverse/transloco";
+import {TranslocoModule} from "@jsverse/transloco";
 import {DefaultValuePipe} from "../../_pipes/default-value.pipe";
 import {TranslocoLocaleModule} from "@jsverse/transloco-locale";
 import {UtcToLocalTimePipe} from "../../_pipes/utc-to-local-time.pipe";
 import {LooseLeafOrDefaultNumber, SpecialVolumeNumber} from "../../_models/chapter";
-import {ColumnMode, NgxDatatableModule} from "@siemens/ngx-datatable";
+import {NgxDatatableModule} from "@siemens/ngx-datatable";
 import {APP_BASE_HREF} from "@angular/common";
 import {AccountService} from "../../_services/account.service";
-import {ToastrService} from "ngx-toastr";
 import {SelectionModel} from "../../typeahead/_models/selection-model";
 import {ResponsiveTableComponent} from "../../shared/_components/responsive-table/responsive-table.component";
 import {RouterLink} from "@angular/router";
-import {ScrobbleProviderNamePipe} from "../../_pipes/scrobble-provider-name.pipe";
 import {
   ScrobbleProviderImageComponent
 } from "../../shared/_components/scrobble-provider-image/scrobble-provider-image.component";
 import {ScrobbleReadStatusPipe} from "../../_pipes/scrobble-read-status.pipe";
-import {EntityTitleService} from "../../_services/entity-title.service";
 
 export interface DataTablePage {
   pageNumber: number,
@@ -48,7 +45,7 @@ export interface DataTablePage {
   selector: 'app-user-scrobble-history',
   imports: [ScrobbleEventTypePipe, ReactiveFormsModule, TranslocoModule,
     DefaultValuePipe, TranslocoLocaleModule, UtcToLocalTimePipe, NgbTooltip, NgxDatatableModule,
-    ResponsiveTableComponent, RouterLink, ScrobbleProviderNamePipe, ScrobbleProviderImageComponent, ScrobbleReadStatusPipe],
+    ResponsiveTableComponent, RouterLink, ScrobbleProviderImageComponent, ScrobbleReadStatusPipe],
   templateUrl: './user-scrobble-history.component.html',
   styleUrls: ['./user-scrobble-history.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush
@@ -57,15 +54,12 @@ export class UserScrobbleHistoryComponent implements OnInit {
 
   protected readonly SpecialVolumeNumber = SpecialVolumeNumber;
   protected readonly LooseLeafOrDefaultNumber = LooseLeafOrDefaultNumber;
-  protected readonly ColumnMode = ColumnMode;
   protected readonly ScrobbleEventType = ScrobbleEventType;
 
   private readonly scrobblingService = inject(ScrobblingService);
   private readonly destroyRef = inject(DestroyRef);
-  private readonly toastr = inject(ToastrService);
   protected readonly accountService = inject(AccountService);
   protected readonly baseUrl = inject(APP_BASE_HREF);
-  private readonly entityTitleService = inject(EntityTitleService);
 
   formGroup: FormGroup = new FormGroup({
     'filter': new FormControl('', [])

--- a/UI/Web/src/app/_single-module/user-scrobble-history/user-scrobble-history.component.ts
+++ b/UI/Web/src/app/_single-module/user-scrobble-history/user-scrobble-history.component.ts
@@ -35,6 +35,7 @@ import {
   ScrobbleProviderImageComponent
 } from "../../shared/_components/scrobble-provider-image/scrobble-provider-image.component";
 import {ScrobbleReadStatusPipe} from "../../_pipes/scrobble-read-status.pipe";
+import {EntityTitleService} from "../../_services/entity-title.service";
 
 export interface DataTablePage {
   pageNumber: number,
@@ -64,6 +65,7 @@ export class UserScrobbleHistoryComponent implements OnInit {
   private readonly toastr = inject(ToastrService);
   protected readonly accountService = inject(AccountService);
   protected readonly baseUrl = inject(APP_BASE_HREF);
+  private readonly entityTitleService = inject(EntityTitleService);
 
   formGroup: FormGroup = new FormGroup({
     'filter': new FormControl('', [])

--- a/UI/Web/src/app/series-detail/_components/series-detail/series-detail.component.html
+++ b/UI/Web/src/app/series-detail/_components/series-detail/series-detail.component.html
@@ -170,13 +170,17 @@
                 <span class="fw-bold">{{t('publication-status-title')}}</span>
                 <div>
                   @if (seriesMetadataValue.publicationStatus | publicationStatus; as pubStatus) {
+                    @let extraInfo = ((seriesMetadataValue.totalCount === 0 || seriesMetadataValue.maxCount === LooseLeafOrSpecialNumber)
+                        ? '' : ' (' + seriesMetadataValue?.maxCount + ' / ' + seriesMetadataValue?.totalCount + ')');
+
                     <a class="dark-exempt btn-icon font-size" (click)="openFilter(FilterField.PublicationStatus, seriesMetadataValue!.publicationStatus)"
                        href="javascript:void(0);"
-                       [ngbTooltip]="t('publication-status-tooltip') +
-                       ((seriesMetadataValue.totalCount === 0 || seriesMetadataValue.maxCount === LooseLeafOrSpecialNumber)
-                       ? '' : ' (' + seriesMetadataValue?.maxCount + ' / ' + seriesMetadataValue?.totalCount + ')')"
+                       [ngbTooltip]="t('publication-status-tooltip') + extraInfo"
                     >
                       {{pubStatus}}
+                      @if (seriesMetadataValue.publicationStatus === PublicationStatus.Ended) {
+                        {{extraInfo}}
+                      }
                     </a>
                   }
                 </div>

--- a/UI/Web/src/app/series-detail/_components/series-detail/series-detail.component.ts
+++ b/UI/Web/src/app/series-detail/_components/series-detail/series-detail.component.ts
@@ -972,6 +972,7 @@ class SeriesDetailComponent implements OnInit, AfterViewInit {
   protected readonly encodeURIComponent = encodeURIComponent;
   protected readonly Breakpoint = Breakpoint;
   protected readonly READING_HISTORY_PAGE_SIZE = READING_HISTORY_PAGE_SIZE;
+  protected readonly PublicationStatus = PublicationStatus;
 }
 
 export default SeriesDetailComponent

--- a/UI/Web/src/app/shared/_components/match-series-result-item/match-series-result-item.component.html
+++ b/UI/Web/src/app/shared/_components/match-series-result-item/match-series-result-item.component.html
@@ -90,23 +90,27 @@
       <div class="match-result-editions d-flex flex-row flex-wrap gap-1">
         @for (edition of item().series.editions; track edition.id) {
           <button type="button"
-                  class="edition-chip d-inline-flex align-items-center"
+                  class="edition-chip d-flex flex-column flex-md-row align-items-center justify-content-md-between gap-1 gap-md-2"
                   [class.selected]="isEditionSelected(edition)"
                   [attr.aria-pressed]="isEditionSelected(edition)"
                   (click)="chooseEdition(edition, $event)">
-            @if (isEditionSelected(edition)) {
-              <i class="fa-solid fa-check edition-chip-icon" aria-hidden="true"></i>
-            }
-            <span>{{ edition.title }}</span>
-            @if (edition.format) {
-              <span class="edition-chip-format">{{ edition.format }}</span>
-            }
-            @if (edition.mainCount > 0) {
-              <span class="edition-chip-count">{{ t('edition-main-count', {num: edition.mainCount}) }}</span>
-            }
-            @if (edition.totalCount - edition.mainCount > 0) {
-              <span class="edition-chip-count edition-chip-extra">{{ t('edition-extra-count', {num: edition.totalCount - edition.mainCount}) }}</span>
-            }
+            <div class="d-flex align-items-center gap-1">
+              @if (isEditionSelected(edition)) {
+                <i class="fa-solid fa-check edition-chip-icon" aria-hidden="true"></i>
+              }
+              <span>{{ edition.title }}</span>
+            </div>
+            <div class="d-flex align-items-center gap-1">
+              @if (edition.format) {
+                <span class="edition-chip-format">{{ edition.format }}</span>
+              }
+              @if (edition.mainCount > 0) {
+                <span class="edition-chip-count">{{ t('edition-main-count', {num: edition.mainCount}) }}</span>
+              }
+              @if (edition.totalCount - edition.mainCount > 0) {
+                <span class="edition-chip-count edition-chip-extra">{{ t('edition-extra-count', {num: edition.totalCount - edition.mainCount}) }}</span>
+              }
+            </div>
           </button>
         }
       </div>

--- a/UI/Web/src/app/shared/_components/match-series-result-item/match-series-result-item.component.scss
+++ b/UI/Web/src/app/shared/_components/match-series-result-item/match-series-result-item.component.scss
@@ -108,6 +108,10 @@
     color: var(--body-text-color);
     font-weight: 600;
   }
+
+  @media (max-width: 768px) {
+    width: 100%;
+  }
 }
 
 .edition-chip-format {
@@ -128,4 +132,39 @@
 .edition-chip-icon {
   font-size: 0.625rem;
   color: rgba(74, 198, 148, 0.9);
+}
+
+@media (max-width: 576px) {
+  .match-result-row {
+    flex-wrap: wrap;
+    gap: 0.75rem !important;
+  }
+
+
+  .match-result-rail {
+    min-width: auto;
+    position: absolute;
+    top: 0.75rem;
+    right: 0.75rem;
+  }
+
+  app-image {
+    flex-shrink: 0;
+  }
+
+  .match-result-editions {
+    gap: 0.25rem !important;
+  }
+
+  .edition-chip {
+    padding: 0.25rem 0.5rem;
+    font-size: 0.65625rem;
+    gap: 0.2rem;
+    max-width: 100%;
+    word-break: break-word;
+  }
+
+  .edition-chip-format {
+    margin-left: 0.125rem;
+  }
 }

--- a/UI/Web/src/app/shared/read-more/read-more.component.ts
+++ b/UI/Web/src/app/shared/read-more/read-more.component.ts
@@ -39,7 +39,7 @@ export class ReadMoreComponent {
 
   private readonly effectiveMaxLength = computed(() => {
     if (this.useResponsiveLength()) {
-      return this.breakpointService.isDesktopOrBelow() ? 170 : 200;
+      return this.breakpointService.isTabletOrBelow() ? 170 : 400;
     }
     return this.maxLength();
   });

--- a/UI/Web/src/app/sidenav/_components/side-nav-item/side-nav-item.component.scss
+++ b/UI/Web/src/app/sidenav/_components/side-nav-item/side-nav-item.component.scss
@@ -42,3 +42,7 @@
 .drag-handle {
   cursor: grab;
 }
+
+.side-nav-item.closed .side-nav-text {
+  display: none;
+}

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -2690,7 +2690,7 @@
         "dropped-series-rule-condition": "If a series/chapter hasn't been read for",
         "all-libraries-label": "All libraries",
         "all-libraries-tooltip": "When enabled, scrobbling runs on all applicable libraries. Disable to restrict it to specific libraries using the selection below.",
-        "confirm-delete": "Are you sure want to disconnect {{provider}}?",
+        "confirm-delete": "Are you sure you want to disconnect {{provider}}?",
         "inactive-series-rule-days-aria": "Inactive series threshold in days",
         "inactive-series-rule-status-aria": "Inactive series transition status",
         "inactive-series-rule-excluded-publication-aria": "Excluded publication statuses for inactive series rule",

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -2690,7 +2690,7 @@
         "dropped-series-rule-condition": "If a series/chapter hasn't been read for",
         "all-libraries-label": "All libraries",
         "all-libraries-tooltip": "When enabled, scrobbling runs on all applicable libraries. Disable to restrict it to specific libraries using the selection below.",
-        "confirm-delete": "Are you sure want to disconnect {{provider}}",
+        "confirm-delete": "Are you sure want to disconnect {{provider}}?",
         "inactive-series-rule-days-aria": "Inactive series threshold in days",
         "inactive-series-rule-status-aria": "Inactive series transition status",
         "inactive-series-rule-excluded-publication-aria": "Excluded publication statuses for inactive series rule",


### PR DESCRIPTION
Alongside a ton of bug fixes this nightly should drastically improve Kavita memory consumption when running for extended periods of time via docker. If you are tracking memory usage of containers please share your results in the nightly testing channel on discord. Thank you!

<img width="985" height="300" src="https://github.com/user-attachments/assets/3ad9a55e-a5b5-4643-b6e5-345c043e9057" />
Dotted line indicates the restart which uses jemalloc instead

# Added
- Added: Added more information in the match modal to help you pick the correct series

# Changed
- Changed: Scrobbling series with only specials (One-Shots) will now scrobble the amount of specials instead skipping the scrobble. 
- Changed: Copied the (x/y) info from the tooltip down to the series detail page for ended series for better visibility
- Changed: Switched to jemalloc as allocator for Docker images

# Fixed
- Fixed: Fixed apiKey being a required parameter in the library controller (Fixes #4816)
- Fixed: Fixed Plugin/parse-bulk throwing with duplicate input
- Fixed: Fixed K+ tasks sometimes not being registered when enabling your subscription again
- Fixed: Fixed read more not using the desktop amount on desktop. Also increased the max amount for a better experience
- Fixed: Fixed the side nav sometimes still showing text despite being closed
- Fixed: Fixed overflow in review cards for non Latin text (Fixes #4116)
- Fixed: Fixed local reviews not being shown on the series page if you have no active K+ subscription