### PR TITLE
Workflow security fixes for the release pipelines

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [ '**' ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build and Test PR

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,12 +10,12 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
             fetch-depth: 1
 
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
             dotnet-version: 10.0.x
 
@@ -26,7 +26,7 @@ jobs:
       - name: Install dependencies
         run: dotnet restore
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: csproj
           path: Kavita.Common/Kavita.Common.csproj

--- a/.github/workflows/build-ui.yml
+++ b/.github/workflows/build-ui.yml
@@ -10,12 +10,12 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           fetch-depth: 1
 
       - name: NodeJS to Compile WebUI
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 24
       - run: |

--- a/.github/workflows/build-ui.yml
+++ b/.github/workflows/build-ui.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [ '**' ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build UI

--- a/.github/workflows/canary-workflow.yml
+++ b/.github/workflows/canary-workflow.yml
@@ -36,7 +36,7 @@ jobs:
             dotnet-version: 10.0.x
 
       - name: Bump versions
-        uses: SiqiLu/dotnet-bump-version@2.0.0
+        uses: majora2007/dotnet-bump-version@a01d35d737a36f2732f750ecaa6b35bc628da4da # v0.0.10
         with:
           version_files: Kavita.Common/Kavita.Common.csproj
           github_token: ${{ secrets.REPO_GHA_PAT }}

--- a/.github/workflows/canary-workflow.yml
+++ b/.github/workflows/canary-workflow.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
             fetch-depth: 0
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: csproj
           path: Kavita.Common/Kavita.Common.csproj
@@ -26,12 +26,12 @@ jobs:
     needs: [ build ]
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           fetch-depth: 0
 
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
             dotnet-version: 10.0.x
 
@@ -52,19 +52,19 @@ jobs:
       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/canary' }}
       steps:
           - name: Find Current Pull Request
-            uses: jwalton/gh-find-current-pr@v1
+            uses: jwalton/gh-find-current-pr@f3d61b485d2801773f7a07b2aaa3306bd8f8e653 # v1.3.5
             id: findPr
             with:
                 state: all
                 github-token: ${{ secrets.GITHUB_TOKEN }}
 
           - name: Check Out Repo
-            uses: actions/checkout@v5
+            uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
             with:
                 ref: canary
 
           - name: NodeJS to Compile WebUI
-            uses: actions/setup-node@v5
+            uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
             with:
                 node-version: 24
           - run: |
@@ -81,7 +81,7 @@ jobs:
                 cd ../ || exit
 
           - name: Get csproj Version
-            uses: kzrnm/get-net-sdk-project-versions-action@v2
+            uses: kzrnm/get-net-sdk-project-versions-action@c33b25a7eeaf70f65fc346fac2306d7d2ada2d66 # v2.0.0
             id: get-version
             with:
                 proj-path: Kavita.Common/Kavita.Common.csproj
@@ -96,7 +96,7 @@ jobs:
             run: echo "${{steps.get-version.outputs.assembly-version}}"
 
           - name: Compile dotnet app
-            uses: actions/setup-dotnet@v5
+            uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
             with:
                 dotnet-version: 10.0.x
 
@@ -106,28 +106,28 @@ jobs:
           - run: ./monorepo-build.sh
 
           - name: Login to Docker Hub
-            uses: docker/login-action@v3
+            uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
             with:
                 username: ${{ secrets.DOCKER_HUB_USERNAME }}
                 password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
           - name: Login to GitHub Container Registry
-            uses: docker/login-action@v3
+            uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
             with:
                 registry: ghcr.io
                 username: ${{ github.actor }}
                 password: ${{ secrets.GITHUB_TOKEN }}
 
           - name: Set up QEMU
-            uses: docker/setup-qemu-action@v3
+            uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
           - name: Set up Docker Buildx
             id: buildx
-            uses: docker/setup-buildx-action@v3
+            uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
           - name: Build and push
             id: docker_build
-            uses: docker/build-push-action@v5
+            uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
             with:
                 context: .
                 platforms: linux/amd64,linux/arm/v7,linux/arm64

--- a/.github/workflows/canary-workflow.yml
+++ b/.github/workflows/canary-workflow.yml
@@ -10,6 +10,8 @@ jobs:
   build:
     name: Upload Kavita.Common for Version Bump
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - name: Checkout Repo
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
@@ -23,6 +25,9 @@ jobs:
 
   version:
     name: Bump version
+    # The bump commit is pushed with the repository PAT, not this token.
+    permissions:
+      contents: read
     needs: [ build ]
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,16 +46,16 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v5
+      uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
       with:
         dotnet-version: 10.0.x
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@c4dd10e44af883a891fe31ced449bcb4a6728b9b # v3.37.6
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -69,7 +69,7 @@ jobs:
     # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      uses: github/codeql-action/autobuild@c4dd10e44af883a891fe31ced449bcb4a6728b9b # v3.37.6
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -82,6 +82,6 @@ jobs:
         dotnet build Kavita.sln
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@c4dd10e44af883a891fe31ced449bcb4a6728b9b # v3.37.6
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/comment-on-issues.yml
+++ b/.github/workflows/comment-on-issues.yml
@@ -16,6 +16,12 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: read
+  # Reads the linked pull requests and comments on their issues.
+  pull-requests: read
+  issues: write
+
 jobs:
   comment-issues:
     name: Comment on Linked Issues

--- a/.github/workflows/comment-on-issues.yml
+++ b/.github/workflows/comment-on-issues.yml
@@ -25,13 +25,13 @@ jobs:
       (github.event.workflow_run.conclusion == 'success')
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: develop
           fetch-depth: 0
 
       - name: Get csproj Version
-        uses: kzrnm/get-net-sdk-project-versions-action@v2
+        uses: kzrnm/get-net-sdk-project-versions-action@c33b25a7eeaf70f65fc346fac2306d7d2ada2d66 # v2.0.0
         id: get-version
         with:
           proj-path: Kavita.Common/Kavita.Common.csproj
@@ -55,7 +55,7 @@ jobs:
 
       - name: Find PR from Commit
         id: pr-number
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -82,7 +82,7 @@ jobs:
 
       - name: Comment on Linked Issues
         if: steps.pr-number.outputs.pr != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         env:
           NIGHTLY_VERSION: ${{ steps.versions.outputs.NIGHTLY_VERSION }}
           STABLE_VERSION: ${{ steps.versions.outputs.STABLE_VERSION }}

--- a/.github/workflows/develop-workflow.yml
+++ b/.github/workflows/develop-workflow.yml
@@ -10,11 +10,16 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Debug Info
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          GIT_REF: ${{ github.ref }}
+          NOT_CONTAINS_RELEASE: ${{ !contains(github.head_ref, 'release') }}
+          MATCHES_DEVELOP: ${{ github.ref == 'refs/heads/develop' }}
         run: |
-          echo "Event Name: ${{ github.event_name }}"
-          echo "Ref: ${{ github.ref }}"
-          echo "Not Contains Release: ${{ !contains(github.head_ref, 'release') }}"
-          echo "Matches Develop: ${{ github.ref == 'refs/heads/develop' }}"
+          echo "Event Name: $EVENT_NAME"
+          echo "Ref: $GIT_REF"
+          echo "Not Contains Release: $NOT_CONTAINS_RELEASE"
+          echo "Matches Develop: $MATCHES_DEVELOP"
   build:
     name: Upload Kavita.Common for Version Bump
     runs-on: ubuntu-24.04

--- a/.github/workflows/develop-workflow.yml
+++ b/.github/workflows/develop-workflow.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   debug:
     runs-on: ubuntu-24.04
+    # No API access needed, the job only echoes context values.
+    permissions: {}
     steps:
       - name: Debug Info
         env:
@@ -23,6 +25,8 @@ jobs:
   build:
     name: Upload Kavita.Common for Version Bump
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     if: github.ref == 'refs/heads/develop'
     steps:
       - name: Checkout Repo
@@ -39,6 +43,9 @@ jobs:
     name: Bump version
     needs: [ build ]
     runs-on: ubuntu-24.04
+    # The bump commit is pushed with the repository PAT, not this token.
+    permissions:
+      contents: read
     if: github.ref == 'refs/heads/develop'
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0

--- a/.github/workflows/develop-workflow.yml
+++ b/.github/workflows/develop-workflow.yml
@@ -26,11 +26,11 @@ jobs:
     if: github.ref == 'refs/heads/develop'
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           fetch-depth: 0
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: csproj
           path: Kavita.Common/Kavita.Common.csproj
@@ -41,17 +41,17 @@ jobs:
     runs-on: ubuntu-24.04
     if: github.ref == 'refs/heads/develop'
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           fetch-depth: 0
 
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
             dotnet-version: 10.0.x
 
       - name: Bump versions
-        uses: majora2007/dotnet-bump-version@v0.0.10
+        uses: majora2007/dotnet-bump-version@a01d35d737a36f2732f750ecaa6b35bc628da4da # v0.0.10
         with:
           version_files: Kavita.Common/Kavita.Common.csproj
           github_token: ${{ secrets.REPO_GHA_PAT }}
@@ -67,7 +67,7 @@ jobs:
       contents: read
     steps:
       - name: Find Current Pull Request
-        uses: jwalton/gh-find-current-pr@v1
+        uses: jwalton/gh-find-current-pr@f3d61b485d2801773f7a07b2aaa3306bd8f8e653 # v1.3.5
         id: findPr
         with:
           state: all
@@ -94,12 +94,12 @@ jobs:
           echo "BODY=$body" >> "$GITHUB_OUTPUT"
 
       - name: Check Out Repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: develop
 
       - name: NodeJS to Compile WebUI
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 24
       - run: |
@@ -116,7 +116,7 @@ jobs:
           cd ../ || exit
 
       - name: Get csproj Version
-        uses: kzrnm/get-net-sdk-project-versions-action@v2
+        uses: kzrnm/get-net-sdk-project-versions-action@c33b25a7eeaf70f65fc346fac2306d7d2ada2d66 # v2.0.0
         id: get-version
         with:
           proj-path: Kavita.Common/Kavita.Common.csproj
@@ -131,7 +131,7 @@ jobs:
         run: echo "${{steps.get-version.outputs.assembly-version}}"
 
       - name: Compile dotnet app
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
           dotnet-version: 10.0.x
 
@@ -141,29 +141,29 @@ jobs:
       - run: ./monorepo-build.sh
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         if: ${{ github.repository_owner == 'Kareadita' }}
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Extract metadata (tags, labels) for Docker
         id: docker_meta_nightly
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           tags: |
             type=raw,value=nightly
@@ -174,7 +174,7 @@ jobs:
 
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           platforms: linux/amd64,linux/arm/v7,linux/arm64
@@ -186,7 +186,7 @@ jobs:
         run: echo ${{ steps.docker_build.outputs.digest }}
 
       - name: Notify Discord
-        uses: rjstone/discord-webhook-notify@v2
+        uses: rjstone/discord-webhook-notify@13eb215cbf853107dd9386c4a2f4035b7988cfc2 # v2.3.0
         if: ${{ github.repository_owner == 'Kareadita' }}
         with:
             severity: info

--- a/.github/workflows/openapi-gen.yml
+++ b/.github/workflows/openapi-gen.yml
@@ -11,6 +11,10 @@ on:
   workflow_dispatch:
 
 
+# The documentation push uses the repository PAT, not this token.
+permissions:
+  contents: read
+
 jobs:
   generate-openapi:
     runs-on: ubuntu-latest

--- a/.github/workflows/openapi-gen.yml
+++ b/.github/workflows/openapi-gen.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
           dotnet-version: 10.0.x
 

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -14,7 +14,7 @@ jobs:
               run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
               id: extract_branch
             - name: Check PR Body
-              uses: JJ/github-pr-contains-action@releases/v10
+              uses: JJ/github-pr-contains-action@43fcaf34d8462de9359ce2a6c8b469d6a13354c8 # releases/v10
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   bodyDoesNotContain: "[\"|`]"

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -5,6 +5,11 @@ on:
         branches: [ main, develop, canary ]
         types: [synchronize]
 
+permissions:
+  contents: read
+  # The body check reads the pull request through the API.
+  pull-requests: read
+
 jobs:
     check_pr:
         runs-on: ubuntu-24.04

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -13,11 +13,16 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Debug Info
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          GIT_REF: ${{ github.ref }}
+          NOT_CONTAINS_RELEASE: ${{ !contains(github.head_ref, 'release') }}
+          MATCHES_DEVELOP: ${{ github.ref == 'refs/heads/develop' }}
         run: |
-          echo "Event Name: ${{ github.event_name }}"
-          echo "Ref: ${{ github.ref }}"
-          echo "Not Contains Release: ${{ !contains(github.head_ref, 'release') }}"
-          echo "Matches Develop: ${{ github.ref == 'refs/heads/develop' }}"
+          echo "Event Name: $EVENT_NAME"
+          echo "Ref: $GIT_REF"
+          echo "Not Contains Release: $NOT_CONTAINS_RELEASE"
+          echo "Matches Develop: $MATCHES_DEVELOP"
   if_merged:
     if: github.event.pull_request.merged == true && contains(github.head_ref, 'release')
     runs-on: ubuntu-24.04

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   debug:
     runs-on: ubuntu-24.04
+    # No API access needed, the job only echoes context values.
+    permissions: {}
     steps:
       - name: Debug Info
         env:
@@ -26,12 +28,15 @@ jobs:
   if_merged:
     if: github.event.pull_request.merged == true && contains(github.head_ref, 'release')
     runs-on: ubuntu-24.04
+    permissions: {}
     steps:
       - run: |
           echo The PR was merged
   build:
     name: Upload Kavita.Common for Version Bump
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     if: github.event.pull_request.merged == true && contains(github.head_ref, 'release')
     steps:
       - name: Checkout Repo

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -35,11 +35,11 @@ jobs:
     if: github.event.pull_request.merged == true && contains(github.head_ref, 'release')
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           fetch-depth: 0
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: csproj
           path: Kavita.Common/Kavita.Common.csproj
@@ -54,7 +54,7 @@ jobs:
       contents: read
     steps:
       - name: Find Current Pull Request
-        uses: jwalton/gh-find-current-pr@v1
+        uses: jwalton/gh-find-current-pr@f3d61b485d2801773f7a07b2aaa3306bd8f8e653 # v1.3.5
         id: findPr
         with:
           state: all
@@ -69,12 +69,12 @@ jobs:
           echo "BODY=$body" >> $GITHUB_OUTPUT
 
       - name: Check Out Repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: develop
 
       - name: NodeJS to Compile WebUI
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 24
       - run: |
@@ -92,7 +92,7 @@ jobs:
           cd ../ || exit
 
       - name: Get csproj Version
-        uses: kzrnm/get-net-sdk-project-versions-action@v2
+        uses: kzrnm/get-net-sdk-project-versions-action@c33b25a7eeaf70f65fc346fac2306d7d2ada2d66 # v2.0.0
         id: get-version
         with:
           proj-path: Kavita.Common/Kavita.Common.csproj
@@ -109,7 +109,7 @@ jobs:
         id: parse-version
 
       - name: Compile dotnet app
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
           dotnet-version: 10.0.x
       - name: Install Swashbuckle CLI
@@ -118,29 +118,29 @@ jobs:
       - run: ./monorepo-build.sh
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         if: ${{ github.repository_owner == 'Kareadita' }}
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Extract metadata (tags, labels) for Docker
         id: docker_meta_stable
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           tags: |
             type=raw,value=latest
@@ -151,7 +151,7 @@ jobs:
 
       - name: Build and push stable
         id: docker_build_stable
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           platforms: linux/amd64,linux/arm/v7,linux/arm64
@@ -161,7 +161,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: docker_meta_nightly
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           tags: |
             type=raw,value=nightly
@@ -172,7 +172,7 @@ jobs:
 
       - name: Build and push nightly
         id: docker_build_nightly
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           platforms: linux/amd64,linux/arm/v7,linux/arm64


### PR DESCRIPTION
# Changed

- Changed: All workflow actions are now referenced by an exact commit instead of a floating tag, so the release and publish pipelines only ever run action code that existed at review time. Versions stay exactly where they were.
- Changed: Workflow jobs now declare the minimal token permissions they need. Only the issue commenter keeps a write scope, the docker publish jobs already had theirs scoped.

# Fixed

- Fixed: Fixed a shell injection risk in the debug steps of the nightly and stable workflows. Values now pass through environment variables, the printed output is unchanged.
- Fixed: Fixed the canary version bump referencing a GitHub repository that no longer exists, which would fail the next canary build. It now uses the same maintained fork the nightly workflow already uses, pinned like the rest.