### PR TITLE
Fix bad request if EPUB already encodes image path

### DIFF
--- a/Kavita.Services.Tests/BookServiceTests.cs
+++ b/Kavita.Services.Tests/BookServiceTests.cs
@@ -204,4 +204,13 @@ public class BookServiceTests
         Assert.True(result.IsSuccess);
         Assert.Equal("image/png", result.ContentType);
     }
+
+    [Theory]
+    [InlineData("images/V02%20TBC.jpg", "images%2FV02%20TBC.jpg")]
+    [InlineData("images/V02 TBC.jpg", "images%2FV02%20TBC.jpg")]
+    [InlineData("images/100% cover.jpg", "images%2F100%25%20cover.jpg")]
+    public void EncodeResourcePath_EncodesPathExactlyOnce(string resourcePath, string expected)
+    {
+        Assert.Equal(expected, BookService.EncodeResourcePath(resourcePath));
+    }
 }

--- a/Kavita.Services/BookService.cs
+++ b/Kavita.Services/BookService.cs
@@ -358,7 +358,7 @@ public partial class BookService(
             if (!imageFile.StartsWith("http"))
             {
                 // UrlEncode here to transform ../ into an escaped version, which avoids blocking on nginx
-                image.Attributes.Add(key, $"{apiBase}" + Uri.EscapeDataString(imageFile));
+                image.Attributes.Add(key, $"{apiBase}" + EncodeResourcePath(imageFile));
             }
             else
             {
@@ -369,6 +369,11 @@ public partial class BookService(
             parent.AddClass("kavita-scale-width-container");
             image.AddClass("kavita-scale-width");
         }
+    }
+
+    internal static string EncodeResourcePath(string resourcePath)
+    {
+        return Uri.EscapeDataString(Uri.UnescapeDataString(resourcePath));
     }
 
 


### PR DESCRIPTION
# Fixed
- Fixed: Fixes an issue that results in images not being able to be displayed on the web reader (also tested on Kover on Android) due to the EPUB file already having an encoded path resulting in double encoding. In this case, an error 400 would be thrown by the api.

## Example
In an EPUB, from my understanding both of these are acceptable in terms of the format itself:
- images/V02 TBC.jpg
- images/V02%20TBC.jpg
Current behaviour results in https://kavita.REDACTED/api/book/4955/book-resources?apiKey=REDACTED&file=images%2FV02%2520TBC.jpg for the second option which does not fully decode and thus does not correctly point to the image inside the EPUB.