### PR TITLE
v0.9.1 - Kavita+ Overhaul and 100K Installs!

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -28,7 +28,7 @@ body:
       label: Kavita Version Number - If you don't see your version number listed, please update Kavita and see if your issue still persists.
       multiple: false
       options:
-        - 0.9.0 - Stable
+        - 0.9.1 - Stable
         - Nightly Testing Branch
     validations:
       required: true

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,5 +14,4 @@ _imageService.Resize(...);
 
 return;
 ```
-- Operation (+,-,*, etc) should always have spaces around it; I.e. `a + b` not `a+b`.
 - When setting href directectly (not using Angulars routing) it should always be prefixed with baseURL

--- a/Kavita.Common/Kavita.Common.csproj
+++ b/Kavita.Common/Kavita.Common.csproj
@@ -3,7 +3,7 @@
         <TargetFramework>net10.0</TargetFramework>
         <Company>kavitareader.com</Company>
         <Product>Kavita</Product>
-        <AssemblyVersion>0.9.0.26</AssemblyVersion>
+        <AssemblyVersion>0.9.1.0</AssemblyVersion>
         <NeutralLanguage>en</NeutralLanguage>
         <TieredPGO>true</TieredPGO>
     </PropertyGroup>


### PR DESCRIPTION
v0.9.1 is here and it's a massive overhaul of Kavita+. I started Kavita+ 3 years ago with a split goal of bringing some of my initial vision of Kavita to fruition (metadata downloading) and setup a way for me to work full time on Kavita. While unfortunately I'm not there yet monetarily, over those last 3 years I have listened to the community and found a few ideas that could take the integration to the next level. That day has finally come and the Kavita+ in this release is a day and night difference to what we've known before. 

Before we get into the Kavita+ features, I'd like to call out a few big items for all users. 

## Epub Variable Font Support
This was a user submitted feature that expanded Kavita's epub custom fonts to apply the bold/italic variants from the font family. While I was testing the code from the user, I also cleaned up the UX. 

<img width="1879" height="613" alt="image" src="https://github.com/user-attachments/assets/8727a71e-8142-427b-aa12-a72674e737e3" />

## Cover Chooser UX 

I finally got around to building the new Cover Chooser with @therobbiedavis's design made last year. The new experience separates the different entity covers into tabs, renders out titles for each, and makes the understanding of a locked cover front and center. For Kavita+ users, you can now use the Kavita+ tab to download and apply series/volume covers from Mangabaka and Hardcover. The covers will be grabbed against the Edition and Language if applicable. 

<img width="1127" height="773" alt="image" src="https://github.com/user-attachments/assets/ba3fe03a-880c-4c48-a348-25169f0afdc8" />

## Security
With AI on the rise, the amount of AI scanning and reporting issues against repositories is also on the rise. This round, we ended up fixing 10 security issues. All of these issues have a very low rate of exploit, but I would still urge you to keep up to date. All CVEs will be requested 1 week after this update.

## Series Rename functionality 🎉
I don't use emoji's often, but I feel it's warranted here. I removed the ability to rename series in the UI a few years ago when I reworked the scanner. The code has been able to support it and user's have been asking for it, with the Kavita+ work, I finally got around to tackling it. If you're using Kavita+, it's even nicer as Kavita can update it for you with language fallbacks (customizable). 

## Kavita+ Overhaul

There is quite a bit of new stuff, with some documented below. One of the biggest improvements is the media support. Prior, books were left out, but now with Hardcover, we have full book support. 

Kavita+ Features added:
- **License Management** - Ability to renew/cancel/view status about subscription, how much you've used it and some health status
- **Accountability** - Understand what Kavita+ is doing to your entities via an Audit log, make corrections quickly
- **Controls** - Expanded controls on what fields Kavita+ writes to and how it interprets data. Tightened matching logic to avoid bad matches.
- **Rich Data** - Expanded data sources (Hardcover, MangaBaka) for better coverage (books, LNs) and more fields (chapter/volume data, covers, etc)
- **Sharability** - Expanded scrobble providers: Hardcover, MangaBaka, MAL, and AniList using OAuth for easier token management 


### License Management

This is the core of the Kavita+ experience. You need to understand when your subscription is renewing, have the ability to change details like your email, cancel and renew the sub, and overall understand the value you're getting from the platform. I designed this new screen to reduce how often you need to reach out to me and provided functionalities for just about everything I've had to manually do over these last 3 years. 

From this new dashboard, you can not only see your sub at a glance, but cancel/renew/change email/change billing (Stripe), see how much usage you've gotten from your Kavita+ sub, and health status of providers as well (since AniList API going down is almost a fact now). In addition, I did a TON of work on the Kavita+ layer to hammer out a lot of bugs, and ensure we send renewal email reminders for yearly plans. 

<img width="1876" height="817" alt="image" src="https://github.com/user-attachments/assets/f62d4b8e-6660-4aca-8b5a-fb98b38b45e9" />

<img width="1880" height="653" alt="image" src="https://github.com/user-attachments/assets/203bc8bf-a4c2-49c0-ae74-03d86de5d4fb" />

<img width="1852" height="794" alt="image" src="https://github.com/user-attachments/assets/d13674e9-28e3-430c-8322-3b131d572018" />


### Accountability

Another big pain point of the system was, Kavita has all these controls and matching flows, but it's hard to know WHAT is actually changing on the system and why. So we built a Audit log with dedicated screens for both Admins (All Activity) and regular users (My Activity). These provide rich insights into what Kavita/Kavita+ are doing, what fields are updated, etc. You can also view this from an individual series detail page. 

<img width="1113" height="751" alt="image" src="https://github.com/user-attachments/assets/ae3496e3-31eb-4854-8c2f-d84307f75881" />

<img width="1860" height="743" alt="image" src="https://github.com/user-attachments/assets/563b5045-c954-4b9a-9206-1ceb81fa773d" />

<img width="1656" height="755" alt="image" src="https://github.com/user-attachments/assets/fb372b91-0ef1-4472-8215-633c776b3ebb" />


### Controls

Kavita has controls for both local metadata and Kavita+ metadata to allow remapping genres -> tags and vice versa or have genre/tags drive Age ratings. With this release, we've updated them with some of the new features, like overriding an provider's age rating (ie Mangabaka says Safe (G), you want safe as Everyone) or telling Kavita what languages to write to Series Name and Localized Name and what fallback to use per-field.

<img width="1595" height="858" alt="image" src="https://github.com/user-attachments/assets/88ef5c4a-08b6-4733-840c-442dada87fd8" />


### Rich Metadata

In this update of Kavita, we added the ability to write Series Name, Chapter/Volume covers and metadata. With the addition of Mangabaka and Hardcover, Kavita now has individual metadata available for Volumes as well as Series and thus can drastically improve metadata, whereas Volume level metadata for Manga was otherwise not possible. Comics already supported Issue-level metadata and just adds Cover updates into the mix. All cover operations use a system to detect if the incoming image is "better" before writing and respect the language on the series/library when applicable. 

<img width="2448" height="1288" alt="image" src="https://github.com/user-attachments/assets/afcdf075-aeb6-4785-b25a-12c0b08c25e6" />


### More Progress Scrobbling

Lastly, we've added way more scrobbling providers along with switching from token-based auth to OAuth, meaning Kavita can refresh your auth with these providers for you. As of v0.9.1, you can now scrobble your progress, ratings, and reviews to AniList, MAL, Mangabaka, and Hardcover. 

In addition, we've added settings per-provider (with some library bindings) so that you can configure what you want to sync up, how you want reviews shared (private, friends, public), how you want series to be treated if you stop reading them for some time, etc. This should cover you in most scenarios (my personal favorite is the new drop rule). 

<img width="1575" height="704" alt="image" src="https://github.com/user-attachments/assets/44f400f1-78f1-44e5-a9f9-d14c1106444d" />

## What's next?

All in all, this has been a monumental release. Not only have we completely reworked Kavita+, we've also seen an uptick in contributions with a few that didn't make the cut, that will likely come next release (a lot of new stuff for the readers). Kavita also hit **100K active installs!**, one of my goals for the year. Amelia and I are looking forward to continuing our work on Kavita.

As mentioned in the [first release](https://github.com/Kareadita/Kavita/releases/tag/v0.8.9) of the year, we have one more promised release which is **v0.9.2 - Native Kobo Sync Support**.  After this, we will likely start working on the foundations for the official mobile app. 


# Added
- Added: (Parser) Added chapter marker support (ch) to Comic libraries
- Added: Added the ability to configure Metadata Settings for Kavita+ around what languages to prioritize for setting series name and localized name. You can configure Global settings and per-library and use multiple language codes, which act as a fallback. (ie en;ja-Latn. If english is not available, will try japanese (Romanji), else don't update. The selected language code will not be used for localized name)
- Added: Added support for {Native} and {Romaji} reserved tokens for the language to fill in the Native and Romaji titles respectively.
- Added: Kavita will now not allow any localized name changes that would orphan files. This means that if a localized name is used to merge a set of files into one series, you can't change it. (ie - dont toy with me v01.cbz and Ijiranaide, Nagatoro-san v2.cbz in one series, changing localized name from Ijiranaide, Nagatoro-san will be rejected as next scan would split these into 2 series)
- Added: Added collapse series relationships as an option for series filter. Overwriting your global preferences for that filter. 
- Added: Added a button to rerun all metadata mappings without needing to force scan your library
- Added: Added collapse series relationships as an option for series filter. Overwriting your global preferences for that filter. 
- Added: Brought back the ability to rename series' name in Kavita via the UI. When changing, Kavita will prompt you to align the SortName if it was previously locked. The name must be unique to the library+format. 
- Added: Kavita+ can now write the series name. No more .hackxxxx, now .hack//xxxx (FR #2902, 9 upvotes)
- Added: Added the ability to upload/support fonts that have variable styles. This allows for richer font expression in the Epub reader. (Thanks @skulwicki)
- Added: Added a new OAuth flow to automatically link Scrobble accounts for supported providers (MAL, MangaBaka, AL)
- Added: Added a nightly job to automatically refresh tokens for supported providers (MAL, MangaBaka)
- Added: Added support for scrobbling to MAL
- Added: Hooked up the discord connect button on the license screen
- Added: Added new audit log events for when a Scrobble Provider is connected and when its token is refreshed (Success & Failure)
- Added: Added the ability to cancel directly from the Kavita instance, rather than using the Stripe portal.
- Added: Added the ability to renew your subscription from your Kavita instance, payment details still are done via Stripe. Nothing touches Kavita/Kavita+ logic. You can choose the appropriate plan as well. 
- Added: Added the ability to change your registered email without contacting support. This is a multi-step process due to security provisioning. 
- Added: MAL Stack Sync now has the original Stack url for Audit log 
- Added: Kavita will now send total reads for a series to MangaBaka
- Added: Show the series matched against in the Audit log
- Added: Match modal will now show which metadata provider Kavita+ will match against and why (library type, format)
- Added: Added a Cameo series relationship since MangaBaka now provides it. 
- Added: Recommendations will now show a badge in the card: Similar (based on tags, existing fall into this batch), User-based (based on other people reading habits), and Personalized (not used yet). User-based will win on duplicate with Similar (as it has more real weighting)
- Added: Added support for loading metadata from Hardcover
- Added: Added the ability to use shortcode:id (hardcover:1234, al:1234, etc) for direct lookup in the search field
- Added: Hardcover ratings are now visible from Series Detail page
- Added: Added more information in the match modal to help you pick the correct series
- Added: (Kavita+) Kavita can now write volume (and chapter) covers during the Match flow from MangaBaka/Hardcover (CBR already supported). You can configure these in Manage Metadata to enable them. 
- Added: Added navigate to home/dashboard keybind
- Added: Kavita can now match to editions (Collections on MB) which are alternative versions and come with their own metadata (volume/chapter metadata) and covers. 
- Added: Added the ability to have Chapter age rating inherit from Series when matching with Kavita+
- Added: Added the ability to rename a series from the UI (and allow Kavita+ to write titles from external metadata providers). Kavita will prompt you when sort name is locked to align it (against your library settings) for you or not. 
- Added: Show an explicit message when SignalR event hub isn't connected
- Added: Added Mangabaka as scrobble provider
- Added: Added Hardcover as scrobble provider
- Added: Added per provider settings (library, age ratings, scrobble progress/ratings/reviews, etc)
- Added: Added inactive & on hold rules (Auto transition series/books from reading to on hold after x days)
- Added: Scrobble Providers can now show information, like username. 
- Added: Added an upsell page that explains what Kavita+ is, so users are more informed, rather than linking to the wiki
- Added: Added a status page to services that Kavita+ relies on, to surface incidents (like AL going down and scrobbling not working)
- Added: Added stats about what Kavita+ is doing and how many calls your license has made (note: Not all data will be present, existing data is mixy)
- Added: Added 3 new screens that help users understand what Kavita+ is doing around their series, their scrobbling, and for admins, the whole behind the scenes logic. 
- Added: (Kavita+) Cover chooser will now present cover image choices from Kavita+ (powered by Hardcover, MangaBaka, and ComicBookRoundup). 
- Added: (Kavita+) Added the ability to take a raw string content rating from Mangabaka and map it to your own Age Rating. This will override the default mapping Kavita+ provides. Kavita will always take the highest age rating produced from the whole mapping process (so a tag mapping that produces a higher rating will be selected)
- Added: (Kavita+) Added the ability to filter out tag weightings (Mangabaka only) from above a weight. So if you select recurrent, incidental and unweighted will be removed. Does not affect remapped tags (ie tag generated from a genre mapping) or white listed tags. 
- Added: (Kavita+) Added the ability to turn off Kavita writing age ratings
- Added: Added the ability to override the Metadata Provider on a Series-basic in the Match modal. This should help users with mixed content libraries (Thanks @StereotypicalCat)
- Added: Pasting a provider URL or header into the Match dialog's search box (hardcover.app, mangabaka.org, anilist.co, myanimelist.net, comicbookroundup.com, or a 'hardcover:'/'mb:'/'al:' style header) now switches the Series to that provider automatically before searching, instead of searching the wrong  (Thanks @StereotypicalCat)

# Changed
- Changed: Match modal now uses a rich url (pre-filtered) for Hardcover and Mangabaka
- Changed: Manage Metadata is now in accordions to make it easier to navigate
- Changed: Inverted the behavior of the last read filter field to be more intuitive. 
- Changed: Switched to jemalloc as allocator for Docker images resulting is drastically better memory management (less memory)
- Changed: Lower log level for flavicon retry failures to reduce log spam.
- Changed: Black- and Whitelists will now be sorted alphabetically to help manage long lists. 
- Changed: User defined OIDC scopes will no longer be filtered by the supported scope list from the discovery document. Please ensure your configured scopes are all supported.
- Changed: Kavita is now better at finding ISBNs in epubs
- Changed: Inverted the behavior of the last read filter field to be more intuitive. 
- Changed: (UX) Updated the UX for the Font Manager and expanded the experience to visualize variable fonts
- Changed: Badges on the settings nav bar will now use compact numbers
- Changed: Disable password authentication (OIDC) now disabled it for everyone. In case of issues remove your OIDC config from appsettings.json
- Changed: Multi-file chapters will now only have one entry in OPDS feeds. Consumers can read and download everything from this entry
- Changed: The cover uploader will now automatically select the upload tab after uploading an image
- Changed: (Performance) Improved performance of the scanner when scanning large amounts of files in a single directory (Thanks @junoh-moon)
- Changed: Kavita will no longer send token almost expiring emails if the Scrobble Provider supports automatically refreshing its tokens (And a refresh token is present). 
- Changed: (UX) Minor tweaks to confirm/alerts in the app to differentiate from the modals
- Changed: Discord id is no longer an option when registering your Kavita+ license, instead you can use the connect with discord button which will use OAuth for a much smoother experience (and get you access for most users that didn't read the tooltip)
- Changed: Kavita will no longer email users when tokens are about to expire since Kavita can now refresh for them.
- Changed: Reworked and simplified the button theming to drive consistency in Kavita. Reworked a few of the theme variables by collapsing into streamlined experiences. (I will no longer be maintaining the wiki for all css themes)
- Changed: Ensure that external ids from a match are only written to the Series when done via a manual match
- Changed: Reworked the match modal to make it more clear what the previous match was and what Kavita will search against for Kavita+ and why.
- Changed: Matched results title can now be clicked to view the metadata provider's page
- Changed: You can now use shortcodes for anilist (al) and mangabaka (mb) for match by id modal. ie) mb:1234 
- Changed: Ratings now come from MangaBaka and include a MB rating (which will aggregate many sites)
- Changed: Automatic matching now requires exactly one match above 90%
- Changed: A library now has a metadata provider (Hardcover, MangaBaka, CBR) associated with it
- Changed: Scrobble events will no longer be created if the required id is missing. This will be logged in the audit log for visibility
- Changed: (Kavita+) Recommendations will stem only from MangaBaka now, AniList and MAL will no longer be used. 
- Changed: (Kavita+) Kavita now allows non-admin's to view external recommendations. Kavita will calculate an age rating through the Metadata Settings (tag/genre mapping + derived age rating) and take the highest between what we get from MangaBaka and the server's rules. 
- Changed: Scrobbling series with only specials (One-Shots) will now scrobble the amount of specials instead skipping the scrobble. 
- Changed: Copied the (x/y) info from the tooltip down to the series detail page for ended series for better visibility
- Changed: Changed the default read more cutoff length to be longer for desktop view
- Changed: Changed Access tokens to 3 days (from 10). All users will have a one time reauth event.
- Changed: Update modals will now show the title from the PR (nightly releases)
- Changed: Prefer the series/library locale when grabbing covers (volume/chapter only)
- Changed: Retry Scrobble Provider token refresh once after 30 minutes when there is a failure.
- Changed: Ensure external series metadata is refreshed oldest to newest 
- Changed: Be smarter about getting failed audit log badge
- Changed: Removed ImageSharp and use NetVips exclusively for metadata. ImageSharp's new licensing model increased friction for development. 
- Changed: Match flow will use external metadata ids if there is no query text. 
- Changed: (Parser) Slight change in how parenthesis are cleaned from Series name. Kavita will now check if there is text on each side of () and skip replacement in that case. This allows Kavita to see that 'Rent-a-(Really-Shy)-Girlfriend' is separate from 'Rent-a-Girlfriend')
- Changed: Massively improved the detect and report a series collision logic and try to give help to user on how to fix. This text is not localized and wont be. 
- Changed: Match Series modal MangaBaka link will prefill the series name for you 
- Changed: Tweaked all logic in the app when finding series to utilize external ids. 
- Changed: Series Preview and Smart Collection drawers have resizers on them
- Changed: Improved AniList scrobble speed drastically 
- Changed: Scrobble keybind now opens my activity instead
- Changed: Users can now run backfilling of history per provider as many times as they want. Kavita will slowly churn thru it all (note: Re-running multiple times will drastically inflate queue for no reason). 
- Changed: (UX) Complete UX overhaul of Scrobble providers (now found under Kavita+ > Connections )
- Changed: Complete overhaul to the Kavita+ license page. New design have an upsell feel (from the main site) that explains what Kavita+ is. 
- Changed: When editing the license, the email is auto-filled for you
- Changed: Kavita+ Audit will now track Metadata Sync trigger (Manual, on file Add, Background Sync)
- Changed: Massive UX refresh to the Match modal for Kavita+ to surface tips on how to search.
- Changed: Scrobbling screen is likely going to be replaced by the new screens
- Changed: OIDC validation no longer requires super safe urls.
- Changed: Redesigned Kavita's Cover Image chooser to use tabs for individual types of media (Current, Uploaded, Volume, Chapter, Kavita+).  (Thanks @therobbiedavis for the great design)
- Changed: Moved the Reset cover image from a weird button into a dedicated button with clear labeling if the underlying cover was locked or not. 
- Changed: (Kavita+) Tag weight filtering is only guarding the writing of tags now. Age Rating mapping will now run against all tags/genres (even before black/whitelisting) to ensure a string doesn't escape deriving an age rating.
- Changed: Tweaked some of the Kavita+ setting item language
- Changed: Parse external Ids for books too (weblinks are parsed from epubs)
- Changed: Moved the config/cache-long version files into their own subfolder.
- Changed: All Kavita+ features are now gated by External Ids being set. With the new matching logic working so well, we feel this is a valid change. 
- Changed: Expose scrobble errors in audit log (with a button to clear/fix)
- Changed: Kavita+ match will never use weblinks anymore. Weblinks are already parsed for seeding External Ids. 
- Changed: Improved K+ relationships and MAL Stack series matching
- Changed: Spread out Kavita+ License checks to reduce load on our servers
- Changed: Ensure we always log out the Support Id when Kavita+ experiences errors

# Fixed
- Fixed: Webtoon pages now keep their original aspect ratio when Width Override changes live. (Thanks @archit-goyal)
- Fixed: (Parser) Fixed a case where a year followed by a volume marker, the year was captured as a chapter, like 'Blade Runner 2019 - Volume 1' (Thanks @StereotypicalCat)
- Fixed: Closing the book/manga reader now exits fullscreen properly (Thanks @JUMBUZI)
- Fixed: Background color for reading profile was missing a preview of the color 
- Fixed: A lot of mobile touchups across the new Kavita+ screens, including missing loading indicators and no data messages
- Fixed: Fixed getting stuck on the resolution step while manually importing metadata settings
- Fixed: Fixed yes/no fields (Want to read & Collapse series relationships) always visually showing as checked when loading a smart filter
- Fixed: Fixed series with non numerical chapter positions always being sorted at the start.
- Fixed: Fixed an incorrect message when deleting bookmarks in bulk
- Fixed: Fixed a heap of missing access checks (low impact)
- Fixed: Fixed series with non numerical chapter positions always being sorted at the start. 
- Fixed: Fixed a bug where selecting a font family that clashes with a Kavita font (Poppins) would override Kavita's webapp font globally. 
- Fixed: Fixed a bug where a user font with the same name as a system font (poppins) would collide on the epub reader and cause webapp font issues. 
- Fixed: Fixed a bug where a user font with the same name as a system font (poppins) would also not be selectable vs the system font. 
- Fixed: Fixed the shortcuts modal not respecting the book theme in the book reader
- Fixed: Fixed the confirm prompt for deleting annotations not respecting the book theme in the book reader
- Fixed: Fixed annotations sometimes duplicating characters
- Fixed: Fixed Copy Settings From modal not opening on the manage library page
- Fixed: Fixed only one collection tag statement being taken into account in the series filter
- Fixed: Fixed the chapter title being displayed twice in the manga reader. And Vol. & Ch. numbers not being displayed
- Fixed: Fixed uploaded thumbnails not always respecting the configured cover image size (Thanks @KobraKid !)
- Fixed: Fixed several issues with multi-page chapters in our OPDS implementation.  (Thanks @TipToe08 !)
- Fixed: Fixed no stale metadata being refresh at night when at least one series has none at all
- Fixed: Fixed side nav not updating after deleting a smart filter
- Fixed: Fixed KPlus ownership of metadata fields not always being removed causing it to sometimes overwrite fields that were changed and locked in the UI
- Fixed: Fixed Media Errors page not loading the errors
- Fixed: Fixed Media Errors filenames getting corrupted with a normalization (aka no /). 
- Fixed: Fixed being unable to logout when using OIDC with a base url if your idp does not support logging out interactively
- Fixed: Fix MAL ValidUntilUtc not being set 
- Fixed: Fixed MAL token sync always reporting invalid
- Fixed: Fixed year selection being ascending order for time pickers.
- Fixed: Fixed Scrobble Read progress using LastModified rather than Created for the first read time
- Fixed: When MAL Stack import page was accessed and there was no token, the spinner would load indefinitely.
- Fixed: Fixed K+ series metadata never being refreshed in the background in some cases
- Fixed: Fixed K+ metadata being fetched for series in libraries with metadata turned off
- Fixed: Fixed Writer/Artist people metadata not working for MangaBaka
- Fixed: Fixed a bug where Scrobbling wouldn't properly record a failure due to a capitalization difference from K+
- Fixed: Fixed a short circuit being executed when there was no existing external metadata row, which prevented background match from properly calling the full K+ series detail API for full metadata.
- Fixed: There was an edge case where a stale file reference cover could exist and cause a throw for finding the better image from an online source. Kavita will now properly catch and log a warning (not error). Chapter will now behave like other entities and accept a cover when there is no cover (data is better than nothing).
- Fixed: Fixed apiKey being a required parameter in the library controller
- Fixed: Fixed Plugin/parse-bulk throwing with duplicate input
- Fixed: Fixed K+ tasks sometimes not being registered when enabling your subscription again
- Fixed: Fixed read more not using the desktop amount on desktop. Also increased the max amount for a better experience
- Fixed: Fixed the side nav sometimes still showing text despite being closed
- Fixed: Fixed overflow in review cards for non Latin text
- Fixed: Fixed local reviews not being shown on the series page if you have no active K+ subscription
- Fixed: Fixed an issue where Kavita's refresh tokens TTL were less than access tokens and user's could be logged out unexpectedly
- Fixed: Fixed a bug where single page chapters would never create reading sessions or mark the chapter as completed
- Fixed: Fixed a bad title for day breakdown chart in stats
- Fixed: Fixed grouping when getting scrobbling events 
- Fixed: Fixed scrobble events not logging chapter data
- Fixed: Fixed the string a hour ago -> an hour ago
- Fixed: Fixed some missing localization and colored text in the book reader
- Fixed: Guard bulk file size endpoint against requesting user (Thanks @5ud0er)
- Fixed: Fixed some missing access guards in reading list controller (Thanks @arpitjain099)
- Fixed: Fixed hardcover id not persisting to person table
- Fixed: Fixed manga reader showing chapter number with too many decimals
- Fixed: Fixed external metadata not being loaded correctly on the series detail page under specific circumstances
- Fixed: Fixed some theming and missing translations in the book reader
- Fixed: Improve the MAL Stack Sync series search logic to utilize external ids 
- Fixed: Fixed up token expired warning showing too often
- Fixed: Fixed being unable to reset external ids
- Fixed: Fixed getting stuck in a loop if OIDC config is removed while previously being logged in with OIDC
- Fixed: Fixed scrobble events getting marked as processed when hitting the rate limit under some circumstances
- Fixed: Fixed a bug where Rereading a chapter then moving to the next wouldn't reset the page to 0
- Fixed: Fixed incorrect native/docker wiki links 
- Fixed: Fixed incorrect setup link 
- Fixed: Fixed CBL Upload restriction and reworked the hardening of how file upload validation checks are done. Ensure we log out when we reject and why.
- Fixed: Fixed up/down not responding to keypresses
- Fixed: Fixed a bug where marking a chapter as read wasn't triggering scrobbling.
- Fixed: Fixed a bug where MAL was never getting a proper response for token expiration in the Account Screen
- Fixed: Fixed a bug where series detail page could refresh the cover when a chapter cover update event triggered. 
- Fixed: Fixed reading list detail tab not having tabs wired up.
- Fixed: Fixed series/chapter rating always returning 0 if you had rated it.
- Fixed: Fixed bookmarks not loading. 
- Fixed: Fixed text & image bookmarks being switched.
- Fixed: Fixed long chapter names causing wrapping in activity overview.
- Fixed: Fixed epub bookmarks not loading. 
- Fixed: Fixed text & image bookmarks being switched. 
- Fixed: Fixed long chapter names causing wrapping in activity overview.
- Fixed: Fixed people not being removed from series if chapter metadata has none. 
- Fixed: Fixed series not being added to a collection under some circumstances. 
- Fixed: Fixed early reloading causing double K+ plus calls when matching on the series page.
- Fixed: Fixed annotations duplicating & swallowing text under some circumstances. 
- Fixed: Fixed annotations not being shown under specific circumstances.
- Fixed: Fixed external links containing sometimes being scoped out of a book. 
- Fixed: Fixed search being unreliable when searching with year metadata.
- Fixed: Fixed up a case where entity title service would avoid having Volume X in some cases
- Fixed: Fixed Chrome PWA not showing the install button (Thanks @Ansh2209 )
- Fixed: Fixed chapter summary not always being written by K+
- Fixed: Fixed artists not always being written for Hardcover metadata
- Fixed: Fixed fields not being locked after K+ writes to them
- Fixed: Fixed an issue where a manual sync of a CBL, where the CBL had issues removed, wouldn't remove them Kavita-side 
- Fixed: Fix 01 & 1 not merging when parsed from ComicInfo 
- Fixed: Fixed timezone skewing stat page
- Fixed: Fix metadata ids being reset when saving without opening the metadata tab 
- Fixed: Fixed collections not showing collapsed series 
- Fixed: Fixed an issue where Kavita series could get back into a Need Manual Match state over time
- Fixed: Attempted to fix relationships acting weird. We were unable to reproduce, but added extra guards.
- Fixed: Fixed users authenticating with auth keys having outdated roles under some conditions
- Fixed: Fixed prequel chapters (<1) sometimes being used for series metadata

# API
- All enum values in request bodies will now be validated. Invalid values will return 400 Bad Request
- Reworked the cover chooser logic so that everything is streamlined via a file upload rather than base64 nonsense (bloated images). Base64 still exists for a non-breaking API, but Kavita will upload a file via upload/upload-by-file which scopes to a temp directory and returns a filename to pass going forward.

# Theme
- Removed the --grid-breakpoints- css variables as they don't actually work in media queries, like I thought they did.
- Built out a theme page (/theme) for devs to work on the theme system. It covers most common components, not everything (nor do I want it).