### PR TITLE
Polish Pass: Part 4

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ Fork the repository on GitHub, then clone your fork onto your local development 
 
 1. Install the required Node Packages
     - `cd Kavita/UI/Web`
-    - `npm install`
+    - `npm ci`
     - `npm install -g @angular/cli`
 2. Start the frontend 
     - `npm run start`

--- a/Kavita.Common/Helpers/StringHelper.cs
+++ b/Kavita.Common/Helpers/StringHelper.cs
@@ -6,7 +6,7 @@ namespace Kavita.Common.Helpers;
 public static partial class StringHelper
 {
     #region Regex Source Generators
-    [GeneratedRegex(@"\s?\(Source:\s*[^)]+\)")]
+    [GeneratedRegex(@"\s?(\s?\(Source:\s*[^)]+\)|\*?Source:\s*[^)]+\*?$)")]
     private static partial Regex SourceRegex();
     [GeneratedRegex(@"<br\s*/?>", RegexOptions.IgnoreCase | RegexOptions.Compiled, "en-US")]
     private static partial Regex BrStandardizeRegex();
@@ -44,7 +44,7 @@ public static partial class StringHelper
     }
 
     /// <summary>
-    /// Removes the (Source: MangaDex) type of tags at the end of descriptions from AL
+    /// Removes the (Source: MangaDex) or "Source: MANGA plus" type of tags at the end of descriptions from AL/MB
     /// </summary>
     /// <param name="description"></param>
     /// <returns></returns>

--- a/Kavita.Models/Entities/MetadataMatching/MetadataSettingField.cs
+++ b/Kavita.Models/Entities/MetadataMatching/MetadataSettingField.cs
@@ -16,6 +16,7 @@ public enum MetadataSettingField
     AgeRating = 8,
     People = 9,
     Name = 10,
+    SortName = 11,
     #endregion
 
     #region Chapter Metadata

--- a/Kavita.Server/Controllers/SeriesController.cs
+++ b/Kavita.Server/Controllers/SeriesController.cs
@@ -214,6 +214,7 @@ public class SeriesController(
             series.SortName = series.Library is {RemovePrefixForSortName: true}
                 ? BookSortTitlePrefixHelper.GetSortTitle(series.Name)
                 : series.Name;
+            series.Metadata.KPlusOverrides.Remove(MetadataSettingField.SortName);
         }
         else if (!string.IsNullOrEmpty(updateSeries.SortName?.Trim()))
         {

--- a/Kavita.Server/Controllers/SeriesController.cs
+++ b/Kavita.Server/Controllers/SeriesController.cs
@@ -224,7 +224,13 @@ public class SeriesController(
 
         var newLocalizedName = updateSeries.LocalizedName?.Trim();
         var newNormalizedLocalizedName = newLocalizedName.ToNormalized();
-        // BUG: This prevents us from changing the case of the localized Name
+        if (series.LocalizedName != newLocalizedName)
+        {
+            series.LocalizedName = newLocalizedName;
+            series.Metadata.KPlusOverrides.Remove(MetadataSettingField.LocalizedName);
+        }
+
+        // Only run expensive check if the name has changed after normalisation
         if (series.NormalizedLocalizedName != newNormalizedLocalizedName)
         {
             // A localized name that collides (normalized) with another series' name in the library+format breaks the scanner
@@ -241,10 +247,8 @@ public class SeriesController(
                 return BadRequest(await localizationService.TranslateAsync(UserId, "series-localized-name-orphans-files"));
             }
 
-            series.LocalizedName = newLocalizedName;
-            series.NormalizedLocalizedName = newNormalizedLocalizedName;
 
-            series.Metadata.KPlusOverrides.Remove(MetadataSettingField.LocalizedName);
+            series.NormalizedLocalizedName = newNormalizedLocalizedName;
         }
 
         series.NameLocked = updateSeries.NameLocked;

--- a/Kavita.Server/Controllers/SeriesController.cs
+++ b/Kavita.Server/Controllers/SeriesController.cs
@@ -219,10 +219,12 @@ public class SeriesController(
         else if (!string.IsNullOrEmpty(updateSeries.SortName?.Trim()))
         {
             series.SortName = updateSeries.SortName.Trim();
+            series.Metadata.KPlusOverrides.Remove(MetadataSettingField.SortName);
         }
 
         var newLocalizedName = updateSeries.LocalizedName?.Trim();
         var newNormalizedLocalizedName = newLocalizedName.ToNormalized();
+        // BUG: This prevents us from changing the case of the localized Name
         if (series.NormalizedLocalizedName != newNormalizedLocalizedName)
         {
             // A localized name that collides (normalized) with another series' name in the library+format breaks the scanner

--- a/Kavita.Services.Tests/SeriesServiceTests.cs
+++ b/Kavita.Services.Tests/SeriesServiceTests.cs
@@ -1284,6 +1284,63 @@ public class SeriesServiceTests(ITestOutputHelper outputHelper): AbstractDbTest(
         Assert.Equal(1, firstChapter.MinNumber);
     }
 
+    [Fact]
+    public void GetFirstChapterForMetadata_ChapterOne_HasPriority()
+    {
+        var file = new MangaFileBuilder("Test.cbz", MangaFormat.Archive, 1).Build();
+
+        var series = new SeriesBuilder("Test")
+            .WithVolume(new VolumeBuilder(Parser.LooseLeafVolume)
+                .WithChapter(new ChapterBuilder("0.5").WithPages(1).WithFile(file).Build())
+                .WithChapter(new ChapterBuilder("1").WithPages(1).WithFile(file).Build())
+                .WithChapter(new ChapterBuilder("2").WithPages(1).WithFile(file).Build())
+                .Build())
+            .Build();
+        series.Library = new LibraryBuilder("Test LIb", LibraryType.Book).Build();
+
+        var firstChapter = SeriesService.GetFirstChapterForMetadata(series);
+        Assert.NotNull(firstChapter);
+        Assert.Equal(1, firstChapter.MinNumber);
+    }
+
+    [Fact]
+    public void GetFirstChapterForMetadata_NonPrequelsGetPriority()
+    {
+        var file = new MangaFileBuilder("Test.cbz", MangaFormat.Archive, 1).Build();
+
+        var series = new SeriesBuilder("Test")
+            .WithVolume(new VolumeBuilder(Parser.LooseLeafVolume)
+                .WithChapter(new ChapterBuilder("0.5").WithPages(1).WithFile(file).Build())
+                .WithChapter(new ChapterBuilder("2").WithPages(1).WithFile(file).Build())
+                .WithChapter(new ChapterBuilder("3").WithPages(1).WithFile(file).Build())
+                .Build())
+            .Build();
+        series.Library = new LibraryBuilder("Test LIb", LibraryType.Book).Build();
+
+        var firstChapter = SeriesService.GetFirstChapterForMetadata(series);
+        Assert.NotNull(firstChapter);
+        Assert.Equal(2, firstChapter.MinNumber);
+    }
+
+    [Fact]
+    public void GetFirstChapterForMetadata_DoFallbackToPrequels()
+    {
+        var file = new MangaFileBuilder("Test.cbz", MangaFormat.Archive, 1).Build();
+
+        var series = new SeriesBuilder("Test")
+            .WithVolume(new VolumeBuilder(Parser.LooseLeafVolume)
+                .WithChapter(new ChapterBuilder("0.5").WithPages(1).WithFile(file).Build())
+                .WithChapter(new ChapterBuilder("0.6").WithPages(1).WithFile(file).Build())
+                .WithChapter(new ChapterBuilder("0.7").WithPages(1).WithFile(file).Build())
+                .Build())
+            .Build();
+        series.Library = new LibraryBuilder("Test LIb", LibraryType.Book).Build();
+
+        var firstChapter = SeriesService.GetFirstChapterForMetadata(series);
+        Assert.NotNull(firstChapter);
+        Assert.Equal(0.5, firstChapter.MinNumber, precision: 2);
+    }
+
     #endregion
 
     #region Series Relation

--- a/Kavita.Services/Extensions/MarkdownExtensions.cs
+++ b/Kavita.Services/Extensions/MarkdownExtensions.cs
@@ -1,6 +1,8 @@
 using Markdig;
+using Markdig.Renderers;
 
 namespace Kavita.Services.Extensions;
+
 
 public static class MarkdownExtensions
 {
@@ -12,11 +14,26 @@ public static class MarkdownExtensions
             .UseGenericAttributes(); // Always last!
     }
 
+    /**
+     * Handles the Mangabaka summary markdown -> Html. Works differently than other html conversions
+     * <example>This should write                     -> This should write</example>
+     * <example>This is **bold**, *italic*, [link](x) -> This is <strong>bold</strong>, <em>italic</em>, <a href="x">link</a></example>
+     * <example>Line one<br /> Line two with **bold** -> Line one<br /> Line two with <strong>bold</strong></example>
+     * <example>R&D &lt; 5                               -> R&amp;D &lt; 5</example>
+     */
     public static MarkdownPipelineBuilder UseKavitaPlus(this MarkdownPipelineBuilder pipeline)
     {
-        return pipeline.UsePipeTables()
-            .UseFootnotes()
-            .UseMathematics()
-            .UseGenericAttributes(); // Always last!
+        pipeline.UsePipeTables().UseFootnotes().UseMathematics().UseGenericAttributes(); // Always last!
+        pipeline.Extensions.Add(new NoParagraphExtension());
+        return pipeline;
+    }
+
+    private sealed class NoParagraphExtension : IMarkdownExtension
+    {
+        public void Setup(MarkdownPipelineBuilder pipeline) { }
+        public void Setup(MarkdownPipeline pipeline, IMarkdownRenderer renderer)
+        {
+            if (renderer is HtmlRenderer html) html.ImplicitParagraph = true;
+        }
     }
 }

--- a/Kavita.Services/Extensions/MarkdownExtensions.cs
+++ b/Kavita.Services/Extensions/MarkdownExtensions.cs
@@ -11,4 +11,12 @@ public static class MarkdownExtensions
             .UseMathematics()
             .UseGenericAttributes(); // Always last!
     }
+
+    public static MarkdownPipelineBuilder UseKavitaPlus(this MarkdownPipelineBuilder pipeline)
+    {
+        return pipeline.UsePipeTables()
+            .UseFootnotes()
+            .UseMathematics()
+            .UseGenericAttributes(); // Always last!
+    }
 }

--- a/Kavita.Services/Plus/ExternalMetadataService.cs
+++ b/Kavita.Services/Plus/ExternalMetadataService.cs
@@ -46,6 +46,7 @@ using Kavita.Models.Extensions;
 using Kavita.Services.Extensions;
 using Kavita.Services.Helpers;
 using Kavita.Services.Scanner;
+using Markdig;
 using Microsoft.Extensions.Logging;
 
 namespace Kavita.Services.Plus;
@@ -83,10 +84,10 @@ public class ExternalMetadataService : IExternalMetadataService
     };
 
     // Allow 50 requests per 24 hours
-    private static readonly RateLimiter RateLimiter = new RateLimiter(50, TimeSpan.FromHours(24), false);
+    private static readonly RateLimiter RateLimiter = new(50, TimeSpan.FromHours(24), false);
     private static readonly ConcurrentDictionary<int, SemaphoreSlim> SeriesWriteLocks = new();
     private static SemaphoreSlim GetSeriesWriteLock(int seriesId) => SeriesWriteLocks.GetOrAdd(seriesId, static _ => new SemaphoreSlim(1, 1));
-    private static bool IsRomanCharacters(string input) => Regex.IsMatch(input, @"^[\p{IsBasicLatin}\p{IsLatin-1Supplement}]+$");
+    private readonly MarkdownPipeline _markdownPipeline = new MarkdownPipelineBuilder().UseGithub().Build();
 
     public ExternalMetadataService(IUnitOfWork unitOfWork, ILogger<ExternalMetadataService> logger, IMapper mapper,
         ILicenseService licenseService, IScrobblingService scrobblingService, IEventHub eventHub, ICoverDbService coverDbService,
@@ -2596,7 +2597,7 @@ public class ExternalMetadataService : IExternalMetadataService
             .Any(segment => segment.ToNormalized() == dropped || Parser.CleanTitle(segment).ToNormalized() == dropped);
     }
 
-    private static (bool, MetadataFieldChangeDto?) UpdateSummary(Series series, MetadataSettingsDto settings, ExternalSeriesDetailDto externalMetadata)
+    private (bool, MetadataFieldChangeDto?) UpdateSummary(Series series, MetadataSettingsDto settings, ExternalSeriesDetailDto externalMetadata)
     {
         if (!settings.EnableSummary) return (false, null);
 
@@ -2613,7 +2614,9 @@ public class ExternalMetadataService : IExternalMetadataService
         }
 
         var from = series.Metadata.Summary;
-        series.Metadata.Summary = StringHelper.RemoveSourceInDescription(StringHelper.SquashBreaklines(externalMetadata.Summary));
+
+        // Mangabaka uses Markdown for Summaries, convert to Html to align with opf/comicinfo
+        series.Metadata.Summary = Markdown.ToHtml(StringHelper.RemoveSourceInDescription(StringHelper.SquashBreaklines(externalMetadata.Summary)) ?? string.Empty, _markdownPipeline);
         series.Metadata.AddKPlusOverride(MetadataSettingField.Summary);
         series.Metadata.SummaryLocked = true;
 
@@ -3074,7 +3077,7 @@ public class ExternalMetadataService : IExternalMetadataService
         var ageRating = DetermineAgeRating(extSeries.Tags.Select(t => t.Name).Concat(extSeries.Genres), settings.AgeRatingMappings);
 
         extSeries.AgeRating = ageRating;
-        extSeries.Summary = StringHelper.RemoveSourceInDescription(StringHelper.SquashBreaklines(extSeries.Summary));
+        extSeries.Summary = Markdown.ToHtml(StringHelper.RemoveSourceInDescription(StringHelper.SquashBreaklines(extSeries.Summary)) ?? string.Empty, _markdownPipeline);
 
         return extSeries;
     }

--- a/Kavita.Services/Plus/ExternalMetadataService.cs
+++ b/Kavita.Services/Plus/ExternalMetadataService.cs
@@ -1020,7 +1020,7 @@ public class ExternalMetadataService : IExternalMetadataService
             {
                 var (namePriority, localizedNamePriority) = ResolveTitleLanguagePriorities(settings, series.LibraryId);
 
-                // One query serves both writes. The set unions NormalizedName/NormalizedLocalizedName/NormalizedOriginalName
+                // The set unions NormalizedName/NormalizedLocalizedName/NormalizedOriginalName
                 // for every OTHER series in this library+format - a collision there makes the scanner's SingleOrDefault throw.
                 var takenNames = await _unitOfWork.SeriesRepository.GetTakenNormalizedNamesInLibraryAsync(
                     series.LibraryId, series.Format, series.Id, ct);
@@ -2535,7 +2535,7 @@ public class ExternalMetadataService : IExternalMetadataService
             // takenNames excludes this Series, so our own columns need checking separately. Dropping the language
             // code above is not enough - two languages can carry the same title text (en and ja-Latn "Bleach").
             // series.NormalizedName is already the post-UpdateName value here.
-            if (normalized == series.NormalizedName || normalized == series.NormalizedOriginalName) continue;
+            if (normalized == series.NormalizedName) continue;
 
             chosen = title;
             chosenLanguageCode = languageCode;

--- a/Kavita.Services/Plus/ExternalMetadataService.cs
+++ b/Kavita.Services/Plus/ExternalMetadataService.cs
@@ -2464,6 +2464,7 @@ public class ExternalMetadataService : IExternalMetadataService
         }
 
         var from = series.Name;
+        var fromSortName = series.SortName;
         series.Name = chosen;
         series.NormalizedName = chosen.ToNormalized();
         series.SortName = series.Library is {RemovePrefixForSortName: true}
@@ -2471,7 +2472,9 @@ public class ExternalMetadataService : IExternalMetadataService
             : series.Name;
 
         series.NameLocked = true;
+        series.SortNameLocked = fromSortName != series.SortName;
         series.Metadata.AddKPlusOverride(MetadataSettingField.Name);
+        series.Metadata.AddKPlusOverride(MetadataSettingField.SortName);
 
         return (true, new MetadataFieldChangeDto(MetadataFieldChangeKind.Name, from, series.Name, chosenLanguageCode));
     }

--- a/Kavita.Services/Plus/ExternalMetadataService.cs
+++ b/Kavita.Services/Plus/ExternalMetadataService.cs
@@ -2440,7 +2440,15 @@ public class ExternalMetadataService : IExternalMetadataService
 
             // The best candidate is already our Name. Stop rather than continue - sliding to a lower-priority
             // language here would rename the series away from a title it correctly holds.
-            if (normalized == series.NormalizedName) return (false, null);
+            if (normalized == series.NormalizedName)
+            {
+                if (string.Equals(title, series.Name, StringComparison.Ordinal)) return (false, null);
+
+                // If the case differs, we need to allow the change
+                chosen = title;
+                chosenLanguageCode = languageCode;
+                break;
+            }
 
             // Never create a normalized collision - it would make the scanner's SingleOrDefault lookup throw
             if (takenNames.Contains(normalized)) continue;

--- a/Kavita.Services/Plus/ExternalMetadataService.cs
+++ b/Kavita.Services/Plus/ExternalMetadataService.cs
@@ -47,6 +47,7 @@ using Kavita.Services.Extensions;
 using Kavita.Services.Helpers;
 using Kavita.Services.Scanner;
 using Markdig;
+using Markdig.Renderers;
 using Microsoft.Extensions.Logging;
 
 namespace Kavita.Services.Plus;
@@ -87,7 +88,7 @@ public class ExternalMetadataService : IExternalMetadataService
     private static readonly RateLimiter RateLimiter = new(50, TimeSpan.FromHours(24), false);
     private static readonly ConcurrentDictionary<int, SemaphoreSlim> SeriesWriteLocks = new();
     private static SemaphoreSlim GetSeriesWriteLock(int seriesId) => SeriesWriteLocks.GetOrAdd(seriesId, static _ => new SemaphoreSlim(1, 1));
-    private static readonly MarkdownPipeline MarkdownPipeline = new MarkdownPipelineBuilder().UseGithub().Build();
+    private static readonly MarkdownPipeline MarkdownPipeline = new MarkdownPipelineBuilder().UseKavitaPlus().Build();
 
     public ExternalMetadataService(IUnitOfWork unitOfWork, ILogger<ExternalMetadataService> logger, IMapper mapper,
         ILicenseService licenseService, IScrobblingService scrobblingService, IEventHub eventHub, ICoverDbService coverDbService,
@@ -2624,7 +2625,7 @@ public class ExternalMetadataService : IExternalMetadataService
         var from = series.Metadata.Summary;
 
         // Mangabaka uses Markdown for Summaries, convert to Html to align with opf/comicinfo
-        series.Metadata.Summary = Markdown.ToHtml(StringHelper.RemoveSourceInDescription(StringHelper.SquashBreaklines(externalMetadata.Summary)) ?? string.Empty, MarkdownPipeline);
+        series.Metadata.Summary = ConvertMarkdownToHtml(externalMetadata.Summary);
         series.Metadata.AddKPlusOverride(MetadataSettingField.Summary);
         series.Metadata.SummaryLocked = true;
 
@@ -3083,9 +3084,20 @@ public class ExternalMetadataService : IExternalMetadataService
         var ageRating = DetermineAgeRating(extSeries.Tags.Select(t => t.Name).Concat(extSeries.Genres), settings.AgeRatingMappings);
 
         extSeries.AgeRating = ageRating;
-        extSeries.Summary = Markdown.ToHtml(StringHelper.RemoveSourceInDescription(StringHelper.SquashBreaklines(extSeries.Summary)) ?? string.Empty, MarkdownPipeline);
+        extSeries.Summary = ConvertMarkdownToHtml(extSeries.Summary);
 
         return extSeries;
+    }
+
+    private static string ConvertMarkdownToHtml(string? summary)
+    {
+        if (string.IsNullOrWhiteSpace(summary)) return string.Empty;
+
+        var ret = Markdown.ToHtml(StringHelper.RemoveSourceInDescription(StringHelper.SquashBreaklines(summary)) ?? string.Empty, MarkdownPipeline).Trim();
+
+        // Check if ret is a single paragraph tag, if so, remove it.
+
+        return ret;
     }
 
     private static bool HasForceOverride(MetadataSettingsDto settings, IHasKPlusMetadata kPlusMetadata,

--- a/Kavita.Services/Plus/ExternalMetadataService.cs
+++ b/Kavita.Services/Plus/ExternalMetadataService.cs
@@ -87,7 +87,7 @@ public class ExternalMetadataService : IExternalMetadataService
     private static readonly RateLimiter RateLimiter = new(50, TimeSpan.FromHours(24), false);
     private static readonly ConcurrentDictionary<int, SemaphoreSlim> SeriesWriteLocks = new();
     private static SemaphoreSlim GetSeriesWriteLock(int seriesId) => SeriesWriteLocks.GetOrAdd(seriesId, static _ => new SemaphoreSlim(1, 1));
-    private readonly MarkdownPipeline _markdownPipeline = new MarkdownPipelineBuilder().UseGithub().Build();
+    private static readonly MarkdownPipeline MarkdownPipeline = new MarkdownPipelineBuilder().UseGithub().Build();
 
     public ExternalMetadataService(IUnitOfWork unitOfWork, ILogger<ExternalMetadataService> logger, IMapper mapper,
         ILicenseService licenseService, IScrobblingService scrobblingService, IEventHub eventHub, ICoverDbService coverDbService,
@@ -2605,7 +2605,7 @@ public class ExternalMetadataService : IExternalMetadataService
             .Any(segment => segment.ToNormalized() == dropped || Parser.CleanTitle(segment).ToNormalized() == dropped);
     }
 
-    private (bool, MetadataFieldChangeDto?) UpdateSummary(Series series, MetadataSettingsDto settings, ExternalSeriesDetailDto externalMetadata)
+    private static (bool, MetadataFieldChangeDto?) UpdateSummary(Series series, MetadataSettingsDto settings, ExternalSeriesDetailDto externalMetadata)
     {
         if (!settings.EnableSummary) return (false, null);
 
@@ -2624,7 +2624,7 @@ public class ExternalMetadataService : IExternalMetadataService
         var from = series.Metadata.Summary;
 
         // Mangabaka uses Markdown for Summaries, convert to Html to align with opf/comicinfo
-        series.Metadata.Summary = Markdown.ToHtml(StringHelper.RemoveSourceInDescription(StringHelper.SquashBreaklines(externalMetadata.Summary)) ?? string.Empty, _markdownPipeline);
+        series.Metadata.Summary = Markdown.ToHtml(StringHelper.RemoveSourceInDescription(StringHelper.SquashBreaklines(externalMetadata.Summary)) ?? string.Empty, MarkdownPipeline);
         series.Metadata.AddKPlusOverride(MetadataSettingField.Summary);
         series.Metadata.SummaryLocked = true;
 
@@ -3022,8 +3022,6 @@ public class ExternalMetadataService : IExternalMetadataService
     /// <returns></returns>
     private async Task<ExternalSeriesDetailDto?> GetSeriesDetail(int? aniListId, long? malId, int? mangaBakaId, int? seriesId, CancellationToken ct = default)
     {
-        // TODO: This is the primary point where we need to integrate ExternalIds since weblink parsing is already handled
-        // TODO: Ensure when we set/update weblinks via API, we reparse and update external ids (if they are empty only)
         var payload = new SeriesDetailRequestV3Dto()
         {
             // We can hardcode this for now. But will need to load from Library setting once Hardcover providers
@@ -3085,7 +3083,7 @@ public class ExternalMetadataService : IExternalMetadataService
         var ageRating = DetermineAgeRating(extSeries.Tags.Select(t => t.Name).Concat(extSeries.Genres), settings.AgeRatingMappings);
 
         extSeries.AgeRating = ageRating;
-        extSeries.Summary = Markdown.ToHtml(StringHelper.RemoveSourceInDescription(StringHelper.SquashBreaklines(extSeries.Summary)) ?? string.Empty, _markdownPipeline);
+        extSeries.Summary = Markdown.ToHtml(StringHelper.RemoveSourceInDescription(StringHelper.SquashBreaklines(extSeries.Summary)) ?? string.Empty, MarkdownPipeline);
 
         return extSeries;
     }

--- a/Kavita.Services/Plus/LicenseService.cs
+++ b/Kavita.Services/Plus/LicenseService.cs
@@ -39,7 +39,6 @@ public class LicenseService(
     : ILicenseService
 {
     private readonly TimeSpan _licenseCacheTimeout = TimeSpan.FromHours(8);
-    public const string Cron = "0 */9 * * *";
     /// <summary>
     /// Cache key for if license is valid or not
     /// </summary>

--- a/Kavita.Services/SeriesService.cs
+++ b/Kavita.Services/SeriesService.cs
@@ -65,17 +65,29 @@ public class SeriesService(
             .OrderBy(v => v.MinNumber);
         var minVolumeNumber = sortedVolumes.MinBy(v => v.MinNumber);
 
-
         var allChapters = series.Volumes
             .SelectMany(v => v.Chapters.OrderBy(c => c.MinNumber, ChapterSortComparerDefaultLast.Default))
             .ToList();
-        var minChapter = allChapters
-            .FirstOrDefault();
+
+        var minChapter = allChapters.FirstOrDefault();
 
         if (minVolumeNumber != null && minChapter != null &&
             (minChapter.MinNumber >= minVolumeNumber.MinNumber || minChapter.MinNumber.Is(Parser.DefaultChapterNumber)))
         {
-            return minVolumeNumber.Chapters.MinBy(c => c.MinNumber, ChapterSortComparerDefaultLast.Default);
+            allChapters = minVolumeNumber.Chapters.OrderBy(c => c.MinNumber, ChapterSortComparerDefaultLast.Default).ToList();
+            minChapter = allChapters.FirstOrDefault();
+        }
+
+        var chapterOne = allChapters.OneOrDefault(c => c.MinNumber.Is(1));
+        if (chapterOne != null)
+        {
+            return chapterOne;
+        }
+
+        var nonPrequelChapter = allChapters.FirstOrDefault(c => c.MinNumber >= 1);
+        if (nonPrequelChapter != null)
+        {
+            return nonPrequelChapter;
         }
 
         return minChapter;

--- a/Kavita.Services/TaskScheduler.cs
+++ b/Kavita.Services/TaskScheduler.cs
@@ -266,7 +266,7 @@ public class TaskScheduler : ITaskScheduler
         // Get the License Info (and cache it) on first load. This will internally cache the Github releases for the Version Service
         BackgroundJob.Enqueue(() => _licenseService.GetLicenseInfo(true, CancellationToken.None));  // Kick this off first to cache it then let it refresh every 9 hours (8 hour cache)
 
-        // Spread out licence checks for the backend
+        // Spread out license checks for the backend
         var randomKPlusLicenseCheck = Rnd.Next(0, 60);
         RecurringJob.AddOrUpdate(LicenseCheckId, () => _licenseService.GetLicenseInfo(false, CancellationToken.None),
             $"{randomKPlusLicenseCheck} */9 * * *", RecurringJobOptions);

--- a/Kavita.Services/TaskScheduler.cs
+++ b/Kavita.Services/TaskScheduler.cs
@@ -265,8 +265,11 @@ public class TaskScheduler : ITaskScheduler
 
         // Get the License Info (and cache it) on first load. This will internally cache the Github releases for the Version Service
         BackgroundJob.Enqueue(() => _licenseService.GetLicenseInfo(true, CancellationToken.None));  // Kick this off first to cache it then let it refresh every 9 hours (8 hour cache)
+
+        // Spread out licence checks for the backend
+        var randomKPlusLicenseCheck = Rnd.Next(0, 60);
         RecurringJob.AddOrUpdate(LicenseCheckId, () => _licenseService.GetLicenseInfo(false, CancellationToken.None),
-            LicenseService.Cron, RecurringJobOptions);
+            $"{randomKPlusLicenseCheck} */9 * * *", RecurringJobOptions);
 
         // KavitaPlus Scrobbling (every hour) - randomise minutes to spread requests out for K+
         var randomMinute = Rnd.Next(0, 60);

--- a/UI/Web/package-lock.json
+++ b/UI/Web/package-lock.json
@@ -455,6 +455,7 @@
       "integrity": "sha512-moERVCTekQKOvR8RMuEOtWSO3VS1qrzA3keI1dPto/JVB8Nqp9w3R5ZpEoXHzh4zgEryosxmPgdi6UczJe2ouQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@angular-eslint/bundled-angular-compiler": "21.3.1",
         "eslint-scope": "9.1.2"
@@ -500,6 +501,7 @@
       "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-21.2.8.tgz",
       "integrity": "sha512-RIqfVmfretQ0x/mXgMXe7Bw0Tpe8+zBV/Mm2OaNVyrmNG+9gYItEn5t/ZnQGcPD5nMNqckgp3+4/ZMc/qkS5ww==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -615,6 +617,7 @@
       "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-21.2.6.tgz",
       "integrity": "sha512-1PBzFf+um/VZ1dFF6cT72Zsq+9C/ZWF9m5dP0uHJgo4psX3yMBoZlZu5YomBiAQ/ePSkqCuryv1vrelK+yd3Mw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "parse5": "^8.0.0",
         "tslib": "^2.3.0"
@@ -632,6 +635,7 @@
       "integrity": "sha512-N/wj8fFRB718efIFYpwnYfy+MecZREZXsUNMTVndFLH6T0jCheb9PVetR6jsyZp6h46USNPOmJYJ/9255lME+Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@angular-devkit/architect": "0.2102.7",
         "@angular-devkit/core": "21.2.7",
@@ -666,6 +670,7 @@
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-21.2.8.tgz",
       "integrity": "sha512-ZvgcxsLPkSG0B1jc2ZXshAWIFBoQ0U9uwIX/zG/RGcfMpoKyEDNAebli6FTIpxIlz/35rtBNV7EGPhinjPTJFQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -682,6 +687,7 @@
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-21.2.8.tgz",
       "integrity": "sha512-Il9KlT6qX8rWmun5jY6wMLx56bCQZpOVIFEyHM4ai2wmxvbqyxgRFKDs4iMRNn1h04Tgupl6cKSqP9lecIvH6w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -694,6 +700,7 @@
       "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-21.2.8.tgz",
       "integrity": "sha512-S0W+6QazCsn/4xWZu0V5VmU9zmKIlqFR2FJSsAQUPReVmpA40SuQSP6A/cyMVIMYaHvO/cAXSHJVgpxBzBSL/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "7.29.0",
         "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -726,6 +733,7 @@
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-21.2.8.tgz",
       "integrity": "sha512-hI7n4t8qgFJaVV55LIaNuzcdP+/IeuqQRu3huSLo47Gf6uZAD0Acj4Ye9SC8YNmhUu5/RiImngm9NOlcI2oCJA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -751,6 +759,7 @@
       "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-21.2.8.tgz",
       "integrity": "sha512-tyQAHjfMHcqETRkKQaZHjYqIK9W8uRenPpY2DF/Jl+S7CwcaX4T8t8TKgzvTynNzQW9QGiLg0pqVosVMKzBXJg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "tslib": "^2.3.0"
@@ -770,6 +779,7 @@
       "resolved": "https://registry.npmjs.org/@angular/localize/-/localize-21.2.8.tgz",
       "integrity": "sha512-wt1ZIE2c7IL1KOgfJyr7pN5SNoQXy02dB/dswZKQlJWduVWkzG83uftPFPjhfASQeqrlpW7tXhb6PiRkJGlCkg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "7.29.0",
         "@types/babel__core": "7.20.5",
@@ -794,6 +804,7 @@
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-21.2.8.tgz",
       "integrity": "sha512-4fwmGf7GCuIsjFqx1gqqWC92YjlN9SmGJO17TPPsOm5zUOnDx+h3Bj9XjdXxlcBtugTb2xHk6Auqyv3lzWGlkw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -875,6 +886,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1155,31 +1167,6 @@
         "node": ">=14.17.0"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -1187,7 +1174,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -2068,6 +2054,7 @@
       "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^4.3.2",
         "@inquirer/confirm": "^5.1.21",
@@ -2285,6 +2272,7 @@
       "resolved": "https://registry.npmjs.org/@jsverse/transloco/-/transloco-8.3.0.tgz",
       "integrity": "sha512-p69/MhhAsTabDAffaiMALx4u9AwAqx24CjdECaCkUKSpCGbiYQUJPCsV4OsWjaSOxDNm9HuIX6NmqbfNZ0S3KA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jsverse/transloco-utils": "^8.2.1",
         "@jsverse/utils": "1.0.0-beta.5",
@@ -2367,7 +2355,8 @@
       "version": "1.0.0-beta.5",
       "resolved": "https://registry.npmjs.org/@jsverse/utils/-/utils-1.0.0-beta.5.tgz",
       "integrity": "sha512-z7IdlV6BdSeF3Veii8Yyk64KuyTjNIQnFaW5PAhmDx0wN29lB2BFp8WO6+tJPLPjtlz2yKeNrjkp1XqnMPaeHA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@listr2/prompt-adapter-inquirer": {
       "version": "3.0.5",
@@ -3542,6 +3531,7 @@
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -4299,7 +4289,8 @@
       "version": "25.0.0",
       "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-25.0.0.tgz",
       "integrity": "sha512-XKLA6syeBUaPzx4j3qwMqzzq+V4uo72BnlbOjmuljLrRqdsd3qnzvZZoxvMHZ23ndsRS4aufU6JOZYpCbU6T1A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
@@ -4701,6 +4692,7 @@
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -4746,6 +4738,7 @@
       "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.2",
         "@typescript-eslint/types": "8.58.2",
@@ -4853,6 +4846,7 @@
       "integrity": "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -4895,6 +4889,7 @@
       "integrity": "sha512-QZfjHNEzPY8+l0+fIXMvuQ2sJlplB4zgDZvA+NmvZsZv3EQwOcc1DuIU1VJUTWZ/RKouBMhDyNaBMx4sWvrzRA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
         "@typescript-eslint/scope-manager": "8.58.2",
@@ -5006,6 +5001,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5312,6 +5308,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -5466,6 +5463,7 @@
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
       "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readdirp": "^5.0.0"
       },
@@ -6131,6 +6129,7 @@
       "integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -6394,6 +6393,7 @@
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -6828,6 +6828,7 @@
       "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -7457,6 +7458,7 @@
       "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cli-truncate": "^5.0.0",
         "colorette": "^2.0.20",
@@ -8863,6 +8865,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -9002,6 +9005,7 @@
       "resolved": "https://registry.npmjs.org/quill/-/quill-2.0.3.tgz",
       "integrity": "sha512-xEYQBqfYx/sfb33VJiKnSJp8ehloavImQ2A6564GAbqG55PGw1dAWUn1MUbQB62t0azawUS2CZZhWCjO8gRvTw==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "eventemitter3": "^5.0.1",
         "lodash-es": "^4.17.21",
@@ -9229,6 +9233,7 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -9902,7 +9907,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tuf-js": {
       "version": "4.1.0",
@@ -9953,6 +9959,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10080,6 +10087,7 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -10507,6 +10515,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -10525,7 +10534,8 @@
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.16.1.tgz",
       "integrity": "sha512-dpvY17vxYIW3+bNrP0ClUlaiY0CiIRK3tnoLaGoQsQcY9/I/NpzIWQ7tQNhbV7LacQMpCII6wVzuL3tuWOyfuA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/zrender": {
       "version": "6.0.0",

--- a/UI/Web/package-lock.json
+++ b/UI/Web/package-lock.json
@@ -1168,9 +1168,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
       "dev": true,
       "license": "MIT",
       "optional": true,

--- a/UI/Web/package-lock.json
+++ b/UI/Web/package-lock.json
@@ -455,7 +455,6 @@
       "integrity": "sha512-moERVCTekQKOvR8RMuEOtWSO3VS1qrzA3keI1dPto/JVB8Nqp9w3R5ZpEoXHzh4zgEryosxmPgdi6UczJe2ouQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@angular-eslint/bundled-angular-compiler": "21.3.1",
         "eslint-scope": "9.1.2"
@@ -501,7 +500,6 @@
       "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-21.2.8.tgz",
       "integrity": "sha512-RIqfVmfretQ0x/mXgMXe7Bw0Tpe8+zBV/Mm2OaNVyrmNG+9gYItEn5t/ZnQGcPD5nMNqckgp3+4/ZMc/qkS5ww==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -617,7 +615,6 @@
       "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-21.2.6.tgz",
       "integrity": "sha512-1PBzFf+um/VZ1dFF6cT72Zsq+9C/ZWF9m5dP0uHJgo4psX3yMBoZlZu5YomBiAQ/ePSkqCuryv1vrelK+yd3Mw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "parse5": "^8.0.0",
         "tslib": "^2.3.0"
@@ -635,7 +632,6 @@
       "integrity": "sha512-N/wj8fFRB718efIFYpwnYfy+MecZREZXsUNMTVndFLH6T0jCheb9PVetR6jsyZp6h46USNPOmJYJ/9255lME+Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@angular-devkit/architect": "0.2102.7",
         "@angular-devkit/core": "21.2.7",
@@ -670,7 +666,6 @@
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-21.2.8.tgz",
       "integrity": "sha512-ZvgcxsLPkSG0B1jc2ZXshAWIFBoQ0U9uwIX/zG/RGcfMpoKyEDNAebli6FTIpxIlz/35rtBNV7EGPhinjPTJFQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -687,7 +682,6 @@
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-21.2.8.tgz",
       "integrity": "sha512-Il9KlT6qX8rWmun5jY6wMLx56bCQZpOVIFEyHM4ai2wmxvbqyxgRFKDs4iMRNn1h04Tgupl6cKSqP9lecIvH6w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -700,7 +694,6 @@
       "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-21.2.8.tgz",
       "integrity": "sha512-S0W+6QazCsn/4xWZu0V5VmU9zmKIlqFR2FJSsAQUPReVmpA40SuQSP6A/cyMVIMYaHvO/cAXSHJVgpxBzBSL/Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "7.29.0",
         "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -733,7 +726,6 @@
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-21.2.8.tgz",
       "integrity": "sha512-hI7n4t8qgFJaVV55LIaNuzcdP+/IeuqQRu3huSLo47Gf6uZAD0Acj4Ye9SC8YNmhUu5/RiImngm9NOlcI2oCJA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -759,7 +751,6 @@
       "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-21.2.8.tgz",
       "integrity": "sha512-tyQAHjfMHcqETRkKQaZHjYqIK9W8uRenPpY2DF/Jl+S7CwcaX4T8t8TKgzvTynNzQW9QGiLg0pqVosVMKzBXJg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "tslib": "^2.3.0"
@@ -779,7 +770,6 @@
       "resolved": "https://registry.npmjs.org/@angular/localize/-/localize-21.2.8.tgz",
       "integrity": "sha512-wt1ZIE2c7IL1KOgfJyr7pN5SNoQXy02dB/dswZKQlJWduVWkzG83uftPFPjhfASQeqrlpW7tXhb6PiRkJGlCkg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "7.29.0",
         "@types/babel__core": "7.20.5",
@@ -804,7 +794,6 @@
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-21.2.8.tgz",
       "integrity": "sha512-4fwmGf7GCuIsjFqx1gqqWC92YjlN9SmGJO17TPPsOm5zUOnDx+h3Bj9XjdXxlcBtugTb2xHk6Auqyv3lzWGlkw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -886,7 +875,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1167,13 +1155,39 @@
         "node": ">=14.17.0"
       }
     },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
-      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -2054,7 +2068,6 @@
       "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^4.3.2",
         "@inquirer/confirm": "^5.1.21",
@@ -2272,7 +2285,6 @@
       "resolved": "https://registry.npmjs.org/@jsverse/transloco/-/transloco-8.3.0.tgz",
       "integrity": "sha512-p69/MhhAsTabDAffaiMALx4u9AwAqx24CjdECaCkUKSpCGbiYQUJPCsV4OsWjaSOxDNm9HuIX6NmqbfNZ0S3KA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jsverse/transloco-utils": "^8.2.1",
         "@jsverse/utils": "1.0.0-beta.5",
@@ -2355,8 +2367,7 @@
       "version": "1.0.0-beta.5",
       "resolved": "https://registry.npmjs.org/@jsverse/utils/-/utils-1.0.0-beta.5.tgz",
       "integrity": "sha512-z7IdlV6BdSeF3Veii8Yyk64KuyTjNIQnFaW5PAhmDx0wN29lB2BFp8WO6+tJPLPjtlz2yKeNrjkp1XqnMPaeHA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@listr2/prompt-adapter-inquirer": {
       "version": "3.0.5",
@@ -3531,7 +3542,6 @@
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -4289,8 +4299,7 @@
       "version": "25.0.0",
       "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-25.0.0.tgz",
       "integrity": "sha512-XKLA6syeBUaPzx4j3qwMqzzq+V4uo72BnlbOjmuljLrRqdsd3qnzvZZoxvMHZ23ndsRS4aufU6JOZYpCbU6T1A==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
@@ -4692,7 +4701,6 @@
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -4738,7 +4746,6 @@
       "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.2",
         "@typescript-eslint/types": "8.58.2",
@@ -4846,7 +4853,6 @@
       "integrity": "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -4889,7 +4895,6 @@
       "integrity": "sha512-QZfjHNEzPY8+l0+fIXMvuQ2sJlplB4zgDZvA+NmvZsZv3EQwOcc1DuIU1VJUTWZ/RKouBMhDyNaBMx4sWvrzRA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
         "@typescript-eslint/scope-manager": "8.58.2",
@@ -5001,7 +5006,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5308,7 +5312,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -5463,7 +5466,6 @@
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
       "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readdirp": "^5.0.0"
       },
@@ -6129,7 +6131,6 @@
       "integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -6393,7 +6394,6 @@
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -6828,7 +6828,6 @@
       "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -7458,7 +7457,6 @@
       "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cli-truncate": "^5.0.0",
         "colorette": "^2.0.20",
@@ -8865,7 +8863,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -9005,7 +9002,6 @@
       "resolved": "https://registry.npmjs.org/quill/-/quill-2.0.3.tgz",
       "integrity": "sha512-xEYQBqfYx/sfb33VJiKnSJp8ehloavImQ2A6564GAbqG55PGw1dAWUn1MUbQB62t0azawUS2CZZhWCjO8gRvTw==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "eventemitter3": "^5.0.1",
         "lodash-es": "^4.17.21",
@@ -9233,7 +9229,6 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -9907,8 +9902,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tuf-js": {
       "version": "4.1.0",
@@ -9959,7 +9953,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10087,7 +10080,6 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -10515,7 +10507,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -10534,8 +10525,7 @@
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.16.1.tgz",
       "integrity": "sha512-dpvY17vxYIW3+bNrP0ClUlaiY0CiIRK3tnoLaGoQsQcY9/I/NpzIWQ7tQNhbV7LacQMpCII6wVzuL3tuWOyfuA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/zrender": {
       "version": "6.0.0",

--- a/UI/Web/src/app/_pipes/metadata-setting-filed.pipe.ts
+++ b/UI/Web/src/app/_pipes/metadata-setting-filed.pipe.ts
@@ -44,6 +44,8 @@ export class MetadataSettingFiledPipe implements PipeTransform {
         return translate('metadata-setting-field-pipe.localized-name');
       case MetadataSettingField.Name:
         return translate('metadata-setting-field-pipe.name');
+      case MetadataSettingField.SortName:
+        return translate('metadata-setting-field-pipe.sort-name');
 
     }
   }

--- a/UI/Web/src/app/_single-module/match-series-modal/match-series-modal.component.html
+++ b/UI/Web/src/app/_single-module/match-series-modal/match-series-modal.component.html
@@ -37,8 +37,8 @@
                 {{ t('special-count', {num: kavitaSpecialCount()}) }}
               }
               <app-series-format [format]="series().format" [useTitle]="false" />
-              @if (seriesDetail(); as seriesDetail) {
-                {{seriesDetail.libraryType | libraryType}}
+              @if (matchInfo(); as matchInfo) {
+                {{matchInfo.libraryType | libraryType}}
               }
             </div>
           </div>

--- a/UI/Web/src/app/_single-module/match-series-modal/match-series-modal.component.html
+++ b/UI/Web/src/app/_single-module/match-series-modal/match-series-modal.component.html
@@ -37,8 +37,8 @@
                 {{ t('special-count', {num: kavitaSpecialCount()}) }}
               }
               <app-series-format [format]="series().format" [useTitle]="false" />
-              @if (matchInfo(); as matchInfo) {
-                {{matchInfo.libraryType | libraryType}}
+              @if (match) {
+                {{match.libraryType | libraryType}}
               }
             </div>
           </div>

--- a/UI/Web/src/app/_single-module/match-series-modal/match-series-modal.component.ts
+++ b/UI/Web/src/app/_single-module/match-series-modal/match-series-modal.component.ts
@@ -16,7 +16,6 @@ import {FormControl, FormGroup, ReactiveFormsModule} from "@angular/forms";
 import {NgbActiveModal, NgbTooltip} from "@ng-bootstrap/ng-bootstrap";
 import {TranslocoDirective} from "@jsverse/transloco";
 import {ExternalSeriesMatch} from "../../_models/series-detail/external-series-match";
-import {ToastrService} from "ngx-toastr";
 import {catchError, filter, of, pairwise, skip, startWith, tap} from "rxjs";
 import {takeUntilDestroyed, toSignal} from "@angular/core/rxjs-interop";
 import {EmptyStateComponent} from "../../shared/_components/empty-state/empty-state.component";
@@ -33,7 +32,7 @@ import {MatchSeriesInfo} from "../../_models/kavitaplus/match-series-info";
 import {AllMetadataProviders, MetadataProvider} from "../../_models/kavitaplus/metadata-provider.enum";
 import {ScrobbleProvider} from "../../_services/scrobbling.service";
 import {MetadataProviderTitlePipe} from "../../_pipes/metadata-provider-title.pipe";
-import {ExternalEditionDto, PlusMediaFormat} from "../../_models/series-detail/external-series-detail";
+import {ExternalEditionDto} from "../../_models/series-detail/external-series-detail";
 import {SeriesFormatComponent} from "../../shared/series-format/series-format.component";
 import {LibraryTypePipe} from "../../_pipes/library-type.pipe";
 import {SeriesMetadata} from "../../_models/metadata/series-metadata";
@@ -61,7 +60,6 @@ export class MatchSeriesModalComponent implements OnInit {
 
   private readonly seriesService = inject(SeriesService);
   private readonly modalService = inject(NgbActiveModal);
-  private readonly toastr = inject(ToastrService);
   private readonly imageService = inject(ImageService);
 
   series = input.required<Series>();
@@ -330,6 +328,5 @@ export class MatchSeriesModalComponent implements OnInit {
 
   protected readonly MetadataProvider = MetadataProvider;
   protected readonly ScrobbleProvider = ScrobbleProvider;
-  protected readonly PlusMediaFormat = PlusMediaFormat;
   protected readonly allMetadataProviders = AllMetadataProviders;
 }

--- a/UI/Web/src/app/_single-module/match-series-modal/match-series-modal.component.ts
+++ b/UI/Web/src/app/_single-module/match-series-modal/match-series-modal.component.ts
@@ -190,9 +190,7 @@ export class MatchSeriesModalComponent implements OnInit {
         this.seriesDetail.set(detail)
 
         const isStandAlone = detail.chapters.length + detail.specials.length == 1;
-        this.formGroup.get('isStandAlone')?.setValue(isStandAlone);
-
-        this.search();
+        this.formGroup.get('isStandAlone')?.setValue(isStandAlone); // This will trigger the initial search
       }),
     ).subscribe();
 

--- a/UI/Web/src/app/admin/_models/metadata-setting-field.ts
+++ b/UI/Web/src/app/admin/_models/metadata-setting-field.ts
@@ -9,6 +9,7 @@ export enum MetadataSettingField {
   AgeRating = 8,
   People = 9,
   Name = 10,
+  SortName = 11,
 
   // Chapter fields
   ChapterTitle = 20,

--- a/UI/Web/src/app/admin/kavita-plus/manage-kavitaplus-activity/manage-kavitaplus-activity.component.ts
+++ b/UI/Web/src/app/admin/kavita-plus/manage-kavitaplus-activity/manage-kavitaplus-activity.component.ts
@@ -74,7 +74,7 @@ export class ManageKavitaplusActivityComponent implements OnInit {
   timeFrameFilter = signal<'all' | '24h' | '7d' | '30d'>('7d');
 
   members = signal<Member[]>([]);
-  currentPage = signal(0);
+  currentPage = signal(1);
   pagination = signal<Pagination | null>(null);
 
   nextScrobble = signal<string | null>(null);
@@ -87,7 +87,7 @@ export class ManageKavitaplusActivityComponent implements OnInit {
 
   hasMore = computed(() => {
     const p = this.pagination();
-    return p != null && p.currentPage < p.totalPages - 1;
+    return p != null && p.currentPage < p.totalPages;
   });
 
   ngOnInit() {
@@ -118,7 +118,7 @@ export class ManageKavitaplusActivityComponent implements OnInit {
 
   private loadEntries(reset = true) {
     if (reset) {
-      this.currentPage.set(0);
+      this.currentPage.set(1);
       this.entries.set([]);
       this.isLoading.set(true);
     } else {

--- a/UI/Web/src/assets/langs/en.json
+++ b/UI/Web/src/assets/langs/en.json
@@ -4468,7 +4468,8 @@
         "chapter-publisher": "{{person-role-pipe.publisher}} (Chapter)",
         "chapter-title": "Title (Chapter)",
         "chapter-age-rating": "Age Rating (Chapter)",
-        "volume-covers": "Covers (Volume)"
+        "volume-covers": "Covers (Volume)",
+        "sort-name": "{{sort-field-pipe.sort-name}}"
     },
 
 


### PR DESCRIPTION
Unless something comes up, this is the last nightly before the stable. 

# Changed
- Changed: Spread out Kavita+ License checks to reduce load on our servers

# Fixed
- Fixed: Fixed the first page on Kavita+ Audit Logs being duplicated (develop)
- Fixed: Fixed prequel chapters (<1) sometimes being used for series metadata (Fixes #3410)
- Fixed: Ensure we lock the sort name when we write it from Kavita+ (develop)
- Fixed: Fixed markdown summaries from Mangabaka not getting converted to html to align with opf/comicinfo (develop)
- Fixed: Handle source text from descriptions from Mangabaka (develop)
- Fixed: Fixed not being able to change localized name casing 
- Fixed: Fixed an issue where a casing difference in series name wouldn't be updated from K+ (Fixes #4880) (develop)
- Fixed: Fixed an issue where a language code can get eaten if the original series name was already Romaji and the Localized name was {Romaji} (Fixes #4879) (develop)
