### PR TITLE
v0.9.1.4 - Hardcover Recommendations + Hotfix - #4909

### DIFF
--- a/Kavita.Common/Kavita.Common.csproj
+++ b/Kavita.Common/Kavita.Common.csproj
@@ -3,7 +3,7 @@
         <TargetFramework>net10.0</TargetFramework>
         <Company>kavitareader.com</Company>
         <Product>Kavita</Product>
-        <AssemblyVersion>0.9.1.3</AssemblyVersion>
+        <AssemblyVersion>0.9.1.4</AssemblyVersion>
         <NeutralLanguage>en</NeutralLanguage>
         <TieredPGO>true</TieredPGO>
     </PropertyGroup>

--- a/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.ts
+++ b/UI/Web/src/app/manga-reader/_components/manga-reader/manga-reader.component.ts
@@ -137,7 +137,6 @@ const KEYBIND_TARGETS = [
 })
 export class MangaReaderComponent implements OnInit, AfterViewInit, OnDestroy {
 
-
   readonly reader = viewChild.required<ElementRef>('reader');
   readonly readingArea = viewChild.required<ElementRef>('readingArea');
   readonly canvas = viewChild<ElementRef>('content');


### PR DESCRIPTION
We had a few bugs and key regressions that I felt it was necessary to release a hotfix for. In addition, since Hardcover officially launched OAuth and Recommendations (Vibes) just as we released v0.9.1, we decided to wrap that in with this. Recommendations from Hardcover REQUIRES this version or later to work. v0.9.1 will not serve recommendations. Hardcover PATs will continue working, but switching to OAuth allows Kavita to refresh your key for you.

# Added
- Added: (Kavita+) Added support for loading recommendations from Hardcover. These will be the books linked to the first book in the series. 
- Added: (Kavita+) Added Hardcover OAuth support (PAT tokens will still work)
- Added: Added support for Mangabaka's new URL structure (released 8/31/2026)

# Changed
- Changed: Opening a completed chapter while reading places you on the first page, but your reading progress won't reset unless you page forward.

# Fixed
- Fixed: (Kavita+) Fixes chapter cover images sometimes being removed when Kavita+ writes a volume image
- Fixed: Fixed black & white lists not being available for non Kavita+ users
- Fixed: Fixed series age rating not being derived from tags on first scan and from updated tags in consecutive scans
- Fixed: Fixed chapter age rating not being derived from tags
- Fixed: Fixed settings not saving for some users 
- Fixed: Fixed chapters with one page not saving progress while paging (Thanks @333fred)
- Fixed: Fixed a bug where users couldn't update reading profile from the reader due to Breakpoint enum values changing when we streamlined the breakpoint service in v0.9.1.
- Fixed: Fixed the fullscreen icon not updating when triggered from the Manga reader
- Fixed: Query parameters (?q=) from Mangabaka would break parsing out ids for Match modal
- Fixed: Version update modal title would render incorrectly on new Stable releases
- Fixed: Fixed an issue where rereading multiple single page chapters, the next chapter would set as unread.
- Fixed: Fixed search in the audit log being case sensitive
- Fixed: Fixed series with only chapters incorrectly being set to completed if upstream has a volume numbers
- Fixed: Fixed no results message showing an empty query for the default (series name) query
- Fixed: Fixed chapter sorting for some users under very specific circumstances
- Fixed: Fixed sent to device action item not rendering when Email is setup without Hostname
- Fixed: Fixed a bug where clients could get logged out on token refresh, when they shouldn't
- Fixed: Fixed up a regression for a unique filename pattern (c79x1) which was getting caught in the scene name regex. 