### PR TITLE
Fix text being cut off on the right on small screens and invisible scroll bars

### DIFF
--- a/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.ts
+++ b/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.ts
@@ -1732,13 +1732,13 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
    */
   pageWidth = computed(() => {
     this.windowWidth(); // Ensure re-compute when windows size changes (element clientWidth isn't a signal)
+    this.pageStyles(); // Ensure re-compute when margins change
 
-    const marginLeft = this.pageStyles()['margin-left'];
-    const margin = (this.convertVwToPx(parseInt(marginLeft, 10)) * 2);
     const columnGapModifier = this.columnGapModifier();
-    if (this.readingSectionElemRef() == null) return 0;
+    const bookContent = this.bookContentElemRef()?.nativeElement;
+    if (this.readingSectionElemRef() == null || bookContent == null) return 0;
 
-    return this.reader().nativeElement.offsetWidth - margin + (COLUMN_GAP * columnGapModifier);
+    return bookContent.clientWidth + (COLUMN_GAP * columnGapModifier);
   });
 
   columnGapModifier = computed(() => {

--- a/UI/Web/src/app/book-reader/_models/book-paper-theme.ts
+++ b/UI/Web/src/app/book-reader/_models/book-paper-theme.ts
@@ -97,6 +97,10 @@ export const BookPaperTheme = `
   --br-actionbar-button-hover-border-color: #6c757d;
   --br-actionbar-bg-color: #F1E4D5;
 
+  /* Scrollbar */
+  --primary-color-scrollbar: rgba(0, 0, 0, 0.45);
+  --default-state-scrollbar: rgba(0, 0, 0, 0.25);
+
   /* Drawer */
   --drawer-pagination-horizontal-rule: inset 0 -1px 0 rgb(0 0 0 / 13%);
 

--- a/UI/Web/src/app/book-reader/_models/book-white-theme.ts
+++ b/UI/Web/src/app/book-reader/_models/book-white-theme.ts
@@ -101,6 +101,10 @@ export const BookWhiteTheme = `
   --br-actionbar-button-hover-border-color: #6c757d;
   --br-actionbar-bg-color: white;
 
+  /* Scrollbar */
+  --primary-color-scrollbar: rgba(0, 0, 0, 0.45);
+  --default-state-scrollbar: rgba(0, 0, 0, 0.25);
+
   /* Drawer */
   --drawer-pagination-horizontal-rule: inset 0 -1px 0 rgb(0 0 0 / 13%);
   --drawer-pagination-border: 1px solid rgb(0 0 0 / 13%);


### PR DESCRIPTION
# Fixed
- Fixed: Scroll bar is invisible with white and paper themes (Fixes #4841)
- Fixed: Text is sometimes cut off on the right on small screens in "1 Column" mode (Fixes #4842)