### PR TITLE
Fix text overflowing to the right in progressive web app

### DIFF
--- a/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.ts
+++ b/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.ts
@@ -1727,7 +1727,7 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
 
 
   /**
-   * This is the total space for the book content, excluding margin and the column gap (aka how big each column is)
+   * This is the total space for the book content, excluding margin
    * @returns Total Page width (excluding margin)
    */
   pageWidth = computed(() => {

--- a/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.ts
+++ b/UI/Web/src/app/book-reader/_components/book-reader/book-reader.component.ts
@@ -1732,13 +1732,13 @@ export class BookReaderComponent implements OnInit, AfterViewInit, OnDestroy {
    */
   pageWidth = computed(() => {
     this.windowWidth(); // Ensure re-compute when windows size changes (element clientWidth isn't a signal)
+    this.pageStyles(); // Ensure re-compute when margins change
 
-    const marginLeft = this.pageStyles()['margin-left'];
-    const margin = (this.convertVwToPx(parseInt(marginLeft, 10)) * 2);
     const columnGapModifier = this.columnGapModifier();
-    if (this.readingSectionElemRef() == null) return 0;
+    const bookContent = this.bookContentElemRef()?.nativeElement;
+    if (this.readingSectionElemRef() == null || bookContent == null) return 0;
 
-    return this.reader().nativeElement.offsetWidth - margin + (COLUMN_GAP * columnGapModifier);
+    return bookContent.clientWidth + (COLUMN_GAP * columnGapModifier);
   });
 
   columnGapModifier = computed(() => {


### PR DESCRIPTION
# Fixed
- Fixed: Text is sometimes cut off on the right on small screens in "1 Column" mode  (Fixes #4842)
