### PR TITLE
A few more bug fixes

### DIFF
--- a/Kavita.Database/Converters/FilterFieldValueConverter.cs
+++ b/Kavita.Database/Converters/FilterFieldValueConverter.cs
@@ -106,6 +106,7 @@ public static class SeriesFilterFieldValueConverter
             SeriesFilterField.ReadTime => string.IsNullOrEmpty(value) ? 0 : int.Parse(value),
             SeriesFilterField.AverageRating => string.IsNullOrEmpty(value) ? 0f : value.AsFloat(),
             SeriesFilterField.FileSize => value.ParseHumanReadableBytes(),
+            SeriesFilterField.CollapseSeriesRelationships => bool.Parse(value),
             _ => throw new ArgumentException("Invalid field type")
         };
     }

--- a/Kavita.Database/Extensions/Filters/SeriesFilter.cs
+++ b/Kavita.Database/Extensions/Filters/SeriesFilter.cs
@@ -319,6 +319,9 @@ public static class SeriesFilter
 
             var date = DateTime.Now.AddDays(-timeDeltaDays);
 
+            // We are flipping the logical comparisons such that the read filter in the UI is more natural
+            // I.e. return all series where my last read is less than 30 days ago. Should return series read in the last
+            // 30 days
             switch (comparison)
             {
                 case FilterComparison.Equal:
@@ -326,17 +329,17 @@ public static class SeriesFilter
                     break;
                 case FilterComparison.IsAfter:
                 case FilterComparison.GreaterThan:
-                    subQuery = subQuery.Where(s => s.MaxDate != null && s.MaxDate > date);
+                    subQuery = subQuery.Where(s => s.MaxDate != null && s.MaxDate < date);
                     break;
                 case FilterComparison.GreaterThanEqual:
-                    subQuery = subQuery.Where(s => s.MaxDate != null && s.MaxDate >= date);
+                    subQuery = subQuery.Where(s => s.MaxDate != null && s.MaxDate <= date);
                     break;
                 case FilterComparison.IsBefore:
                 case FilterComparison.LessThan:
-                    subQuery = subQuery.Where(s => s.MaxDate != null && s.MaxDate < date);
+                    subQuery = subQuery.Where(s => s.MaxDate != null && s.MaxDate > date);
                     break;
                 case FilterComparison.LessThanEqual:
-                    subQuery = subQuery.Where(s => s.MaxDate != null && s.MaxDate <= date);
+                    subQuery = subQuery.Where(s => s.MaxDate != null && s.MaxDate >= date);
                     break;
                 case FilterComparison.NotEqual:
                     subQuery = subQuery.Where(s => s.MaxDate != null && !s.MaxDate.Equals(date));

--- a/Kavita.Database/Repositories/SeriesRepository.cs
+++ b/Kavita.Database/Repositories/SeriesRepository.cs
@@ -775,9 +775,8 @@ public class SeriesRepository(DataContext context, IMapper mapper) : ISeriesRepo
         var userLibraries = await GetUserLibrariesForFilteredQuery(0, userId, queryContext, ct);
         var allLibraryCount = await context.Library.CountAsync(ct);
         var userRating = await context.AppUser.GetUserAgeRestriction(userId, ct: ct);
-        var onlyParentSeries = await context.AppUserPreferences.Where(u => u.AppUserId == userId)
-            .Select(u => u.CollapseSeriesRelationships)
-            .SingleOrDefaultAsync(ct);
+
+
 
         query ??= context.Series
             .AsNoTracking();
@@ -795,17 +794,14 @@ public class SeriesRepository(DataContext context, IMapper mapper) : ISeriesRepo
 
         query = await ApplyCollectionFilter(seriesFilter, query, userId, userRating, ct);
 
+        query = await AppleCollapseSeriesRelationshipsFilter(query, seriesFilter, userId, ct);
 
         query = FilterQueryBuilder.Apply(seriesFilter, query,
             (stmt, q) => BuildFilterGroup(userId, stmt, q));
 
         query = query
             .WhereIf(allLibraryCount != userLibraries.Count && userLibraries.Count > 0, s => userLibraries.Contains(s.LibraryId))
-            .WhereIf(onlyParentSeries, s =>
-                s.RelationOf.Count == 0 ||
-                s.RelationOf.All(p => p.RelationKind == RelationKind.Prequel))
             .RestrictAgainstAgeRestriction(userRating);
-
 
         return query
                 .Sort(userId, seriesFilter.SortOptions)
@@ -866,6 +862,29 @@ public class SeriesRepository(DataContext context, IMapper mapper) : ISeriesRepo
         }
 
         return query;
+    }
+
+    private async Task<IQueryable<Series>> AppleCollapseSeriesRelationshipsFilter(IQueryable<Series> query,
+        SeriesFilterV2Dto seriesFilter, int userId, CancellationToken ct = default)
+    {
+        bool onlyParentSeries;
+
+        var collapseSeriesRelationshipsStmt = seriesFilter.Statements
+            .FirstOrDefault(stmt => stmt.Field == SeriesFilterField.CollapseSeriesRelationships);
+        if (collapseSeriesRelationshipsStmt != null)
+        {
+            onlyParentSeries = bool.Parse(collapseSeriesRelationshipsStmt.Value);
+        }
+        else
+        {
+            onlyParentSeries = await context.AppUserPreferences.Where(u => u.AppUserId == userId)
+                .Select(u => u.CollapseSeriesRelationships)
+                .SingleOrDefaultAsync(ct);
+        }
+
+        return query.WhereIf(onlyParentSeries, s =>
+            s.RelationOf.Count == 0 ||
+            s.RelationOf.All(p => p.RelationKind == RelationKind.Prequel));
     }
 
     private IQueryable<Series> ApplyWantToReadFilter(SeriesFilterV2Dto seriesFilter, IQueryable<Series> query, int userId)
@@ -970,6 +989,9 @@ public class SeriesRepository(DataContext context, IMapper mapper) : ISeriesRepo
                 // This is handled in the code before this as it's handled in a more general, combined manner
                 query,
             SeriesFilterField.WantToRead =>
+                // This is handled in the higher level of code as it's more general
+                query,
+            SeriesFilterField.CollapseSeriesRelationships =>
                 // This is handled in the higher level of code as it's more general
                 query,
             SeriesFilterField.ReadProgress => query.HasReadingProgress(true, statement.Comparison, (float) value, userId),

--- a/Kavita.Models/DTOs/Filtering/v2/FilterFields/SeriesFilterField.cs
+++ b/Kavita.Models/DTOs/Filtering/v2/FilterFields/SeriesFilterField.cs
@@ -1,4 +1,6 @@
-﻿namespace Kavita.Models.DTOs.Filtering.v2;
+﻿using Kavita.Models.Entities.User;
+
+namespace Kavita.Models.DTOs.Filtering.v2;
 
 /// <summary>
 /// Represents the field which will dictate the value type and the Extension used for filtering
@@ -60,6 +62,10 @@ public enum SeriesFilterField
     /// Total filesize accross all files for all chapters of the series
     /// </summary>
     FileSize = 33,
+    /// <summary>
+    /// If presents in the filter overwrites <see cref="AppUserPreferences.CollapseSeriesRelationships"/>
+    /// </summary>
+    CollapseSeriesRelationships = 34,
 }
 
 

--- a/Kavita.Server/ManualMigrations/v0.9.1/ManualMigrateLastReadDates.cs
+++ b/Kavita.Server/ManualMigrations/v0.9.1/ManualMigrateLastReadDates.cs
@@ -1,0 +1,53 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Kavita.Database;
+using Kavita.Models.DTOs.Filtering.v2;
+using Kavita.Models.DTOs.Filtering.v2.Requests;
+using Kavita.Server;
+using Kavita.Server.ManualMigrations;
+using Kavita.Services.Helpers.SmartFilter;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Kavita.Server.ManualMigrations.v0._9._1;
+
+public class ManualMigrateLastReadDates: ManualMigration
+{
+    protected override string MigrationName => nameof(ManualMigrateLastReadDates);
+    protected override async Task ExecuteAsync(DataContext context, ILogger<Program> logger)
+    {
+        var allSeriesSmartFilters = await context.AppUserSmartFilter
+            .Where(f => f.EntityType == FilterEntityType.Series)
+            .ToListAsync();
+
+        var updatedCount = 0;
+
+        foreach (var filter in allSeriesSmartFilters)
+        {
+            var decodedFilter = (SeriesFilterV2Dto) SmartFilterHelper.Decode(filter.Filter);
+            foreach (var statement in decodedFilter.Statements.Where(s => s.Field == SeriesFilterField.ReadLast))
+            {
+                statement.Comparison = statement.Comparison switch
+                {
+                    FilterComparison.GreaterThan => FilterComparison.LessThan,
+                    FilterComparison.GreaterThanEqual => FilterComparison.LessThanEqual,
+                    FilterComparison.LessThan => FilterComparison.GreaterThan,
+                    FilterComparison.LessThanEqual => FilterComparison.GreaterThanEqual,
+                    _ => statement.Comparison
+                };
+            }
+
+            var encodedFilter = SmartFilterHelper.Encode(decodedFilter);
+            if (encodedFilter != filter.Filter)
+            {
+                filter.Filter = SmartFilterHelper.Encode(decodedFilter);
+                context.AppUserSmartFilter.Update(filter);
+                updatedCount++;
+            }
+        }
+
+        await context.SaveChangesAsync();
+
+        logger.LogInformation("[ManualMigrateLastReadDates] Updated {Count} smart filter(s)", updatedCount);
+    }
+}

--- a/Kavita.Server/Startup.cs
+++ b/Kavita.Server/Startup.cs
@@ -536,6 +536,7 @@ public class Startup
                     await new ManualMigrationMetadataSettingFieldRenumber().RunAsync(dataContext, logger);
                     await new ManualMigrateOriginalNameBackfill().RunAsync(dataContext, logger);
                     await new ManualMigrateNormalizedOriginalNameBackfill().RunAsync(dataContext, logger);
+                    await new ManualMigrateLastReadDates().RunAsync(dataContext, logger);
 
                     #endregion
 

--- a/Kavita.Services.Tests/ParseScannedFilesTests.cs
+++ b/Kavita.Services.Tests/ParseScannedFilesTests.cs
@@ -771,33 +771,75 @@ public class ParseScannedFilesTests: AbstractDbTest
 
     #region Sort Order
 
-    [Fact]
-    public void TestUpdateSortOrder_BEY_LR_Nonsense()
+    public static IEnumerable<object[]> UpdateSortOrderData => new List<object[]>
+    {
+        // All whole numbers
+        new object[] { new[] { "1", "2", "3" }, new[] { 1f, 2f, 3f } },
+
+        // Whole and float numbers
+        new object[] { new[] { "1", "2.5", "3" }, new[] { 1f, 2.5f, 3f } },
+
+        // Whole ranges (uses min of range)
+        new object[] { new[] { "1-3", "4-6" }, new[] { 1f, 4f } },
+
+        // Whole, float, and ranges mixed
+        new object[] { new[] { "1", "2.5", "4-6" }, new[] { 1f, 2.5f, 4f } },
+
+        // Out-of-order input still resolves correctly per item
+        new object[] { new[] { "3", "1", "2" }, new[] { 3f, 1f, 2f } },
+
+        // Original: single nonsense suffix
+        new object[] { new[] { "15", "15.HU" }, new[] { 15f, 15.1f } },
+
+        // Original: story A/B suffixes
+        new object[] { new[] { "15", "15 (A Story)", "15 (B Story)" }, new[] { 15f, 15.1f, 15.2f } },
+
+        // Two different nonsense suffixes on the same base
+        // BEY comes before UH
+        new object[] { new[] { "15", "15.UH", "15.BEY" }, new[] { 15f, 15.2f, 15.1f } },
+
+        // Duplicate whole numbers (no suffix at all)
+        new object[] { new[] { "15", "15" }, new[] { 15f, 15.1f } },
+
+        // Nonsense suffixes with different bases: no bump between them
+        new object[] { new[] { "15.UH", "16.BEY" }, new[] { 15f, 16f } },
+
+        // Decimal base with story suffixes
+        new object[] { new[] { "15.5 (A Story)", "15.5 (B Story)" }, new[] { 15.5f, 15.6f } },
+
+        // Range collides with a plain duplicate of its min value. Non range goes first; numbers get priority
+        new object[] { new[] { "4-6", "4" }, new[] { 4.1f, 4f } },
+
+        // Three-way duplicate nonsense chain
+        new object[] { new[] { "15", "15.HU", "15.LR" }, new[] { 15f, 15.1f, 15.2f } },
+    };
+
+    [Theory]
+    [MemberData(nameof(UpdateSortOrderData))]
+    public void TestUpdateSortOrder(string[] chapters, float[] expectedOrders)
     {
         var series = new ParsedSeries
         {
-            Name = "Amazing Spider-Man (2018)",
-            NormalizedName = "Amazing Spider-Man (2018)".ToNormalized(),
+            Name = "Spice and Wolf",
+            NormalizedName = "Spice and Wolf".ToNormalized(),
             Format = MangaFormat.Archive
         };
 
         ConcurrentDictionary<ParsedSeries, List<ParserInfo>> scannedSeries = [];
-        scannedSeries[series] = [
-            new ParserInfo
+        scannedSeries[series] = chapters
+            .Select(c => new ParserInfo
             {
-                Series = "Amazing Spider-Man",
-                Chapters = "15"
-            },
-            new ParserInfo
-            {
-                Series = "Amazing Spider-Man",
-                Chapters = "15.HU"
-            },
-        ];
+                Series = "Spice and Wolf",
+                Chapters = c
+            })
+            .ToList();
 
         ParseScannedFiles.UpdateSortOrder(scannedSeries, series);
-        Assert.Equal(15f, scannedSeries[series][0].IssueOrder);
-        Assert.Equal(15.1f, scannedSeries[series][1].IssueOrder);
+
+        for (var i = 0; i < expectedOrders.Length; i++)
+        {
+            Assert.Equal(expectedOrders[i], scannedSeries[series][i].IssueOrder, precision: 2);
+        }
     }
 
     #endregion

--- a/Kavita.Services.Tests/ParseScannedFilesTests.cs
+++ b/Kavita.Services.Tests/ParseScannedFilesTests.cs
@@ -6,6 +6,7 @@ using Kavita.API.Database;
 using Kavita.API.Repositories;
 using Kavita.API.Services;
 using Kavita.API.Services.SignalR;
+using Kavita.Common.Extensions;
 using Kavita.Database.Tests;
 using Kavita.Models.Entities.Enums;
 using Kavita.Models.Metadata;
@@ -764,6 +765,39 @@ public class ParseScannedFilesTests: AbstractDbTest
         var expectedMax = Math.Max(1, Environment.ProcessorCount / 2);
         Assert.True(readingItemService.MaxObservedConcurrency <= expectedMax,
             $"Observed parse concurrency {readingItemService.MaxObservedConcurrency} exceeded the cap {expectedMax}");
+    }
+
+    #endregion
+
+    #region Sort Order
+
+    [Fact]
+    public void TestUpdateSortOrder_BEY_LR_Nonsense()
+    {
+        var series = new ParsedSeries
+        {
+            Name = "Amazing Spider-Man (2018)",
+            NormalizedName = "Amazing Spider-Man (2018)".ToNormalized(),
+            Format = MangaFormat.Archive
+        };
+
+        ConcurrentDictionary<ParsedSeries, List<ParserInfo>> scannedSeries = [];
+        scannedSeries[series] = [
+            new ParserInfo
+            {
+                Series = "Amazing Spider-Man",
+                Chapters = "15"
+            },
+            new ParserInfo
+            {
+                Series = "Amazing Spider-Man",
+                Chapters = "15.HU"
+            },
+        ];
+
+        ParseScannedFiles.UpdateSortOrder(scannedSeries, series);
+        Assert.Equal(15f, scannedSeries[series][0].IssueOrder);
+        Assert.Equal(15.1f, scannedSeries[series][1].IssueOrder);
     }
 
     #endregion

--- a/Kavita.Services/Scanner/ParseScannedFiles.cs
+++ b/Kavita.Services/Scanner/ParseScannedFiles.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Kavita.API.Services;
@@ -856,39 +857,52 @@ public class ParseScannedFiles
             // Ensure chapters are sorted numerically when possible, otherwise push unparseable to the end
             chapters = infos
                 .OrderBy(info => float.TryParse(info.Chapters, NumberStyles.Any, CultureInfo.InvariantCulture, out var val) ? val : float.MaxValue)
+                .ThenBy(info => info.Chapters, StringComparer.OrdinalIgnoreCase)
                 .ToList();
 
             counter = 0f;
-            var prevIssue = string.Empty;
+            float? prevBase = null;
+
             foreach (var chapter in chapters)
             {
-                // Use MinNumber in case there is a range, as otherwise sort order will cause it to be processed last
                 var chapterNum = Parser.IsRange(chapter.Chapters) ?
                     $"{Parser.MinNumberFromRange(chapter.Chapters).ToString(CultureInfo.InvariantCulture)}"
                     : chapter.Chapters;
+
                 if (float.TryParse(chapterNum, NumberStyles.Any, CultureInfo.InvariantCulture, out var parsedChapter))
                 {
-                    // Parsed successfully, use the numeric value
                     counter = parsedChapter;
-                    chapter.IssueOrder = counter;
-
-                    // Increment for next chapter (unless the next has a similar value, then add 0.1)
-                    if (!string.IsNullOrEmpty(prevIssue) && float.TryParse(prevIssue, NumberStyles.Any, CultureInfo.InvariantCulture, out var prevIssueFloat) && parsedChapter.Is(prevIssueFloat))
+                    if (prevBase.HasValue && parsedChapter.Is(prevBase.Value))
                     {
-                        counter += 0.1f; // bump if same value as the previous issue
+                        counter += 0.1f;
                     }
-                    prevIssue = $"{parsedChapter.ToString(CultureInfo.InvariantCulture)}";
+                    chapter.IssueOrder = counter;
+                    prevBase = parsedChapter;
                 }
                 else
                 {
-                    // Unparsed chapters: use the current counter and bump for the next
-                    if (!string.IsNullOrEmpty(prevIssue) && prevIssue == counter.ToString(CultureInfo.InvariantCulture))
+                    // Pull out the leading numeric part, e.g. "15.UH" -> 15, "15.BEY" -> 15
+                    var leadingMatch = Regex.Match(chapter.Chapters, @"^\d+(\.\d+)?");
+                    float? currentBase = leadingMatch.Success &&
+                                         float.TryParse(leadingMatch.Value, NumberStyles.Any, CultureInfo.InvariantCulture, out var lb)
+                        ? lb : null;
+
+                    if (currentBase.HasValue && prevBase.HasValue && currentBase.Value.Is(prevBase.Value))
                     {
-                        counter += 0.1f; // bump if same value as the previous issue
+                        // Same base number as the previous entry -> keep bumping within the group
+                        counter += 0.1f;
                     }
+                    else if (currentBase.HasValue)
+                    {
+                        counter = currentBase.Value;
+                    }
+                    else
+                    {
+                        counter++;
+                    }
+
                     chapter.IssueOrder = counter;
-                    counter++;
-                    prevIssue = chapter.Chapters;
+                    prevBase = currentBase ?? prevBase;
                 }
             }
         }

--- a/Kavita.Services/Scanner/ParseScannedFiles.cs
+++ b/Kavita.Services/Scanner/ParseScannedFiles.cs
@@ -811,7 +811,7 @@ public class ParseScannedFiles
     }
 
 
-    private static void UpdateSortOrder(ConcurrentDictionary<ParsedSeries, List<ParserInfo>> scannedSeries, ParsedSeries series)
+    public static void UpdateSortOrder(ConcurrentDictionary<ParsedSeries, List<ParserInfo>> scannedSeries, ParsedSeries series)
     {
         // Set the Sort order per Volume
         var volumes = scannedSeries[series].GroupBy(info => info.Volumes);
@@ -863,8 +863,9 @@ public class ParseScannedFiles
             foreach (var chapter in chapters)
             {
                 // Use MinNumber in case there is a range, as otherwise sort order will cause it to be processed last
-                var chapterNum =
-                    $"{Parser.MinNumberFromRange(chapter.Chapters).ToString(CultureInfo.InvariantCulture)}";
+                var chapterNum = Parser.IsRange(chapter.Chapters) ?
+                    $"{Parser.MinNumberFromRange(chapter.Chapters).ToString(CultureInfo.InvariantCulture)}"
+                    : chapter.Chapters;
                 if (float.TryParse(chapterNum, NumberStyles.Any, CultureInfo.InvariantCulture, out var parsedChapter))
                 {
                     // Parsed successfully, use the numeric value

--- a/Kavita.Services/Scanner/Parser.cs
+++ b/Kavita.Services/Scanner/Parser.cs
@@ -101,6 +101,8 @@ public static partial class Parser
     [GeneratedRegex(@"[^a-zA-Z0-9]")]
     public static partial Regex NonAlphanumericRegex();
 
+
+
     private static readonly Regex ImageRegex = new(ImageFileExtensions,
         MatchOptions, RegexTimeout);
     private static readonly Regex ArchiveFileRegex = new(ArchiveFileExtensions,
@@ -1055,6 +1057,10 @@ public static partial class Parser
         return XmlRegex.IsMatch(Path.GetExtension(filePath));
     }
 
+    public static bool IsRange(string range)
+    {
+        return !string.IsNullOrEmpty(range) && Regex.IsMatch(range, @"^[\d\-.]+$", MatchOptions, RegexTimeout);
+    }
 
     public static float MinNumberFromRange(string range)
     {

--- a/UI/Web/src/app/_models/metadata/v2/series-filter-field.ts
+++ b/UI/Web/src/app/_models/metadata/v2/series-filter-field.ts
@@ -37,6 +37,7 @@ export enum SeriesFilterField
     Location = 31,
     ReadLast = 32,
     FileSize = 33,
+    CollapseSeriesRelationships = 34,
 }
 
 

--- a/UI/Web/src/app/_pipes/browse-title.pipe.ts
+++ b/UI/Web/src/app/_pipes/browse-title.pipe.ts
@@ -71,6 +71,7 @@ export class BrowseTitlePipe implements PipeTransform {
       case SeriesFilterField.Summary:
       case SeriesFilterField.SeriesName:
       case SeriesFilterField.FileSize:
+      case SeriesFilterField.CollapseSeriesRelationships:
       default:
         return '';
     }

--- a/UI/Web/src/app/_pipes/filter-field.pipe.ts
+++ b/UI/Web/src/app/_pipes/filter-field.pipe.ts
@@ -78,6 +78,8 @@ export class FilterFieldPipe implements PipeTransform {
         return translate('filter-field-pipe.average-rating');
       case SeriesFilterField.FileSize:
         return translate('filter-field-pipe.file-size');
+      case SeriesFilterField.CollapseSeriesRelationships:
+        return translate('filter-field-pipe.collapse-series-relationships');
       default:
         throw new Error(`Invalid FilterField value: ${value}`);
     }

--- a/UI/Web/src/app/_pipes/generic-filter-field.pipe.ts
+++ b/UI/Web/src/app/_pipes/generic-filter-field.pipe.ts
@@ -155,6 +155,8 @@ export class GenericFilterFieldPipe implements PipeTransform {
         return translate('filter-field-pipe.average-rating');
       case SeriesFilterField.FileSize:
         return translate('filter-field-pipe.file-size');
+      case SeriesFilterField.CollapseSeriesRelationships:
+        return translate('filter-field-pipe.collapse-series-relationships');
       default:
         throw new Error(`Invalid FilterField value: ${value}`);
     }

--- a/UI/Web/src/app/shared/_services/filter-utilities.service.ts
+++ b/UI/Web/src/app/shared/_services/filter-utilities.service.ts
@@ -321,7 +321,7 @@ export class FilterUtilitiesService {
         ] as T[];
       case 'series':
         return [
-          SeriesFilterField.WantToRead
+          SeriesFilterField.WantToRead, SeriesFilterField.CollapseSeriesRelationships
         ] as unknown as T[];
       case 'person':
         return [] as unknown as T[];

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -4153,7 +4153,8 @@
         "read-date": "Reading Date",
         "read-last": "Read Last",
         "average-rating": "Average rating",
-        "file-size": "File size"
+        "file-size": "File size",
+        "collapse-series-relationships": "{{user-preferences.collapse-series-relationships-label}}"
     },
 
     "filter-entity-type-pipe": {

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -3427,7 +3427,7 @@
         "unit-average-rating": "Kavita+ external rating, percent",
         "unit-reading-progress": "Percent",
         "unit-user-rating": "0.0 - 5.0 Stars",
-        "unit-read-last": "Days from TODAY",
+        "unit-read-last": "Days ago",
         "disclaimer-highlight-slots": "When using this field, only your own annotations will be shown",
         "unit-file-size": "GB, MB, KB, B",
         "disclaimer-file-size": "File size must include the unit"


### PR DESCRIPTION
# Added
- Added: Added collapse series relationships as an option for series filter. Overwriting your global preferences for that filter. (Closes #4664)


# Changed
- Changed: Inverted the behaviour of the last read filter field to be more intuitive. (Closes #4716)

# Fixed
- Fixed: Fixed series with non numerical chapter positions always being sorted at the start. (Fixes #4820, Fixes #4380)
