### PR TITLE
Shed chapters that a re-parse no longer maps to

### DIFF
--- a/Kavita.Services.Tests/ScannerServiceTests.cs
+++ b/Kavita.Services.Tests/ScannerServiceTests.cs
@@ -1230,4 +1230,52 @@ public class ScannerServiceTests: AbstractDbTest
         Assert.Equal("The Avengers", postLib.Series.First().Name);
         Assert.Equal("Avengers", postLib.Series.First().SortName);
     }
+
+    /// <summary>
+    /// When parsing rules change, a file that used to map to one chapter and now maps to another must shed the
+    /// old chapter. Ex: "Blade Runner 2019 - Volume 1.pdf" used to parse as Volume 1/Chapter 2019 and now parses
+    /// as Volume 1 only, but Chapter 2019 lingered in the library forever, even on a forced scan.
+    /// </summary>
+    [Fact]
+    public async Task ScanLibrary_ChapterNoLongerParsed_IsRemovedOnRescan()
+    {
+        var (unitOfWork, context, _) = await CreateDatabase();
+        var scannerHelper = new ScannerHelper(unitOfWork, _testOutputHelper);
+
+        const string testcase = "Stale Chapter - Book.json";
+        var library = await scannerHelper.GenerateScannerData(testcase);
+        var scanner = scannerHelper.CreateServices();
+        await scanner.ScanLibrary(library.Id);
+
+        var postLib = await unitOfWork.LibraryRepository.GetLibraryForIdAsync(library.Id, LibraryIncludes.Series);
+        Assert.NotNull(postLib);
+        Assert.Single(postLib.Series);
+
+        var volume = postLib.Series.First().Volumes.Single();
+        var chapter = volume.Chapters.Single();
+        var expectedRange = chapter.Range;
+        Assert.NotEqual("2019", expectedRange);
+
+        // Simulate what the old parser wrote to the DB for this exact file: Chapter 2019
+        var stale = await unitOfWork.ChapterRepository.GetChapterAsync(chapter.Id);
+        stale!.Range = "2019";
+        stale.MinNumber = 2019f;
+        stale.MaxNumber = 2019f;
+        unitOfWork.ChapterRepository.Update(stale);
+        await unitOfWork.CommitAsync();
+
+        // Force a full rescan, which is what a user would reach for
+        await SetAllSeriesLastScannedInThePast(context, postLib);
+        await scanner.ScanLibrary(library.Id, true);
+
+        var postLib2 = await unitOfWork.LibraryRepository.GetLibraryForIdAsync(library.Id, LibraryIncludes.Series);
+        Assert.NotNull(postLib2);
+        Assert.Single(postLib2.Series);
+
+        var volume2 = postLib2.Series.First().Volumes.Single();
+        Assert.DoesNotContain(volume2.Chapters, c => c.Range == "2019");
+        var survivor = Assert.Single(volume2.Chapters);
+        Assert.Equal(expectedRange, survivor.Range);
+        Assert.Single(survivor.Files);
+    }
 }

--- a/Kavita.Services.Tests/Test Data/ScannerService/TestCases/Stale Chapter - Book.json
+++ b/Kavita.Services.Tests/Test Data/ScannerService/TestCases/Stale Chapter - Book.json
@@ -1,0 +1,3 @@
+[
+    "Blade Runner 2019/Blade Runner 2019 - Volume 1.pdf"
+]

--- a/Kavita.Services/Scanner/ProcessSeries.cs
+++ b/Kavita.Services/Scanner/ProcessSeries.cs
@@ -744,6 +744,10 @@ public class ProcessSeries(
 
     private async Task UpdateChapters(UpdateChapterArgs args)
     {
+        // Tracks which files this scan actually mapped onto each chapter. Needed so that when parsing rules change
+        // and a file resolves to a different chapter than it did before, the old chapter can be shed (see RemoveChapters)
+        var parsedChapterFiles = new Dictionary<Chapter, HashSet<string>>();
+
         // Add new chapters
         foreach (var info in args.ParsedInfos)
         {
@@ -773,6 +777,12 @@ public class ProcessSeries(
                 chapter.UpdateFrom(info);
             }
 
+            if (!parsedChapterFiles.TryGetValue(chapter, out var mappedFiles))
+            {
+                mappedFiles = [];
+                parsedChapterFiles[chapter] = mappedFiles;
+            }
+            mappedFiles.Add(Parser.NormalizePath(info.FullFilePath));
 
             // Add files
             AddOrUpdateFileForChapter(chapter, info, args.ForceUpdate);
@@ -846,10 +856,16 @@ public class ProcessSeries(
             }
         }
 
-        RemoveChapters(args.Volume, args.ParsedInfos);
+        RemoveChapters(args.Volume, args.ParsedInfos, parsedChapterFiles);
     }
 
-    private void RemoveChapters(Volume volume, IList<ParserInfo> parsedInfos)
+    /// <summary>
+    /// Removes any chapters (and files on them) that the current parse no longer maps onto them
+    /// </summary>
+    /// <param name="volume">Volume being updated</param>
+    /// <param name="parsedInfos">The infos parsed for this volume</param>
+    /// <param name="parsedChapterFiles">Normalized file paths this parse mapped onto each chapter, from <see cref="UpdateChapters"/></param>
+    private void RemoveChapters(Volume volume, IList<ParserInfo> parsedInfos, Dictionary<Chapter, HashSet<string>> parsedChapterFiles)
     {
         // Chapters to remove after enumeration
         var chaptersToRemove = new List<Chapter>();
@@ -873,8 +889,16 @@ public class ProcessSeries(
 
             if (hasMatchingDirectory)
             {
+                // Only keep the files this parse mapped onto this exact chapter. Checking against all parsedInfos instead
+                // would keep a stale chapter alive whenever parsing rules change and its file now maps to another chapter
+                // (ex: "Blade Runner 2019 - Volume 1.pdf" used to parse as Chapter 2019 and no longer does)
+                if (!parsedChapterFiles.TryGetValue(existingChapter, out var mappedFiles))
+                {
+                    mappedFiles = [];
+                }
+
                 existingChapter.Files = existingChapter.Files
-                    .Where(f => parsedInfos.Any(p => Parser.NormalizePath(p.FullFilePath) == Parser.NormalizePath(f.FilePath)))
+                    .Where(f => mappedFiles.Contains(Parser.NormalizePath(f.FilePath)))
                     .OrderByNatural(f => f.FilePath)
                     .ToList();
 


### PR DESCRIPTION
# Fixed
 - Fixed: Fixed a bug where chapters that no longer parse out of a filename stayed in the library forever, even after a forced scan. For example, 'Blade Runner 2019 - Volume 1.pdf' was previously read as both Volume 1 and Chapter 2019, and kept showing a Chapter 2019 entry long after parsing stopped producing one. (Fixes #4831)
