### PR TITLE
Extend single-page exception for pagination

### DIFF
--- a/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.ts
+++ b/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.ts
@@ -1118,7 +1118,7 @@ export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
       let page = results.progress.pageNum;
 
       // Handle an edge case where there is only 1 page, save progress instantly as progress saving is gated on pagination
-      if (direction === 'None' && page === 0 && this.maxPages === 1) {
+      if (direction !== 'Prev' && page === 0 && this.maxPages === 1) {
         if (!this.incognitoMode) {
           this.readerService.saveProgress(this.libraryId, this.seriesId, this.volumeId, this.chapterId, 1).subscribe();
         }


### PR DESCRIPTION
When moving from one single-page chapter to the next, direction is not "None", it's "Next". Avoid doing this for "Prev", since moving backwards a chapter probably shouldn't mark that chapter as read.
