### PR TITLE
Hardcover Recommendations and OAuth (Hotfix)

### DIFF
--- a/.github/workflows/develop-workflow.yml
+++ b/.github/workflows/develop-workflow.yml
@@ -100,7 +100,7 @@ jobs:
       - run: |
           cd UI/Web || exit
           echo 'Installing web dependencies'
-          npm ci
+          npm ci --legacy-peer-deps
 
           echo 'Building UI'
           npm run prod

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -76,7 +76,7 @@ jobs:
 
           cd UI/Web || exit
           echo 'Installing web dependencies'
-          npm ci
+          npm ci --legacy-peer-deps
 
           echo 'Building UI'
           npm run prod


### PR DESCRIPTION
# Added
- Added: (Kavita+) Added support for loading recommendations from Hardcover. These will be the books linked to the first book in the series
- Added: (Kavita+) Added Hardcover OAuth support (PAT tokens will still work)
- Added: Added support for Mangabaka's new URL structure (released 8/31/2026)

# Changed
- Changed: Updated to Angular 22
- Changed: Opening a completed chapter while reading places you on the first page, but your reading progress won't reset unless you page forward. (Closes #4895)

# Fixed
- Fixed: (Kavita+) Fixes chapter cover images sometimes being removed when Kavita+ writes a volume image
- Fixed: Fixed black & white lists not being available for non Kavita+ users
- Fixed: Fixed series age rating not being derived from tags on first scan and from updated tags in consecutive scans
- Fixed: Fixed chapter age rating not being derived from tags
- Fixed: Fixed settings not saving for some users (Closes #4894)
- Fixed: Fixed chapters with one page not saving progress while paging (Fixes #4893) (Thanks @333fred)
- Fixed: Fixed a bug where users couldn't update reading profile from the reader due to Breakpoint enum values changing when we streamlined the breakpoint service in v0.9.1.
- Fixed: Fixed the fullscreen icon not updating when triggered from the Manga reader
- Fixed: Query parameters (?q=) from Mangabaka would break parsing out ids for Match modal
- Fixed: Version update modal title would render incorrectly on new Stable releases
- Fixed: Fixed an issue where rereading multiple single page chapters, the next chapter would set as unread. (Fixes #4771)
- Fixed: Fixed search in the audit log being case sensitive
- Fixed: Fixed series with only chapters incorrectly being set to completed if upstream has a volume numbers
- Fixed: Fixed no results message showing an empty query for the default (series name) query (Fixes #4899)
- Fixed: Fixed chapter sorting for some users under very specific circumstances
- Fixed: Fixed sent to device action item not rendering when Email is setup without Hostname
- Fixed: Fixed a bug where clients could get logged out on token refresh, when they shouldn't
- Fixed: Fixed up a regression for a unique filename pattern (c79x1) which was getting caught in the scene name regex. (Fixes #4898)

# Developer
- Setting-items now required [control]. This will be used to render out validations for you automatically
- Validations can be manually rendered via <app-validation-messages [control]='' [messages]={'validation-key': 'localized message'} /> Messages provides a way to override any validation messages (pattern). Validations otherwise will be handled via setting-item component and overrides are passed via [validations].
- Use directive appFormField='control' which handles setting the invalid classes on the input for you (along with enhanced accessibility)
- Typeaheads are now configured via a TypeaheadSettingsFactory.forX(). Streamlined like Card Config.
- switch-setting-item no longer required '#switch' on the template
- ids are no longer required for inputs with setting-item. The component will now generate ids and ensure all accessibility is wired up correctly.
- Removed timeAgo pipe as it was deprecated, along with some other dead code
