### PR TITLE
Fixed: Library scan no longer wipes cached pages out from under a live reader

### DIFF
--- a/Kavita.API/Repositories/IChapterRepository.cs
+++ b/Kavita.API/Repositories/IChapterRepository.cs
@@ -54,6 +54,11 @@ public interface IChapterRepository
     Task<IList<RatingDto>> GetExternalChapterRatingDtos(int chapterId, CancellationToken ct = default);
     Task<IList<ExternalRating>> GetExternalChapterRatings(int chapterId, CancellationToken ct = default);
     Task<ChapterDto?> GetCurrentlyReadingChapterAsync(int seriesId, int userId, CancellationToken ct = default);
+    /// <summary>
+    /// Chapter ids referenced by currently active reading sessions. These chapters are
+    /// being read right now, so their page cache must not be wiped by maintenance jobs.
+    /// </summary>
+    Task<IList<int>> GetActiveReadingChapterIdsAsync(CancellationToken ct = default);
     Task<ChapterDto?> GetFirstChapterForSeriesAsync(int seriesId, int userId, CancellationToken ct = default);
     Task<ChapterDto?> GetFirstChapterForVolumeAsync(int volumeId, int userId, CancellationToken ct = default);
     Task<IList<ChapterDto>> GetChapterDtosAsync(IEnumerable<int> chapterIds, int userId, CancellationToken ct = default);

--- a/Kavita.API/Services/ICacheService.cs
+++ b/Kavita.API/Services/ICacheService.cs
@@ -22,6 +22,12 @@ public interface ICacheService
     /// </summary>
     /// <param name="chapterIds">Volumes that belong to that library. Assume the library might have been deleted before this invocation.</param>
     void CleanupChapters(IEnumerable<int> chapterIds);
+    /// <summary>
+    /// Wipes the whole page cache directory, except chapters tied to currently active
+    /// reading sessions. Used after a scan so cached pages are never deleted out from
+    /// under a live reader.
+    /// </summary>
+    Task CleanupCacheExceptActiveChaptersAsync();
     void CleanupBookmarks(IEnumerable<int> seriesIds);
     string GetCachedPagePath(int chapterId, int page);
     string GetCachePath(int chapterId);

--- a/Kavita.Database/Repositories/ChapterRepository.cs
+++ b/Kavita.Database/Repositories/ChapterRepository.cs
@@ -332,6 +332,15 @@ public class ChapterRepository(DataContext context, IMapper mapper) : IChapterRe
             .ToListAsync(ct);
     }
 
+    public async Task<IList<int>> GetActiveReadingChapterIdsAsync(CancellationToken ct = default)
+    {
+        return await context.AppUserReadingSession
+            .Where(s => s.IsActive)
+            .SelectMany(s => s.ActivityData.Select(a => a.ChapterId))
+            .Distinct()
+            .ToListAsync(ct);
+    }
+
     public async Task<ChapterDto?> GetCurrentlyReadingChapterAsync(int seriesId, int userId, CancellationToken ct = default)
     {
         var chapterWithProgress = await context.AppUserProgresses

--- a/Kavita.Services.Tests/CacheServiceTests.cs
+++ b/Kavita.Services.Tests/CacheServiceTests.cs
@@ -1,12 +1,18 @@
 ﻿using System.IO.Abstractions.TestingHelpers;
+using Kavita.API.Repositories;
 using Kavita.API.Services;
+using Kavita.Database.Extensions;
 using Kavita.Database.Tests;
 using Kavita.Models.Builders;
+using Kavita.Models.DTOs.Progress;
 using Kavita.Models.Entities.Enums;
+using Kavita.Models.Entities.Progress;
+using Kavita.Models.Entities.User;
 using Kavita.Models.Metadata;
 using Kavita.Models.Parser;
 using Kavita.Services.Builders;
 using Kavita.Services.Reading;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using Xunit.Abstractions;
@@ -154,6 +160,57 @@ public class CacheServiceTests(ITestOutputHelper outputHelper): AbstractDbTest(o
 
         cleanupService.CleanupChapters(new []{1, 3});
         Assert.Empty(ds.GetFiles(CacheDirectory, searchOption:SearchOption.AllDirectories));
+    }
+
+    [Fact]
+    public async Task CleanupCacheExceptActiveChaptersAsync_SkipsChaptersWithActiveSessions()
+    {
+        var (unitOfWork, context, _) = await CreateDatabase();
+
+        var lib = await context.Library.Includes(LibraryIncludes.Series).FirstAsync();
+        lib.Series.Add(new SeriesBuilder("Test")
+            .WithVolume(new VolumeBuilder("1")
+                .WithChapter(new ChapterBuilder("1").WithPages(2).Build())
+                .WithChapter(new ChapterBuilder("2").WithPages(2).Build())
+                .Build())
+            .Build());
+        await context.AppUser.AddAsync(new AppUser() { UserName = "Test" });
+        await context.SaveChangesAsync();
+
+        var chapterIds = await context.Chapter.OrderBy(c => c.Id).Select(c => c.Id).ToListAsync();
+        var liveChapterId = chapterIds[0];
+        var staleChapterId = chapterIds[1];
+
+        await context.AppUserReadingSession.AddAsync(new AppUserReadingSession()
+        {
+            ActivityData =
+            [
+                new AppUserReadingSessionActivityData(new ProgressDto()
+                {
+                    ChapterId = liveChapterId, VolumeId = 1, LibraryId = 1, PageNum = 1, SeriesId = 1
+                }, 1, MangaFormat.Archive)
+            ],
+            AppUserId = 1,
+            StartTime = DateTime.Now,
+            StartTimeUtc = DateTime.UtcNow,
+            IsActive = true,
+        });
+        await context.SaveChangesAsync();
+
+        var filesystem = CreateFileSystem();
+        filesystem.AddFile($"{CacheDirectory}{liveChapterId}/001.jpg", new MockFileData(""));
+        filesystem.AddFile($"{CacheDirectory}{staleChapterId}/001.jpg", new MockFileData(""));
+        var ds = new DirectoryService(Substitute.For<ILogger<DirectoryService>>(), filesystem);
+        var cacheService = new CacheService(_logger, unitOfWork, ds,
+            new ReadingItemService(Substitute.For<IArchiveService>(),
+                Substitute.For<IBookService>(), Substitute.For<IImageService>(), ds, Substitute.For<ILogger<ReadingItemService>>(),
+                Substitute.For<IMediaErrorService>()),
+            Substitute.For<IBookmarkService>(), Substitute.For<ILocalizationService>());
+
+        await cacheService.CleanupCacheExceptActiveChaptersAsync();
+
+        Assert.True(filesystem.FileExists($"{CacheDirectory}{liveChapterId}/001.jpg"));
+        Assert.False(filesystem.Directory.Exists($"{CacheDirectory}{staleChapterId}/"));
     }
 
 

--- a/Kavita.Services/CacheService.cs
+++ b/Kavita.Services/CacheService.cs
@@ -290,7 +290,7 @@ public class CacheService(
         {
             if (keepPaths.Contains(NormalizeDirPath(dir)))
             {
-                logger.LogDebug("Skipping cache cleanup for {Directory} with an active reading session", dir);
+                logger.LogTrace("Skipping cache cleanup for {Directory} with an active reading session", dir);
                 continue;
             }
             directoryService.ClearAndDeleteDirectory(dir);
@@ -298,7 +298,8 @@ public class CacheService(
 
         static string NormalizeDirPath(string path)
         {
-            return Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            return Parser.NormalizePath(Path.GetFullPath(path)
+                .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
         }
     }
 

--- a/Kavita.Services/CacheService.cs
+++ b/Kavita.Services/CacheService.cs
@@ -275,6 +275,34 @@ public class CacheService(
     }
 
     /// <summary>
+    /// Wipes the whole page cache directory, except chapters tied to currently active
+    /// reading sessions, so a scan never deletes pages out from under a live reader.
+    /// Skipped chapters are cleaned by a later scan once their sessions close.
+    /// </summary>
+    public async Task CleanupCacheExceptActiveChaptersAsync()
+    {
+        var keepPaths = (await unitOfWork.ChapterRepository.GetActiveReadingChapterIdsAsync())
+            .Select(GetCachePath)
+            .Select(NormalizeDirPath)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var dir in directoryService.GetDirectories(directoryService.CacheDirectory))
+        {
+            if (keepPaths.Contains(NormalizeDirPath(dir)))
+            {
+                logger.LogDebug("Skipping cache cleanup for {Directory} with an active reading session", dir);
+                continue;
+            }
+            directoryService.ClearAndDeleteDirectory(dir);
+        }
+
+        static string NormalizeDirPath(string path)
+        {
+            return Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        }
+    }
+
+    /// <summary>
     /// Removes the cached files and folders for a set of chapterIds
     /// </summary>
     /// <param name="seriesIds"></param>

--- a/Kavita.Services/DirectoryService.cs
+++ b/Kavita.Services/DirectoryService.cs
@@ -377,7 +377,16 @@ public class DirectoryService : IDirectoryService
             foreach (var dir in di.EnumerateDirectories())
             {
                 if (!dir.Exists) continue;
-                dir.Delete(true);
+                try
+                {
+                    dir.Delete(true);
+                }
+                catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException || ex is DirectoryNotFoundException)
+                {
+                    // A chapter cache can be re-created (or partially removed) by a live reader
+                    // between enumeration and delete; skip it and let the next cleanup take it.
+                    _logger.LogWarning(ex, "[ClearDirectory] Could not delete {DirectoryPath}, skipping", dir.FullName);
+                }
             }
         }
         catch (UnauthorizedAccessException ex)

--- a/Kavita.Services/Scanner/ScannerService.cs
+++ b/Kavita.Services/Scanner/ScannerService.cs
@@ -330,7 +330,7 @@ public class ScannerService(
         await metadataService.RemoveAbandonedMetadataKeys();
 
         BackgroundJob.Enqueue(() => cacheService.CleanupChapters(existingChapterIdsToClean));
-        BackgroundJob.Enqueue(() => directoryService.ClearDirectory(directoryService.CacheDirectory));
+        BackgroundJob.Enqueue(() => cacheService.CleanupCacheExceptActiveChaptersAsync());
     }
 
     private static Dictionary<ParsedSeries, IList<ParserInfo>> TrackFoundSeriesAndFiles(IList<ScannedSeriesResult> seenSeries)
@@ -574,7 +574,7 @@ public class ScannerService(
             MessageFactory.LibraryScanProgressEvent(library.Name, ProgressEventType.Ended, string.Empty));
         await metadataService.RemoveAbandonedMetadataKeys();
 
-        BackgroundJob.Enqueue(() => directoryService.ClearDirectory(directoryService.CacheDirectory));
+        BackgroundJob.Enqueue(() => cacheService.CleanupCacheExceptActiveChaptersAsync());
     }
 
     private async Task RemoveSeriesNotFound(Dictionary<ParsedSeries, IList<ParserInfo>> parsedSeries, Library library)


### PR DESCRIPTION
# Fixed
- Fixed: Fixed a library scan wiping the whole page cache while the reader is serving from it, which deleted pages mid-chapter and failed the cleanup jobs with IOExceptions (Fixes #4918)

After a scan, ScannerService wiped the entire cache directory without checking whether any cached chapter was being read. The wipe now goes through CacheService.CleanupCacheExceptActiveChaptersAsync, which excludes chapters tied to currently active reading sessions (chapter ids from AppUserReadingSession activity data, which already close out on expiry, so the exclusion set stays fresh). Skipped chapters are picked up by a later scan once their sessions close. In addition, DirectoryService.ClearDirectory now skips (with a warning, instead of failing the job) a chapter directory that changes under it mid-wipe, which was the source of the reported Directory not empty / DirectoryNotFound failures.